### PR TITLE
v0.2: Add analytics dashboard with charts

### DIFF
--- a/packages/dashboard/app/api/analytics/route.ts
+++ b/packages/dashboard/app/api/analytics/route.ts
@@ -1,0 +1,171 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getDashboardStore } from "@/lib/store";
+import {
+  fetchUserInstallations,
+  fetchAccessibleRepoNames,
+  TokenExpiredError,
+} from "@/lib/github-repos";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/analytics?installation_id=<id>
+ *
+ * Returns aggregated analytics data for repos the user has access to.
+ */
+export async function GET(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const accessToken = (session as any).accessToken as string | undefined;
+  if (!accessToken) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const sp = req.nextUrl.searchParams;
+  const installationIdParam = sp.get("installation_id");
+
+  try {
+    const userInstallations = await fetchUserInstallations(accessToken);
+    if (userInstallations.length === 0) {
+      return NextResponse.json({ analytics: null });
+    }
+
+    const targetInstallations = installationIdParam
+      ? userInstallations.filter((i) => String(i.id) === installationIdParam)
+      : userInstallations;
+
+    const store = await getDashboardStore();
+
+    // Get repos the user can actually access via GitHub API, then intersect
+    // with monitored repos from the store.
+    const githubAccessible = await Promise.all(
+      targetInstallations.map((inst) => fetchAccessibleRepoNames(accessToken, inst.id)),
+    );
+    const userRepoNames = new Set<string>();
+    for (const set of githubAccessible) {
+      set.forEach((name) => userRepoNames.add(name));
+    }
+
+    const accessibleRepos = new Set<string>();
+    for (const installation of targetInstallations) {
+      const items = await store.installations.listByInstallation(String(installation.id));
+      for (const item of items) {
+        if (item.monitored === true && userRepoNames.has(item.repoFullName)) {
+          accessibleRepos.add(item.repoFullName);
+        }
+      }
+    }
+
+    if (accessibleRepos.size === 0) {
+      return NextResponse.json({ analytics: null });
+    }
+
+    const targetRepos = Array.from(accessibleRepos);
+
+    // Fetch up to 500 reviews for aggregation
+    const result = await store.reviews.listReviews(targetRepos, 500);
+    const reviews = result.items;
+
+    // --- Aggregate analytics in-memory ---
+
+    // Score trend: average mergeScore per day
+    const scoreByDate = new Map<string, { sum: number; count: number }>();
+    // Severity breakdown
+    const severityBreakdown: Record<string, number> = { critical: 0, warning: 0, info: 0 };
+    // Duration stats
+    const durations: number[] = [];
+    // Repo breakdown
+    const repoBreakdown = new Map<string, number>();
+    // Category breakdown
+    const categoryBreakdown: Record<string, number> = { security: 0, bug: 0, style: 0 };
+    // Totals
+    let totalFindings = 0;
+    let mergeScoreSum = 0;
+    let mergeScoreCount = 0;
+
+    for (const review of reviews) {
+      // Score trend
+      if (review.createdAt && review.mergeScore != null) {
+        const date = review.createdAt.substring(0, 10); // YYYY-MM-DD
+        const entry = scoreByDate.get(date) ?? { sum: 0, count: 0 };
+        entry.sum += review.mergeScore;
+        entry.count += 1;
+        scoreByDate.set(date, entry);
+        mergeScoreSum += review.mergeScore;
+        mergeScoreCount += 1;
+      }
+
+      // Severity and category from findings
+      if (review.findings && Array.isArray(review.findings)) {
+        totalFindings += review.findings.length;
+        for (const finding of review.findings) {
+          if (finding.severity && severityBreakdown[finding.severity] !== undefined) {
+            severityBreakdown[finding.severity]++;
+          }
+          if (finding.category && categoryBreakdown[finding.category] !== undefined) {
+            categoryBreakdown[finding.category]++;
+          }
+        }
+      }
+
+      // Duration stats
+      if (review.durationMs != null && review.status === "complete") {
+        durations.push(review.durationMs);
+      }
+
+      // Repo breakdown
+      const repoCount = repoBreakdown.get(review.repoFullName) ?? 0;
+      repoBreakdown.set(review.repoFullName, repoCount + 1);
+    }
+
+    // Compute score trend sorted by date
+    const scoreTrend = Array.from(scoreByDate.entries())
+      .map(([date, { sum, count }]) => ({
+        date,
+        avgScore: Math.round((sum / count) * 100) / 100,
+        count,
+      }))
+      .sort((a, b) => a.date.localeCompare(b.date));
+
+    // Duration statistics
+    durations.sort((a, b) => a - b);
+    const avgDuration = durations.length > 0
+      ? Math.round(durations.reduce((s, d) => s + d, 0) / durations.length)
+      : 0;
+    const p95Duration = durations.length > 0
+      ? durations[Math.floor(durations.length * 0.95)]
+      : 0;
+
+    const analytics = {
+      totalReviews: reviews.length,
+      totalFindings,
+      avgMergeScore: mergeScoreCount > 0
+        ? Math.round((mergeScoreSum / mergeScoreCount) * 100) / 100
+        : 0,
+      scoreTrend,
+      severityBreakdown,
+      durationStats: {
+        avgMs: avgDuration,
+        p95Ms: p95Duration,
+        count: durations.length,
+      },
+      repoBreakdown: Array.from(repoBreakdown.entries())
+        .map(([repo, count]) => ({ repo, count }))
+        .sort((a, b) => b.count - a.count),
+      categoryBreakdown,
+    };
+
+    return NextResponse.json({ analytics });
+  } catch (err) {
+    if (err instanceof TokenExpiredError) {
+      return NextResponse.json({ error: "Token expired" }, { status: 401 });
+    }
+    console.error("[/api/analytics] error:", err);
+    return NextResponse.json({ analytics: null });
+  }
+}

