### PR TITLE
Prevent duplicate review processing across containers

### DIFF
--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -16,6 +16,13 @@ export interface IInstallationStore {
 
 export interface IReviewStore {
   upsert(review: ReviewItem): Promise<void>;
+  /**
+   * Atomically claim a review for processing.
+   * Inserts the review record only if no record with the same key exists
+   * or the existing record is not already in_progress/complete.
+   * Returns true if this caller claimed the review, false if another worker already has it.
+   */
+  claimReview(review: ReviewItem): Promise<boolean>;
   updateStatus(
     repoFullName: string,
     key: string,

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -188,7 +188,7 @@ export async function handler(
     };
   }
 
-  // Create the initial review record
+  // Atomically claim this review — prevents duplicate processing
   const reviewStartedAt = new Date().toISOString();
   const reviewRecord: ReviewItem = {
     repoFullName,
@@ -202,7 +202,14 @@ export async function handler(
     baseBranch: prDetails.data.base.ref,
     installationId: String(installationId),
   };
-  await reviewStore.upsert(reviewRecord);
+  const claimed = await reviewStore.claimReview(reviewRecord);
+  if (!claimed) {
+    console.log(`Review already in progress for ${repoFullName}#${prNumber}@${shortSha}, skipping`);
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ message: 'Already in progress', prNumberCommitSha }),
+    };
+  }
 
   await addPRReaction(octokit, owner, repo, prNumber, 'eyes');
 

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -26,9 +26,9 @@ export async function processReviewJob(
   const shortSha = prContext.headBranch?.slice(0, 7) || 'unknown';
   const prNumberCommitSha = `${prNumber}#${shortSha}`;
 
-  // Create initial review record
+  // Atomically claim this review — prevents duplicate processing
   const now = new Date().toISOString();
-  await deps.reviewStore.upsert({
+  const claimed = await deps.reviewStore.claimReview({
     repoFullName,
     prNumberCommitSha,
     status: 'in_progress',
@@ -37,6 +37,10 @@ export async function processReviewJob(
     prAuthor: owner,
     installationId: instId,
   });
+  if (!claimed) {
+    console.log(`Review already in progress for ${repoFullName}#${prNumber}@${shortSha}, skipping`);
+    return;
+  }
 
   // Add eyes reaction
   await addPRReaction(octokit, owner, repo, prNumber, 'eyes').catch(() => {});

--- a/packages/storage-dynamo/src/review-store.ts
+++ b/packages/storage-dynamo/src/review-store.ts
@@ -24,6 +24,30 @@ export class DynamoReviewStore implements IReviewStore {
     );
   }
 
+  async claimReview(review: ReviewItem): Promise<boolean> {
+    try {
+      await this.client.send(
+        new PutCommand({
+          TableName: this.tableName,
+          Item: { ...review, status: 'in_progress' },
+          ConditionExpression:
+            'attribute_not_exists(repoFullName) OR #s IN (:failed, :skipped)',
+          ExpressionAttributeNames: { '#s': 'status' },
+          ExpressionAttributeValues: {
+            ':failed': 'failed',
+            ':skipped': 'skipped',
+          },
+        }),
+      );
+      return true;
+    } catch (err: unknown) {
+      if (err && typeof err === 'object' && 'name' in err && err.name === 'ConditionalCheckFailedException') {
+        return false;
+      }
+      throw err;
+    }
+  }
+
   async updateStatus(
     repoFullName: string,
     prNumberCommitSha: string,

--- a/packages/storage-postgres/src/review-store.ts
+++ b/packages/storage-postgres/src/review-store.ts
@@ -1,4 +1,4 @@
-import { eq, and, like, desc } from 'drizzle-orm';
+import { eq, and, like, desc, sql } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type { IReviewStore, ReviewItem, ReviewStatus } from '@mergewatch/core';
 import { reviews } from './schema.js';
@@ -63,6 +63,24 @@ export class PostgresReviewStore implements IReviewStore {
           settingsUsed: (review.settingsUsed as any) ?? null,
         },
       });
+  }
+
+  async claimReview(review: ReviewItem): Promise<boolean> {
+    // INSERT only if no row exists, or existing row is in a retriable state
+    const result = await this.db.execute(sql`
+      INSERT INTO reviews (repo_full_name, pr_number_commit_sha, status, created_at,
+        pr_title, pr_author, pr_author_avatar, head_branch, base_branch, installation_id)
+      VALUES (
+        ${review.repoFullName}, ${review.prNumberCommitSha}, 'in_progress', ${review.createdAt},
+        ${review.prTitle ?? null}, ${review.prAuthor ?? null}, ${review.prAuthorAvatar ?? null},
+        ${review.headBranch ?? null}, ${review.baseBranch ?? null}, ${review.installationId ?? null}
+      )
+      ON CONFLICT (repo_full_name, pr_number_commit_sha)
+      DO UPDATE SET status = 'in_progress', created_at = ${review.createdAt}
+      WHERE reviews.status IN ('failed', 'skipped')
+      RETURNING repo_full_name
+    `);
+    return (result as any[]).length > 0;
   }
 
   async updateStatus(


### PR DESCRIPTION
## Summary
- Adds atomic `claimReview()` to `IReviewStore` interface — prevents duplicate reviews when multiple containers or Lambda invocations process the same webhook
- **DynamoDB**: conditional `PutCommand` with `attribute_not_exists OR status IN (failed, skipped)`
- **Postgres**: `INSERT ... ON CONFLICT DO UPDATE WHERE status IN (failed, skipped) RETURNING`
- Both Lambda and server handlers call `claimReview()` before starting the pipeline — if another worker already claimed it, exits early

## Why this matters
- Without this, two containers behind a load balancer could both process the same PR webhook, running the full multi-agent pipeline twice (5-8 LLM calls each)
- Wastes LLM spend and can produce duplicate/conflicting GitHub comments
- Also protects against GitHub's webhook retry behavior

## Design decisions
- `claimReview()` allows re-processing of `failed` and `skipped` reviews (retriable states) but blocks `in_progress` and `complete`
- Uses database-level atomicity (DynamoDB conditional writes / Postgres conflict handling) — no external locks needed
- Existing `upsert()` is kept for backwards compatibility (used in skip path and other non-concurrent flows)

## Test plan
- [ ] `pnpm run build && pnpm run typecheck` passes
- [ ] Single webhook → review completes normally
- [ ] Duplicate webhook (same PR+commit) → second instance exits with "already in progress" log
- [ ] Failed review → retry succeeds (re-claims the record)
- [ ] Skipped review → re-review succeeds (re-claims the record)

🤖 Generated with [Claude Code](https://claude.com/claude-code)