### PR TITLE
Fix diagram agent truncation by returning raw Mermaid

### DIFF
--- a/packages/core/src/agents/prompts.ts
+++ b/packages/core/src/agents/prompts.ts
@@ -168,15 +168,19 @@ Guidelines:
 - Keep it concise: 5-15 nodes max. Collapse trivial files into groups.
 - Use clear, short labels. Wrap labels with special characters in double quotes.
 - Use subgraphs to group related files or modules when helpful.
-- If the diff is too trivial for a useful diagram (e.g. a one-line config change, a typo fix, or a single variable rename), return empty strings for both fields.
+- If the diff is too trivial for a useful diagram (e.g. a one-line config change, a typo fix, or a single variable rename), return EMPTY (nothing at all).
 
-Return a JSON object:
-{
-  "diagram": "mermaid diagram code (no fences)",
-  "caption": "One-line description of what the diagram shows"
-}
+Return ONLY raw Mermaid code — no JSON, no fences, no explanation.
+Use a Mermaid comment on the very first line as a caption: %% One-line description
 
-If no useful diagram can be generated, return: { "diagram": "", "caption": "" }`;
+Example response:
+%% Auth flow after middleware refactor
+sequenceDiagram
+    Client->>API: request
+    API->>Auth: validate
+    Auth-->>API: token
+
+If no useful diagram can be generated, return nothing (empty response).`;
 
 // ─── Error handling agent ─────────────────────────────────────────────────
 export const ERROR_HANDLING_REVIEWER_PROMPT = `${SHARED_PREAMBLE}

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -210,8 +210,27 @@ export async function runDiagramAgent(
 ): Promise<DiagramResult> {
   const prompt = buildPrompt(DIAGRAM_PROMPT, diff, context, false);
   const raw = await llm.invoke(modelId, prompt);
-  const parsed = safeParseJson<DiagramResult>(raw, { diagram: '', caption: '' });
-  return parsed;
+  return parseDiagramResponse(raw);
+}
+
+/** Parse raw Mermaid response: extract caption from leading %% comment. */
+function parseDiagramResponse(raw: string): DiagramResult {
+  let cleaned = raw.trim();
+  // Strip markdown code fences if the model wraps them anyway
+  if (cleaned.startsWith('```')) {
+    cleaned = cleaned.replace(/^```(?:mermaid)?\s*\n?/, '').replace(/\n?```\s*$/, '');
+  }
+  if (!cleaned) return { diagram: '', caption: '' };
+
+  // Extract caption from leading Mermaid comment (%% ...)
+  const lines = cleaned.split('\n');
+  let caption = '';
+  if (lines[0].startsWith('%%')) {
+    caption = lines[0].replace(/^%%\s*/, '').trim();
+    lines.shift();
+  }
+  const diagram = lines.join('\n').trim();
+  return { diagram, caption };
 }
 
 /** Run the error handling review agent. */

--- a/packages/core/src/comment-formatter.ts
+++ b/packages/core/src/comment-formatter.ts
@@ -240,16 +240,14 @@ export function formatReviewComment(options: FormatOptions): string {
     lines.push('');
   }
 
-  // 6. Diagram (collapsible)
+  // 6. Diagram
   if (diagram && showDiagram) {
-    const captionText = diagramCaption ? ` \u2014 ${diagramCaption}` : '';
-    lines.push(`<details><summary>Diagram${captionText}</summary>`);
+    const captionText = diagramCaption ? `**Diagram** \u2014 ${diagramCaption}` : '**Diagram**';
+    lines.push(captionText);
     lines.push('');
     lines.push('```mermaid');
     lines.push(diagram);
     lines.push('```');
-    lines.push('');
-    lines.push('</details>');
     lines.push('');
   }
 


### PR DESCRIPTION
## Summary
- **Root cause**: Diagram agent returned JSON-wrapped Mermaid code. Escaped quotes and newlines bloated token count, truncating the response mid-JSON and causing `safeParseJson` to fall back to empty diagrams.
- **Fix**: Diagram prompt now asks for raw Mermaid code with a `%%` caption comment on the first line. New `parseDiagramResponse()` parser replaces `safeParseJson` for diagrams.
- **Bonus**: Diagram section no longer wrapped in collapsed `<details>` — GitHub doesn't render Mermaid inside those.

## Test plan
- [ ] Deploy to dev and trigger a review on a non-trivial PR
- [ ] Verify Mermaid diagram renders visually in the GitHub comment
- [ ] Verify caption appears above the diagram
- [ ] Verify trivial PRs (e.g. typo fix) produce no diagram section

🤖 Generated with [Claude Code](https://claude.com/claude-code)