### PR TITLE
Add agentAuthored flag to review pipeline

### DIFF
--- a/packages/core/src/agents/prompts.ts
+++ b/packages/core/src/agents/prompts.ts
@@ -23,10 +23,25 @@ export const TONE_PLACEHOLDER = '{{TONE_DIRECTIVE}}';
  */
 export const CONVENTIONS_PLACEHOLDER = '{{CONVENTIONS}}';
 
+/**
+ * Placeholder substituted at runtime with AGENT_MODE_SUFFIX when the diff is
+ * known to be agent-authored (e.g. via the MCP server pre-commit path, or the
+ * webhook path when source detection flips to 'agent'). Stripped otherwise.
+ */
+export const AGENT_MODE_PLACEHOLDER = '{{AGENT_MODE}}';
+
+/**
+ * Suffix injected into finding-producing agent prompts when the diff is
+ * agent-authored. Warns the model about patterns common in AI-generated code
+ * so it doesn't lower its bar just because the output looks plausible.
+ */
+export const AGENT_MODE_SUFFIX = `This diff is agent-authored. Be extra suspicious of: (1) hallucinated or non-existent imports/APIs; (2) tests that pass without meaningful assertions; (3) unused code, dead branches, or over-abstraction; (4) references to deprecated or stale patterns the repo has moved past. Do not lower your bar for these categories just because the code looks plausible.`;
+
 // ─── Shared preamble inserted into every agent prompt ──────────────────────
 const SHARED_PREAMBLE = `You are a senior software engineer performing an automated code review.
 ${TONE_PLACEHOLDER}
 ${CONVENTIONS_PLACEHOLDER}
+${AGENT_MODE_PLACEHOLDER}
 Rules:
 - Be concise and high-signal. Do NOT nitpick formatting, whitespace, or trivial naming.
 - Only report issues you are confident about.
@@ -423,6 +438,8 @@ Preserve the "confidence" score (1-100) from the original agent findings. If two
 
 // ─── Custom agent response format ──────────────────────────────────────────
 export const CUSTOM_AGENT_RESPONSE_FORMAT = `
