### PR TITLE
v0.2: Add .mergewatch.yml config parsing

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,9 +11,11 @@
   "dependencies": {
     "@octokit/auth-app": "^7.1.0",
     "@octokit/rest": "^21.0.0",
+    "js-yaml": "^4.1.0",
     "minimatch": "^10.2.4"
   },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.17.12",
     "typescript": "^5.7.3"
   }

--- a/packages/core/src/github/client.ts
+++ b/packages/core/src/github/client.ts
@@ -10,7 +10,9 @@
  */
 
 import { Octokit } from "@octokit/rest";
+import yaml from 'js-yaml';
 import type { PRContext } from "../types/github.js";
+import type { MergeWatchConfig } from '../config/defaults.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -379,4 +381,72 @@ export async function postReplyComment(
     body,
   });
   return data.id;
+}
+
+// ---------------------------------------------------------------------------
+// Repository config (.mergewatch.yml)
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch and parse .mergewatch.yml from a repository's default branch.
+ * Returns null if the file doesn't exist.
+ */
+export async function fetchRepoConfig(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+): Promise<Partial<MergeWatchConfig> | null> {
+  try {
+    const { data } = await octokit.repos.getContent({
+      owner,
+      repo,
+      path: '.mergewatch.yml',
+    });
+
+    if (Array.isArray(data) || data.type !== 'file' || !data.content) {
+      return null;
+    }
+
+    const content = Buffer.from(data.content, 'base64').toString('utf-8');
+    const parsed = yaml.load(content) as Record<string, unknown> | null;
+    if (!parsed || typeof parsed !== 'object') {
+      return null;
+    }
+
+    // Map YAML fields to MergeWatchConfig fields
+    const config: Partial<MergeWatchConfig> = {};
+
+    if (typeof parsed.model === 'string') config.model = parsed.model;
+    if (typeof parsed.lightModel === 'string') config.lightModel = parsed.lightModel;
+    if (typeof parsed.maxTokensPerAgent === 'number') config.maxTokensPerAgent = parsed.maxTokensPerAgent;
+    if (typeof parsed.minSeverity === 'string' && ['info', 'warning', 'critical'].includes(parsed.minSeverity)) {
+      config.minSeverity = parsed.minSeverity as 'info' | 'warning' | 'critical';
+    }
+    if (typeof parsed.maxFindings === 'number') config.maxFindings = parsed.maxFindings;
+    if (typeof parsed.postSummaryOnClean === 'boolean') config.postSummaryOnClean = parsed.postSummaryOnClean;
+    if (Array.isArray(parsed.customStyleRules)) {
+      config.customStyleRules = parsed.customStyleRules.filter((r: unknown) => typeof r === 'string');
+    }
+    if (Array.isArray(parsed.excludePatterns)) {
+      config.excludePatterns = parsed.excludePatterns.filter((p: unknown) => typeof p === 'string');
+    }
+    if (parsed.agents && typeof parsed.agents === 'object') {
+      const a = parsed.agents as Record<string, unknown>;
+      config.agents = {
+        security: typeof a.security === 'boolean' ? a.security : true,
+        bugs: typeof a.bugs === 'boolean' ? a.bugs : true,
+        style: typeof a.style === 'boolean' ? a.style : true,
+        summary: typeof a.summary === 'boolean' ? a.summary : true,
+      };
+    }
+
+    return config;
+  } catch (err: unknown) {
+    // 404 means no config file — that's fine
+    if (err && typeof err === 'object' && 'status' in err && (err as { status: number }).status === 404) {
+      return null;
+    }
+    console.warn(`Failed to fetch .mergewatch.yml from ${owner}/${repo}:`, err);
+    return null;
+  }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -56,6 +56,7 @@ export {
   mergeScoreToReviewEvent,
   submitPRReview,
   dismissStaleReviews,
+  fetchRepoConfig,
 } from './github/client.js';
 
 // ─── Comment formatter ──────────────────────────────────────────────────────

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -31,6 +31,7 @@ import {
   submitPRReview,
   dismissStaleReviews,
   mergeScoreToReviewEvent,
+  fetchRepoConfig,
 } from '@mergewatch/core';
 import type {
   ReviewJobPayload,
@@ -232,7 +233,8 @@ export async function handler(
         : [],
     };
 
-    const runtimeConfig = mergeConfig(settingsOverrides);
+    const yamlConfig = await fetchRepoConfig(octokit, owner, repo);
+    const runtimeConfig = mergeConfig({ ...(yamlConfig ?? {}), ...settingsOverrides });
 
     const modelId = installation?.modelId ?? DEFAULT_BEDROCK_MODEL_ID;
     const lightModelId = runtimeConfig.lightModel;

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -5,6 +5,7 @@ import {
   formatReviewComment, runReviewPipeline, shouldSkipPR,
   DEFAULT_CONFIG, mergeConfig,
   BOT_COMMENT_MARKER, submitPRReview, dismissStaleReviews, mergeScoreToReviewEvent,
+  fetchRepoConfig,
 } from '@mergewatch/core';
 import type { WebhookDeps } from './webhook-handler.js';
 
@@ -52,9 +53,11 @@ export async function processReviewJob(
   const installation = await deps.installationStore.get(instId, repoFullName);
   const instSettings = await deps.installationStore.getSettings(instId);
 
-  // Merge config
+  // Merge config: YAML provides base, dashboard settings override, env var model overrides all
+  const yamlConfig = await fetchRepoConfig(octokit, owner, repo);
   const modelOverride = process.env.LLM_MODEL;
   const config = mergeConfig({
+    ...(yamlConfig ?? {}),
     ...(installation?.config || {}),
     ...(modelOverride ? { model: modelOverride, lightModel: modelOverride } : {}),
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,10 +23,16 @@ importers:
       '@octokit/rest':
         specifier: ^21.0.0
         version: 21.1.1
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.1
       minimatch:
         specifier: ^10.2.4
         version: 10.2.4
     devDependencies:
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@types/node':
         specifier: ^20.17.12
         version: 20.19.37
@@ -1443,6 +1449,9 @@ packages:
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
@@ -1517,6 +1526,9 @@ packages:
 
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
@@ -2063,6 +2075,10 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -4180,6 +4196,8 @@ snapshots:
 
   '@types/http-errors@2.0.5': {}
 
+  '@types/js-yaml@4.0.9': {}
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -4258,6 +4276,8 @@ snapshots:
       picomatch: 2.3.1
 
   arg@5.0.2: {}
+
+  argparse@2.0.1: {}
 
   array-flatten@1.1.1: {}
 
@@ -4829,6 +4849,10 @@ snapshots:
   jose@4.15.9: {}
 
   js-tokens@4.0.0: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
 
   lilconfig@3.1.3: {}
 


### PR DESCRIPTION
## Summary
**Workstream 2 / 4** — Fetches and parses `.mergewatch.yml` from repo default branch, merges with dashboard settings.

- New `fetchRepoConfig()` in `core/github/client.ts` — fetches YAML via GitHub API, base64 decodes, parses with js-yaml, validates fields
- Graceful 404 handling (no config file → defaults apply)
- Merge order: YAML provides base config, dashboard settings override
- Added `js-yaml` + `@types/js-yaml` to `@mergewatch/core`

## Files changed
- `packages/core/package.json` (js-yaml dep)
- `packages/core/src/github/client.ts` (fetchRepoConfig)
- `packages/core/src/index.ts` (export)
- `packages/lambda/src/handlers/review-agent.ts` (integration)
- `packages/server/src/review-processor.ts` (integration)

## Test plan
- [ ] `pnpm run build && pnpm run typecheck` passes
- [ ] Repo with `.mergewatch.yml` → config values applied
- [ ] Repo without `.mergewatch.yml` → 404 handled gracefully, defaults apply
- [ ] Dashboard setting overrides YAML value → dashboard wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)