### PR TITLE
v0.2: Add custom agents support

### DIFF
--- a/packages/core/src/agents/prompts.ts
+++ b/packages/core/src/agents/prompts.ts
@@ -208,3 +208,25 @@ Return a JSON object:
 }
 
 Preserve the "confidence" score (1-100) from the original agent findings. If two agents flagged the same issue, keep the higher confidence score.`;
+
+// ─── Custom agent response format ──────────────────────────────────────────
+export const CUSTOM_AGENT_RESPONSE_FORMAT = `
+
+Return a JSON object with this exact shape:
+{
+  "findings": [
+    {
+      "file": "path/to/file.ts",
+      "line": 42,
+      "severity": "critical" | "warning" | "info",
+      "confidence": 85,
+      "title": "Short title (≤80 chars)",
+      "description": "Explanation of the issue.",
+      "suggestion": "Concrete fix or recommendation."
+    }
+  ]
+}
+
+The "confidence" field is a number from 1 to 100 representing how confident you are that this is a real issue (not a false positive). Use 90+ for obvious, clear-cut issues; 70-89 for likely issues; 50-69 for possible issues worth flagging; below 50 for speculative concerns.
+
+If there are no findings, return: { "findings": [] }`;

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -18,7 +18,9 @@ import {
   SUMMARY_PROMPT,
   DIAGRAM_PROMPT,
   ORCHESTRATOR_PROMPT,
+  CUSTOM_AGENT_RESPONSE_FORMAT,
 } from './prompts.js';
+import type { CustomAgentDef } from '../config/defaults.js';
 
 // ─── Types ─────────────────────────────────────────────────────────────────
 
@@ -33,7 +35,7 @@ export interface AgentFinding {
 }
 
 export interface OrchestratedFinding extends AgentFinding {
-  category: 'security' | 'bug' | 'style';
+  category: string;
 }
 
 export interface ReviewContext {
@@ -192,10 +194,32 @@ export async function runSummaryAgent(
   return parsed.summary;
 }
 
+// ─── Custom agents ──────────────────────────────────────────────────────────
+
+/** Run a user-defined custom review agent. */
+export async function runCustomAgent(
+  agentDef: CustomAgentDef,
+  diff: string,
+  context: ReviewContext,
+  modelId: string,
+  llm: ILLMProvider,
+  relatedFiles?: Record<string, string>,
+): Promise<AgentFinding[]> {
+  const systemPrompt = `${agentDef.prompt}\n${CUSTOM_AGENT_RESPONSE_FORMAT}`;
+  const prompt = buildPrompt(systemPrompt, diff, context, relatedFiles);
+  const raw = await llm.invoke(modelId, prompt);
+  const parsed = safeParseJson<{ findings: AgentFinding[] }>(raw, { findings: [] });
+  // Apply default severity if agent didn't specify
+  return parsed.findings.map((f) => ({
+    ...f,
+    severity: f.severity || agentDef.severityDefault,
+  }));
+}
+
 // ─── Orchestrator ──────────────────────────────────────────────────────────
 
 interface TaggedFindings {
-  category: 'security' | 'bug' | 'style';
+  category: string;
   findings: AgentFinding[];
 }
 
@@ -258,6 +282,8 @@ export interface ReviewPipelineOptions {
     diagram: boolean;
   };
   relatedFiles?: Record<string, string>;
+  /** User-defined custom review agents */
+  customAgents?: CustomAgentDef[];
 }
 
 export interface ReviewPipelineResult {
@@ -286,6 +312,7 @@ export async function runReviewPipeline(
     maxFindings,
     enabledAgents,
     relatedFiles,
+    customAgents = [],
   } = options;
   const { llm } = deps;
 
@@ -308,11 +335,32 @@ export async function runReviewPipeline(
       : Promise.resolve({ diagram: '', caption: '' } as DiagramResult),
   ]);
 
+  // Run enabled custom agents in parallel
+  const enabledCustomAgents = customAgents.filter((a) => a.enabled);
+  const customResults = enabledCustomAgents.length > 0
+    ? await Promise.all(
+        enabledCustomAgents.map((agentDef) =>
+          runCustomAgent(agentDef, diff, context, modelId, llm, relatedFiles)
+            .catch((err) => {
+              console.warn(`Custom agent "${agentDef.name}" failed:`, err);
+              return [] as AgentFinding[];
+            })
+        ),
+      )
+    : [];
+
+  // Tag custom agent findings
+  const customTagged: TaggedFindings[] = enabledCustomAgents.map((agentDef, i) => ({
+    category: agentDef.name,
+    findings: customResults[i] || [],
+  }));
+
   // Orchestrate: deduplicate + rank all findings
   const taggedFindings: TaggedFindings[] = [
     { category: 'security', findings: securityFindings },
     { category: 'bug', findings: bugFindings },
     { category: 'style', findings: styleFindings },
+    ...customTagged,
   ];
 
   const orchestratorResult = await runOrchestratorAgent(

--- a/packages/core/src/comment-formatter.ts
+++ b/packages/core/src/comment-formatter.ts
@@ -12,7 +12,7 @@ export interface Finding {
   line: number;
   severity: 'critical' | 'warning' | 'info';
   confidence?: number;
-  category: 'security' | 'bug' | 'style';
+  category: string;
   title: string;
   description: string;
   suggestion: string;

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -4,6 +4,18 @@
  * or when specific fields are omitted from the config.
  */
 
+/** Definition of a user-defined custom review agent. */
+export interface CustomAgentDef {
+  /** Display name for the agent (used as finding category) */
+  name: string;
+  /** System prompt for the agent */
+  prompt: string;
+  /** Default severity for findings from this agent */
+  severityDefault: 'info' | 'warning' | 'critical';
+  /** Whether this custom agent is enabled */
+  enabled: boolean;
+}
+
 export interface MergeWatchConfig {
   /** Primary model used for review agents */
   model: string;
@@ -34,6 +46,8 @@ export interface MergeWatchConfig {
   maxDependencyDepth: number;
   /** Maximum total size of related file context in KB */
   maxContextKB: number;
+  /** User-defined custom review agents */
+  customAgents: CustomAgentDef[];
 }
 
 export const DEFAULT_CONFIG: MergeWatchConfig = {
@@ -63,6 +77,7 @@ export const DEFAULT_CONFIG: MergeWatchConfig = {
   codebaseAwareness: true,
   maxDependencyDepth: 1,
   maxContextKB: 256,
+  customAgents: [],
 };
 
 /**
@@ -77,5 +92,6 @@ export function mergeConfig(partial: Partial<MergeWatchConfig>): MergeWatchConfi
       ...DEFAULT_CONFIG.agents,
       ...(partial.agents ?? {}),
     },
+    customAgents: partial.customAgents ?? DEFAULT_CONFIG.customAgents,
   };
 }

--- a/packages/core/src/github/client.ts
+++ b/packages/core/src/github/client.ts
@@ -12,7 +12,7 @@
 import { Octokit } from "@octokit/rest";
 import yaml from 'js-yaml';
 import type { PRContext } from "../types/github.js";
-import type { MergeWatchConfig } from '../config/defaults.js';
+import type { MergeWatchConfig, CustomAgentDef } from '../config/defaults.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -438,6 +438,27 @@ export async function fetchRepoConfig(
         style: typeof a.style === 'boolean' ? a.style : true,
         summary: typeof a.summary === 'boolean' ? a.summary : true,
       };
+    }
+
+    // Codebase awareness fields
+    if (typeof parsed.codebaseAwareness === 'boolean') config.codebaseAwareness = parsed.codebaseAwareness;
+    if (typeof parsed.maxDependencyDepth === 'number') config.maxDependencyDepth = parsed.maxDependencyDepth;
+    if (typeof parsed.maxContextKB === 'number') config.maxContextKB = parsed.maxContextKB;
+
+    // Custom agents
+    if (Array.isArray(parsed.customAgents)) {
+      const validSeverities = new Set(['info', 'warning', 'critical']);
+      config.customAgents = (parsed.customAgents as unknown[])
+        .filter((a): a is Record<string, unknown> => !!a && typeof a === 'object')
+        .filter((a) => typeof a.name === 'string' && typeof a.prompt === 'string')
+        .map((a): CustomAgentDef => ({
+          name: a.name as string,
+          prompt: a.prompt as string,
+          severityDefault: validSeverities.has(a.severityDefault as string)
+            ? (a.severityDefault as 'info' | 'warning' | 'critical')
+            : 'warning',
+          enabled: typeof a.enabled === 'boolean' ? a.enabled : true,
+        }));
     }
 
     return config;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,7 @@ export {
   runSummaryAgent,
   runDiagramAgent,
   runOrchestratorAgent,
+  runCustomAgent,
 } from './agents/reviewer.js';
 export type {
   AgentFinding,
@@ -39,6 +40,7 @@ export {
   DIAGRAM_PROMPT,
   ORCHESTRATOR_PROMPT,
   RESPOND_PROMPT,
+  CUSTOM_AGENT_RESPONSE_FORMAT,
 } from './agents/prompts.js';
 
 // ─── GitHub client (portable Octokit ops) ───────────────────────────────────
@@ -65,7 +67,7 @@ export type { Finding } from './comment-formatter.js';
 
 // ─── Config ─────────────────────────────────────────────────────────────────
 export { DEFAULT_CONFIG, mergeConfig } from './config/defaults.js';
-export type { MergeWatchConfig } from './config/defaults.js';
+export type { MergeWatchConfig, CustomAgentDef } from './config/defaults.js';
 
 // ─── Context (codebase awareness) ────────────────────────────────────────────
 export { fetchFileContents } from './context/file-fetcher.js';

--- a/packages/core/src/types/db.ts
+++ b/packages/core/src/types/db.ts
@@ -321,7 +321,7 @@ export interface ReviewFinding {
   line: number;
   severity: 'critical' | 'warning' | 'info';
   confidence?: number;
-  category: 'security' | 'bug' | 'style';
+  category: string;
   title: string;
   description: string;
   suggestion: string;

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -290,6 +290,7 @@ export async function handler(
         ? { security: false, bugs: false, style: false, summary: true, diagram: false }
         : { ...runtimeConfig.agents, diagram: instSettings.summary.diagram },
       relatedFiles,
+      customAgents: runtimeConfig.customAgents,
     }, { llm });
 
     const reviewDetailUrl = `${DASHBOARD_BASE_URL}/dashboard/reviews/${encodeURIComponent(`${repoFullName}:${prNumberCommitSha}`)}`;

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -116,6 +116,7 @@ export async function processReviewJob(
           diagram: instSettings.summary?.diagram !== false,
         },
         relatedFiles,
+        customAgents: config.customAgents,
       },
       { llm: deps.llm },
     );


### PR DESCRIPTION
## Summary
**Workstream 4 / 4** — Stacked on #10 (Codebase awareness). Allows users to define custom review agents via config.

- New `CustomAgentDef` interface: name, prompt, severityDefault, enabled
- New `runCustomAgent()` function with structured JSON output
- Custom agents run in parallel after built-in agents, findings flow through orchestrator
- Widened `category` type to `string` across `OrchestratedFinding`, `ReviewFinding`, and `Finding`
- `fetchRepoConfig()` (from #9) now parses `customAgents` from YAML
- Custom agents receive `relatedFiles` (from #10) for context-aware reviews

## Files changed
- `packages/core/src/config/defaults.ts` (CustomAgentDef interface + config field)
- `packages/core/src/agents/prompts.ts` (CUSTOM_AGENT_RESPONSE_FORMAT)
- `packages/core/src/agents/reviewer.ts` (runCustomAgent + pipeline integration)
- `packages/core/src/types/db.ts` (widen category type)
- `packages/core/src/comment-formatter.ts` (widen category type)
- `packages/core/src/index.ts` (exports)
- `packages/core/src/github/client.ts` (YAML parsing for customAgents + codebaseAwareness)
- `packages/lambda/src/handlers/review-agent.ts` (pass customAgents)
- `packages/server/src/review-processor.ts` (pass customAgents)

## Test plan
- [ ] `pnpm run build && pnpm run typecheck` passes
- [ ] Config with custom agent → findings appear with custom category name
- [ ] `enabled: false` → agent skipped
- [ ] Zero custom agents → no regression on existing behavior
- [ ] Custom agents receive related files context (from WS1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)