### PR TITLE
Prevent Wordmark from being squished on narrow viewports

### DIFF
--- a/packages/dashboard/components/MergeWatchLogo.tsx
+++ b/packages/dashboard/components/MergeWatchLogo.tsx
@@ -49,9 +49,12 @@ export function LogoIcon({ size = 20, className }: { size?: number; className?: 
 /** Full wordmark: logo icon + "merge" white + "watch" green + ".ai" */
 export function Wordmark({ iconSize = 20, className }: { iconSize?: number; className?: string }) {
   return (
-    <span className={`inline-flex items-center gap-1.5 ${className ?? ""}`}>
-      <LogoIcon size={iconSize} />
-      <span className="text-lg font-bold tracking-tight">
+    <span className={`inline-flex shrink-0 items-center gap-1.5 ${className ?? ""}`}>
+      <LogoIcon
+        size={iconSize}
+        className="shrink-0"
+      />
+      <span className="whitespace-nowrap text-lg font-bold tracking-tight">
         <span className="text-fg-primary">merge</span>
         <span className="text-accent-green">watch</span>
         <span className="text-fg-tertiary">.ai</span>


### PR DESCRIPTION
## Problem

On narrow mobile viewports, the Wordmark in the landing nav was visibly distorted — the logo eye appeared squished and the text could wrap.

## Root cause

The \`LogoIcon\` SVG and the text span are flex children of the \`Wordmark\`'s \`inline-flex\` parent, which is itself a flex child of the landing \`<nav>\` that uses \`justify-between\`. Flexbox's default \`flex-shrink: 1\` let the nav compress the Wordmark when space was tight — the SVG kept its \`viewBox\` but had its rendered width compressed, distorting the eye, and the text span had room to wrap awkwardly.

## Fix

Three guards in \`components/MergeWatchLogo.tsx\`:

- \`shrink-0\` on the outer Wordmark \`<span>\` so the landing nav's flex layout can never compress it
- \`shrink-0\` on the \`LogoIcon\` SVG itself (belt-and-braces — prevents the SVG from being compressed independently even if a parent allows shrinking)
- \`whitespace-nowrap\` on the text span so the wordmark never wraps across two lines

Applies everywhere the Wordmark is used, not just the landing page.

## Test plan

- [x] \`pnpm --filter @mergewatch/dashboard run build\` passes
- [ ] Mobile Safari @ 320px, 375px, 414px: Wordmark renders at natural size, no distortion
- [ ] Desktop @ 1280px+: no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)