### PR TITLE
SEO Phase 4a: live GitHub stars, pricing schema, freshness signal

### DIFF
--- a/packages/dashboard/app/page.tsx
+++ b/packages/dashboard/app/page.tsx
@@ -18,7 +18,32 @@ import {
   Server,
   Cloud,
   CheckCircle2,
+  Star,
+  Lock,
 } from "lucide-react";
+
+const GITHUB_REPO = "santthosh/mergewatch.ai";
+
+/**
+ * Fetch live GitHub star count for social proof. ISR-cached for 5 minutes
+ * via the fetch options, matching the page `revalidate` setting. Returns
+ * null on any failure so the UI can fall back gracefully.
+ */
+async function getGithubStars(): Promise<number | null> {
+  try {
+    const res = await fetch(`https://api.github.com/repos/${GITHUB_REPO}`, {
+      next: { revalidate: 300 },
+      headers: { Accept: "application/vnd.github+json" },
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { stargazers_count?: number };
+    return typeof data.stargazers_count === "number"
+      ? data.stargazers_count
+      : null;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Landing page for mergewatch.ai — psychological copy rewrite.
@@ -28,10 +53,11 @@ import {
  *
  * Self-hosted deployments skip straight to /signin.
  */
-export default function LandingPage() {
+export default async function LandingPage() {
   if (process.env.DEPLOYMENT_MODE !== "saas") {
     redirect("/signin");
   }
+  const stars = await getGithubStars();
   return (
     <div className="flex min-h-screen flex-col">
       {/* ─── 1. Nav ────────────────────────────────────────────────────── */}
@@ -112,6 +138,10 @@ export default function LandingPage() {
           AGPL v3&nbsp;&mdash; the whole codebase, not just the parts
           we&rsquo;re comfortable showing you.
         </p>
+
+        <p className="mt-3 text-[11px] uppercase tracking-widest text-primer-muted">
+          v1.0 &middot; Updated April 2026 &middot; Actively maintained
+        </p>
       </section>
 
       {/* ─── 3. Social Proof Bar ───────────────────────────────────────── */}
@@ -121,15 +151,52 @@ export default function LandingPage() {
           Fly.io &middot; Railway
         </p>
 
-        <div className="mx-auto mt-10 grid max-w-4xl gap-8 md:grid-cols-2">
-          <Testimonial
-            quote="We switched from our previous review tool after they went closed-source. MergeWatch catches the same issues, costs a fraction of the price, and our infra team can actually audit what's running on our code."
-            author="Engineering lead, Series B startup"
-          />
-          <Testimonial
-            quote="The security agent flagged a path traversal vulnerability on our first PR. Our human reviewer had been looking at that file for 10 minutes."
-            author="Senior engineer"
-          />
+        <div className="mx-auto mt-10 grid max-w-4xl gap-6 md:grid-cols-2">
+          <a
+            href={`https://github.com/${GITHUB_REPO}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group flex items-start gap-4 rounded-xl border border-border-default bg-surface-card/60 p-5 transition hover:border-primer-green hover:bg-surface-card"
+          >
+            <div className="rounded-lg bg-surface-inset p-2 text-primer-green">
+              <Star className="h-5 w-5" />
+            </div>
+            <div className="flex-1">
+              <p className="text-sm font-semibold text-fg-primary">
+                {stars !== null
+                  ? `${stars.toLocaleString()} stars on GitHub`
+                  : "Star MergeWatch on GitHub"}
+              </p>
+              <p className="mt-1 text-xs leading-relaxed text-primer-muted">
+                Real numbers, not testimonials. The full pipeline is public
+                &mdash; agent prompts, orchestrator, comment templates. Audit
+                what runs on your code before you install it.
+              </p>
+              <p className="mt-2 text-xs text-primer-green transition group-hover:underline">
+                View the repo &rarr;
+              </p>
+            </div>
+          </a>
+
+          <div className="flex items-start gap-4 rounded-xl border border-border-default bg-surface-card/60 p-5">
+            <div className="rounded-lg bg-surface-inset p-2 text-primer-purple">
+              <Lock className="h-5 w-5" />
+            </div>
+            <div className="flex-1">
+              <p className="text-sm font-semibold text-fg-primary">
+                AGPL v3 &middot; Self-host anywhere
+              </p>
+              <p className="mt-1 text-xs leading-relaxed text-primer-muted">
+                Your code never has to leave your infrastructure.{" "}
+                <code className="rounded bg-surface-inset px-1 py-0.5 text-[10px] text-fg-primary">
+                  docker-compose up
+                </code>{" "}
+                and point it at Anthropic, OpenAI via LiteLLM, Ollama for
+                air-gapped, or Amazon Bedrock with IAM auth. No API keys
+                leave your network.
+              </p>
+            </div>
+          </div>
         </div>
       </section>
 
@@ -577,25 +644,6 @@ export default function LandingPage() {
 }
 
 /* ─── Inline sub-components ──────────────────────────────────────────────── */
-
-function Testimonial({
-  quote,
-  author,
-}: {
-  quote: string;
-  author: string;
-}) {
-  return (
-    <blockquote className="rounded-xl border border-border-default bg-surface-card/60 p-5">
-      <p className="text-sm leading-relaxed text-fg-primary">
-        &ldquo;{quote}&rdquo;
-      </p>
-      <cite className="mt-3 block text-xs not-italic text-primer-muted">
-        &mdash; {author}
-      </cite>
-    </blockquote>
-  );
-}
 
 function AgentCard({
   icon,

--- a/packages/dashboard/app/pricing/layout.tsx
+++ b/packages/dashboard/app/pricing/layout.tsx
@@ -4,9 +4,55 @@ import { redirect } from "next/navigation";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "MergeWatch Pricing — Pay for what you review",
+  title: "Pricing — Pay for what you review",
   description:
     "No per-seat fees. First 5 reviews free. Self-host for free or use the managed SaaS with prepaid credits based on actual LLM cost.",
+  alternates: { canonical: "/pricing" },
+};
+
+function serializeJsonLd(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
+const pricingJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  name: "MergeWatch",
+  url: "https://mergewatch.ai",
+  applicationCategory: "DeveloperApplication",
+  operatingSystem: "Web, Linux, macOS",
+  description:
+    "AI-powered GitHub App that reviews pull requests with a multi-agent pipeline. Bring your own model, run in your cloud, or use the hosted SaaS.",
+  offers: [
+    {
+      "@type": "Offer",
+      name: "Self-Hosted",
+      price: "0",
+      priceCurrency: "USD",
+      description:
+        "Open source under AGPL v3. Deploy with Docker Compose, bring your own LLM provider.",
+      url: "https://github.com/santthosh/mergewatch.ai",
+    },
+    {
+      "@type": "Offer",
+      name: "Managed SaaS",
+      price: "0",
+      priceCurrency: "USD",
+      description:
+        "First 5 reviews free. Prepaid credits based on actual LLM cost + small platform fee. No per-seat pricing.",
+      url: "https://mergewatch.ai/pricing",
+    },
+  ],
+  publisher: {
+    "@type": "Organization",
+    name: "MergeWatch",
+    url: "https://mergewatch.ai",
+  },
 };
 
 export default function PricingLayout({
@@ -18,5 +64,13 @@ export default function PricingLayout({
     redirect("/signin");
   }
 
-  return <>{children}</>;
+  return (
+    <>
+      {children}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(pricingJsonLd) }}
+      />
+    </>
+  );
 }


### PR DESCRIPTION
## Summary

Partial Phase 4 of the SEO audit remediation plan ([Notion](https://www.notion.so/3415017da73981c28a39f804476846bd)). This covers the three items with clear, low-risk wins — items 3, 4, 5 from the plan. The heavier question-format H2/H3 rewrite and 134–167 word answer blocks are held for a follow-up PR once we've decided on voice.

### 1. Replace anonymous testimonials (item 3)
The two fake testimonials on the landing page had near-zero E-E-A-T value per the Sept 2025 QRG. Replaced with:
- **Live GitHub star count card** — fetched server-side via \`fetch()\` with \`next.revalidate = 300\` (matches the page's ISR interval). Falls back to "Star on GitHub" on API failure or rate limit. Real, verifiable signal.
- **AGPL / self-host trust card** — honest positioning around the open-source and deployment story.

### 2. Add pricing schema (item 4)
\`app/pricing/layout.tsx\` now emits a \`SoftwareApplication\` JSON-LD block with two \`Offer\` entries (Self-Hosted free and Managed SaaS). Uses the same escaped serializer as the root layout to prevent \`</script>\` breakout. Also added \`alternates.canonical: "/pricing"\`.

### 3. Freshness signal + word count (item 5)
Added \`v1.0 · Updated April 2026 · Actively maintained\` below the hero CTA. Closes the 500-word minimum finding and gives crawlers a content-freshness signal (the audit specifically flagged the absence of publication/update dates).

## Test plan

- [x] \`pnpm --filter @mergewatch/dashboard run build\` passes
- [x] Homepage still prerenders as Static (\`┌ ○ /\`) — Next.js handles async fetch + ISR correctly
- [ ] After deploy: verify star count renders on homepage
- [ ] After deploy: Rich Results Test validates the new \`SoftwareApplication\` + \`Offer\` schema on /pricing
- [ ] Follow-up PR: question-format H2/H3 rewrite + 134–167 word AI-citable answer blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)