### PR TITLE
Fix PR file list truncated at 100 files

### DIFF
--- a/packages/core/src/github/client.ts
+++ b/packages/core/src/github/client.ts
@@ -69,12 +69,11 @@ export async function getPRContext(
   prNumber: number
 ): Promise<PRContext> {
   // Fetch the PR metadata and the list of changed files in parallel.
-  const [pr, filesResponse] = await Promise.all([
+  // GitHub caps listFiles at 100 per page, so paginate to get all files.
+  const [pr, files] = await Promise.all([
     octokit.pulls.get({ owner, repo, pull_number: prNumber }),
-    octokit.pulls.listFiles({ owner, repo, pull_number: prNumber, per_page: 300 }),
+    octokit.paginate(octokit.pulls.listFiles, { owner, repo, pull_number: prNumber, per_page: 100 }),
   ]);
-
-  const files = filesResponse.data;
   return {
     owner,
     repo,


### PR DESCRIPTION
## Summary
- GitHub's `pulls.listFiles` API caps `per_page` at 100, silently ignoring higher values like the previous `per_page: 300`
- PRs with >100 changed files only had the first 100 reported in the "files scanned" count and used for skip-logic evaluation
- Fix: use `octokit.paginate` to fetch all pages (up to GitHub's 3000 file limit)

## Test plan
- [ ] `pnpm run build` passes
- [ ] Review a PR with >100 changed files and verify the correct file count is reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)