### PR TITLE
Consistent loading states and graceful error handling across dashboard

### DIFF
--- a/packages/dashboard/app/dashboard/analytics/loading.tsx
+++ b/packages/dashboard/app/dashboard/analytics/loading.tsx
@@ -1,0 +1,31 @@
+export default function AnalyticsLoading() {
+  return (
+    <div className="px-4 py-6 sm:px-8">
+      {/* Filter bar skeleton */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4 mb-6">
+        <div className="h-9 w-32 animate-pulse rounded-lg bg-surface-subtle" />
+        <div className="h-9 w-40 animate-pulse rounded-lg bg-surface-subtle" />
+      </div>
+
+      {/* Stat cards skeleton */}
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4 mb-6">
+        {[...Array(4)].map((_, i) => (
+          <div key={i} className="rounded-lg border border-border-default bg-surface-card p-4">
+            <div className="h-3 w-20 animate-pulse rounded bg-surface-subtle" />
+            <div className="mt-2 h-7 w-16 animate-pulse rounded bg-surface-subtle" />
+          </div>
+        ))}
+      </div>
+
+      {/* Chart cards skeleton */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2 xl:grid-cols-3">
+        {[...Array(6)].map((_, i) => (
+          <div key={i} className="rounded-lg border border-border-default bg-surface-card p-4">
+            <div className="h-4 w-32 animate-pulse rounded bg-surface-subtle" />
+            <div className="mt-4 h-48 animate-pulse rounded bg-surface-subtle opacity-50" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard/app/dashboard/error.tsx
+++ b/packages/dashboard/app/dashboard/error.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[dashboard] Unhandled error:", error);
+  }, [error]);
+
+  const isTimeout =
+    error.message?.includes("fetch failed") ||
+    error.message?.includes("Connect Timeout") ||
+    error.message?.includes("ETIMEDOUT") ||
+    error.message?.includes("UND_ERR");
+
+  return (
+    <div className="px-4 py-6 sm:px-8">
+      <div className="rounded-lg border border-border-default bg-surface-card p-12 text-center">
+        <p className="text-base font-medium text-fg-primary">
+          {isTimeout ? "Connection timed out" : "Something went wrong"}
+        </p>
+        <p className="mt-2 text-sm text-fg-secondary">
+          {isTimeout
+            ? "We couldn't reach GitHub. This is usually temporary — please try again."
+            : "An unexpected error occurred while loading this page."}
+        </p>
+        <button
+          onClick={reset}
+          className="mt-6 rounded-md bg-[#00ff88] px-4 py-2 text-sm font-medium text-black hover:bg-[#00e67a] transition-colors"
+        >
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard/app/dashboard/loading.tsx
+++ b/packages/dashboard/app/dashboard/loading.tsx
@@ -1,9 +1,31 @@
-import { LoadingOverlay } from "@/components/Spinner";
-
 export default function DashboardLoading() {
   return (
-    <div className="px-4 py-6 sm:px-6 sm:py-10">
-      <LoadingOverlay label="Loading dashboard..." />
+    <div>
+      {/* Header skeleton */}
+      <div className="px-4 pt-6 pb-5 border-b border-border-default sm:px-8 sm:pt-8 sm:pb-6">
+        <div className="h-6 w-32 animate-pulse rounded bg-surface-subtle" />
+        <div className="mt-2 h-4 w-64 animate-pulse rounded bg-surface-subtle" />
+      </div>
+
+      {/* Monitored repos skeleton */}
+      <div className="px-4 py-6 sm:px-8 sm:py-8">
+        <div className="h-3 w-40 animate-pulse rounded bg-surface-subtle mb-4" />
+        <div className="grid gap-3 grid-cols-1 sm:grid-cols-2">
+          {[...Array(4)].map((_, i) => (
+            <div key={i} className="h-20 animate-pulse rounded-lg bg-surface-card-hover" />
+          ))}
+        </div>
+      </div>
+
+      {/* Recent reviews skeleton */}
+      <div className="px-4 pb-6 sm:px-8 sm:pb-8">
+        <div className="h-3 w-32 animate-pulse rounded bg-surface-subtle mb-4" />
+        <div className="space-y-2">
+          {[...Array(5)].map((_, i) => (
+            <div key={i} className="h-14 animate-pulse rounded-lg bg-surface-card-hover" />
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/packages/dashboard/app/dashboard/repositories/loading.tsx
+++ b/packages/dashboard/app/dashboard/repositories/loading.tsx
@@ -1,9 +1,20 @@
-import { LoadingOverlay } from "@/components/Spinner";
-
 export default function RepositoriesLoading() {
   return (
-    <div className="px-4 py-6 sm:px-6 sm:py-10">
-      <LoadingOverlay label="Loading repositories..." />
+    <div>
+      {/* Header skeleton */}
+      <div className="px-4 pt-6 pb-5 border-b border-border-default sm:px-8 sm:pt-8 sm:pb-6">
+        <div className="h-6 w-40 animate-pulse rounded bg-surface-subtle" />
+        <div className="mt-2 h-4 w-60 animate-pulse rounded bg-surface-subtle" />
+      </div>
+
+      {/* Repo cards skeleton */}
+      <div className="px-4 py-6 sm:px-8 sm:py-8">
+        <div className="grid gap-3 grid-cols-1 sm:grid-cols-2">
+          {[...Array(6)].map((_, i) => (
+            <div key={i} className="h-20 animate-pulse rounded-lg bg-surface-card-hover" />
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/packages/dashboard/app/dashboard/reviews/[id]/loading.tsx
+++ b/packages/dashboard/app/dashboard/reviews/[id]/loading.tsx
@@ -1,9 +1,50 @@
-import { LoadingOverlay } from "@/components/Spinner";
-
 export default function ReviewDetailLoading() {
   return (
     <div className="px-4 py-6 sm:px-6 sm:py-10">
-      <LoadingOverlay label="Loading review..." />
+      {/* Back link skeleton */}
+      <div className="h-4 w-32 animate-pulse rounded bg-surface-subtle mb-6" />
+
+      {/* Header skeleton */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0 flex-1">
+          <div className="h-7 w-80 animate-pulse rounded bg-surface-subtle" />
+          <div className="mt-2 h-4 w-40 animate-pulse rounded bg-surface-subtle" />
+        </div>
+        <div className="h-6 w-20 animate-pulse rounded-full bg-surface-subtle" />
+      </div>
+
+      {/* Two-column skeleton */}
+      <div className="mt-8 grid gap-6 lg:grid-cols-2">
+        <div className="rounded-lg border border-border-default overflow-hidden">
+          <div className="bg-surface-card-hover px-4 py-2.5 border-b border-border-default">
+            <div className="h-3 w-28 animate-pulse rounded bg-surface-subtle" />
+          </div>
+          <div className="space-y-0 divide-y divide-border-subtle px-4">
+            {[...Array(5)].map((_, i) => (
+              <div key={i} className="flex items-center gap-3 py-3">
+                <div className="h-4 w-4 animate-pulse rounded bg-surface-subtle" />
+                <div className="flex-1">
+                  <div className="h-3 w-16 animate-pulse rounded bg-surface-subtle" />
+                  <div className="mt-1.5 h-4 w-32 animate-pulse rounded bg-surface-subtle" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="rounded-lg border border-border-default overflow-hidden">
+          <div className="bg-surface-card-hover px-4 py-2.5 border-b border-border-default">
+            <div className="h-3 w-24 animate-pulse rounded bg-surface-subtle" />
+          </div>
+          <div className="space-y-0 divide-y divide-border-subtle">
+            {[...Array(5)].map((_, i) => (
+              <div key={i} className="flex items-center justify-between px-4 py-3">
+                <div className="h-4 w-28 animate-pulse rounded bg-surface-subtle" />
+                <div className="h-4 w-16 animate-pulse rounded bg-surface-subtle" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/packages/dashboard/app/dashboard/reviews/loading.tsx
+++ b/packages/dashboard/app/dashboard/reviews/loading.tsx
@@ -1,0 +1,36 @@
+export default function ReviewsLoading() {
+  return (
+    <div>
+      {/* Header skeleton */}
+      <div className="px-4 pt-6 pb-5 border-b border-border-default sm:px-8 sm:pt-8 sm:pb-6">
+        <div className="h-6 w-28 animate-pulse rounded bg-surface-subtle" />
+        <div className="mt-2 h-4 w-64 animate-pulse rounded bg-surface-subtle" />
+      </div>
+
+      {/* Stats strip skeleton */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 px-4 py-4 border-b border-border-default sm:px-8">
+        {[...Array(4)].map((_, i) => (
+          <div key={i} className="rounded-lg border border-border-default bg-surface-card px-4 py-3">
+            <div className="h-3 w-20 animate-pulse rounded bg-surface-subtle" />
+            <div className="mt-2 h-6 w-12 animate-pulse rounded bg-surface-subtle" />
+          </div>
+        ))}
+      </div>
+
+      {/* Filter bar skeleton */}
+      <div className="px-4 py-4 border-b border-border-default sm:px-8">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+          <div className="h-9 w-48 animate-pulse rounded-lg bg-surface-subtle" />
+          <div className="h-9 w-32 animate-pulse rounded-lg bg-surface-subtle" />
+        </div>
+      </div>
+
+      {/* Table rows skeleton */}
+      <div className="space-y-2 p-4 sm:p-8">
+        {[...Array(5)].map((_, i) => (
+          <div key={i} className="h-14 animate-pulse rounded-lg bg-surface-card-hover" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard/app/dashboard/settings/loading.tsx
+++ b/packages/dashboard/app/dashboard/settings/loading.tsx
@@ -1,9 +1,31 @@
-import { LoadingOverlay } from "@/components/Spinner";
-
 export default function SettingsLoading() {
   return (
-    <div className="px-4 py-6 sm:px-6 sm:py-10">
-      <LoadingOverlay label="Loading settings..." />
+    <div>
+      {/* Header skeleton */}
+      <div className="px-4 pt-6 pb-5 border-b border-border-default sm:px-8 sm:pt-8 sm:pb-6">
+        <div className="h-6 w-28 animate-pulse rounded bg-surface-subtle" />
+        <div className="mt-2 h-4 w-72 animate-pulse rounded bg-surface-subtle" />
+      </div>
+
+      {/* Settings sections skeleton */}
+      <div className="px-4 sm:px-8 pb-6">
+        {[...Array(3)].map((_, i) => (
+          <div key={i} className="mt-8">
+            <div className="h-3 w-24 animate-pulse rounded bg-surface-subtle mb-4" />
+            <div className="rounded-lg border border-border-default overflow-hidden">
+              {[...Array(3)].map((_, j) => (
+                <div key={j} className="flex items-center justify-between px-4 py-4 border-b border-border-subtle last:border-0">
+                  <div>
+                    <div className="h-4 w-36 animate-pulse rounded bg-surface-subtle" />
+                    <div className="mt-1.5 h-3 w-52 animate-pulse rounded bg-surface-subtle" />
+                  </div>
+                  <div className="h-6 w-11 animate-pulse rounded-full bg-surface-subtle" />
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/packages/dashboard/app/layout.tsx
+++ b/packages/dashboard/app/layout.tsx
@@ -3,7 +3,7 @@ import ThemeProvider from "@/components/ThemeProvider";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "MergeWatch.ai — AI-Powered PR Reviews",
+  title: "mergewatch.ai — AI-Powered PR Reviews",
   description:
     "Bring your own model. Run in your cloud. AI code reviews that respect your infrastructure.",
   icons: {

--- a/packages/dashboard/components/DashboardContent.tsx
+++ b/packages/dashboard/components/DashboardContent.tsx
@@ -150,10 +150,11 @@ export default function DashboardContent({
           Monitored Repositories
         </h2>
         {repos.length === 0 ? (
-          <div className="rounded-lg border border-border-default bg-surface-card px-6 py-10 text-center">
-            <p className="text-sm text-fg-tertiary">
+          <div className="rounded-lg border border-border-default bg-surface-card p-12 text-center">
+            <p className="text-base font-medium text-fg-primary">No monitored repositories</p>
+            <p className="mt-2 text-sm text-fg-secondary">
               {isAdmin
-                ? "No repositories are being monitored. Click \"Manage Repositories\" to select repos."
+                ? "Click \"Manage Repositories\" to select which repos MergeWatch should review."
                 : "No repositories are being monitored for this organization."}
             </p>
           </div>
@@ -177,7 +178,11 @@ export default function DashboardContent({
           Recent Reviews
         </h2>
         {loadingReviews ? (
-          <p className="py-12 text-center text-sm text-fg-tertiary">Loading reviews…</p>
+          <div className="space-y-2">
+            {[...Array(5)].map((_, i) => (
+              <div key={i} className="h-14 animate-pulse rounded-lg bg-surface-card-hover" />
+            ))}
+          </div>
         ) : (
           <ReviewTable reviews={reviews} onSelect={handleReviewSelect} />
         )}

--- a/packages/dashboard/components/ReviewDrawer.tsx
+++ b/packages/dashboard/components/ReviewDrawer.tsx
@@ -466,8 +466,11 @@ export default function ReviewDrawer({
               </div>
             </>
           ) : (
-            <div className="flex items-center justify-center h-full text-sm text-fg-tertiary">
-              Review not found.
+            <div className="flex flex-col items-center justify-center h-full text-center px-6">
+              <p className="text-base font-medium text-fg-primary">Review not found</p>
+              <p className="mt-2 text-sm text-fg-secondary">
+                This review may have been removed or the link may be incorrect.
+              </p>
             </div>
           )}
         </div>

--- a/packages/dashboard/components/ReviewTable.tsx
+++ b/packages/dashboard/components/ReviewTable.tsx
@@ -214,9 +214,12 @@ export default function ReviewTable({
 }) {
   if (reviews.length === 0) {
     return (
-      <p className="py-12 text-center text-sm text-fg-tertiary">
-        No reviews yet. Connect a repo and open a pull request to get started.
-      </p>
+      <div className="rounded-lg border border-border-default bg-surface-card p-12 text-center">
+        <p className="text-base font-medium text-fg-primary">No reviews yet</p>
+        <p className="mt-2 text-sm text-fg-secondary">
+          Reviews will appear here once MergeWatch has reviewed some pull requests.
+        </p>
+      </div>
     );
   }
 

--- a/packages/dashboard/components/ReviewsClient.tsx
+++ b/packages/dashboard/components/ReviewsClient.tsx
@@ -525,12 +525,19 @@ export default function ReviewsClient({ repos, installationId }: ReviewsClientPr
           ))}
         </div>
       ) : filtered.length === 0 ? (
-        <div className="py-16 text-center px-4 sm:px-8">
-          <p className="text-sm text-fg-tertiary">
-            {searchQuery || statusFilter || repoFilter
-              ? "No reviews match your filters."
-              : "No reviews yet. Open a pull request to get started."}
-          </p>
+        <div className="px-4 py-6 sm:px-8">
+          <div className="rounded-lg border border-border-default bg-surface-card p-12 text-center">
+            <p className="text-base font-medium text-fg-primary">
+              {searchQuery || statusFilter || repoFilter
+                ? "No matching reviews"
+                : "No reviews yet"}
+            </p>
+            <p className="mt-2 text-sm text-fg-secondary">
+              {searchQuery || statusFilter || repoFilter
+                ? "Try adjusting your search or filters to find what you're looking for."
+                : "Reviews will appear here once MergeWatch has reviewed some pull requests."}
+            </p>
+          </div>
         </div>
       ) : (() => {
         const groups = groupByPR(filtered);

--- a/packages/dashboard/components/SettingsForm.tsx
+++ b/packages/dashboard/components/SettingsForm.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { Lock } from "lucide-react";
-import { LoadingOverlay } from "./Spinner";
 
 interface InstallationSettings {
   severityThreshold: "Low" | "Med" | "High";
@@ -148,7 +147,35 @@ export default function SettingsForm({
   }, [installationId, settings]);
 
   if (loading) {
-    return <LoadingOverlay label="Loading settings..." />;
+    return (
+      <div>
+        {/* Header skeleton */}
+        <div className="px-4 pt-6 pb-5 border-b border-border-default sm:px-8 sm:pt-8 sm:pb-6">
+          <div className="h-6 w-28 animate-pulse rounded bg-surface-subtle" />
+          <div className="mt-2 h-4 w-72 animate-pulse rounded bg-surface-subtle" />
+        </div>
+
+        {/* Settings sections skeleton */}
+        <div className="px-4 sm:px-8 pb-6">
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className="mt-8">
+              <div className="h-3 w-24 animate-pulse rounded bg-surface-subtle mb-4" />
+              <div className="rounded-lg border border-border-default overflow-hidden">
+                {[...Array(3)].map((_, j) => (
+                  <div key={j} className="flex items-center justify-between px-4 py-4 border-b border-border-subtle last:border-0">
+                    <div>
+                      <div className="h-4 w-36 animate-pulse rounded bg-surface-subtle" />
+                      <div className="mt-1.5 h-3 w-52 animate-pulse rounded bg-surface-subtle" />
+                    </div>
+                    <div className="h-6 w-11 animate-pulse rounded-full bg-surface-subtle" />
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
   }
 
   const disabled = !isAdmin;

--- a/packages/dashboard/lib/github-repos.ts
+++ b/packages/dashboard/lib/github-repos.ts
@@ -12,6 +12,16 @@ export class TokenExpiredError extends Error {
   }
 }
 
+/** Thrown when a GitHub API call fails due to a network error (timeout, DNS, etc.). */
+export class GitHubNetworkError extends Error {
+  constructor(cause?: unknown) {
+    const msg = cause instanceof Error ? cause.message : "Network error";
+    super(`GitHub API unavailable: ${msg}`);
+    this.name = "GitHubNetworkError";
+    this.cause = cause;
+  }
+}
+
 export interface Installation {
   id: number;
   account: {
@@ -38,10 +48,15 @@ export interface RepoResult {
 export async function fetchUserInstallations(
   accessToken: string,
 ): Promise<Installation[]> {
-  const res = await fetch(
-    `${GITHUB_API}/user/installations?per_page=100`,
-    { headers: GITHUB_HEADERS(accessToken), cache: "no-store" },
-  );
+  let res: Response;
+  try {
+    res = await fetch(
+      `${GITHUB_API}/user/installations?per_page=100`,
+      { headers: GITHUB_HEADERS(accessToken), cache: "no-store" },
+    );
+  } catch (err) {
+    throw new GitHubNetworkError(err);
+  }
 
   if (res.status === 401 || res.status === 403) {
     throw new TokenExpiredError();
@@ -79,10 +94,15 @@ export async function fetchInstallationRepos(
     `${GITHUB_API}/user/installations/${installationId}/repositories?per_page=100`;
 
   while (nextUrl) {
-    const res = await fetch(nextUrl, {
-      headers: GITHUB_HEADERS(accessToken),
-      cache: "no-store",
-    });
+    let res: Response;
+    try {
+      res = await fetch(nextUrl, {
+        headers: GITHUB_HEADERS(accessToken),
+        cache: "no-store",
+      });
+    } catch (err) {
+      throw new GitHubNetworkError(err);
+    }
 
     if (!res.ok) break;
 
@@ -127,10 +147,15 @@ export async function fetchInstallationReposPage(
   perPage: number = 30,
 ): Promise<{ repos: RepoResult[]; totalCount: number; hasMore: boolean }> {
   const url = `${GITHUB_API}/user/installations/${installationId}/repositories?per_page=${perPage}&page=${page}`;
-  const res = await fetch(url, {
-    headers: GITHUB_HEADERS(accessToken),
-    cache: "no-store",
-  });
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers: GITHUB_HEADERS(accessToken),
+      cache: "no-store",
+    });
+  } catch (err) {
+    throw new GitHubNetworkError(err);
+  }
 
   if (res.status === 401 || res.status === 403) {
     throw new TokenExpiredError();
@@ -169,10 +194,15 @@ export async function fetchAccessibleRepoNames(
     `${GITHUB_API}/user/installations/${installationId}/repositories?per_page=100`;
 
   while (nextUrl) {
-    const res = await fetch(nextUrl, {
-      headers: GITHUB_HEADERS(accessToken),
-      cache: "no-store",
-    });
+    let res: Response;
+    try {
+      res = await fetch(nextUrl, {
+        headers: GITHUB_HEADERS(accessToken),
+        cache: "no-store",
+      });
+    } catch (err) {
+      throw new GitHubNetworkError(err);
+    }
 
     if (res.status === 401 || res.status === 403) {
       throw new TokenExpiredError();
@@ -205,10 +235,15 @@ export async function checkInstallationAdmin(
   if (installation.account.type === "User") {
     // Personal account — only the owner should be admin.
     // Compare the authenticated user's login against the installation account.
-    const res = await fetch(`${GITHUB_API}/user`, {
-      headers: GITHUB_HEADERS(accessToken),
-      cache: "no-store",
-    });
+    let res: Response;
+    try {
+      res = await fetch(`${GITHUB_API}/user`, {
+        headers: GITHUB_HEADERS(accessToken),
+        cache: "no-store",
+      });
+    } catch (err) {
+      throw new GitHubNetworkError(err);
+    }
     if (res.status === 401 || res.status === 403) {
       throw new TokenExpiredError();
     }
@@ -218,10 +253,15 @@ export async function checkInstallationAdmin(
   }
 
   // For org installations, check user's membership role
-  const res = await fetch(
-    `${GITHUB_API}/user/memberships/orgs/${installation.account.login}`,
-    { headers: GITHUB_HEADERS(accessToken), cache: "no-store" },
-  );
+  let res: Response;
+  try {
+    res = await fetch(
+      `${GITHUB_API}/user/memberships/orgs/${installation.account.login}`,
+      { headers: GITHUB_HEADERS(accessToken), cache: "no-store" },
+    );
+  } catch (err) {
+    throw new GitHubNetworkError(err);
+  }
 
   if (res.status === 401 || res.status === 403) {
     throw new TokenExpiredError();


### PR DESCRIPTION
## Summary
- Replace spinner + "Loading..." text with skeleton layouts that match each page's structure (cards, tables, settings toggles) for a polished loading experience
- Standardize all empty states with a consistent card format: bold title + descriptive subtitle (matching Analytics page pattern)
- Add `error.tsx` boundary at the dashboard level to gracefully catch GitHub API timeouts and network errors with a "Try again" button
- Add `GitHubNetworkError` class wrapping all `fetch()` calls in `github-repos.ts` so raw `TypeError: fetch failed` never reaches the user
- Add missing `loading.tsx` files for analytics and reviews pages
- Fix page title casing: `MergeWatch.ai` → `mergewatch.ai`

## Test plan
- [x] `pnpm run build` — all 10 packages compile successfully
- [ ] Navigate each dashboard tab and verify skeleton loading states render correctly
- [ ] Verify empty states show consistent card format with helpful copy
- [ ] Simulate network timeout to confirm error boundary shows retry UI
- [ ] Verify "Try again" button re-renders the page successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)