### PR TITLE
Hide secondary nav links on mobile landing page

### DIFF
--- a/packages/dashboard/app/page.tsx
+++ b/packages/dashboard/app/page.tsx
@@ -106,13 +106,13 @@ export default async function LandingPage() {
             href="https://docs.mergewatch.ai"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-sm text-primer-muted transition hover:text-fg-primary"
+            className="hidden text-sm text-primer-muted transition hover:text-fg-primary sm:inline"
           >
             Docs
           </a>
           <Link
             href="/pricing"
-            className="text-sm text-primer-muted transition hover:text-fg-primary"
+            className="hidden text-sm text-primer-muted transition hover:text-fg-primary sm:inline"
           >
             Pricing
           </Link>
@@ -120,7 +120,7 @@ export default async function LandingPage() {
             href="https://github.com/santthosh/mergewatch.ai"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-primer-muted transition hover:text-fg-primary"
+            className="hidden text-primer-muted transition hover:text-fg-primary sm:inline"
             aria-label="GitHub repository"
           >
             <Github size={20} />


### PR DESCRIPTION
## Problem

On the landing page, viewports below the \`sm\` breakpoint (640px) squish the nav bar — Wordmark, Docs, Pricing, GitHub icon, and Get Started all compete for horizontal space and overflow or wrap awkwardly.

## Fix

Add \`hidden sm:inline\` to Docs, Pricing, and the GitHub icon. On mobile the nav collapses to just Wordmark + Get Started.

## Why no hamburger

The marketing page has only two real destinations (Pricing, GitHub) and both are reachable from elsewhere on the page:
- Hero has a "Read the source code" GitHub button
- Deployment Choice section links to /pricing
- Footer has full Product / Company / Legal link groups

A hamburger for a 2-item menu adds client-side JS and a tap-to-open step for no navigation gain.

## Test plan

- [x] \`pnpm --filter @mergewatch/dashboard run build\` passes
- [ ] Mobile Safari @ 375px: nav shows Wordmark + Get Started only
- [ ] Desktop @ 1280px: nav shows all links

🤖 Generated with [Claude Code](https://claude.com/claude-code)