+
+${AGENT_MODE_PLACEHOLDER}
 
 Return a JSON object with this exact shape:
 {

--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -18,6 +18,7 @@ import {
   type AgentFinding,
   type ReviewPipelineOptions,
 } from './reviewer.js';
+import { AGENT_MODE_SUFFIX, AGENT_MODE_PLACEHOLDER } from './prompts.js';
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -592,5 +593,138 @@ describe('runReviewPipeline', () => {
     // Token counts will be 0 since our mock doesn't return usage info
     expect(typeof result.inputTokens).toBe('number');
     expect(typeof result.outputTokens).toBe('number');
+  });
+});
+
+// ─── agentAuthored flag (AGENT_MODE_SUFFIX injection) ───────────────
+
+describe('agentAuthored flag', () => {
+  const allAgentsEnabled: ReviewPipelineOptions['enabledAgents'] = {
+    security: true,
+    bugs: true,
+    style: true,
+    summary: true,
+    diagram: true,
+    errorHandling: true,
+    testCoverage: true,
+    commentAccuracy: true,
+  };
+
+  const emptyAgentResponse = JSON.stringify({ findings: [] });
+  const summaryResponse = JSON.stringify({ summary: 'Clean.' });
+  const diagramResponse = '%% flow\nflowchart TD\n  A-->B';
+
+  function responsesForAllAgents(): string[] {
+    // 6 finding agents + summary + diagram (orchestrator skipped when findings empty)
+    return [
+      emptyAgentResponse, emptyAgentResponse, emptyAgentResponse,
+      emptyAgentResponse, emptyAgentResponse, emptyAgentResponse,
+      summaryResponse, diagramResponse,
+    ];
+  }
+
+  it('injects AGENT_MODE_SUFFIX into every finding-producing agent prompt when true', async () => {
+    const llm = createMockLLM(responsesForAllAgents());
+    await runReviewPipeline(
+      {
+        diff: sampleDiff,
+        context: sampleContext,
+        modelId: 'heavy-model',
+        lightModelId: 'light-model',
+        maxFindings: 25,
+        enabledAgents: allAgentsEnabled,
+        agentAuthored: true,
+      },
+      { llm },
+    );
+    // 8 calls: 6 finding agents + summary + diagram
+    expect(llm.calls).toHaveLength(8);
+    // All finding agents + summary should contain the suffix (diagram is exempt)
+    const findingAgentPrompts = llm.calls.slice(0, 7).map((c) => c.prompt);
+    for (const prompt of findingAgentPrompts) {
+      expect(prompt).toContain(AGENT_MODE_SUFFIX);
+      expect(prompt).not.toContain(AGENT_MODE_PLACEHOLDER);
+    }
+    // Diagram agent does not include the suffix
+    expect(llm.calls[7].prompt).not.toContain(AGENT_MODE_SUFFIX);
+  });
+
+  it('strips AGENT_MODE_PLACEHOLDER and does not inject suffix when false', async () => {
+    const llm = createMockLLM(responsesForAllAgents());
+    await runReviewPipeline(
+      {
+        diff: sampleDiff,
+        context: sampleContext,
+        modelId: 'heavy-model',
+        lightModelId: 'light-model',
+        maxFindings: 25,
+        enabledAgents: allAgentsEnabled,
+        agentAuthored: false,
+      },
+      { llm },
+    );
+    for (const call of llm.calls) {
+      expect(call.prompt).not.toContain(AGENT_MODE_SUFFIX);
+      expect(call.prompt).not.toContain(AGENT_MODE_PLACEHOLDER);
+    }
+  });
+
+  it('behaves like false when agentAuthored is undefined', async () => {
+    const llm = createMockLLM(responsesForAllAgents());
+    await runReviewPipeline(
+      {
+        diff: sampleDiff,
+        context: sampleContext,
+        modelId: 'heavy-model',
+        lightModelId: 'light-model',
+        maxFindings: 25,
+        enabledAgents: allAgentsEnabled,
+      },
+      { llm },
+    );
+    for (const call of llm.calls) {
+      expect(call.prompt).not.toContain(AGENT_MODE_SUFFIX);
+      expect(call.prompt).not.toContain(AGENT_MODE_PLACEHOLDER);
+    }
+  });
+
+  it('injects suffix into orchestrator prompt when agentAuthored is true', async () => {
+    const orchestratorResponse = JSON.stringify({ findings: [], mergeScore: 5, mergeScoreReason: 'clean' });
+    const llm = createMockLLM([orchestratorResponse]);
+    await runOrchestratorAgent(
+      [{ category: 'bug', findings: [{ file: 'a.ts', line: 1, severity: 'info', title: 't', description: 'd', suggestion: 's' }] }],
+      'model-1', 25, llm, undefined, undefined, true,
+    );
+    expect(llm.calls[0].prompt).toContain(AGENT_MODE_SUFFIX);
+    expect(llm.calls[0].prompt).not.toContain(AGENT_MODE_PLACEHOLDER);
+  });
+
+  it('strips placeholder from orchestrator prompt when agentAuthored is false/undefined', async () => {
+    const orchestratorResponse = JSON.stringify({ findings: [], mergeScore: 5, mergeScoreReason: 'clean' });
+    const llm = createMockLLM([orchestratorResponse]);
+    await runOrchestratorAgent(
+      [{ category: 'bug', findings: [{ file: 'a.ts', line: 1, severity: 'info', title: 't', description: 'd', suggestion: 's' }] }],
+      'model-1', 25, llm,
+    );
+    expect(llm.calls[0].prompt).not.toContain(AGENT_MODE_SUFFIX);
+    expect(llm.calls[0].prompt).not.toContain(AGENT_MODE_PLACEHOLDER);
+  });
+
+  it('injects suffix into individual security agent prompt when passed directly', async () => {
+    const llm = createMockLLM([emptyAgentResponse]);
+    await runSecurityAgent(sampleDiff, sampleContext, 'model-1', llm, undefined, undefined, undefined, true);
+    expect(llm.calls[0].prompt).toContain(AGENT_MODE_SUFFIX);
+  });
+
+  it('injects suffix into custom agent prompt when passed directly', async () => {
+    const agentDef: CustomAgentDef = {
+      name: 'perf',
+      prompt: 'Check perf issues.',
+      severityDefault: 'info',
+      enabled: true,
+    };
+    const llm = createMockLLM([emptyAgentResponse]);
+    await runCustomAgent(agentDef, sampleDiff, sampleContext, 'model-1', llm, undefined, undefined, true);
+    expect(llm.calls[0].prompt).toContain(AGENT_MODE_SUFFIX);
   });
 });

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -29,6 +29,8 @@ import {
   CUSTOM_AGENT_RESPONSE_FORMAT,
   TONE_DIRECTIVES,
   TONE_PLACEHOLDER,
+  AGENT_MODE_PLACEHOLDER,
+  AGENT_MODE_SUFFIX,
 } from './prompts.js';
 import type { CustomAgentDef, UXConfig } from '../config/defaults.js';
 import { FILE_REQUEST_INSTRUCTION, invokeWithFileFetching } from '../context/agentic-fetcher.js';
