### PR TITLE
Fix diagram agent returning JSON instead of Mermaid

### DIFF
--- a/packages/core/src/agents/prompts.ts
+++ b/packages/core/src/agents/prompts.ts
@@ -153,7 +153,7 @@ Return a JSON object:
 }`;
 
 // ─── Diagram agent ────────────────────────────────────────────────────────
-export const DIAGRAM_PROMPT = `${SHARED_PREAMBLE}
+export const DIAGRAM_PROMPT = `You are a senior software engineer performing an automated code review.
 
 Analyse the diff and produce a Mermaid diagram that visualises the structure or flow of the changes.
 


### PR DESCRIPTION
## Summary
- `SHARED_PREAMBLE` contains the instruction "Respond ONLY with the JSON object described below" which conflicts with the diagram prompt's "Return ONLY raw Mermaid code — no JSON"
- The LLM follows the preamble's JSON instruction, returning `{"issues": [], "diagram": ""}` instead of raw Mermaid code, which GitHub cannot render
- Fix: replace `SHARED_PREAMBLE` with a minimal role intro for the diagram agent — it doesn't need the findings-specific rules (verification, confidence thresholds, etc.)

## Test plan
- [ ] `pnpm run build` passes
- [ ] Deploy and trigger a review — verify the diagram renders as valid Mermaid on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)