--- a/packages/dashboard/app/dashboard/analytics/page.tsx
+++ b/packages/dashboard/app/dashboard/analytics/page.tsx
@@ -1,0 +1,45 @@
+export const dynamic = "force-dynamic";
+
+import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import {
+  fetchUserInstallations,
+  TokenExpiredError,
+} from "@/lib/github-repos";
+import AnalyticsClient from "@/components/AnalyticsClient";
+
+interface AnalyticsPageProps {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}
+
+export default async function AnalyticsPage({ searchParams }: AnalyticsPageProps) {
+  const session = await getServerSession(authOptions);
+  if (!session) redirect("/");
+
+  const accessToken = (session as any).accessToken as string | undefined;
+  if (!accessToken) redirect("/");
+
+  const params = await searchParams;
+
+  let installations;
+  try {
+    installations = await fetchUserInstallations(accessToken);
+  } catch (err) {
+    if (err instanceof TokenExpiredError) {
+      redirect("/signout");
+    }
+    throw err;
+  }
+
+  if (installations.length === 0) redirect("/onboarding");
+
+  const orgParam = typeof params.org === "string" ? params.org : undefined;
+  const activeInstallation = orgParam
+    ? installations.find((i) => String(i.id) === orgParam) ?? installations[0]
+    : installations[0];
+
+  const installationId = String(activeInstallation.id);
+
+  return <AnalyticsClient installationId={installationId} />;
+}