@@ -82,6 +84,14 @@ ${conventions.trim()}
 }
 
 /**
+ * Build the agent-mode block injected when the diff is agent-authored. Returns
+ * AGENT_MODE_SUFFIX when true, empty string otherwise (strips the placeholder).
+ */
+function buildAgentModeBlock(agentAuthored: boolean | undefined): string {
+  return agentAuthored ? AGENT_MODE_SUFFIX : '';
+}
+
+/**
  * Build the user-facing prompt by combining the system prompt with the diff
  * and optional PR context. When agentic file fetching is enabled, injects
  * the FILE_REQUEST_INSTRUCTION via the FILE_REQUEST_PLACEHOLDER in prompts.
@@ -93,6 +103,7 @@ function buildPrompt(
   agenticFetch: boolean,
   tone?: UXConfig['tone'],
   conventions?: string,
+  agentAuthored?: boolean,
 ): string {
   // Inject tone directive or strip placeholder
   const toneDirective = tone ? (TONE_DIRECTIVES[tone] ?? '') : '';
@@ -101,10 +112,13 @@ function buildPrompt(
   // Inject or strip the conventions block
   const withConventions = tonedPrompt.replace(CONVENTIONS_PLACEHOLDER, buildConventionsBlock(conventions));
 
+  // Inject or strip the agent-mode block
+  const withAgentMode = withConventions.replace(AGENT_MODE_PLACEHOLDER, buildAgentModeBlock(agentAuthored));
+
   // Inject or strip the file request instruction placeholder
   const resolvedPrompt = agenticFetch
-    ? withConventions.replace('FILE_REQUEST_PLACEHOLDER', FILE_REQUEST_INSTRUCTION)
-    : withConventions.replace('FILE_REQUEST_PLACEHOLDER', '');
+    ? withAgentMode.replace('FILE_REQUEST_PLACEHOLDER', FILE_REQUEST_INSTRUCTION)
+    : withAgentMode.replace('FILE_REQUEST_PLACEHOLDER', '');
 
   const contextBlock = [
     `Current date: ${new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}`,
@@ -177,8 +191,9 @@ export async function runSecurityAgent(
   fileFetchOptions?: FileFetchOptions,
   tone?: UXConfig['tone'],
   conventions?: string,
+  agentAuthored?: boolean,
 ): Promise<AgentFinding[]> {
-  const prompt = buildPrompt(SECURITY_REVIEWER_PROMPT, diff, context, !!fileFetchOptions, tone, conventions);
+  const prompt = buildPrompt(SECURITY_REVIEWER_PROMPT, diff, context, !!fileFetchOptions, tone, conventions, agentAuthored);
   const raw = await invokeAgent(llm, modelId, prompt, fileFetchOptions);
   const parsed = safeParseJson<{ findings: AgentFinding[] }>(raw, { findings: [] });
   return parsed.findings ?? [];
@@ -193,8 +208,9 @@ export async function runBugAgent(
   fileFetchOptions?: FileFetchOptions,
   tone?: UXConfig['tone'],
   conventions?: string,
+  agentAuthored?: boolean,
 ): Promise<AgentFinding[]> {
-  const prompt = buildPrompt(BUG_REVIEWER_PROMPT, diff, context, !!fileFetchOptions, tone, conventions);
+  const prompt = buildPrompt(BUG_REVIEWER_PROMPT, diff, context, !!fileFetchOptions, tone, conventions, agentAuthored);
   const raw = await invokeAgent(llm, modelId, prompt, fileFetchOptions);
   const parsed = safeParseJson<{ findings: AgentFinding[] }>(raw, { findings: [] });
   return parsed.findings ?? [];
@@ -210,6 +226,7 @@ export async function runStyleAgent(
   fileFetchOptions?: FileFetchOptions,
   tone?: UXConfig['tone'],
   conventions?: string,
+  agentAuthored?: boolean,
 ): Promise<AgentFinding[]> {
   let systemPrompt = STYLE_REVIEWER_PROMPT;
 
@@ -224,7 +241,7 @@ export async function runStyleAgent(
     systemPrompt = systemPrompt.replace('CUSTOM_RULES_PLACEHOLDER', '');
   }
 
-  const prompt = buildPrompt(systemPrompt, diff, context, !!fileFetchOptions, tone, conventions);
+  const prompt = buildPrompt(systemPrompt, diff, context, !!fileFetchOptions, tone, conventions, agentAuthored);
   const raw = await invokeAgent(llm, modelId, prompt, fileFetchOptions);
   const parsed = safeParseJson<{ findings: AgentFinding[] }>(raw, { findings: [] });
   return parsed.findings ?? [];
@@ -394,8 +411,9 @@ export async function runErrorHandlingAgent(
   fileFetchOptions?: FileFetchOptions,
   tone?: UXConfig['tone'],
   conventions?: string,
+  agentAuthored?: boolean,
 ): Promise<AgentFinding[]> {
-  const prompt = buildPrompt(ERROR_HANDLING_REVIEWER_PROMPT, diff, context, !!fileFetchOptions, tone, conventions);
+  const prompt = buildPrompt(ERROR_HANDLING_REVIEWER_PROMPT, diff, context, !!fileFetchOptions, tone, conventions, agentAuthored);
   const raw = await invokeAgent(llm, modelId, prompt, fileFetchOptions);
   const parsed = safeParseJson<{ findings: AgentFinding[] }>(raw, { findings: [] });
   return parsed.findings ?? [];
@@ -410,8 +428,9 @@ export async function runTestCoverageAgent(
   fileFetchOptions?: FileFetchOptions,
   tone?: UXConfig['tone'],
   conventions?: string,
+  agentAuthored?: boolean,
 ): Promise<AgentFinding[]> {
-  const prompt = buildPrompt(TEST_COVERAGE_REVIEWER_PROMPT, diff, context, !!fileFetchOptions, tone, conventions);
+  const prompt = buildPrompt(TEST_COVERAGE_REVIEWER_PROMPT, diff, context, !!fileFetchOptions, tone, conventions, agentAuthored);
   const raw = await invokeAgent(llm, modelId, prompt, fileFetchOptions);
   const parsed = safeParseJson<{ findings: AgentFinding[] }>(raw, { findings: [] });
   return parsed.findings ?? [];
@@ -426,8 +445,9 @@ export async function runCommentAccuracyAgent(
   fileFetchOptions?: FileFetchOptions,
   tone?: UXConfig['tone'],
   conventions?: string,
+  agentAuthored?: boolean,
 ): Promise<AgentFinding[]> {
-  const prompt = buildPrompt(COMMENT_ACCURACY_REVIEWER_PROMPT, diff, context, !!fileFetchOptions, tone, conventions);
+  const prompt = buildPrompt(COMMENT_ACCURACY_REVIEWER_PROMPT, diff, context, !!fileFetchOptions, tone, conventions, agentAuthored);
   const raw = await invokeAgent(llm, modelId, prompt, fileFetchOptions);
   const parsed = safeParseJson<{ findings: AgentFinding[] }>(raw, { findings: [] });
   return parsed.findings ?? [];
@@ -440,8 +460,9 @@ export async function runSummaryAgent(
   modelId: string,
   llm: ILLMProvider,
   conventions?: string,
+  agentAuthored?: boolean,
 ): Promise<string> {
-  const prompt = buildPrompt(SUMMARY_PROMPT, diff, context, false, undefined, conventions);
+  const prompt = buildPrompt(SUMMARY_PROMPT, diff, context, false, undefined, conventions, agentAuthored);
   const raw = normalizeLLMResult(await llm.invoke(modelId, prompt)).text;
   const parsed = safeParseJson<{ summary: string }>(raw, { summary: '' });
   return parsed.summary;
@@ -458,9 +479,10 @@ export async function runCustomAgent(
   llm: ILLMProvider,
   fileFetchOptions?: FileFetchOptions,
   conventions?: string,
+  agentAuthored?: boolean,
 ): Promise<AgentFinding[]> {
   const systemPrompt = `${agentDef.prompt}\n${CUSTOM_AGENT_RESPONSE_FORMAT}`;
-  const prompt = buildPrompt(systemPrompt, diff, context, !!fileFetchOptions, undefined, conventions);
+  const prompt = buildPrompt(systemPrompt, diff, context, !!fileFetchOptions, undefined, conventions, agentAuthored);
   const raw = await invokeAgent(llm, modelId, prompt, fileFetchOptions);
   const parsed = safeParseJson<{ findings: AgentFinding[] }>(raw, { findings: [] });
   // Apply default severity if agent didn't specify
@@ -550,6 +572,7 @@ export async function runOrchestratorAgent(
   llm: ILLMProvider,
   previousFindings?: PreviousFinding[],
   conventions?: string,
+  agentAuthored?: boolean,
 ): Promise<OrchestratorResult> {
   // Build a combined findings list with category tags for the orchestrator
   const allFindings = taggedFindings.flatMap(({ category, findings }) =>
@@ -568,6 +591,7 @@ export async function runOrchestratorAgent(
   const prompt = ORCHESTRATOR_PROMPT
     .replace(TONE_PLACEHOLDER, '')
     .replace(CONVENTIONS_PLACEHOLDER, buildConventionsBlock(conventions))
+    .replace(AGENT_MODE_PLACEHOLDER, buildAgentModeBlock(agentAuthored))
     .replace('MAX_FINDINGS_PLACEHOLDER', String(maxFindings))
     .replace(PREVIOUS_FINDINGS_PLACEHOLDER, buildPreviousFindingsBlock(previousFindings))
     + `\n\n--- Findings from all agents (new on this commit) ---\n${JSON.stringify(allFindings, null, 2)}`;
@@ -628,6 +652,13 @@ export interface ReviewPipelineOptions {
    * generic best practices.
    */
   conventions?: string;
