### PR TITLE
Submit PR reviews via GitHub Reviews API

### DIFF
--- a/packages/core/src/github/client.ts
+++ b/packages/core/src/github/client.ts
@@ -285,6 +285,79 @@ export async function createCheckRun(
 }
 
 // ---------------------------------------------------------------------------
+// PR Reviews API
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a merge readiness score (1–5) to a GitHub review event type.
+ *
+ *  1-2 → REQUEST_CHANGES (critical issues)
+ *  3   → COMMENT (feedback without blocking)
+ *  4-5 → APPROVE (looks good)
+ */
+export function mergeScoreToReviewEvent(
+  mergeScore: number,
+): 'APPROVE' | 'REQUEST_CHANGES' | 'COMMENT' {
+  if (mergeScore >= 4) return 'APPROVE';
+  if (mergeScore <= 2) return 'REQUEST_CHANGES';
+  return 'COMMENT';
+}
+
+/**
+ * Submit a formal PR review using the Pull Request Reviews API.
+ *
+ * This makes MergeWatch appear as a proper reviewer in GitHub's
+ * "Reviewers" section, similar to how Greptile/CodeRabbit appear.
+ */
+export async function submitPRReview(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  body: string,
+  event: 'APPROVE' | 'REQUEST_CHANGES' | 'COMMENT',
+): Promise<void> {
+  await octokit.pulls.createReview({
+    owner,
+    repo,
+    pull_number: prNumber,
+    body,
+    event,
+  });
+}
+
+/**
+ * Dismiss any existing bot reviews on a PR so they don't conflict
+ * with a new review on a later commit.
+ *
+ * Called on `synchronize` events before submitting a fresh review.
+ */
+export async function dismissStaleReviews(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  prNumber: number,
+): Promise<void> {
+  const reviews = await octokit.pulls.listReviews({
+    owner,
+    repo,
+    pull_number: prNumber,
+  });
+
+  for (const review of reviews.data) {
+    if (review.user?.type === 'Bot' && review.state !== 'DISMISSED') {
+      await octokit.pulls.dismissReview({
+        owner,
+        repo,
+        pull_number: prNumber,
+        review_id: review.id,
+        message: 'Superseded by new review on latest commit.',
+      }).catch(() => {});
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Reply comments (for conversational responses)
 // ---------------------------------------------------------------------------
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -53,6 +53,9 @@ export {
   getCommentReactions,
   createCheckRun,
   postReplyComment,
+  mergeScoreToReviewEvent,
+  submitPRReview,
+  dismissStaleReviews,
 } from './github/client.js';
 
 // ─── Comment formatter ──────────────────────────────────────────────────────

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -27,6 +27,10 @@ import {
   mergeConfig,
   shouldSkipPR,
   RESPOND_PROMPT,
+  BOT_COMMENT_MARKER,
+  submitPRReview,
+  dismissStaleReviews,
+  mergeScoreToReviewEvent,
 } from '@mergewatch/core';
 import type {
   ReviewJobPayload,
@@ -271,7 +275,16 @@ export async function handler(
       mergeScoreReason: result.mergeScoreReason || undefined,
     });
 
-    // Post or update the review comment
+    // Submit as a proper PR review (shows MergeWatch as a reviewer)
+    const reviewEvent = mergeScoreToReviewEvent(result.mergeScore);
+    try {
+      await dismissStaleReviews(octokit, owner, repo, prNumber);
+      await submitPRReview(octokit, owner, repo, prNumber, `${BOT_COMMENT_MARKER}\n${commentBody}`, reviewEvent);
+    } catch (err) {
+      console.warn('Failed to submit PR review, falling back to issue comment:', err);
+    }
+
+    // Post or update the issue comment (fallback / backwards compatibility)
     let commentId: number | undefined;
     let targetCommentId = existingCommentId;
 

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -4,6 +4,7 @@ import {
   findExistingBotComment, getCommentReactions, createCheckRun,
   formatReviewComment, runReviewPipeline, shouldSkipPR,
   DEFAULT_CONFIG, mergeConfig,
+  BOT_COMMENT_MARKER, submitPRReview, dismissStaleReviews, mergeScoreToReviewEvent,
 } from '@mergewatch/core';
 import type { WebhookDeps } from './webhook-handler.js';
 
@@ -107,7 +108,16 @@ export async function processReviewJob(
         : undefined,
     });
 
-    // Post or update comment
+    // Submit as a proper PR review (shows MergeWatch as a reviewer)
+    const reviewEvent = mergeScoreToReviewEvent(result.mergeScore);
+    try {
+      await dismissStaleReviews(octokit, owner, repo, prNumber);
+      await submitPRReview(octokit, owner, repo, prNumber, `${BOT_COMMENT_MARKER}\n${comment}`, reviewEvent);
+    } catch (err) {
+      console.warn('Failed to submit PR review, falling back to issue comment:', err);
+    }
+
+    // Post or update issue comment (fallback / backwards compatibility)
     let commentId: number | undefined;
     if (job.existingCommentId) {
       await updateReviewComment(octokit, owner, repo, job.existingCommentId, comment);


### PR DESCRIPTION
## Summary
- MergeWatch now uses `octokit.pulls.createReview` to appear as a formal PR reviewer (like Greptile/CodeRabbit) instead of just posting issue comments
- Merge score maps to review event: 1-2 → `REQUEST_CHANGES`, 3 → `COMMENT`, 4-5 → `APPROVE`
- Stale bot reviews are automatically dismissed before submitting new ones
- Issue comments kept as fallback for backwards compatibility

## Test plan
- [ ] Open a test PR → MergeWatch should appear in the "Reviewers" section
- [ ] Push a new commit → old review should be dismissed, new review submitted
- [ ] Verify merge score mapping: score 1-2 shows "Changes requested", 3 shows "Reviewed", 4-5 shows "Approved"
- [ ] If reviews API fails, verify fallback to issue comment still works
- [ ] `pnpm run build` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)