### PR TITLE
Reduce logo height in PR review comments

### DIFF
--- a/packages/core/src/comment-formatter.ts
+++ b/packages/core/src/comment-formatter.ts
@@ -125,7 +125,7 @@ export function formatReviewComment(options: FormatOptions): string {
   // postReviewComment / updateReviewComment in github/client.ts — not here.
 
   // Header — logo wordmark
-  lines.push('<img src="https://raw.githubusercontent.com/santthosh/mergewatch.ai/main/assets/wordmark-fit.png" alt="mergewatch" height="32" />');
+  lines.push('<img src="https://raw.githubusercontent.com/santthosh/mergewatch.ai/main/assets/wordmark-fit.png" alt="mergewatch" height="16" />');
   lines.push('');
 
   // Merge readiness score — highly visible


### PR DESCRIPTION
## Summary
- Reduce the MergeWatch wordmark logo from `height="32"` to `height="16"` in PR review comments to take up less vertical space

## Test plan
- [ ] Trigger a review on a test PR and verify the logo renders at half the previous size

🤖 Generated with [Claude Code](https://claude.com/claude-code)