### PR TITLE
Seed diagram agent with previous diagram for consistent re-reviews

### DIFF
--- a/packages/core/src/agents/prompts.ts
+++ b/packages/core/src/agents/prompts.ts
@@ -153,7 +153,7 @@ Return a JSON object:
 }`;
 
 // ─── Diagram agent ────────────────────────────────────────────────────────
-// Replaced with consistency guidance when previousDiagram exists, otherwise stripped
+// Placeholder used in DIAGRAM_PROMPT; see runDiagramAgent() in reviewer.ts for replacement logic
 export const PREVIOUS_DIAGRAM_PLACEHOLDER = '{{PREVIOUS_DIAGRAM}}';
 
 export const DIAGRAM_PROMPT = `You are a senior software engineer performing an automated code review.

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -212,7 +212,9 @@ export async function runDiagramAgent(
   llm: ILLMProvider,
   previousDiagram?: string,
 ): Promise<DiagramResult> {
-  // Inject previous diagram for consistency or strip the placeholder
+  // Inject previous diagram for consistency or strip the placeholder.
+  // When previousDiagram exists and is non-empty, replaces PREVIOUS_DIAGRAM_PLACEHOLDER
+  // with consistency guidance; otherwise strips it from the prompt.
   let diagramPrompt = DIAGRAM_PROMPT;
   if (previousDiagram && previousDiagram.trim()) {
     diagramPrompt = diagramPrompt.replace(

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -275,7 +275,7 @@ export async function handler(
     try {
       prevReviews = await reviewStore.queryByPR(repoFullName, `${prNumber}#`, 5);
       prevComplete = prevReviews.find(
-        (r) => r.status === 'complete' && r.prNumberCommitSha !== prNumberCommitSha && r.findings,
+        (r) => r.status === 'complete' && r.prNumberCommitSha !== prNumberCommitSha && r.findings && r.findings.length > 0,
       );
     } catch (err) {
       console.warn('Failed to fetch previous reviews:', err);

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -90,7 +90,7 @@ export async function processReviewJob(
       return [] as Awaited<ReturnType<typeof deps.reviewStore.queryByPR>>;
     });
     prevComplete = prevReviewsResult.find(
-      (r) => r.status === 'complete' && r.prNumberCommitSha !== prNumberCommitSha && r.findings,
+      (r) => r.status === 'complete' && r.prNumberCommitSha !== prNumberCommitSha && r.findings && r.findings.length > 0,
     );
 
     const previousDiagram = typeof prevComplete?.diagramText === 'string' ? prevComplete.diagramText : undefined;


### PR DESCRIPTION
## Summary
- When re-reviewing a PR (new commits), the diagram agent now receives the previous diagram via a `{{PREVIOUS_DIAGRAM}}` placeholder in the prompt, instructing it to maintain consistent node IDs, naming, diagram type, and layout
- Moves the `queryByPR` call before `runReviewPipeline` in both Lambda and server runtimes, eliminating a duplicate DB query (the same result is reused for delta computation)
- Adds `previousDiagram?: string` to `ReviewPipelineOptions` and threads it through to `runDiagramAgent()`

## Test plan
- [ ] `pnpm run build` passes across all 10 packages
- [ ] Deploy to dev and trigger two reviews on the same PR with different commits
- [ ] Verify the second diagram maintains consistent node names and layout from the first
- [ ] Verify the first review (no previous diagram) still produces a diagram normally
- [ ] Verify delta computation still works correctly (reused query result)

🤖 Generated with [Claude Code](https://claude.com/claude-code)