### PR TITLE
Skip signout confirmation and redirect to home

### DIFF
--- a/packages/dashboard/app/dashboard/layout.tsx
+++ b/packages/dashboard/app/dashboard/layout.tsx
@@ -25,7 +25,7 @@ export default async function DashboardLayout({
     installations = await fetchUserInstallations(accessToken);
   } catch (err) {
     if (err instanceof TokenExpiredError) {
-      redirect("/api/auth/signout");
+      redirect("/signout");
     }
     throw err;
   }

--- a/packages/dashboard/app/dashboard/page.tsx
+++ b/packages/dashboard/app/dashboard/page.tsx
@@ -41,7 +41,7 @@ export default async function DashboardPage({ searchParams }: DashboardPageProps
     installations = await fetchUserInstallations(accessToken);
   } catch (err) {
     if (err instanceof TokenExpiredError) {
-      redirect("/api/auth/signout");
+      redirect("/signout");
     }
     throw err;
   }

--- a/packages/dashboard/app/dashboard/repositories/page.tsx
+++ b/packages/dashboard/app/dashboard/repositories/page.tsx
@@ -30,7 +30,7 @@ export default async function RepositoriesPage({
     installations = await fetchUserInstallations(accessToken);
   } catch (err) {
     if (err instanceof TokenExpiredError) {
-      redirect("/api/auth/signout");
+      redirect("/signout");
     }
     throw err;
   }

--- a/packages/dashboard/app/dashboard/reviews/[id]/page.tsx
+++ b/packages/dashboard/app/dashboard/reviews/[id]/page.tsx
@@ -41,7 +41,7 @@ export default async function ReviewDetailPage({ params }: ReviewDetailPageProps
     const hasAccess = await canAccessRepo(accessToken, repoFullName);
     if (!hasAccess) notFound();
   } catch {
-    redirect("/api/auth/signout");
+    redirect("/signout");
   }
 
   const store = await getDashboardStore();

--- a/packages/dashboard/app/dashboard/reviews/page.tsx
+++ b/packages/dashboard/app/dashboard/reviews/page.tsx
@@ -29,7 +29,7 @@ export default async function ReviewsPage({ searchParams }: ReviewsPageProps) {
     installations = await fetchUserInstallations(accessToken);
   } catch (err) {
     if (err instanceof TokenExpiredError) {
-      redirect("/api/auth/signout");
+      redirect("/signout");
     }
     throw err;
   }
@@ -58,7 +58,7 @@ export default async function ReviewsPage({ searchParams }: ReviewsPageProps) {
     }
   } catch (err) {
     if (err instanceof TokenExpiredError) {
-      redirect("/api/auth/signout");
+      redirect("/signout");
     }
     // Other errors — show empty state
   }

--- a/packages/dashboard/app/dashboard/settings/page.tsx
+++ b/packages/dashboard/app/dashboard/settings/page.tsx
@@ -23,7 +23,7 @@ export default async function SettingsPage({ searchParams }: SettingsPageProps) 
     installations = await fetchUserInstallations(accessToken);
   } catch (err) {
     if (err instanceof TokenExpiredError) {
-      redirect("/api/auth/signout");
+      redirect("/signout");
     }
     throw err;
   }

--- a/packages/dashboard/app/onboarding/page.tsx
+++ b/packages/dashboard/app/onboarding/page.tsx
@@ -28,7 +28,7 @@ export default async function OnboardingPage() {
       }
     } catch (err) {
       if (err instanceof TokenExpiredError) {
-        redirect("/api/auth/signout");
+        redirect("/signout");
       }
       throw err;
     }

--- a/packages/dashboard/app/signout/page.tsx
+++ b/packages/dashboard/app/signout/page.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { signOut } from "next-auth/react";
+import { useEffect } from "react";
+
+export default function SignOutPage() {
+  useEffect(() => {
+    signOut({ callbackUrl: "/" });
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- Removes the NextAuth default signout confirmation page (the unstyled "Are you sure?" screen)
- Adds a `/signout` client page that immediately calls `signOut({ callbackUrl: "/" })` and redirects to the home page
- Updates all 7 server-side `redirect("/api/auth/signout")` calls across dashboard pages to use `/signout` instead

## Test plan
- [ ] Click sign out from the sidebar → should go straight to the home page with no confirmation
- [ ] Trigger a `TokenExpiredError` (e.g., revoke token) → should redirect to home, not the signout confirmation page
- [ ] `pnpm run build` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)