### PR TITLE
SEO Phase 1: robots, sitemap, canonical/OG metadata, JSON-LD

### DIFF
--- a/packages/dashboard/app/layout.tsx
+++ b/packages/dashboard/app/layout.tsx
@@ -2,19 +2,86 @@ import type { Metadata } from "next";
 import ThemeProvider from "@/components/ThemeProvider";
 import "./globals.css";
 
+const SITE_URL = "https://mergewatch.ai";
+const SITE_NAME = "MergeWatch";
+const SITE_DESCRIPTION =
+  "AI-powered GitHub App that reviews pull requests with a multi-agent pipeline. Bring your own model, run in your cloud, or use the hosted SaaS.";
+
 export const metadata: Metadata = {
-  title: "mergewatch.ai — AI-Powered PR Reviews",
-  description:
-    "Bring your own model. Run in your cloud. AI code reviews that respect your infrastructure.",
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: "MergeWatch — AI-Powered PR Reviews",
+    template: "%s — MergeWatch",
+  },
+  description: SITE_DESCRIPTION,
+  applicationName: SITE_NAME,
+  alternates: {
+    canonical: "/",
+  },
   icons: {
     icon: "/icon.svg",
   },
+  openGraph: {
+    type: "website",
+    url: SITE_URL,
+    siteName: SITE_NAME,
+    title: "MergeWatch — AI-Powered PR Reviews",
+    description: SITE_DESCRIPTION,
+    locale: "en_US",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "MergeWatch — AI-Powered PR Reviews",
+    description: SITE_DESCRIPTION,
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+    },
+  },
 };
 
-/**
- * Root layout — wraps every page with a consistent shell.
- * Uses the system sans-serif stack for a clean, fast-loading UI.
- */
+const jsonLd = [
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: SITE_NAME,
+    url: SITE_URL,
+    logo: `${SITE_URL}/icon.svg`,
+    sameAs: ["https://github.com/santthosh/mergewatch.ai"],
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: SITE_NAME,
+    url: SITE_URL,
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name: SITE_NAME,
+    url: SITE_URL,
+    applicationCategory: "DeveloperApplication",
+    operatingSystem: "Web, Linux, macOS",
+    description: SITE_DESCRIPTION,
+    offers: {
+      "@type": "Offer",
+      price: "0",
+      priceCurrency: "USD",
+    },
+    publisher: {
+      "@type": "Organization",
+      name: SITE_NAME,
+      url: SITE_URL,
+    },
+  },
+];
+
 export default function RootLayout({
   children,
 }: {
@@ -24,6 +91,10 @@ export default function RootLayout({
     <html lang="en" className="antialiased" suppressHydrationWarning>
       <body className="min-h-screen font-sans">
         <ThemeProvider>{children}</ThemeProvider>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
       </body>
     </html>
   );

--- a/packages/dashboard/app/layout.tsx
+++ b/packages/dashboard/app/layout.tsx
@@ -46,6 +46,15 @@ export const metadata: Metadata = {
   },
 };
 
+function serializeJsonLd(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
 const jsonLd = [
   {
     "@context": "https://schema.org",
@@ -93,7 +102,7 @@ export default function RootLayout({
         <ThemeProvider>{children}</ThemeProvider>
         <script
           type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+          dangerouslySetInnerHTML={{ __html: serializeJsonLd(jsonLd) }}
         />
       </body>
     </html>

--- a/packages/dashboard/app/opengraph-image.tsx
+++ b/packages/dashboard/app/opengraph-image.tsx
@@ -1,0 +1,63 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "edge";
+export const alt = "MergeWatch — AI-Powered PR Reviews";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function OpengraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          alignItems: "flex-start",
+          padding: "80px",
+          background:
+            "linear-gradient(135deg, #0b1020 0%, #111936 50%, #1a2550 100%)",
+          fontFamily: "system-ui, sans-serif",
+        }}
+      >
+        <div
+          style={{
+            fontSize: 36,
+            color: "#7dd3fc",
+            letterSpacing: "-0.02em",
+            marginBottom: 20,
+          }}
+        >
+          mergewatch.ai
+        </div>
+        <div
+          style={{
+            fontSize: 84,
+            color: "#ffffff",
+            fontWeight: 700,
+            lineHeight: 1.05,
+            letterSpacing: "-0.03em",
+            maxWidth: 1000,
+          }}
+        >
+          AI-Powered PR Reviews
+        </div>
+        <div
+          style={{
+            fontSize: 32,
+            color: "#cbd5e1",
+            marginTop: 28,
+            maxWidth: 980,
+            lineHeight: 1.3,
+          }}
+        >
+          Bring your own model. Run in your cloud. Multi-agent code review for
+          GitHub.
+        </div>
+      </div>
+    ),
+    size,
+  );
+}

--- a/packages/dashboard/app/robots.ts
+++ b/packages/dashboard/app/robots.ts
@@ -1,0 +1,33 @@
+import type { MetadataRoute } from "next";
+
+const SITE_URL = "https://mergewatch.ai";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/dashboard", "/api/", "/signin", "/signout", "/onboarding"],
+      },
+      {
+        userAgent: [
+          "GPTBot",
+          "OAI-SearchBot",
+          "ChatGPT-User",
+          "ClaudeBot",
+          "Claude-Web",
+          "anthropic-ai",
+          "PerplexityBot",
+          "Perplexity-User",
+          "Google-Extended",
+          "Applebot-Extended",
+        ],
+        allow: "/",
+        disallow: ["/dashboard", "/api/", "/signin", "/signout", "/onboarding"],
+      },
+    ],
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/packages/dashboard/app/sitemap.ts
+++ b/packages/dashboard/app/sitemap.ts
@@ -1,0 +1,21 @@
+import type { MetadataRoute } from "next";
+
+const SITE_URL = "https://mergewatch.ai";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date();
+  return [
+    {
+      url: `${SITE_URL}/`,
+      lastModified: now,
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+    {
+      url: `${SITE_URL}/pricing`,
+      lastModified: now,
+      changeFrequency: "weekly",
+      priority: 0.9,
+    },
+  ];
+}


