### PR TITLE
Fix www redirect leaking Lambda port into Location header

### DIFF
--- a/packages/dashboard/middleware.ts
+++ b/packages/dashboard/middleware.ts
@@ -25,6 +25,13 @@ export function middleware(req: NextRequest) {
 
   if (host.startsWith("www.")) {
     const url = req.nextUrl.clone();
+    // Clear the inbound port before rewriting the host. req.nextUrl.clone()
+    // preserves the internal Lambda port (3000 on Amplify SSR), and the
+    // URL API keeps `port` and `host` as independent properties — setting
+    // `host` alone does not strip the port, so the Location header would
+    // otherwise read https://mergewatch.ai:3000/ and break canonical
+    // consolidation for Googlebot.
+    url.port = "";
     url.host = host.slice(4);
     url.protocol = "https";
     return NextResponse.redirect(url, 301);


### PR DESCRIPTION
## Problem

The 2026-04-14 SEO audit flagged that \`www.mergewatch.ai\` was 301-redirecting to \`https://mergewatch.ai:3000/\` instead of \`https://mergewatch.ai/\`. Googlebot follows the 301 but lands on a non-standard port, which breaks canonical consolidation and can split link equity.

## Root cause

\`req.nextUrl.clone()\` in the middleware preserves the internal Lambda port (3000 on Amplify SSR). The URL API treats \`host\` and \`port\` as independent properties — setting \`url.host = "mergewatch.ai"\` rewrites only the hostname portion and leaves \`url.port = "3000"\` intact, which gets serialized into the Location header.

## Fix

One-line addition: clear \`url.port = ""\` before rewriting the host.

\`\`\`ts
url.port = "";
url.host = host.slice(4);
url.protocol = "https";
\`\`\`

## Test plan

- [x] \`pnpm --filter @mergewatch/dashboard run build\` passes
- [ ] After deploy: \`curl -I https://www.mergewatch.ai/\` returns \`Location: https://mergewatch.ai/\` (no \`:3000\`)
- [ ] After deploy: \`curl -I https://www.mergewatch.ai/pricing\` returns \`Location: https://mergewatch.ai/pricing\` (path preserved, port stripped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)