### PR TITLE
SEO Phase 3: security headers + CDN caching for public pages

### DIFF
--- a/packages/dashboard/app/page.tsx
+++ b/packages/dashboard/app/page.tsx
@@ -1,4 +1,9 @@
-export const dynamic = "force-dynamic";
+// Revalidate every 5 minutes so the CDN can cache the rendered HTML while
+// still picking up deploy-time env changes within a reasonable window.
+// DEPLOYMENT_MODE is inlined at build time via next.config.js, so the
+// redirect branch is dead code in the SaaS build and this page renders
+// as a static ISR asset.
+export const revalidate = 300;
 
 import { redirect } from "next/navigation";
 import Link from "next/link";

--- a/packages/dashboard/next.config.js
+++ b/packages/dashboard/next.config.js
@@ -1,11 +1,79 @@
 const path = require('path');
 
+/**
+ * Security headers applied to every response. HSTS and the nosniff/frame/
+ * referrer policies are safe universal defaults; CSP is intentionally left
+ * out for now because the app uses inline JSON-LD and NextAuth redirects
+ * that would require report-only rollout first.
+ */
+const securityHeaders = [
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=63072000; includeSubDomains; preload',
+  },
+  {
+    key: 'X-Content-Type-Options',
+    value: 'nosniff',
+  },
+  {
+    key: 'X-Frame-Options',
+    value: 'DENY',
+  },
+  {
+    key: 'Referrer-Policy',
+    value: 'strict-origin-when-cross-origin',
+  },
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=(), interest-cohort=()',
+  },
+];
+
+// Public marketing pages — safe to cache aggressively at the CDN edge.
+const publicCacheControl = {
+  key: 'Cache-Control',
+  value: 'public, s-maxage=300, stale-while-revalidate=86400',
+};
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   // 'standalone' output bundles the server into a self-contained directory.
   // Required for AWS Amplify SSR hosting — Amplify deploys the .next/standalone
   // output as Lambda@Edge functions.
   output: 'standalone',
+
+  // Strip the X-Powered-By: Next.js fingerprint header.
+  poweredByHeader: false,
+
+  async headers() {
+    return [
+      {
+        // Apply the security headers to every route.
+        source: '/:path*',
+        headers: securityHeaders,
+      },
+      {
+        source: '/',
+        headers: [publicCacheControl],
+      },
+      {
+        source: '/pricing',
+        headers: [publicCacheControl],
+      },
+      {
+        source: '/about',
+        headers: [publicCacheControl],
+      },
+      {
+        source: '/privacy',
+        headers: [publicCacheControl],
+      },
+      {
+        source: '/terms',
+        headers: [publicCacheControl],
+      },
+    ];
+  },
 
   // Expose env vars to the server runtime (Amplify SSR only gets build-time
   // env vars by default — this ensures they're bundled into the runtime).


### PR DESCRIPTION
## Summary

Phase 3 of the SEO audit remediation plan ([Notion](https://www.notion.so/3415017da73981c28a39f804476846bd)). Addresses the High-priority security header and Core Web Vitals findings from the 2026-04-13 audit.

### Security headers (via \`next.config.js\` \`headers()\`)
Applied to every route:
- \`Strict-Transport-Security: max-age=63072000; includeSubDomains; preload\`
- \`X-Content-Type-Options: nosniff\`
- \`X-Frame-Options: DENY\`
- \`Referrer-Policy: strict-origin-when-cross-origin\`
- \`Permissions-Policy: camera=(), microphone=(), geolocation=(), interest-cohort=()\`
- \`poweredByHeader: false\` — strips the \`X-Powered-By: Next.js\` fingerprint

CSP is intentionally omitted; inline JSON-LD and NextAuth redirect flows need a report-only rollout first, which will ship separately.

### Public-page CDN caching
Added \`Cache-Control: public, s-maxage=300, stale-while-revalidate=86400\` to \`/\`, \`/pricing\`, \`/about\`, \`/privacy\`, \`/terms\` so CloudFront caches the rendered HTML at the edge. This directly addresses the **566ms TTFB** measured in the audit.

### Landing page now prerenders
\`app/page.tsx\` switched from \`force-dynamic\` to \`revalidate = 300\`. \`DEPLOYMENT_MODE\` is inlined at build time via \`next.config.js\` env, so the self-hosted redirect branch is dead code in the SaaS build — the homepage now prerenders as a static ISR asset. Build output confirms: \`┌ ○ /\` (was \`ƒ /\`).

## Test plan

- [x] \`pnpm --filter @mergewatch/dashboard run build\` — homepage shows as Static
- [ ] After deploy: \`curl -I https://mergewatch.ai/\` shows all security headers + public Cache-Control + no \`X-Powered-By\`
- [ ] After deploy: TTFB measurably improved via WebPageTest or CrUX
- [ ] After deploy: verify self-hosted Docker image still redirects \`/\` to \`/signin\` correctly (revalidate=300 caches the rendered output per build, not per request)
- [ ] Follow-up: add CSP in report-only mode, then enforce

🤖 Generated with [Claude Code](https://claude.com/claude-code)