--- a/packages/dashboard/components/AnalyticsClient.tsx
+++ b/packages/dashboard/components/AnalyticsClient.tsx
@@ -1,0 +1,511 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  PieChart,
+  Pie,
+  Cell,
+  BarChart,
+  Bar,
+  Legend,
+} from "recharts";
+
+// -- Types ------------------------------------------------------------------
+
+interface ScoreTrendPoint {
+  date: string;
+  avgScore: number;
+  count: number;
+}
+
+interface RepoBreakdownItem {
+  repo: string;
+  count: number;
+}
+
+interface AnalyticsData {
+  totalReviews: number;
+  totalFindings: number;
+  avgMergeScore: number;
+  scoreTrend: ScoreTrendPoint[];
+  severityBreakdown: Record<string, number>;
+  durationStats: { avgMs: number; p95Ms: number; count: number };
+  repoBreakdown: RepoBreakdownItem[];
+  categoryBreakdown: Record<string, number>;
+}
+
+interface AnalyticsClientProps {
+  installationId: string;
+}
+
+// -- Constants ---------------------------------------------------------------
+
+const CHART_COLORS = {
+  green: "#22c55e",
+  yellow: "#eab308",
+  red: "#ef4444",
+  blue: "#3b82f6",
+  purple: "#8b5cf6",
+  orange: "#f97316",
+};
+
+const SEVERITY_COLORS: Record<string, string> = {
+  critical: CHART_COLORS.red,
+  warning: CHART_COLORS.yellow,
+  info: CHART_COLORS.blue,
+};
+
+const CATEGORY_COLORS: Record<string, string> = {
+  security: CHART_COLORS.red,
+  bug: CHART_COLORS.orange,
+  style: CHART_COLORS.purple,
+};
+
+// -- Helpers -----------------------------------------------------------------
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = ms / 1000;
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = Math.round(seconds % 60);
+  return `${minutes}m ${remainingSeconds}s`;
+}
+
+function formatDateLabel(dateStr: string): string {
+  const d = new Date(dateStr + "T00:00:00");
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+// -- Sub-components ----------------------------------------------------------
+
+function StatCard({ label, value, subtext }: { label: string; value: string | number; subtext?: string }) {
+  return (
+    <div
+      className="rounded-lg border p-4 sm:p-5"
+      style={{
+        backgroundColor: "var(--color-surface-elevated)",
+        borderColor: "var(--color-border-default)",
+      }}
+    >
+      <p className="text-xs font-medium uppercase tracking-wider" style={{ color: "var(--color-fg-tertiary)" }}>
+        {label}
+      </p>
+      <p className="mt-1 text-2xl font-bold" style={{ color: "var(--color-fg-primary)" }}>
+        {value}
+      </p>
+      {subtext && (
+        <p className="mt-0.5 text-xs" style={{ color: "var(--color-fg-secondary)" }}>
+          {subtext}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function ChartCard({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div
+      className="rounded-lg border p-4 sm:p-5"
+      style={{
+        backgroundColor: "var(--color-surface-elevated)",
+        borderColor: "var(--color-border-default)",
+      }}
+    >
+      <h3 className="mb-4 text-sm font-semibold" style={{ color: "var(--color-fg-primary)" }}>
+        {title}
+      </h3>
+      {children}
+    </div>
+  );
+}
+
+function SkeletonCard() {
+  return (
+    <div
+      className="animate-pulse rounded-lg border p-4 sm:p-5"
+      style={{
+        backgroundColor: "var(--color-surface-elevated)",
+        borderColor: "var(--color-border-default)",
+      }}
+    >
+      <div className="h-3 w-20 rounded" style={{ backgroundColor: "var(--color-border-default)" }} />
+      <div className="mt-3 h-7 w-16 rounded" style={{ backgroundColor: "var(--color-border-default)" }} />
+    </div>
+  );
+}
+
+function SkeletonChartCard() {
+  return (
+    <div
+      className="animate-pulse rounded-lg border p-4 sm:p-5"
+      style={{
+        backgroundColor: "var(--color-surface-elevated)",
+        borderColor: "var(--color-border-default)",
+      }}
+    >
+      <div className="h-4 w-32 rounded" style={{ backgroundColor: "var(--color-border-default)" }} />
+      <div className="mt-6 h-48 w-full rounded" style={{ backgroundColor: "var(--color-border-default)", opacity: 0.5 }} />
+    </div>
+  );
+}
+
+// -- Custom Tooltip ----------------------------------------------------------
+
+function ChartTooltip({ active, payload, label }: any) {
+  if (!active || !payload || payload.length === 0) return null;
+  return (
+    <div
+      className="rounded-md border px-3 py-2 text-xs shadow-lg"
+      style={{
+        backgroundColor: "var(--color-surface-elevated)",
+        borderColor: "var(--color-border-default)",
+        color: "var(--color-fg-primary)",
+      }}
+    >
+      <p className="font-medium">{label}</p>
+      {payload.map((entry: any, i: number) => (
+        <p key={i} style={{ color: entry.color }}>
+          {entry.name}: {entry.value}
+        </p>
+      ))}
+    </div>
+  );
+}
+
+// -- Main Component ----------------------------------------------------------
+
+export default function AnalyticsClient({ installationId }: AnalyticsClientProps) {
+  const [data, setData] = useState<AnalyticsData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchAnalytics() {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(`/api/analytics?installation_id=${installationId}`);
+        if (!res.ok) {
+          if (res.status === 401) {
+            window.location.href = "/signout";
+            return;
+          }
+          throw new Error("Failed to fetch analytics");
+        }
+        const json = await res.json();
+        if (!cancelled) {
+          setData(json.analytics);
+        }
+      } catch (err: any) {
+        if (!cancelled) {
+          setError(err.message ?? "Failed to load analytics");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    fetchAnalytics();
+    return () => { cancelled = true; };
+  }, [installationId]);
+
+  // Loading state
+  if (loading) {
+    return (
+      <div className="mx-auto max-w-6xl px-4 py-6 sm:px-6">
+        <div className="mb-6">
+          <div className="h-7 w-32 animate-pulse rounded" style={{ backgroundColor: "var(--color-border-default)" }} />
+        </div>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3 mb-6">
+          <SkeletonCard />
+          <SkeletonCard />
+          <SkeletonCard />
+        </div>
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <SkeletonChartCard />
+          <SkeletonChartCard />
+          <SkeletonChartCard />
+          <SkeletonChartCard />
+        </div>
+      </div>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <div className="mx-auto max-w-6xl px-4 py-6 sm:px-6">
+        <h1 className="mb-6 text-xl font-bold" style={{ color: "var(--color-fg-primary)" }}>Analytics</h1>
+        <div
+          className="rounded-lg border p-8 text-center"
+          style={{
+            backgroundColor: "var(--color-surface-elevated)",
+            borderColor: "var(--color-border-default)",
+          }}
+        >
+          <p className="text-sm" style={{ color: "var(--color-fg-secondary)" }}>{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Empty state
+  if (!data || data.totalReviews === 0) {
+    return (
+      <div className="mx-auto max-w-6xl px-4 py-6 sm:px-6">
+        <h1 className="mb-6 text-xl font-bold" style={{ color: "var(--color-fg-primary)" }}>Analytics</h1>
+        <div
+          className="rounded-lg border p-12 text-center"
+          style={{
+            backgroundColor: "var(--color-surface-elevated)",
+            borderColor: "var(--color-border-default)",
+          }}
+        >
+          <p className="text-base font-medium" style={{ color: "var(--color-fg-primary)" }}>No review data yet</p>
+          <p className="mt-2 text-sm" style={{ color: "var(--color-fg-secondary)" }}>
+            Analytics will appear here once MergeWatch has reviewed some pull requests.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // Prepare chart data
+  const scoreTrendData = data.scoreTrend.map((p) => ({
+    ...p,
+    dateLabel: formatDateLabel(p.date),
+  }));
+
+  const severityData = Object.entries(data.severityBreakdown)
+    .filter(([, count]) => count > 0)
+    .map(([severity, count]) => ({
+      name: severity.charAt(0).toUpperCase() + severity.slice(1),
+      value: count,
+      color: SEVERITY_COLORS[severity] ?? CHART_COLORS.blue,
+    }));
+
+  const categoryData = Object.entries(data.categoryBreakdown)
+    .filter(([, count]) => count > 0)
+    .map(([category, count]) => ({
+      name: category.charAt(0).toUpperCase() + category.slice(1),
+      value: count,
+      color: CATEGORY_COLORS[category] ?? CHART_COLORS.blue,
+    }));
+
+  const repoData = data.repoBreakdown.slice(0, 10).map((r) => ({
+    name: r.repo.includes("/") ? r.repo.split("/")[1] : r.repo,
+    fullName: r.repo,
+    reviews: r.count,
+  }));
+
+  const durationData = [
+    { name: "Average", value: Math.round(data.durationStats.avgMs / 1000), fill: CHART_COLORS.blue },
+    { name: "P95", value: Math.round(data.durationStats.p95Ms / 1000), fill: CHART_COLORS.purple },
+  ];
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-6 sm:px-6">
+      <h1 className="mb-6 text-xl font-bold" style={{ color: "var(--color-fg-primary)" }}>Analytics</h1>
+
+      {/* Stat cards */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3 mb-6">
+        <StatCard label="Total Reviews" value={data.totalReviews} />
+        <StatCard label="Total Findings" value={data.totalFindings} />
+        <StatCard
+          label="Avg Merge Score"
+          value={data.avgMergeScore > 0 ? `${data.avgMergeScore} / 5` : "N/A"}
+          subtext={data.avgMergeScore > 0 ? "Higher is better" : undefined}
+        />
+      </div>
+
+      {/* Charts */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        {/* Score Trend */}
+        {scoreTrendData.length > 0 && (
+          <ChartCard title="Merge Score Trend">
+            <ResponsiveContainer width="100%" height={240}>
+              <LineChart data={scoreTrendData}>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-default)" />
+                <XAxis
+                  dataKey="dateLabel"
+                  tick={{ fontSize: 11, fill: "var(--color-fg-tertiary)" }}
+                  tickLine={false}
+                  axisLine={{ stroke: "var(--color-border-default)" }}
+                />
+                <YAxis
+                  domain={[0, 5]}
+                  tick={{ fontSize: 11, fill: "var(--color-fg-tertiary)" }}
+                  tickLine={false}
+                  axisLine={{ stroke: "var(--color-border-default)" }}
+                />
+                <Tooltip content={<ChartTooltip />} />
+                <Line
+                  type="monotone"
+                  dataKey="avgScore"
+                  name="Avg Score"
+                  stroke={CHART_COLORS.green}
+                  strokeWidth={2}
+                  dot={{ r: 3, fill: CHART_COLORS.green }}
+                  activeDot={{ r: 5 }}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </ChartCard>
+        )}
+
+        {/* Severity Breakdown */}
+        {severityData.length > 0 && (
+          <ChartCard title="Findings by Severity">
+            <ResponsiveContainer width="100%" height={240}>
+              <PieChart>
+                <Pie
+                  data={severityData}
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={50}
+                  outerRadius={80}
+                  paddingAngle={4}
+                  dataKey="value"
+                  nameKey="name"
+                  label={({ name, value }) => `${name}: ${value}`}
+                >
+                  {severityData.map((entry, index) => (
+                    <Cell key={`severity-${index}`} fill={entry.color} />
+                  ))}
+                </Pie>
+                <Tooltip content={<ChartTooltip />} />
+              </PieChart>
+            </ResponsiveContainer>
+          </ChartCard>
+        )}
+
+        {/* Review Duration */}
+        {data.durationStats.count > 0 && (
+          <ChartCard title="Review Duration">
+            <div className="mb-3 flex gap-4">
+              <div>
+                <p className="text-xs" style={{ color: "var(--color-fg-tertiary)" }}>Average</p>
+                <p className="text-lg font-semibold" style={{ color: "var(--color-fg-primary)" }}>
+                  {formatDuration(data.durationStats.avgMs)}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs" style={{ color: "var(--color-fg-tertiary)" }}>P95</p>
+                <p className="text-lg font-semibold" style={{ color: "var(--color-fg-primary)" }}>
+                  {formatDuration(data.durationStats.p95Ms)}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs" style={{ color: "var(--color-fg-tertiary)" }}>Completed</p>
+                <p className="text-lg font-semibold" style={{ color: "var(--color-fg-primary)" }}>
+                  {data.durationStats.count}
+                </p>
+              </div>
+            </div>
+            <ResponsiveContainer width="100%" height={180}>
+              <BarChart data={durationData} layout="vertical">
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-default)" horizontal={false} />
+                <XAxis
+                  type="number"
+                  tick={{ fontSize: 11, fill: "var(--color-fg-tertiary)" }}
+                  tickLine={false}
+                  axisLine={{ stroke: "var(--color-border-default)" }}
+                  unit="s"
+                />
+                <YAxis
+                  type="category"
+                  dataKey="name"
+                  tick={{ fontSize: 11, fill: "var(--color-fg-tertiary)" }}
+                  tickLine={false}
+                  axisLine={{ stroke: "var(--color-border-default)" }}
+                  width={60}
+                />
+                <Tooltip
+                  content={<ChartTooltip />}
+                  formatter={(value: number) => [`${value}s`, "Duration"]}
+                />
+                <Bar dataKey="value" name="Duration" radius={[0, 4, 4, 0]}>
+                  {durationData.map((entry, index) => (
+                    <Cell key={`duration-${index}`} fill={entry.fill} />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </ChartCard>
+        )}
+
+        {/* Reviews per Repo */}
+        {repoData.length > 0 && (
+          <ChartCard title="Reviews per Repository">
+            <ResponsiveContainer width="100%" height={Math.max(180, repoData.length * 36)}>
+              <BarChart data={repoData} layout="vertical">
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-default)" horizontal={false} />
+                <XAxis
+                  type="number"
+                  tick={{ fontSize: 11, fill: "var(--color-fg-tertiary)" }}
+                  tickLine={false}
+                  axisLine={{ stroke: "var(--color-border-default)" }}
+                  allowDecimals={false}
+                />
+                <YAxis
+                  type="category"
+                  dataKey="name"
+                  tick={{ fontSize: 11, fill: "var(--color-fg-tertiary)" }}
+                  tickLine={false}
+                  axisLine={{ stroke: "var(--color-border-default)" }}
+                  width={120}
+                />
+                <Tooltip
+                  content={<ChartTooltip />}
+                  formatter={(value: number) => [value, "Reviews"]}
+                />
+                <Bar dataKey="reviews" name="Reviews" fill={CHART_COLORS.green} radius={[0, 4, 4, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </ChartCard>
+        )}
+
+        {/* Category Breakdown */}
+        {categoryData.length > 0 && (
+          <ChartCard title="Findings by Category">
+            <ResponsiveContainer width="100%" height={240}>
+              <BarChart data={categoryData}>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-default)" />
+                <XAxis
+                  dataKey="name"
+                  tick={{ fontSize: 11, fill: "var(--color-fg-tertiary)" }}
+                  tickLine={false}
+                  axisLine={{ stroke: "var(--color-border-default)" }}
+                />
+                <YAxis
+                  tick={{ fontSize: 11, fill: "var(--color-fg-tertiary)" }}
+                  tickLine={false}
+                  axisLine={{ stroke: "var(--color-border-default)" }}
+                  allowDecimals={false}
+                />
+                <Tooltip content={<ChartTooltip />} />
+                <Bar dataKey="value" name="Findings" radius={[4, 4, 0, 0]}>
+                  {categoryData.map((entry, index) => (
+                    <Cell key={`category-${index}`} fill={entry.color} />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </ChartCard>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard/components/layout/Sidenav.tsx
+++ b/packages/dashboard/components/layout/Sidenav.tsx
@@ -8,6 +8,7 @@ import { useTheme } from "next-themes";
 import {
   Home,
   GitPullRequest,
+  BarChart3,
   GitBranch,
   Settings,
   ChevronDown,
@@ -31,6 +32,7 @@ const navItems: NavEntry[] = [
   { type: "section", label: "MAIN" },
   { type: "item", label: "Home", href: "/dashboard", icon: Home },
   { type: "item", label: "Reviews", href: "/dashboard/reviews", icon: GitPullRequest },
+  { type: "item", label: "Analytics", href: "/dashboard/analytics", icon: BarChart3 },
   { type: "section", label: "CONFIGURE" },
   { type: "item", label: "Repositories", href: "/dashboard/repositories", icon: GitBranch },
   { type: "item", label: "Settings", href: "/dashboard/settings", icon: Settings },

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -18,7 +18,8 @@
     "next-themes": "^0.4.6",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-markdown": "^10.1.0"
+    "react-markdown": "^10.1.0",
+    "recharts": "^2.15.0"
   },
   "devDependencies": {
     "@types/node": "^20.17.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@18.3.28)(react@18.3.1)
+      recharts:
+        specifier: ^2.15.0
+        version: 2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@types/node':
         specifier: ^20.17.12
@@ -1422,6 +1425,33 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -1618,6 +1648,10 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
@@ -1652,6 +1686,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -1668,6 +1746,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -1696,6 +1777,9 @@ packages:
 
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+
+  dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
   drizzle-kit@0.30.6:
     resolution: {integrity: sha512-U4wWit0fyZuGuP7iNmRleQyK2V8wCuv57vf5l3MnG4z4fzNTjY/U13M8owyQ5RavqvqxBifWORaR3wIUzlN64g==}
@@ -1870,6 +1954,9 @@ packages:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
@@ -1879,6 +1966,10 @@ packages:
 
   fast-content-type-parse@2.0.1:
     resolution: {integrity: sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==}
+
+  fast-equals@5.4.0:
+    resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
+    engines: {node: '>=6.0.0'}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -2010,6 +2101,10 @@ packages:
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
+
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -2070,6 +2165,9 @@ packages:
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -2429,6 +2527,9 @@ packages:
   pretty-format@3.8.0:
     resolution: {integrity: sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==}
 
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
@@ -2456,11 +2557,29 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
   react-markdown@10.1.0:
     resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
     peerDependencies:
       '@types/react': '>=18'
       react: '>=18'
+
+  react-smooth@4.0.4:
+    resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  react-transition-group@4.4.5:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -2472,6 +2591,16 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+
+  recharts-scale@0.4.5:
+    resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
+
+  recharts@2.15.4:
+    resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
@@ -2606,6 +2735,9 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
@@ -2746,6 +2878,9 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  victory-vendor@36.9.2:
+    resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
   web-streams-polyfill@4.0.0-beta.3:
     resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
@@ -4150,6 +4285,30 @@ snapshots:
     dependencies:
       '@types/node': 20.19.37
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
@@ -4363,6 +4522,8 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  clsx@2.1.1: {}
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
@@ -4385,6 +4546,44 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   debug@2.6.9:
     dependencies:
       ms: 2.0.0
@@ -4392,6 +4591,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -4412,6 +4613,11 @@ snapshots:
   didyoumean@1.2.2: {}
 
   dlv@1.1.3: {}
+
+  dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.28.6
+      csstype: 3.2.3
 
   drizzle-kit@0.30.6:
     dependencies:
@@ -4583,6 +4789,8 @@ snapshots:
 
   event-target-shim@5.0.1: {}
 
+  eventemitter3@4.0.7: {}
+
   express@4.22.1:
     dependencies:
       accepts: 1.3.8
@@ -4622,6 +4830,8 @@ snapshots:
   extend@3.0.2: {}
 
   fast-content-type-parse@2.0.1: {}
+
+  fast-equals@5.4.0: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -4791,6 +5001,8 @@ snapshots:
 
   inline-style-parser@0.2.7: {}
 
+  internmap@2.0.3: {}
+
   ipaddr.js@1.9.1: {}
 
   is-alphabetical@2.0.1: {}
@@ -4833,6 +5045,8 @@ snapshots:
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
+
+  lodash@4.17.23: {}
 
   longest-streak@3.1.0: {}
 
@@ -5278,6 +5492,12 @@ snapshots:
 
   pretty-format@3.8.0: {}
 
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
   property-information@7.1.0: {}
 
   proxy-addr@2.0.7:
@@ -5306,6 +5526,10 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
+  react-is@16.13.1: {}
+
+  react-is@18.3.1: {}
+
   react-markdown@10.1.0(@types/react@18.3.28)(react@18.3.1):
     dependencies:
       '@types/hast': 3.0.4
@@ -5324,6 +5548,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  react-smooth@4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      fast-equals: 5.4.0
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
+  react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.28.6
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
@@ -5335,6 +5576,23 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+
+  recharts-scale@0.4.5:
+    dependencies:
+      decimal.js-light: 2.5.1
+
+  recharts@2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      clsx: 2.1.1
+      eventemitter3: 4.0.7
+      lodash: 4.17.23
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-is: 18.3.1
+      react-smooth: 4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recharts-scale: 0.4.5
+      tiny-invariant: 1.3.3
+      victory-vendor: 36.9.2
 
   remark-parse@11.0.0:
     dependencies:
@@ -5519,6 +5777,8 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tiny-invariant@1.3.3: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
@@ -5649,6 +5909,23 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
+
+  victory-vendor@36.9.2:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   web-streams-polyfill@4.0.0-beta.3: {}
 


### PR DESCRIPTION
## Summary
**Workstream 3 / 4** — Most isolated, only touches `packages/dashboard`.

- New `/api/analytics` endpoint that aggregates review data: score trends, severity/category breakdowns, duration stats, per-repo breakdown
- New `/dashboard/analytics` page with recharts visualizations (line chart, pie chart, bar charts)
- Stat cards for total reviews, total findings, average merge score
- Loading skeleton and empty state handling
- Theme-aware chart colors, mobile responsive
- Added "Analytics" nav item to sidebar with `BarChart3` icon

## Files changed
- `packages/dashboard/app/api/analytics/route.ts` (new)
- `packages/dashboard/app/dashboard/analytics/page.tsx` (new)
- `packages/dashboard/components/AnalyticsClient.tsx` (new)
- `packages/dashboard/components/layout/Sidenav.tsx` (nav item)
- `packages/dashboard/package.json` (recharts dep)

## Test plan
- [ ] `pnpm run build` passes
- [ ] Navigate to `/dashboard/analytics` → charts render
- [ ] Empty state (no reviews) → graceful display
- [ ] Light/dark theme toggle → charts adapt
- [ ] Mobile responsive layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)