### PR TITLE
SEO Phase 2: Privacy, Terms, About pages

### DIFF
--- a/packages/dashboard/app/about/page.tsx
+++ b/packages/dashboard/app/about/page.tsx
@@ -1,0 +1,114 @@
+import type { Metadata } from "next";
+import { LegalPage } from "@/components/LegalPage";
+
+export const metadata: Metadata = {
+  title: "About",
+  description:
+    "MergeWatch is an open-source multi-agent AI code reviewer built by Santthosh. Bring your own model, run in your cloud, or use the hosted SaaS.",
+  alternates: { canonical: "/about" },
+};
+
+export default function AboutPage() {
+  return (
+    <LegalPage title="About MergeWatch" lastUpdated="April 13, 2026">
+      <p>
+        MergeWatch is an open-source GitHub App that reviews pull requests
+        using a multi-agent AI pipeline. It was built to answer a simple
+        question: <em>why should the tool that reviews your code cost more as
+        your team grows, run on infrastructure you can&rsquo;t see, and lock you
+        into a model you didn&rsquo;t choose?</em>
+      </p>
+
+      <h2>What it does</h2>
+      <p>
+        Every pull request triggers a parallel pipeline of specialized agents
+        &mdash; security, bugs, style, summary, architectural impact &mdash;
+        plus any custom agents you define in <code>.mergewatch.yml</code>. The
+        orchestrator deduplicates findings, ranks them by severity and
+        confidence, and posts a single upsert-style comment on the PR. Most
+        reviews complete in under 60 seconds.
+      </p>
+
+      <h2>Two ways to run it</h2>
+      <ul>
+        <li>
+          <strong>Self-hosted (free, AGPL v3).</strong> One{" "}
+          <code>docker-compose up</code>. Bring your own LLM provider &mdash;
+          Anthropic direct, Amazon Bedrock, any OpenAI-compatible endpoint via
+          LiteLLM (100+ providers), or Ollama for air-gapped environments.
+          Your code never leaves your infrastructure.
+        </li>
+        <li>
+          <strong>Managed SaaS.</strong> Install the GitHub App and go. Runs on
+          Claude via Amazon Bedrock with IAM-native auth &mdash; no API keys to
+          manage. Priced by pull request volume, not per seat, so hiring
+          doesn&rsquo;t make your bill bigger.
+        </li>
+      </ul>
+
+      <h2>Why open source</h2>
+      <p>
+        Code review tools read every line your team writes. Closing the source
+        on that is the wrong trade-off. MergeWatch ships under AGPL v3 &mdash;
+        the full pipeline, every agent prompt, every orchestrator, every
+        comment template is in the repo. Your security team can audit it.
+        Your engineers can fork it. If we disappear tomorrow, your workflow
+        keeps running.
+      </p>
+
+      <h2>Who builds it</h2>
+      <p>
+        MergeWatch is built and maintained by{" "}
+        <a
+          href="https://github.com/santthosh"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Santthosh
+        </a>
+        , a software engineer with a long background shipping developer
+        tooling. Contributions are welcome &mdash; pull requests, bug reports,
+        and feature ideas all land in the{" "}
+        <a
+          href="https://github.com/santthosh/mergewatch.ai"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          GitHub repository
+        </a>
+        .
+      </p>
+
+      <h2>Get involved</h2>
+      <ul>
+        <li>
+          <a
+            href="https://github.com/santthosh/mergewatch.ai"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Star the repo on GitHub
+          </a>
+        </li>
+        <li>
+          <a
+            href="https://docs.mergewatch.ai"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Read the docs
+          </a>
+        </li>
+        <li>
+          <a
+            href="https://github.com/santthosh/mergewatch.ai/issues"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Open an issue or feature request
+          </a>
+        </li>
+      </ul>
+    </LegalPage>
+  );
+}

