### PR TITLE
Remove platform fee and margin details from landing FAQ

### DIFF
--- a/packages/dashboard/app/page.tsx
+++ b/packages/dashboard/app/page.tsx
@@ -48,7 +48,7 @@ const faqs: { question: string; answer: string }[] = [
   {
     question: "How much does MergeWatch cost?",
     answer:
-      "MergeWatch is priced by pull request volume, not per developer. A five-person team and a hundred-person team merging the same number of PRs pay the same amount, so hiring engineers does not make your bill bigger. The self-hosted distribution is free forever under the GNU AGPL v3 license — you bring your own LLM provider and pay that provider directly. The managed SaaS gives the first 5 reviews free, then uses prepaid credits based on actual LLM cost plus a small platform fee (roughly $0.005 per review plus a 40% margin on the LLM call itself). No credit card is required to start, and you can cancel at any time.",
+      "MergeWatch is priced by pull request volume, not per developer. A five-person team and a hundred-person team merging the same number of PRs pay the same amount, so hiring engineers does not make your bill bigger. The self-hosted distribution is free forever under the GNU AGPL v3 license — you bring your own LLM provider and pay that provider directly. The managed SaaS gives the first 5 reviews free, then uses prepaid credits based on actual LLM cost plus a small platform fee. No credit card is required to start, and you can cancel at any time. See mergewatch.ai/pricing for the full breakdown.",
   },
   {
     question: "Does MergeWatch support self-hosting?",


### PR DESCRIPTION
## Summary

The "How much does MergeWatch cost?" FAQ answer on the landing page currently leaks the exact platform fee ($0.005 per review) and 40% LLM margin. These are competitive numbers that shouldn't be on a public marketing page, and they came along for the ride when the FAQ was drafted from the pricing page constants.

Replaces the specific figures with "a small platform fee" and points readers to \`mergewatch.ai/pricing\` for the interactive breakdown — same language the \`llms.txt\` file already uses.

## Test plan

- [x] \`pnpm --filter @mergewatch/dashboard run build\` passes; homepage still \`┌ ○ /\`
- [ ] After deploy: verify FAQ card no longer shows \`$0.005\` or \`40%\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)