### PR TITLE
Fix repo active/paused toggle not persisting in self-hosted

### DIFF
--- a/packages/storage-postgres/src/dashboard-store.ts
+++ b/packages/storage-postgres/src/dashboard-store.ts
@@ -127,14 +127,18 @@ class PostgresDashboardInstallationStore implements IDashboardInstallationStore 
     monitored: boolean,
   ): Promise<void> {
     await this.db
-      .update(installations)
-      .set({ monitored })
-      .where(
-        and(
-          eq(installations.installationId, installationId),
-          eq(installations.repoFullName, repoFullName),
-        ),
-      );
+      .insert(installations)
+      .values({
+        installationId,
+        repoFullName,
+        installedAt: new Date().toISOString(),
+        config: {},
+        monitored,
+      })
+      .onConflictDoUpdate({
+        target: [installations.installationId, installations.repoFullName],
+        set: { monitored },
+      });
   }
 }
 


### PR DESCRIPTION
## Summary
- In self-hosted (Postgres) deployments, toggling a repo from paused to active in the dashboard didn't persist — the UI would revert on refresh while webhooks continued working
- Root cause: `updateMonitored` used a plain `UPDATE` which silently affected 0 rows when the `installations` row didn't exist (e.g. the `installation.created` webhook was missed or the server wasn't running when the GitHub App was installed)
- Fix: changed to `INSERT ... ON CONFLICT DO UPDATE` (upsert) so the row is created if missing
- DynamoDB (SaaS) was unaffected since `UpdateCommand` upserts by default

## Test plan
- [ ] `pnpm run build` passes
- [ ] Self-hosted: install GitHub App on a repo, toggle pause/active in dashboard, verify it persists on refresh
- [ ] Self-hosted: verify toggling works for repos that had no prior `installations` row

🤖 Generated with [Claude Code](https://claude.com/claude-code)