+  /**
+   * When true, injects AGENT_MODE_SUFFIX into every finding-producing agent
+   * prompt warning the model about patterns common in AI-generated code
+   * (hallucinated imports, unasserted tests, dead code, stale patterns).
+   * Used by the MCP pre-commit path and webhook source='agent' detection.
+   */
+  agentAuthored?: boolean;
 }
 
 export interface ReviewPipelineResult {
@@ -676,6 +707,7 @@ export async function runReviewPipeline(
     previousDiagram,
     previousFindings,
     conventions,
+    agentAuthored,
   } = options;
 
   // Wrap the LLM provider to track token usage across all agents
@@ -690,25 +722,25 @@ export async function runReviewPipeline(
     summary, diagramResult,
   ] = await Promise.all([
     enabledAgents.security
-      ? runSecurityAgent(diff, context, modelId, llm, fileFetchOptions, tone, conventions)
+      ? runSecurityAgent(diff, context, modelId, llm, fileFetchOptions, tone, conventions, agentAuthored)
       : Promise.resolve([]),
     enabledAgents.bugs
-      ? runBugAgent(diff, context, modelId, llm, fileFetchOptions, tone, conventions)
+      ? runBugAgent(diff, context, modelId, llm, fileFetchOptions, tone, conventions, agentAuthored)
       : Promise.resolve([]),
     enabledAgents.style
-      ? runStyleAgent(diff, context, modelId, llm, customStyleRules, fileFetchOptions, tone, conventions)
+      ? runStyleAgent(diff, context, modelId, llm, customStyleRules, fileFetchOptions, tone, conventions, agentAuthored)
       : Promise.resolve([]),
     enabledAgents.errorHandling
-      ? runErrorHandlingAgent(diff, context, modelId, llm, fileFetchOptions, tone, conventions)
+      ? runErrorHandlingAgent(diff, context, modelId, llm, fileFetchOptions, tone, conventions, agentAuthored)
       : Promise.resolve([]),
     enabledAgents.testCoverage
-      ? runTestCoverageAgent(diff, context, modelId, llm, fileFetchOptions, tone, conventions)
+      ? runTestCoverageAgent(diff, context, modelId, llm, fileFetchOptions, tone, conventions, agentAuthored)
       : Promise.resolve([]),
     enabledAgents.commentAccuracy
-      ? runCommentAccuracyAgent(diff, context, lightModelId, llm, fileFetchOptions, tone, conventions)
+      ? runCommentAccuracyAgent(diff, context, lightModelId, llm, fileFetchOptions, tone, conventions, agentAuthored)
       : Promise.resolve([]),
     enabledAgents.summary
-      ? runSummaryAgent(diff, context, lightModelId, llm, conventions)
+      ? runSummaryAgent(diff, context, lightModelId, llm, conventions, agentAuthored)
       : Promise.resolve(''),
     enabledAgents.diagram
       ? runDiagramAgent(diff, context, lightModelId, llm, previousDiagram)
@@ -720,7 +752,7 @@ export async function runReviewPipeline(
   const customResults = enabledCustomAgents.length > 0
     ? await Promise.all(
         enabledCustomAgents.map((agentDef) =>
-          runCustomAgent(agentDef, diff, context, modelId, llm, fileFetchOptions, conventions)
+          runCustomAgent(agentDef, diff, context, modelId, llm, fileFetchOptions, conventions, agentAuthored)
             .catch((err) => {
               console.warn(`Custom agent "${agentDef.name}" failed:`, err);
               return [] as AgentFinding[];
@@ -756,6 +788,7 @@ export async function runReviewPipeline(
     llm,
     previousFindings,
     conventions,
+    agentAuthored,
   );
 
   // Count enabled finding agents (exclude summary + diagram)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -63,6 +63,8 @@ export {
   CUSTOM_AGENT_RESPONSE_FORMAT,
   TONE_DIRECTIVES,
   TONE_PLACEHOLDER,
+  AGENT_MODE_SUFFIX,
+  AGENT_MODE_PLACEHOLDER,
 } from './agents/prompts.js';
 
 // ─── GitHub client (portable Octokit ops) ───────────────────────────────────


### PR DESCRIPTION
## Summary
- New `agentAuthored?: boolean` option on `ReviewPipelineOptions` that injects `AGENT_MODE_SUFFIX` into every finding-producing review agent prompt
- Suffix tells agents to be extra suspicious of hallucinated imports, unasserted tests, dead code, and stale patterns
- Default (unset/false) keeps existing behavior — no regression for webhook-triggered reviews

This is PR 1 of the MCP Server implementation plan. Downstream PRs (session store, MCP Lambda, webhook-path agent detection) will use the flag.

## Test plan
- [x] Unit tests: flag=true injects suffix in every finding agent prompt
- [x] Unit tests: flag=false/undefined strips placeholder cleanly
- [x] `pnpm run build` passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm --filter @mergewatch/core run test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)