### PR TITLE
Parse agentReview block in .mergewatch.yml

### DIFF
--- a/packages/core/src/config/defaults.test.ts
+++ b/packages/core/src/config/defaults.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { DEFAULT_CONFIG, DEFAULT_RULES_CONFIG, mergeConfig } from './defaults.js';
+import {
+  DEFAULT_CONFIG,
+  DEFAULT_RULES_CONFIG,
+  DEFAULT_AGENT_REVIEW_CONFIG,
+  mergeConfig,
+} from './defaults.js';
 
 describe('DEFAULT_CONFIG', () => {
   it('has all agent flags as booleans', () => {
@@ -96,5 +101,33 @@ describe('mergeConfig', () => {
     const result = mergeConfig({ rules: { ignorePatterns: ['*.generated.ts'] } });
     expect(result.rules.ignorePatterns).toEqual(['*.generated.ts']);
     expect(result.rules.maxFiles).toBe(DEFAULT_RULES_CONFIG.maxFiles);
+  });
+
+  it('leaves agentReview undefined when partial omits it', () => {
+    const result = mergeConfig({});
+    expect(result.agentReview).toBeUndefined();
+  });
+
+  it('deep-merges partial agentReview with DEFAULT_AGENT_REVIEW_CONFIG', () => {
+    const result = mergeConfig({
+      agentReview: {
+        enabled: false,
+        maxIterations: 7,
+        detection: { labels: ['bot-pr'] },
+      },
+    });
+    expect(result.agentReview).toBeDefined();
+    expect(result.agentReview!.enabled).toBe(false);
+    expect(result.agentReview!.maxIterations).toBe(7);
+    expect(result.agentReview!.strictChecks).toBe(DEFAULT_AGENT_REVIEW_CONFIG.strictChecks);
+    expect(result.agentReview!.autoIterate).toBe(DEFAULT_AGENT_REVIEW_CONFIG.autoIterate);
+    expect(result.agentReview!.passThreshold).toBe(DEFAULT_AGENT_REVIEW_CONFIG.passThreshold);
+    expect(result.agentReview!.detection.labels).toEqual(['bot-pr']);
+    expect(result.agentReview!.detection.commitTrailers).toEqual(
+      DEFAULT_AGENT_REVIEW_CONFIG.detection.commitTrailers,
+    );
+    expect(result.agentReview!.detection.branchPrefixes).toEqual(
+      DEFAULT_AGENT_REVIEW_CONFIG.detection.branchPrefixes,
+    );
   });
 });

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -64,6 +64,48 @@ export const DEFAULT_RULES_CONFIG: RulesConfig = {
   ignoreLabels: ['skip-review'],
 };
 
+/** Valid values for agentReview.passThreshold. */
+export const PASS_THRESHOLDS = ['noCritical', 'noFindings', 'scoreAtLeast4', 'scoreAtLeast5'] as const;
+
+export type PassThreshold = (typeof PASS_THRESHOLDS)[number];
+
+export interface AgentReviewDetectionConfig {
+  /** Commit trailer substrings that identify agent-authored commits */
+  commitTrailers: string[];
+  /** Branch name prefixes that identify agent-authored PRs */
+  branchPrefixes: string[];
+  /** Labels that mark a PR as agent-authored */
+  labels: string[];
+}
+
+export interface AgentReviewConfig {
+  /** Master switch for agent-authored PR handling */
+  enabled: boolean;
+  /** Inject agent-mode prompt suffix when source='agent' */
+  strictChecks: boolean;
+  /** Gate iteration tracking + reviewer whisper */
+  autoIterate: boolean;
+  /** Cap re-reviews per PR for iteration metadata (1..20) */
+  maxIterations: number;
+  /** Threshold required for an agent-authored PR to pass */
+  passThreshold: PassThreshold;
+  /** Heuristics for detecting agent-authored PRs */
+  detection: AgentReviewDetectionConfig;
+}
+
+export const DEFAULT_AGENT_REVIEW_CONFIG: AgentReviewConfig = {
+  enabled: true,
+  strictChecks: true,
+  autoIterate: true,
+  maxIterations: 3,
+  passThreshold: 'noCritical',
+  detection: {
+    commitTrailers: ['Co-authored-by: Claude'],
+    branchPrefixes: ['claude/'],
+    labels: ['ai-generated'],
+  },
+};
+
 export interface MergeWatchConfig {
   /** Primary model used for review agents */
   model: string;
@@ -114,6 +156,8 @@ export interface MergeWatchConfig {
   rules: RulesConfig;
   /** Custom pricing overrides (model ID → USD per 1M tokens) for cost estimation */
   pricing?: Record<string, { inputPer1M: number; outputPer1M: number }>;
+  /** Agent-authored PR detection + strict-mode review settings */
+  agentReview?: AgentReviewConfig;
 }
 
 export const DEFAULT_CONFIG: MergeWatchConfig = {
@@ -156,8 +200,17 @@ export const DEFAULT_CONFIG: MergeWatchConfig = {
  * Merges a partial user config (from .mergewatch.yml / DynamoDB) with defaults.
  * Only defined fields in the partial override the defaults.
  */
-export function mergeConfig(partial: Partial<Omit<MergeWatchConfig, 'agents' | 'ux' | 'rules'>> & { agents?: Partial<MergeWatchConfig['agents']>; ux?: Partial<UXConfig>; rules?: Partial<RulesConfig> }): MergeWatchConfig {
-  return {
+export function mergeConfig(
+  partial: Partial<Omit<MergeWatchConfig, 'agents' | 'ux' | 'rules' | 'agentReview'>> & {
+    agents?: Partial<MergeWatchConfig['agents']>;
+    ux?: Partial<UXConfig>;
+    rules?: Partial<RulesConfig>;
+    agentReview?: Partial<Omit<AgentReviewConfig, 'detection'>> & {
+      detection?: Partial<AgentReviewDetectionConfig>;
+    };
+  },
+): MergeWatchConfig {
+  const merged: MergeWatchConfig = {
     ...DEFAULT_CONFIG,
     ...partial,
     agents: {
@@ -175,4 +228,15 @@ export function mergeConfig(partial: Partial<Omit<MergeWatchConfig, 'agents' | '
       ...(partial.rules ?? {}),
     },
   };
+  if (partial.agentReview !== undefined) {
+    merged.agentReview = {
+      ...DEFAULT_AGENT_REVIEW_CONFIG,
+      ...partial.agentReview,
+      detection: {
+        ...DEFAULT_AGENT_REVIEW_CONFIG.detection,
+        ...(partial.agentReview.detection ?? {}),
+      },
+    };
+  }
+  return merged;
 }

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -210,31 +210,38 @@ export function mergeConfig(
     };
   },
 ): MergeWatchConfig {
+  const { agentReview, ...rest } = partial;
   const merged: MergeWatchConfig = {
     ...DEFAULT_CONFIG,
-    ...partial,
+    ...rest,
     agents: {
       ...DEFAULT_CONFIG.agents,
-      ...(partial.agents ?? {}),
+      ...(rest.agents ?? {}),
     },
-    customAgents: partial.customAgents ?? DEFAULT_CONFIG.customAgents,
-    pricing: partial.pricing ?? DEFAULT_CONFIG.pricing,
+    customAgents: rest.customAgents ?? DEFAULT_CONFIG.customAgents,
+    pricing: rest.pricing ?? DEFAULT_CONFIG.pricing,
     ux: {
       ...DEFAULT_UX_CONFIG,
-      ...(partial.ux ?? {}),
+      ...(rest.ux ?? {}),
     },
     rules: {
       ...DEFAULT_RULES_CONFIG,
-      ...(partial.rules ?? {}),
+      ...(rest.rules ?? {}),
     },
   };
-  if (partial.agentReview !== undefined) {
+  if (agentReview !== undefined) {
+    const a = agentReview;
+    const d = a.detection ?? {};
     merged.agentReview = {
-      ...DEFAULT_AGENT_REVIEW_CONFIG,
-      ...partial.agentReview,
+      enabled: a.enabled ?? DEFAULT_AGENT_REVIEW_CONFIG.enabled,
+      strictChecks: a.strictChecks ?? DEFAULT_AGENT_REVIEW_CONFIG.strictChecks,
+      autoIterate: a.autoIterate ?? DEFAULT_AGENT_REVIEW_CONFIG.autoIterate,
+      maxIterations: a.maxIterations ?? DEFAULT_AGENT_REVIEW_CONFIG.maxIterations,
+      passThreshold: a.passThreshold ?? DEFAULT_AGENT_REVIEW_CONFIG.passThreshold,
       detection: {
-        ...DEFAULT_AGENT_REVIEW_CONFIG.detection,
-        ...(partial.agentReview.detection ?? {}),
+        commitTrailers: d.commitTrailers ?? DEFAULT_AGENT_REVIEW_CONFIG.detection.commitTrailers,
+        branchPrefixes: d.branchPrefixes ?? DEFAULT_AGENT_REVIEW_CONFIG.detection.branchPrefixes,
+        labels: d.labels ?? DEFAULT_AGENT_REVIEW_CONFIG.detection.labels,
       },
     };
   }

--- a/packages/core/src/github/client.test.ts
+++ b/packages/core/src/github/client.test.ts
@@ -385,4 +385,115 @@ customAgents:
     expect(result!.customAgents![0].name).toBe('perf');
     expect(result!.customAgents![0].severityDefault).toBe('warning');
   });
+
+  // ─── Agent review parsing ────────────────────────────────────────────────
+  it('parses a full agentReview block', () => {
+    const yaml = `
+agentReview:
+  enabled: true
+  strictChecks: true
+  autoIterate: false
+  maxIterations: 5
+  passThreshold: scoreAtLeast4
+  detection:
+    commitTrailers:
+      - "Co-authored-by: Claude"
+      - "Co-authored-by: Cursor"
+    branchPrefixes:
+      - "claude/"
+      - "cursor/"
+    labels:
+      - ai-generated
+      - bot
+`;
+    const result = parseRepoConfigYaml(yaml);
+    expect(result?.agentReview).toBeDefined();
+    expect(result!.agentReview!.enabled).toBe(true);
+    expect(result!.agentReview!.strictChecks).toBe(true);
+    expect(result!.agentReview!.autoIterate).toBe(false);
+    expect(result!.agentReview!.maxIterations).toBe(5);
+    expect(result!.agentReview!.passThreshold).toBe('scoreAtLeast4');
+    expect(result!.agentReview!.detection!.commitTrailers).toEqual([
+      'Co-authored-by: Claude',
+      'Co-authored-by: Cursor',
+    ]);
+    expect(result!.agentReview!.detection!.branchPrefixes).toEqual(['claude/', 'cursor/']);
+    expect(result!.agentReview!.detection!.labels).toEqual(['ai-generated', 'bot']);
+  });
+
+  it('leaves agentReview undefined when block is missing', () => {
+    const result = parseRepoConfigYaml('model: foo');
+    expect(result?.agentReview).toBeUndefined();
+  });
+
+  it('parses partial agentReview (only enabled)', () => {
+    const yaml = `
+agentReview:
+  enabled: true
+`;
+    const result = parseRepoConfigYaml(yaml);
+    expect(result?.agentReview).toBeDefined();
+    expect(result!.agentReview!.enabled).toBe(true);
+    expect(result!.agentReview!.strictChecks).toBeUndefined();
+    expect(result!.agentReview!.autoIterate).toBeUndefined();
+    expect(result!.agentReview!.maxIterations).toBeUndefined();
+    expect(result!.agentReview!.passThreshold).toBeUndefined();
+    expect(result!.agentReview!.detection).toBeUndefined();
+  });
+
+  it('omits invalid passThreshold while keeping other valid fields', () => {
+    const yaml = `
+agentReview:
+  enabled: true
+  passThreshold: bogus
+`;
+    const result = parseRepoConfigYaml(yaml);
+    expect(result?.agentReview).toBeDefined();
+    expect(result!.agentReview!.enabled).toBe(true);
+    expect(result!.agentReview!.passThreshold).toBeUndefined();
+  });
+
+  it('omits invalid maxIterations (negative, zero, non-integer, >20)', () => {
+    const cases = [
+      'maxIterations: -1',
+      'maxIterations: 0',
+      'maxIterations: 2.5',
+      'maxIterations: 21',
+      'maxIterations: "3"',
+    ];
+    for (const line of cases) {
+      const result = parseRepoConfigYaml(`agentReview:\n  enabled: true\n  ${line}\n`);
+      expect(result?.agentReview).toBeDefined();
+      expect(result!.agentReview!.enabled).toBe(true);
+      expect(result!.agentReview!.maxIterations, line).toBeUndefined();
+    }
+  });
+
+  it('filters non-string entries from detection.commitTrailers', () => {
+    const yaml = `
+agentReview:
+  detection:
+    commitTrailers:
+      - "Co-authored-by: Claude"
+      - 123
+      - null
+      - "Co-authored-by: Cursor"
+`;
+    const result = parseRepoConfigYaml(yaml);
+    expect(result?.agentReview?.detection?.commitTrailers).toEqual([
+      'Co-authored-by: Claude',
+      'Co-authored-by: Cursor',
+    ]);
+  });
+
+  it('leaves detection undefined when absent', () => {
+    const yaml = `
+agentReview:
+  enabled: true
+  maxIterations: 3
+`;
+    const result = parseRepoConfigYaml(yaml);
+    expect(result?.agentReview).toBeDefined();
+    expect(result!.agentReview!.detection).toBeUndefined();
+  });
 });

--- a/packages/core/src/github/client.ts
+++ b/packages/core/src/github/client.ts
@@ -12,7 +12,16 @@
 import { Octokit } from "@octokit/rest";
 import yaml from 'js-yaml';
 import type { PRContext } from "../types/github.js";
-import type { MergeWatchConfig, CustomAgentDef, UXConfig, RulesConfig } from '../config/defaults.js';
+import type {
+  MergeWatchConfig,
+  CustomAgentDef,
+  UXConfig,
+  RulesConfig,
+  AgentReviewConfig,
+  AgentReviewDetectionConfig,
+  PassThreshold,
+} from '../config/defaults.js';
+import { PASS_THRESHOLDS } from '../config/defaults.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -815,6 +824,45 @@ export function parseRepoConfigYaml(content: string): Partial<MergeWatchConfig> 
         rules.ignoreLabels = r.ignoreLabels.filter((l: unknown) => typeof l === 'string');
       }
       config.rules = rules as RulesConfig;
+    }
+
+    // Agent review config
+    if (parsed.agentReview && typeof parsed.agentReview === 'object') {
+      const ar = parsed.agentReview as Record<string, unknown>;
+      const agentReview: Partial<AgentReviewConfig> = {};
+      if (typeof ar.enabled === 'boolean') agentReview.enabled = ar.enabled;
+      if (typeof ar.strictChecks === 'boolean') agentReview.strictChecks = ar.strictChecks;
+      if (typeof ar.autoIterate === 'boolean') agentReview.autoIterate = ar.autoIterate;
+      if (
+        typeof ar.maxIterations === 'number' &&
+        Number.isInteger(ar.maxIterations) &&
+        ar.maxIterations >= 1 &&
+        ar.maxIterations <= 20
+      ) {
+        agentReview.maxIterations = ar.maxIterations;
+      }
+      if (typeof ar.passThreshold === 'string' && (PASS_THRESHOLDS as readonly string[]).includes(ar.passThreshold)) {
+        agentReview.passThreshold = ar.passThreshold as PassThreshold;
+      }
+      if (ar.detection && typeof ar.detection === 'object') {
+        const d = ar.detection as Record<string, unknown>;
+        const detection: Partial<AgentReviewDetectionConfig> = {};
+        if (Array.isArray(d.commitTrailers)) {
+          detection.commitTrailers = d.commitTrailers.filter((t: unknown) => typeof t === 'string');
+        }
+        if (Array.isArray(d.branchPrefixes)) {
+          detection.branchPrefixes = d.branchPrefixes.filter((p: unknown) => typeof p === 'string');
+        }
+        if (Array.isArray(d.labels)) {
+          detection.labels = d.labels.filter((l: unknown) => typeof l === 'string');
+        }
+        if (Object.keys(detection).length > 0) {
+          agentReview.detection = detection as AgentReviewDetectionConfig;
+        }
+      }
+      if (Object.keys(agentReview).length > 0) {
+        config.agentReview = agentReview as AgentReviewConfig;
+      }
     }
 
   return config;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,14 +3,7 @@ export type { ILLMProvider, TokenUsage, LLMInvokeResult } from './llm/types.js';
 export { normalizeLLMResult } from './llm/types.js';
 export { TokenAccumulator, TrackingLLMProvider } from './llm/token-accumulator.js';
 export { estimateCost, DEFAULT_PRICING } from './llm/pricing.js';
-export type {
-  IInstallationStore,
-  IReviewStore,
-  IApiKeyStore,
-  IMcpSessionStore,
-  ApiKeyRecord,
-  McpSessionRecord,
-} from './storage/types.js';
+export type { IInstallationStore, IReviewStore } from './storage/types.js';
 export type { IGitHubAuthProvider } from './github/auth.js';
 export type {
   IDashboardStore,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,14 @@ export type { ILLMProvider, TokenUsage, LLMInvokeResult } from './llm/types.js';
 export { normalizeLLMResult } from './llm/types.js';
 export { TokenAccumulator, TrackingLLMProvider } from './llm/token-accumulator.js';
 export { estimateCost, DEFAULT_PRICING } from './llm/pricing.js';
-export type { IInstallationStore, IReviewStore } from './storage/types.js';
+export type {
+  IInstallationStore,
+  IReviewStore,
+  IApiKeyStore,
+  IMcpSessionStore,
+  ApiKeyRecord,
+  McpSessionRecord,
+} from './storage/types.js';
 export type { IGitHubAuthProvider } from './github/auth.js';
 export type {
   IDashboardStore,
@@ -104,8 +111,23 @@ export { computeReviewDelta } from './review-delta.js';
 export type { ReviewDelta, FindingLike } from './review-delta.js';
 
 // ─── Config ─────────────────────────────────────────────────────────────────
-export { DEFAULT_CONFIG, DEFAULT_UX_CONFIG, DEFAULT_RULES_CONFIG, mergeConfig } from './config/defaults.js';
-export type { MergeWatchConfig, CustomAgentDef, UXConfig, RulesConfig } from './config/defaults.js';
+export {
+  DEFAULT_CONFIG,
+  DEFAULT_UX_CONFIG,
+  DEFAULT_RULES_CONFIG,
+  DEFAULT_AGENT_REVIEW_CONFIG,
+  PASS_THRESHOLDS,
+  mergeConfig,
+} from './config/defaults.js';
+export type {
+  MergeWatchConfig,
+  CustomAgentDef,
+  UXConfig,
+  RulesConfig,
+  AgentReviewConfig,
+  AgentReviewDetectionConfig,
+  PassThreshold,
+} from './config/defaults.js';
 export {
   fetchConventions,
   truncateConventions,


### PR DESCRIPTION
## Summary

- Adds `AgentReviewConfig` + `AgentReviewDetectionConfig` interfaces, `PASS_THRESHOLDS` enum tuple, and `DEFAULT_AGENT_REVIEW_CONFIG` to `packages/core/src/config/defaults.ts`.
- Extends `parseRepoConfigYaml` in `packages/core/src/github/client.ts` to read and validate `agentReview` fields (`enabled`, `strictChecks`, `autoIterate`, `maxIterations` bounded 1..20 integer, `passThreshold` enum, and `detection.{commitTrailers,branchPrefixes,labels}` string arrays). Uses partial merge — unset fields remain undefined.
- Extends `mergeConfig` to deep-merge `agentReview` with defaults when the partial includes it, leaves it undefined when absent (mirrors `ux`/`rules` pattern).
- Re-exports new types and constants from `@mergewatch/core` index.

No consumers wired yet — a downstream PR will hook detection into the webhook handler / review pipeline.

## Follow-up

- Noticed an extra indentation level around line 734 of `parseRepoConfigYaml` that looks like a phantom try/catch residue — flagging for a follow-up cleanup PR, not fixing here.

## Test plan

- [x] `pnpm --filter @mergewatch/core run test` — 280/280 green (60 new/existing cases in `defaults.test.ts` + `client.test.ts`)
- [x] `tsc --noEmit` on `packages/core` — clean
- [ ] `pnpm run build` at root (unable to run in worktree without node_modules)
- [ ] Manual smoke test: add `agentReview` block to a repo's `.mergewatch.yml` and confirm parse via logs (deferred — no consumers yet)

Test cases added:
- Valid full `agentReview` block → all fields populated
- Missing block → `config.agentReview` is undefined
- Partial block (only `enabled`) → only that field set
- Invalid `passThreshold` → field omitted, siblings retained
- Invalid `maxIterations` (negative, zero, non-integer, >20, string) → field omitted
- Mixed string/non-string `detection.commitTrailers` → non-strings filtered
- `detection` absent → undefined
- `mergeConfig` deep-merges partial `agentReview` with `DEFAULT_AGENT_REVIEW_CONFIG`

🤖 Generated with [Claude Code](https://claude.com/claude-code)