### PR DESCRIPTION
## Summary

Phase 1 of the SEO audit remediation plan ([Notion](https://www.notion.so/3415017da73981c28a39f804476846bd)). Closes all 6 Critical findings from the 2026-04-13 `/seo audit` run.

- `app/robots.ts` — crawl directives with explicit AI crawler allows (GPTBot, OAI-SearchBot, ClaudeBot, anthropic-ai, PerplexityBot, Google-Extended, Applebot-Extended) and disallows for `/dashboard`, `/api/`, `/signin`, `/signout`, `/onboarding`. References sitemap.
- `app/sitemap.ts` — emits `/` and `/pricing` with `lastModified`.
- `app/layout.tsx` — adds `metadataBase`, canonical, Open Graph, Twitter Card, robots directives, and JSON-LD (`Organization`, `WebSite`, `SoftwareApplication`).
- `app/opengraph-image.tsx` — generated 1200×630 social preview image via Next.js `ImageResponse`.

Baseline SEO Health Score before this PR: **39/100**. This PR addresses the Critical tier; Phases 2–5 (Trust/Legal, Security Headers, Content, GEO/llms.txt) follow in separate PRs.

## Test plan

- [x] `pnpm -w run typecheck` passes
- [x] `pnpm --filter @mergewatch/dashboard run build` passes — routes table shows `/robots.txt`, `/sitemap.xml`, `/opengraph-image`
- [ ] After deploy: `curl https://mergewatch.ai/robots.txt` returns 200 with AI crawler rules
- [ ] After deploy: `curl https://mergewatch.ai/sitemap.xml` returns 200 with both URLs
- [ ] After deploy: Google Rich Results Test validates JSON-LD
- [ ] After deploy: Open Graph debugger shows preview image + title/description

🤖 Generated with [Claude Code](https://claude.com/claude-code)