### PR TITLE
Redirect self-hosted deployments to /signin

### DIFF
--- a/packages/dashboard/app/page.tsx
+++ b/packages/dashboard/app/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = "force-dynamic";
+
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import { Wordmark } from "@/components/MergeWatchLogo";

--- a/packages/dashboard/app/pricing/layout.tsx
+++ b/packages/dashboard/app/pricing/layout.tsx
@@ -1,3 +1,5 @@
+export const dynamic = "force-dynamic";
+
 import { redirect } from "next/navigation";
 import type { Metadata } from "next";
 


### PR DESCRIPTION
## Summary
- Self-hosted deployments (default) redirect `/` and `/pricing` to `/signin` — users already know the product, they just need to sign in
- Only `DEPLOYMENT_MODE=saas` (set on Amplify) shows the marketing landing page and pricing page
- `DEPLOYMENT_MODE` was already in `next.config.js` env block

## Test plan
- [ ] Without `DEPLOYMENT_MODE` set: `/` redirects to `/signin`
- [ ] Without `DEPLOYMENT_MODE` set: `/pricing` redirects to `/signin`
- [ ] With `DEPLOYMENT_MODE=saas`: `/` shows landing page
- [ ] With `DEPLOYMENT_MODE=saas`: `/pricing` shows pricing page
- [ ] `pnpm run build` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)