### PR TITLE
Fix onboarding flow not persisting monitored repos

### DIFF
--- a/packages/dashboard/components/Onboarding.tsx
+++ b/packages/dashboard/components/Onboarding.tsx
@@ -101,9 +101,44 @@ export default function Onboarding() {
     }
   }
 
-  async function handleSave(_selected: AvailableRepo[]) {
-    setStep(3);
-    setTimeout(() => router.push("/dashboard"), 1500);
+  async function handleSave(selected: AvailableRepo[]) {
+    setError("");
+    setLoading(true);
+
+    // Group selected repos by installationId
+    const byInstallation = new Map<string, { repoFullName: string }[]>();
+    for (const repo of selected) {
+      const list = byInstallation.get(repo.installationId) ?? [];
+      list.push({ repoFullName: repo.repoFullName });
+      byInstallation.set(repo.installationId, list);
+    }
+
+    try {
+      // Persist monitoring for each installation
+      const results = await Promise.all(
+        Array.from(byInstallation.entries()).map(([installationId, repos]) =>
+          fetch("/api/repos/monitored", {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ installationId, repos }),
+          }),
+        ),
+      );
+
+      const failed = results.some((r) => !r.ok);
+      if (failed) {
+        setError("Failed to save some repositories. Please try again.");
+        setLoading(false);
+        return;
+      }
+
+      setStep(3);
+      setTimeout(() => router.push("/dashboard"), 1500);
+    } catch {
+      setError("Something went wrong saving your selections. Please try again.");
+    } finally {
+      setLoading(false);
+    }
   }
 
   const installedCount = accounts.filter((a) => a.installed).length;


### PR DESCRIPTION
## Summary

- The `handleSave` callback in `Onboarding.tsx` was ignoring the selected repos — it advanced to step 3 and redirected without making any API call to persist monitoring state
- Users had to manually enable monitoring from the dashboard after completing onboarding
- Now groups selected repos by `installationId` and calls `PUT /api/repos/monitored` for each installation, matching the same persistence pattern used by the dashboard's "Manage Repositories" modal

## Test plan

- [ ] Complete onboarding flow: install app, select repos, click "Enable MergeWatch"
- [ ] Verify selected repos appear as monitored on the dashboard immediately after redirect
- [ ] Test with repos across multiple installations (if applicable)
- [ ] Verify error handling: simulate API failure and confirm error message appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)