### PR TITLE
Paginate repo picker to fix timeout on large installations

### DIFF
--- a/packages/dashboard/app/api/repos/route.ts
+++ b/packages/dashboard/app/api/repos/route.ts
@@ -3,16 +3,19 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import {
   fetchUserInstallations,
-  fetchInstallationRepos,
+  fetchInstallationReposPage,
   TokenExpiredError,
 } from "@/lib/github-repos";
 
 export const dynamic = "force-dynamic";
 
+const PER_PAGE = 30;
+
 /**
- * GET /api/repos?q=<search>&installation_id=<id>
+ * GET /api/repos?page=1&per_page=30&installation_id=<id>
  *
  * Returns repositories the user has connected via the MergeWatch GitHub App.
+ * Paginated — returns one page at a time with hasMore flag.
  * Optionally filter by installation_id to scope to a single org/account.
  */
 export async function GET(req: NextRequest) {
@@ -26,7 +29,8 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "No access token" }, { status: 401 });
   }
 
-  const query = req.nextUrl.searchParams.get("q")?.toLowerCase() ?? "";
+  const page = Math.max(1, Number(req.nextUrl.searchParams.get("page") ?? "1"));
+  const perPage = Math.min(100, Math.max(1, Number(req.nextUrl.searchParams.get("per_page") ?? String(PER_PAGE))));
   const installationIdParam = req.nextUrl.searchParams.get("installation_id");
 
   try {
@@ -41,23 +45,35 @@ export async function GET(req: NextRequest) {
       ? installations.filter((i) => String(i.id) === installationIdParam)
       : installations;
 
-    const allRepos: { repoFullName: string; installedAt: string; installationId: string }[] = [];
-
-    for (const installation of targetInstallations) {
-      const { repos } = await fetchInstallationRepos(
+    if (targetInstallations.length === 1) {
+      // Single installation — use GitHub pagination directly
+      const inst = targetInstallations[0];
+      const { repos, totalCount, hasMore } = await fetchInstallationReposPage(
         accessToken,
-        installation.id,
-        query,
+        inst.id,
+        page,
+        perPage,
       );
-      allRepos.push(...repos);
+      return NextResponse.json({ repos, totalCount, hasMore });
     }
 
+    // Multiple installations — fetch the requested page from each and merge
+    const results = await Promise.all(
+      targetInstallations.map((inst) =>
+        fetchInstallationReposPage(accessToken, inst.id, page, perPage),
+      ),
+    );
+
+    const allRepos = results.flatMap((r) => r.repos);
     allRepos.sort((a, b) => a.repoFullName.localeCompare(b.repoFullName));
+
+    const totalCount = results.reduce((sum, r) => sum + r.totalCount, 0);
+    const hasMore = results.some((r) => r.hasMore);
 
     return NextResponse.json({
       repos: allRepos,
-      totalCount: allRepos.length,
-      hasMore: false,
+      totalCount,
+      hasMore,
     });
   } catch (err) {
     if (err instanceof TokenExpiredError) {

--- a/packages/dashboard/components/RepoPicker.tsx
+++ b/packages/dashboard/components/RepoPicker.tsx
@@ -49,28 +49,43 @@ export default function RepoPicker({
   );
   const [query, setQuery] = useState("");
   const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [saving, setSaving] = useState(false);
   const [totalCount, setTotalCount] = useState(0);
+  const [hasMore, setHasMore] = useState(false);
+  const [currentPage, setCurrentPage] = useState(1);
   const inputRef = useRef<HTMLInputElement>(null);
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
 
   // Track whether we've done the initial seed of monitored repos
   const seededRef = useRef(false);
 
-  // Fetch repos (with optional search query)
-  const fetchRepos = useCallback(async (q: string = "") => {
-    setLoading(true);
+  // Fetch repos (paginated)
+  const fetchRepos = useCallback(async (page: number = 1, append: boolean = false) => {
+    if (append) {
+      setLoadingMore(true);
+    } else {
+      setLoading(true);
+    }
     try {
       const searchParams = new URLSearchParams();
-      if (q) searchParams.set("q", q);
+      searchParams.set("page", String(page));
       if (installationId) searchParams.set("installation_id", installationId);
-      const qs = searchParams.toString();
-      const res = await fetch(`/api/repos${qs ? `?${qs}` : ""}`);
+      const res = await fetch(`/api/repos?${searchParams.toString()}`);
       if (res.ok) {
         const data = await res.json();
         const repos: AvailableRepo[] = data.repos ?? [];
-        setAllRepos(repos);
+        if (append) {
+          setAllRepos((prev) => {
+            const existing = new Set(prev.map((r) => r.repoFullName));
+            const newRepos = repos.filter((r) => !existing.has(r.repoFullName));
+            return [...prev, ...newRepos];
+          });
+        } else {
+          setAllRepos(repos);
+        }
         setTotalCount(data.totalCount ?? 0);
+        setHasMore(data.hasMore ?? false);
+        setCurrentPage(page);
 
         // On first load, pre-select repos that are already monitored
         if (!seededRef.current && monitoredNames.size > 0) {
@@ -88,6 +103,7 @@ export default function RepoPicker({
       }
     } finally {
       setLoading(false);
+      setLoadingMore(false);
     }
   }, [monitoredNames, installationId]);
 
@@ -103,16 +119,12 @@ export default function RepoPicker({
     inputRef.current?.focus();
   }, []);
 
-  // Debounced search
+  // Client-side search filter
   function handleSearch(value: string) {
     setQuery(value);
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => {
-      fetchRepos(value);
-    }, 300);
   }
 
-  // Filter results client-side for instant feedback while debounce fires
+  // Filter loaded repos client-side for instant feedback
   const displayed = useMemo(() => {
     if (!query) return allRepos;
     const q = query.toLowerCase();
@@ -244,36 +256,47 @@ export default function RepoPicker({
               : "No repositories found."}
           </p>
         ) : (
-          Array.from(grouped.entries()).map(([owner, repos]) => (
-            <div key={owner}>
-              <div className="sticky top-0 border-b border-border-default/50 bg-surface-card px-4 py-1.5 text-xs font-semibold text-primer-muted">
-                {owner}
+          <>
+            {Array.from(grouped.entries()).map(([owner, repos]) => (
+              <div key={owner}>
+                <div className="sticky top-0 border-b border-border-default/50 bg-surface-card px-4 py-1.5 text-xs font-semibold text-primer-muted">
+                  {owner}
+                </div>
+                {repos.map((repo: AvailableRepo) => {
+                  const isSelected = selected.has(repo.repoFullName);
+                  return (
+                    <label
+                      key={repo.repoFullName}
+                      className={`flex cursor-pointer items-center gap-3 px-4 py-2 transition ${
+                        isSelected
+                          ? "bg-primer-green/5"
+                          : "hover:bg-surface-card/50"
+                      }`}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={isSelected}
+                        onChange={() => toggle(repo)}
+                        className="h-4 w-4 rounded border-zinc-600 bg-surface-card text-primer-green focus:ring-primer-green"
+                      />
+                      <span className="text-sm text-fg-primary">
+                        {repo.repoFullName.split("/")[1]}
+                      </span>
+                    </label>
+                  );
+                })}
               </div>
-              {repos.map((repo: AvailableRepo) => {
-                const isSelected = selected.has(repo.repoFullName);
-                return (
-                  <label
-                    key={repo.repoFullName}
-                    className={`flex cursor-pointer items-center gap-3 px-4 py-2 transition ${
-                      isSelected
-                        ? "bg-primer-green/5"
-                        : "hover:bg-surface-card/50"
-                    }`}
-                  >
-                    <input
-                      type="checkbox"
-                      checked={isSelected}
-                      onChange={() => toggle(repo)}
-                      className="h-4 w-4 rounded border-zinc-600 bg-surface-card text-primer-green focus:ring-primer-green"
-                    />
-                    <span className="text-sm text-fg-primary">
-                      {repo.repoFullName.split("/")[1]}
-                    </span>
-                  </label>
-                );
-              })}
-            </div>
-          ))
+            ))}
+            {hasMore && !query && (
+              <button
+                onClick={() => fetchRepos(currentPage + 1, true)}
+                disabled={loadingMore}
+                className="w-full border-t border-border-default/50 px-4 py-2.5 text-center text-xs font-medium text-primer-blue hover:bg-surface-card/50 disabled:opacity-50"
+              >
+                {loadingMore ? "Loading..." : "Load more repositories"}
+              </button>
+            )}
+          </>
         )}
       </div>
 


### PR DESCRIPTION
## Summary

- `/api/repos` was calling `fetchInstallationRepos()` which fetches **all pages** from the GitHub API sequentially before responding — for users with many repos this would timeout or hit rate limits, breaking the repo picker in onboarding and the dashboard "Manage Repositories" modal
- Switched to `fetchInstallationReposPage()` which returns one page (30 repos) at a time with a `hasMore` flag
- RepoPicker now shows a "Load more repositories" button at the bottom of the list when more pages are available, appending results incrementally
- Search filters loaded repos client-side for instant feedback

## Test plan

- [ ] Open onboarding flow — verify first 30 repos load quickly
- [ ] Click "Load more repositories" — verify next page appends without duplicates
- [ ] Type in search box — verify instant client-side filtering across all loaded repos
- [ ] Open dashboard "Manage Repositories" modal — verify same pagination behavior
- [ ] Test with an installation that has fewer than 30 repos — verify "Load more" button does not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)