--- a/packages/dashboard/app/page.tsx
+++ b/packages/dashboard/app/page.tsx
@@ -492,6 +492,14 @@ export default function LandingPage() {
             <h4 className="font-semibold text-fg-primary">Company</h4>
             <ul className="mt-3 space-y-2 text-primer-muted">
               <li>
+                <Link
+                  href="/about"
+                  className="transition hover:text-fg-primary"
+                >
+                  About
+                </Link>
+              </li>
+              <li>
                 <a
                   href="https://github.com/santthosh/mergewatch.ai"
                   target="_blank"
@@ -517,6 +525,22 @@ export default function LandingPage() {
             <h4 className="font-semibold text-fg-primary">Legal</h4>
             <ul className="mt-3 space-y-2 text-primer-muted">
               <li>
+                <Link
+                  href="/privacy"
+                  className="transition hover:text-fg-primary"
+                >
+                  Privacy Policy
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/terms"
+                  className="transition hover:text-fg-primary"
+                >
+                  Terms of Service
+                </Link>
+              </li>
+              <li>
                 <a
                   href="https://github.com/santthosh/mergewatch.ai/blob/main/LICENSE"
                   target="_blank"
@@ -530,7 +554,16 @@ export default function LandingPage() {
           </div>
         </div>
         <p className="mt-8 text-center text-xs text-primer-muted">
-          Open source under AGPL-3.0 &copy; {new Date().getFullYear()}{" "}
+          Built by{" "}
+          <a
+            href="https://github.com/santthosh"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="transition hover:text-fg-primary"
+          >
+            Santthosh
+          </a>{" "}
+          &middot; Open source under AGPL-3.0 &copy; {new Date().getFullYear()}{" "}
           mergewatch.ai
         </p>
       </footer>

--- a/packages/dashboard/app/privacy/page.tsx
+++ b/packages/dashboard/app/privacy/page.tsx
@@ -1,0 +1,161 @@
+import type { Metadata } from "next";
+import { LegalPage } from "@/components/LegalPage";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy",
+  description:
+    "How MergeWatch handles your GitHub data, what we store, who we share it with, and how to delete it.",
+  alternates: { canonical: "/privacy" },
+};
+
+export default function PrivacyPolicyPage() {
+  return (
+    <LegalPage title="Privacy Policy" lastUpdated="April 13, 2026">
+      <p>
+        MergeWatch is an open-source GitHub App that reviews pull requests using
+        AI. This Privacy Policy explains what data the hosted MergeWatch SaaS
+        (&ldquo;we&rdquo;, &ldquo;us&rdquo;) collects when you install the App
+        on your repositories, what we do with it, and how you can remove it.
+        The self-hosted distribution (AGPL v3) does not send any data to us and
+        is not covered by this policy.
+      </p>
+
+      <h2>1. Data We Read From GitHub</h2>
+      <p>
+        When you install the MergeWatch GitHub App, it is granted the
+        permissions you approve during installation. At minimum, MergeWatch
+        reads the following when a pull request is opened, synchronized, or
+        reopened:
+      </p>
+      <ul>
+        <li>The pull request diff (changed file paths, added and removed lines).</li>
+        <li>Pull request metadata (title, description, base and head branch, commit SHAs, author login).</li>
+        <li>Repository metadata (owner, repo name, default branch, visibility).</li>
+        <li>
+          The contents of <code>.mergewatch.yml</code> if one is present in the repository root.
+        </li>
+      </ul>
+      <p>
+        MergeWatch does <strong>not</strong> clone your repository, does not
+        read files outside the PR diff, and does not access issues, wikis,
+        actions, secrets, or deployments.
+      </p>
+
+      <h2>2. Data We Store</h2>
+      <p>
+        We store the minimum data required to operate the service. All data is
+        held in AWS DynamoDB in the region where you install the service.
+      </p>
+      <ul>
+        <li>
+          <strong>Installation records:</strong> installation ID, repository
+          full name, per-repo settings you choose in the dashboard.
+        </li>
+        <li>
+          <strong>Review records:</strong> repository full name, PR number,
+          commit SHA, review status, finding summaries, and the comment ID
+          posted back to GitHub. Reviews are retained for <strong>90 days</strong> and
+          then automatically deleted via DynamoDB TTL.
+        </li>
+        <li>
+          <strong>Account and billing data:</strong> your GitHub user ID,
+          email, and any billing metadata required by our payment processor if
+          you are on a paid plan.
+        </li>
+      </ul>
+      <p>
+        We do <strong>not</strong> persist raw pull request diffs, raw file
+        contents, or the full text of LLM responses. Diffs are held only in
+        memory during a review and discarded when the review completes.
+      </p>
+
+      <h2>3. How Your Data Flows To LLM Providers</h2>
+      <p>
+        To generate a review, MergeWatch sends the pull request diff and
+        metadata to a large language model provider. On the hosted SaaS that
+        provider is <strong>Amazon Bedrock</strong>, using Anthropic Claude
+        models hosted in AWS. No data is sent to any third-party LLM provider
+        outside AWS.
+      </p>
+      <ul>
+        <li>
+          Amazon Bedrock does not use your inputs to train its models. See the{" "}
+          <a
+            href="https://docs.aws.amazon.com/bedrock/latest/userguide/data-protection.html"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Bedrock data protection documentation
+          </a>
+          .
+        </li>
+        <li>Prompts are not retained by Bedrock beyond the duration of the inference call.</li>
+        <li>
+          If you self-host MergeWatch, you choose your own LLM provider via the{" "}
+          <code>LLM_PROVIDER</code> environment variable; data flows only to
+          the provider you configure.
+        </li>
+      </ul>
+
+      <h2>4. Sub-Processors</h2>
+      <ul>
+        <li><strong>Amazon Web Services</strong> &mdash; compute, storage, and LLM inference (Bedrock).</li>
+        <li><strong>GitHub, Inc.</strong> &mdash; authentication and the source of all code data we process.</li>
+      </ul>
+
+      <h2>5. Retention and Deletion</h2>
+      <p>
+        Review records are deleted automatically 90 days after creation.
+        Installation records persist until you uninstall the GitHub App. When
+        you uninstall, MergeWatch receives an{" "}
+        <code>installation.deleted</code> webhook and removes all installation
+        and settings records associated with your installation. To request
+        deletion of any residual data, email the address in Section 9.
+      </p>
+
+      <h2>6. Security</h2>
+      <p>
+        All traffic is encrypted in transit via TLS. Secrets (GitHub App
+        private key, webhook secret) are stored in AWS SSM Parameter Store with
+        KMS encryption. The MergeWatch codebase is fully open source under AGPL
+        v3 &mdash; you can audit exactly what runs on your code at{" "}
+        <a
+          href="https://github.com/santthosh/mergewatch.ai"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          github.com/santthosh/mergewatch.ai
+        </a>
+        .
+      </p>
+
+      <h2>7. Your Rights</h2>
+      <p>
+        You can uninstall the GitHub App at any time from your GitHub settings,
+        which revokes our access and triggers deletion of your installation
+        data. You can request a copy of any data we hold about you, or request
+        its deletion, by contacting us at the address in Section 9.
+      </p>
+
+      <h2>8. Changes To This Policy</h2>
+      <p>
+        Material changes to this Privacy Policy will be announced on{" "}
+        <a
+          href="https://github.com/santthosh/mergewatch.ai/releases"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          our GitHub releases page
+        </a>{" "}
+        and reflected in the &ldquo;Last updated&rdquo; date above.
+      </p>
+
+      <h2>9. Contact</h2>
+      <p>
+        Questions, data requests, or deletion requests:{" "}
+        <a href="mailto:privacy@mergewatch.ai">privacy@mergewatch.ai</a>. You
+        can also open a GitHub issue on the repository linked above.
+      </p>
+    </LegalPage>
+  );
+}

--- a/packages/dashboard/app/sitemap.ts
+++ b/packages/dashboard/app/sitemap.ts
@@ -17,5 +17,23 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "weekly",
       priority: 0.9,
     },
+    {
+      url: `${SITE_URL}/about`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.6,
+    },
+    {
+      url: `${SITE_URL}/privacy`,
+      lastModified: now,
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
+    {
+      url: `${SITE_URL}/terms`,
+      lastModified: now,
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
   ];
 }

--- a/packages/dashboard/app/terms/page.tsx
+++ b/packages/dashboard/app/terms/page.tsx
@@ -1,0 +1,136 @@
+import type { Metadata } from "next";
+import { LegalPage } from "@/components/LegalPage";
+
+export const metadata: Metadata = {
+  title: "Terms of Service",
+  description:
+    "Terms governing use of the hosted MergeWatch SaaS. The self-hosted distribution is licensed under AGPL v3.",
+  alternates: { canonical: "/terms" },
+};
+
+export default function TermsOfServicePage() {
+  return (
+    <LegalPage title="Terms of Service" lastUpdated="April 13, 2026">
+      <p>
+        These Terms of Service (&ldquo;Terms&rdquo;) govern your use of the
+        hosted MergeWatch SaaS available at{" "}
+        <a href="https://mergewatch.ai">mergewatch.ai</a> (the
+        &ldquo;Service&rdquo;). The self-hosted MergeWatch distribution is
+        licensed separately under the GNU Affero General Public License v3.0
+        and is not governed by these Terms.
+      </p>
+
+      <h2>1. Acceptance</h2>
+      <p>
+        By installing the MergeWatch GitHub App or signing in to the hosted
+        dashboard, you agree to these Terms. If you do not agree, do not
+        install the App and do not use the Service.
+      </p>
+
+      <h2>2. The Service</h2>
+      <p>
+        MergeWatch reviews pull requests in repositories where you have
+        installed the GitHub App, using large language models to produce
+        comments and summaries. The Service is provided as-is and may be
+        updated, suspended, or discontinued at any time. We do not guarantee
+        that AI-generated reviews will catch all issues or be free of false
+        positives. <strong>You remain responsible for the code you merge.</strong>
+      </p>
+
+      <h2>3. Your Responsibilities</h2>
+      <ul>
+        <li>You must have the authority to install MergeWatch on the repositories you connect.</li>
+        <li>You must not use the Service to process code you are not permitted to share with third-party LLM providers (Amazon Bedrock).</li>
+        <li>You must not attempt to reverse-engineer, disrupt, or abuse the Service, or use it to generate content that violates applicable law.</li>
+        <li>You are responsible for keeping your GitHub account secure.</li>
+      </ul>
+
+      <h2>4. Billing and Plans</h2>
+      <p>
+        Paid plans are billed according to the pricing published at{" "}
+        <a href="/pricing">mergewatch.ai/pricing</a>. You may upgrade,
+        downgrade, or cancel at any time; changes take effect at the end of
+        the current billing period. We do not offer refunds for partial
+        periods except where required by law.
+      </p>
+
+      <h2>5. Open Source License</h2>
+      <p>
+        The MergeWatch source code is licensed under the GNU AGPL v3.0. Hosting
+        your own modified version is permitted and encouraged under the terms
+        of that license. See the{" "}
+        <a
+          href="https://github.com/santthosh/mergewatch.ai/blob/main/LICENSE"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          LICENSE file
+        </a>{" "}
+        for details.
+      </p>
+
+      <h2>6. Intellectual Property</h2>
+      <p>
+        You retain all rights to your code. MergeWatch does not claim any
+        ownership of the repositories it reviews or the outputs it generates
+        on your behalf. The MergeWatch name and logo are trademarks of the
+        project maintainers.
+      </p>
+
+      <h2>7. Disclaimer of Warranties</h2>
+      <p>
+        THE SERVICE IS PROVIDED &ldquo;AS IS&rdquo; AND &ldquo;AS
+        AVAILABLE&rdquo; WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED,
+        INCLUDING BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, FITNESS
+        FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. WE DO NOT WARRANT
+        THAT THE SERVICE WILL BE UNINTERRUPTED, ERROR-FREE, OR FREE OF
+        HARMFUL COMPONENTS.
+      </p>
+
+      <h2>8. Limitation of Liability</h2>
+      <p>
+        TO THE MAXIMUM EXTENT PERMITTED BY LAW, IN NO EVENT SHALL MERGEWATCH
+        OR ITS MAINTAINERS BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL,
+        CONSEQUENTIAL, OR PUNITIVE DAMAGES, OR ANY LOSS OF PROFITS, DATA, OR
+        GOODWILL, ARISING OUT OF OR IN CONNECTION WITH YOUR USE OF THE
+        SERVICE. OUR TOTAL AGGREGATE LIABILITY SHALL NOT EXCEED THE GREATER
+        OF (A) THE AMOUNTS YOU HAVE PAID US IN THE TWELVE MONTHS PRECEDING
+        THE CLAIM OR (B) USD $100.
+      </p>
+
+      <h2>9. Termination</h2>
+      <p>
+        You may terminate your use of the Service at any time by uninstalling
+        the GitHub App. We may suspend or terminate accounts that violate
+        these Terms. Sections 6, 7, 8, and 10 survive termination.
+      </p>
+
+      <h2>10. Governing Law</h2>
+      <p>
+        These Terms are governed by the laws of the jurisdiction in which the
+        maintainers reside, without regard to conflict-of-laws principles.
+      </p>
+
+      <h2>11. Changes</h2>
+      <p>
+        We may update these Terms from time to time. Material changes will be
+        announced on{" "}
+        <a
+          href="https://github.com/santthosh/mergewatch.ai/releases"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          our GitHub releases page
+        </a>
+        . Continued use of the Service after a change constitutes acceptance
+        of the updated Terms.
+      </p>
+
+      <h2>12. Contact</h2>
+      <p>
+        Questions: <a href="mailto:hello@mergewatch.ai">hello@mergewatch.ai</a>
+        , or open a GitHub issue on the repository.
+      </p>
+    </LegalPage>
+  );
+}

--- a/packages/dashboard/components/LegalPage.tsx
+++ b/packages/dashboard/components/LegalPage.tsx
@@ -1,0 +1,80 @@
+import Link from "next/link";
+import { Wordmark } from "@/components/MergeWatchLogo";
+
+export function LegalPage({
+  title,
+  lastUpdated,
+  children,
+}: {
+  title: string;
+  lastUpdated: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <nav className="flex items-center justify-between px-6 py-4 md:px-12">
+        <Link href="/">
+          <Wordmark iconSize={20} />
+        </Link>
+        <div className="flex items-center gap-4 text-sm text-primer-muted">
+          <Link href="/pricing" className="transition hover:text-fg-primary">
+            Pricing
+          </Link>
+          <Link href="/signin" className="transition hover:text-fg-primary">
+            Sign in
+          </Link>
+        </div>
+      </nav>
+
+      <main className="mx-auto w-full max-w-3xl flex-1 px-6 py-12 md:py-20">
+        <h1 className="text-3xl font-extrabold tracking-tight md:text-5xl">
+          {title}
+        </h1>
+        <p className="mt-2 text-sm text-primer-muted">
+          Last updated: {lastUpdated}
+        </p>
+        <div className="prose prose-invert mt-8 max-w-none text-fg-primary [&_a]:text-primer-blue [&_a]:underline [&_h2]:mt-10 [&_h2]:text-2xl [&_h2]:font-bold [&_h3]:mt-6 [&_h3]:text-lg [&_h3]:font-semibold [&_li]:my-1 [&_p]:my-4 [&_p]:leading-relaxed [&_p]:text-primer-muted [&_ul]:my-4 [&_ul]:list-disc [&_ul]:pl-6 [&_ul]:text-primer-muted">
+          {children}
+        </div>
+      </main>
+
+      <footer className="border-t border-border-default px-6 py-8 text-center text-xs text-primer-muted">
+        <div className="flex flex-wrap justify-center gap-4">
+          <Link href="/" className="hover:text-fg-primary">
+            Home
+          </Link>
+          <Link href="/about" className="hover:text-fg-primary">
+            About
+          </Link>
+          <Link href="/privacy" className="hover:text-fg-primary">
+            Privacy
+          </Link>
+          <Link href="/terms" className="hover:text-fg-primary">
+            Terms
+          </Link>
+          <a
+            href="https://github.com/santthosh/mergewatch.ai"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-fg-primary"
+          >
+            GitHub
+          </a>
+        </div>
+        <p className="mt-4">
+          Built by{" "}
+          <a
+            href="https://github.com/santthosh"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-fg-primary"
+          >
+            Santthosh
+          </a>{" "}
+          &middot; Open source under AGPL-3.0 &copy; {new Date().getFullYear()}{" "}
+          mergewatch.ai
+        </p>
+      </footer>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Phase 2 of the SEO audit remediation plan ([Notion](https://www.notion.so/3415017da73981c28a39f804476846bd)). Closes the trust/legal gap that the audit flagged as a hard blocker for enterprise adoption: a GitHub App with code-read access had no privacy policy, terms of service, or creator attribution.

- **`app/privacy/page.tsx`** — full disclosure: what GitHub data we read (PR diff + metadata only, no repo clone), what we store (DynamoDB, 90-day TTL on reviews), how data flows to Amazon Bedrock, sub-processors, retention, deletion on uninstall, contact.
- **`app/terms/page.tsx`** — SaaS ToS covering acceptance, service description, user responsibilities, billing, AGPL v3 reference, IP, warranty disclaimer, liability cap, termination, governing law.
- **`app/about/page.tsx`** — product rationale, two-way deployment story, open-source positioning, creator attribution linking to @santthosh.
- **`components/LegalPage.tsx`** — shared nav/footer wrapper so all three prose pages match the site chrome and link back to Home / About / Privacy / Terms / GitHub.
- **`app/page.tsx`** — landing footer gains Privacy / Terms / About links and a "Built by Santthosh" byline.
- **`app/sitemap.ts`** — includes `/about`, `/privacy`, `/terms`.

## Test plan

- [x] `pnpm --filter @mergewatch/dashboard run build` passes — `/about`, `/privacy`, `/terms` all prerendered statically
- [ ] After deploy: visit each page and verify nav/footer render correctly
- [ ] After deploy: `curl https://mergewatch.ai/sitemap.xml` returns 5 URLs (up from 2)
- [ ] Review the privacy policy disclosures for factual accuracy (DynamoDB regions, 90-day TTL, Bedrock data-protection language) before sharing with any enterprise prospects

## Follow-ups

- Replace `privacy@mergewatch.ai` / `hello@mergewatch.ai` in copy once real inboxes are set up.
- Phase 3 (security headers + Cache-Control fix) is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)