### PR TITLE
Add API key + MCP session stores

### DIFF
--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -96,6 +96,8 @@ Globals:
         # DynamoDB table names — injected so Lambda code doesn't hardcode them
         INSTALLATIONS_TABLE: !Ref InstallationsTable
         REVIEWS_TABLE: !Ref ReviewsTable
+        API_KEYS_TABLE: !Ref ApiKeysTable
+        SESSIONS_TABLE: !Ref SessionsTable
 
         # SSM parameter paths for GitHub App credentials.
         # The Lambda functions read these at runtime via the AWS SDK.
@@ -420,6 +422,112 @@ Resources:
     UpdateReplacePolicy: Retain
 
   # ===========================================================================
+  # DynamoDB Table: ApiKeys
+  # ===========================================================================
+  # Stores hashed API keys that unlock MCP server access for a GitHub App
+  # installation. The raw key is never stored — only its sha256 hex digest.
+  #
+  # Schema:
+  #   PK: keyHash (String)           — sha256 hex of the raw key
+  #   GSI "ByInstallation":
+  #     PK: installationId (String)  — list keys for a given installation
+  #
+  # Additional attributes (schemaless):
+  #   - label (String)               — human-friendly label
+  #   - scope ('all' | String[])     — repos this key unlocks
+  #   - createdBy (String)           — GitHub user ID that minted the key
+  #   - createdAt (String)           — ISO 8601
+  #   - lastUsedAt (String)          — ISO 8601, updated on each MCP request
+
+  ApiKeysTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub 'mergewatch-api-keys-${Stage}'
+      BillingMode: PAY_PER_REQUEST
+
+      KeySchema:
+        - AttributeName: keyHash
+          KeyType: HASH
+
+      AttributeDefinitions:
+        - AttributeName: keyHash
+          AttributeType: S
+        - AttributeName: installationId
+          AttributeType: S
+
+      GlobalSecondaryIndexes:
+        - IndexName: ByInstallation
+          KeySchema:
+            - AttributeName: installationId
+              KeyType: HASH
+          Projection:
+            ProjectionType: ALL
+
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+
+      SSESpecification:
+        SSEEnabled: true
+
+      Tags:
+        - Key: Project
+          Value: MergeWatch
+        - Key: Stage
+          Value: !Ref Stage
+
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+
+  # ===========================================================================
+  # DynamoDB Table: Sessions
+  # ===========================================================================
+  # Ephemeral dedupe store for MCP review_diff billing. A session collapses
+  # repeated calls from an agent into a single 30-minute billing window.
+  #
+  # Schema:
+  #   PK: sessionId (String)
+  #
+  # Additional attributes:
+  #   - installationId (String)
+  #   - firstBilledAt (String)   — ISO 8601
+  #   - maxBilledCents (Number)  — highest cost billed so far
+  #   - iteration (Number)       — review_diff call count
+  #   - ttl (Number)             — Unix epoch seconds; auto-expired by DDB
+  #
+  # Diverges from other tables: DeletionPolicy=Delete because sessions are
+  # ephemeral by design and have no historical value.
+
+  SessionsTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub 'mergewatch-sessions-${Stage}'
+      BillingMode: PAY_PER_REQUEST
+
+      KeySchema:
+        - AttributeName: sessionId
+          KeyType: HASH
+
+      AttributeDefinitions:
+        - AttributeName: sessionId
+          AttributeType: S
+
+      TimeToLiveSpecification:
+        AttributeName: ttl
+        Enabled: true
+
+      SSESpecification:
+        SSEEnabled: true
+
+      Tags:
+        - Key: Project
+          Value: MergeWatch
+        - Key: Stage
+          Value: !Ref Stage
+
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+
+  # ===========================================================================
   # IAM Role: Lambda Execution Role
   # ===========================================================================
   # A single shared role for both Lambda functions. This simplifies management
@@ -491,9 +599,13 @@ Resources:
                   # Table ARNs
                   - !GetAtt InstallationsTable.Arn
                   - !GetAtt ReviewsTable.Arn
+                  - !GetAtt ApiKeysTable.Arn
+                  - !GetAtt SessionsTable.Arn
                   # Index ARNs (for future GSIs)
                   - !Sub '${InstallationsTable.Arn}/index/*'
                   - !Sub '${ReviewsTable.Arn}/index/*'
+                  - !Sub '${ApiKeysTable.Arn}/index/*'
+                  - !Sub '${SessionsTable.Arn}/index/*'
 
         # --- SSM Parameter Store ---
         # Read-only access to GitHub credentials stored in SSM.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,14 @@ export type { ILLMProvider, TokenUsage, LLMInvokeResult } from './llm/types.js';
 export { normalizeLLMResult } from './llm/types.js';
 export { TokenAccumulator, TrackingLLMProvider } from './llm/token-accumulator.js';
 export { estimateCost, DEFAULT_PRICING } from './llm/pricing.js';
-export type { IInstallationStore, IReviewStore } from './storage/types.js';
+export type {
+  IInstallationStore,
+  IReviewStore,
+  IApiKeyStore,
+  IMcpSessionStore,
+  ApiKeyRecord,
+  McpSessionRecord,
+} from './storage/types.js';
 export type { IGitHubAuthProvider } from './github/auth.js';
 export type {
   IDashboardStore,

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -31,3 +31,46 @@ export interface IReviewStore {
   ): Promise<void>;
   queryByPR(repoFullName: string, prPrefix: string, limit?: number): Promise<ReviewItem[]>;
 }
+
+export interface ApiKeyRecord {
+  /** sha256 hex of the raw key. Raw key is never stored. */
+  keyHash: string;
+  /** GitHub App installation this key unlocks. */
+  installationId: string;
+  /** Human-friendly label for the dashboard. */
+  label: string;
+  /** Either 'all' (all repos in the installation) or a specific list of owner/repo strings. */
+  scope: 'all' | string[];
+  /** GitHub user ID of the dashboard user who created the key. */
+  createdBy: string;
+  /** ISO 8601. */
+  createdAt: string;
+  /** ISO 8601, set on each MCP request. Optional on create. */
+  lastUsedAt?: string;
+}
+
+export interface IApiKeyStore {
+  create(record: Omit<ApiKeyRecord, 'lastUsedAt'>): Promise<void>;
+  getByHash(keyHash: string): Promise<ApiKeyRecord | null>;
+  listByInstallation(installationId: string): Promise<ApiKeyRecord[]>;
+  delete(keyHash: string): Promise<void>;
+  touchLastUsed(keyHash: string, isoTimestamp: string): Promise<void>;
+}
+
+export interface McpSessionRecord {
+  sessionId: string;
+  installationId: string;
+  /** ISO 8601 — used to derive ttl. */
+  firstBilledAt: string;
+  /** Highest cost billed so far in this session, in cents. */
+  maxBilledCents: number;
+  /** How many review_diff calls have been made in this session. */
+  iteration: number;
+  /** Unix epoch seconds for DynamoDB TTL. Postgres uses firstBilledAt + 30 min. */
+  ttl: number;
+}
+
+export interface IMcpSessionStore {
+  get(sessionId: string): Promise<McpSessionRecord | null>;
+  upsert(record: McpSessionRecord): Promise<void>;
+}

--- a/packages/storage-dynamo/package.json
+++ b/packages/storage-dynamo/package.json
@@ -6,7 +6,8 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@mergewatch/core": "workspace:*",

--- a/packages/storage-dynamo/src/api-key-store.test.ts
+++ b/packages/storage-dynamo/src/api-key-store.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  DeleteCommand,
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+  UpdateCommand,
+} from '@aws-sdk/lib-dynamodb';
+import { DynamoApiKeyStore, API_KEYS_INSTALLATION_INDEX } from './api-key-store.js';
+
+const TABLE = 'test-api-keys';
+
+function makeClient(response: unknown = {}) {
+  return { send: vi.fn().mockResolvedValue(response) } as any;
+}
+
+describe('DynamoApiKeyStore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('create issues a PutCommand with attribute_not_exists guard', async () => {
+    const client = makeClient();
+    const store = new DynamoApiKeyStore(client, TABLE);
+    const record = {
+      keyHash: 'abc',
+      installationId: 'inst-1',
+      label: 'dev laptop',
+      scope: 'all' as const,
+      createdBy: 'user-42',
+      createdAt: '2026-04-19T00:00:00.000Z',
+    };
+    await store.create(record);
+    const call = client.send.mock.calls[0][0];
+    expect(call).toBeInstanceOf(PutCommand);
+    expect(call.input).toEqual({
+      TableName: TABLE,
+      Item: record,
+      ConditionExpression: 'attribute_not_exists(keyHash)',
+    });
+  });
+
+  it('getByHash returns the item when present', async () => {
+    const record = {
+      keyHash: 'abc',
+      installationId: 'inst-1',
+      label: 'x',
+      scope: 'all',
+      createdBy: 'u',
+      createdAt: 't',
+    };
+    const client = makeClient({ Item: record });
+    const store = new DynamoApiKeyStore(client, TABLE);
+    const got = await store.getByHash('abc');
+    expect(got).toEqual(record);
+    const call = client.send.mock.calls[0][0];
+    expect(call).toBeInstanceOf(GetCommand);
+    expect(call.input.Key).toEqual({ keyHash: 'abc' });
+  });
+
+  it('getByHash returns null when not found', async () => {
+    const client = makeClient({});
+    const store = new DynamoApiKeyStore(client, TABLE);
+    expect(await store.getByHash('missing')).toBeNull();
+  });
+
+  it('listByInstallation queries the GSI', async () => {
+    const items = [
+      { keyHash: 'a', installationId: 'inst-1' },
+      { keyHash: 'b', installationId: 'inst-1' },
+    ];
+    const client = makeClient({ Items: items });
+    const store = new DynamoApiKeyStore(client, TABLE);
+    const got = await store.listByInstallation('inst-1');
+    expect(got).toEqual(items);
+    const call = client.send.mock.calls[0][0];
+    expect(call).toBeInstanceOf(QueryCommand);
+    expect(call.input).toEqual({
+      TableName: TABLE,
+      IndexName: API_KEYS_INSTALLATION_INDEX,
+      KeyConditionExpression: 'installationId = :iid',
+      ExpressionAttributeValues: { ':iid': 'inst-1' },
+    });
+  });
+
+  it('listByInstallation returns [] when Items missing', async () => {
+    const client = makeClient({});
+    const store = new DynamoApiKeyStore(client, TABLE);
+    expect(await store.listByInstallation('inst-x')).toEqual([]);
+  });
+
+  it('delete issues DeleteCommand by keyHash', async () => {
+    const client = makeClient();
+    const store = new DynamoApiKeyStore(client, TABLE);
+    await store.delete('abc');
+    const call = client.send.mock.calls[0][0];
+    expect(call).toBeInstanceOf(DeleteCommand);
+    expect(call.input.Key).toEqual({ keyHash: 'abc' });
+  });
+
+  it('touchLastUsed updates lastUsedAt', async () => {
+    const client = makeClient();
+    const store = new DynamoApiKeyStore(client, TABLE);
+    await store.touchLastUsed('abc', '2026-04-19T12:00:00.000Z');
+    const call = client.send.mock.calls[0][0];
+    expect(call).toBeInstanceOf(UpdateCommand);
+    expect(call.input).toEqual({
+      TableName: TABLE,
+      Key: { keyHash: 'abc' },
+      UpdateExpression: 'SET lastUsedAt = :ts',
+      ExpressionAttributeValues: { ':ts': '2026-04-19T12:00:00.000Z' },
+    });
+  });
+});

--- a/packages/storage-dynamo/src/api-key-store.ts
+++ b/packages/storage-dynamo/src/api-key-store.ts
@@ -1,0 +1,81 @@
+/**
+ * DynamoDB implementation of IApiKeyStore.
+ *
+ * Schema:
+ *   PK: keyHash (String) — sha256 hex of the raw key
+ *   GSI "ByInstallation": PK=installationId (projection=ALL)
+ *
+ * Table name: env API_KEYS_TABLE, fallback mergewatch-api-keys.
+ */
+
+import {
+  DynamoDBDocumentClient,
+  DeleteCommand,
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+  UpdateCommand,
+} from '@aws-sdk/lib-dynamodb';
+import type { ApiKeyRecord, IApiKeyStore } from '@mergewatch/core';
+
+export const DEFAULT_API_KEYS_TABLE = 'mergewatch-api-keys';
+export const API_KEYS_INSTALLATION_INDEX = 'ByInstallation';
+
+export class DynamoApiKeyStore implements IApiKeyStore {
+  constructor(
+    private readonly client: DynamoDBDocumentClient,
+    private readonly tableName: string = process.env.API_KEYS_TABLE ?? DEFAULT_API_KEYS_TABLE,
+  ) {}
+
+  async create(record: Omit<ApiKeyRecord, 'lastUsedAt'>): Promise<void> {
+    await this.client.send(
+      new PutCommand({
+        TableName: this.tableName,
+        Item: record,
+        ConditionExpression: 'attribute_not_exists(keyHash)',
+      }),
+    );
+  }
+
+  async getByHash(keyHash: string): Promise<ApiKeyRecord | null> {
+    const result = await this.client.send(
+      new GetCommand({
+        TableName: this.tableName,
+        Key: { keyHash },
+      }),
+    );
+    return (result.Item as ApiKeyRecord) ?? null;
+  }
+
+  async listByInstallation(installationId: string): Promise<ApiKeyRecord[]> {
+    const result = await this.client.send(
+      new QueryCommand({
+        TableName: this.tableName,
+        IndexName: API_KEYS_INSTALLATION_INDEX,
+        KeyConditionExpression: 'installationId = :iid',
+        ExpressionAttributeValues: { ':iid': installationId },
+      }),
+    );
+    return (result.Items ?? []) as ApiKeyRecord[];
+  }
+
+  async delete(keyHash: string): Promise<void> {
+    await this.client.send(
+      new DeleteCommand({
+        TableName: this.tableName,
+        Key: { keyHash },
+      }),
+    );
+  }
+
+  async touchLastUsed(keyHash: string, isoTimestamp: string): Promise<void> {
+    await this.client.send(
+      new UpdateCommand({
+        TableName: this.tableName,
+        Key: { keyHash },
+        UpdateExpression: 'SET lastUsedAt = :ts',
+        ExpressionAttributeValues: { ':ts': isoTimestamp },
+      }),
+    );
+  }
+}

--- a/packages/storage-dynamo/src/index.ts
+++ b/packages/storage-dynamo/src/index.ts
@@ -2,3 +2,9 @@ export { DynamoInstallationStore } from './installation-store.js';
 export { DynamoReviewStore } from './review-store.js';
 export { createDynamoDashboardStore } from './dashboard-store.js';
 export type { DynamoDashboardStoreOptions } from './dashboard-store.js';
+export {
+  DynamoApiKeyStore,
+  DEFAULT_API_KEYS_TABLE,
+  API_KEYS_INSTALLATION_INDEX,
+} from './api-key-store.js';
+export { DynamoMcpSessionStore, DEFAULT_SESSIONS_TABLE } from './mcp-session-store.js';

--- a/packages/storage-dynamo/src/mcp-session-store.test.ts
+++ b/packages/storage-dynamo/src/mcp-session-store.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { DynamoMcpSessionStore } from './mcp-session-store.js';
+
+const TABLE = 'test-sessions';
+
+function makeClient(response: unknown = {}) {
+  return { send: vi.fn().mockResolvedValue(response) } as any;
+}
+
+describe('DynamoMcpSessionStore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('get returns the item when present', async () => {
+    const record = {
+      sessionId: 'sess-1',
+      installationId: 'inst-1',
+      firstBilledAt: '2026-04-19T00:00:00.000Z',
+      maxBilledCents: 50,
+      iteration: 2,
+      ttl: 1_800_000_000,
+    };
+    const client = makeClient({ Item: record });
+    const store = new DynamoMcpSessionStore(client, TABLE);
+    const got = await store.get('sess-1');
+    expect(got).toEqual(record);
+    const call = client.send.mock.calls[0][0];
+    expect(call).toBeInstanceOf(GetCommand);
+    expect(call.input.Key).toEqual({ sessionId: 'sess-1' });
+  });
+
+  it('get returns null when absent', async () => {
+    const client = makeClient({});
+    const store = new DynamoMcpSessionStore(client, TABLE);
+    expect(await store.get('missing')).toBeNull();
+  });
+
+  it('upsert writes the record with ttl intact (unix epoch seconds)', async () => {
+    const client = makeClient();
+    const store = new DynamoMcpSessionStore(client, TABLE);
+    const firstBilledAt = '2026-04-19T00:00:00.000Z';
+    const ttl = Math.floor(new Date(firstBilledAt).getTime() / 1000) + 1800;
+    const record = {
+      sessionId: 'sess-1',
+      installationId: 'inst-1',
+      firstBilledAt,
+      maxBilledCents: 10,
+      iteration: 1,
+      ttl,
+    };
+    await store.upsert(record);
+    const call = client.send.mock.calls[0][0];
+    expect(call).toBeInstanceOf(PutCommand);
+    expect(call.input).toEqual({ TableName: TABLE, Item: record });
+    // Roundtrip sanity: ttl * 1000 -> Date should be firstBilled + 30min
+    expect(new Date(ttl * 1000).toISOString()).toBe('2026-04-19T00:30:00.000Z');
+  });
+});

--- a/packages/storage-dynamo/src/mcp-session-store.ts
+++ b/packages/storage-dynamo/src/mcp-session-store.ts
@@ -1,0 +1,40 @@
+/**
+ * DynamoDB implementation of IMcpSessionStore.
+ *
+ * Schema:
+ *   PK: sessionId (String)
+ *   TTL attribute: ttl (Unix epoch seconds)
+ *
+ * Table name: env SESSIONS_TABLE, fallback mergewatch-sessions.
+ */
+
+import { DynamoDBDocumentClient, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
+import type { IMcpSessionStore, McpSessionRecord } from '@mergewatch/core';
+
+export const DEFAULT_SESSIONS_TABLE = 'mergewatch-sessions';
+
+export class DynamoMcpSessionStore implements IMcpSessionStore {
+  constructor(
+    private readonly client: DynamoDBDocumentClient,
+    private readonly tableName: string = process.env.SESSIONS_TABLE ?? DEFAULT_SESSIONS_TABLE,
+  ) {}
+
+  async get(sessionId: string): Promise<McpSessionRecord | null> {
+    const result = await this.client.send(
+      new GetCommand({
+        TableName: this.tableName,
+        Key: { sessionId },
+      }),
+    );
+    return (result.Item as McpSessionRecord) ?? null;
+  }
+
+  async upsert(record: McpSessionRecord): Promise<void> {
+    await this.client.send(
+      new PutCommand({
+        TableName: this.tableName,
+        Item: record,
+      }),
+    );
+  }
+}

--- a/packages/storage-dynamo/tsconfig.build.json
+++ b/packages/storage-dynamo/tsconfig.build.json
@@ -9,5 +9,5 @@
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
 }

--- a/packages/storage-dynamo/vitest.config.ts
+++ b/packages/storage-dynamo/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/storage-postgres/src/api-key-store.test.ts
+++ b/packages/storage-postgres/src/api-key-store.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PostgresApiKeyStore } from './api-key-store';
+import { apiKeys } from './schema';
+
+/**
+ * Drizzle's query builder chains .select().from().where().limit() and
+ * terminates on await. We model each call as a thenable chain that ultimately
+ * resolves to the configured result.
+ */
+function chain(result: any) {
+  const p: any = {
+    select: vi.fn(() => p),
+    from: vi.fn(() => p),
+    where: vi.fn(() => p),
+    limit: vi.fn(() => p),
+    insert: vi.fn(() => p),
+    values: vi.fn(() => Promise.resolve(result)),
+    update: vi.fn(() => p),
+    set: vi.fn(() => p),
+    delete: vi.fn(() => p),
+    then: (resolve: any) => Promise.resolve(result).then(resolve),
+  };
+  return p;
+}
+
+describe('PostgresApiKeyStore', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('create inserts the record with createdAt as Date', async () => {
+    const db: any = chain(undefined);
+    const store = new PostgresApiKeyStore(db);
+    await store.create({
+      keyHash: 'h',
+      installationId: 'inst-1',
+      label: 'dev',
+      scope: 'all',
+      createdBy: 'u',
+      createdAt: '2026-04-19T00:00:00.000Z',
+    });
+    expect(db.insert).toHaveBeenCalledWith(apiKeys);
+    expect(db.values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        keyHash: 'h',
+        installationId: 'inst-1',
+        label: 'dev',
+        scope: 'all',
+        createdBy: 'u',
+        createdAt: new Date('2026-04-19T00:00:00.000Z'),
+      }),
+    );
+  });
+
+  it('getByHash returns null when no row', async () => {
+    const db: any = chain([]);
+    const store = new PostgresApiKeyStore(db);
+    expect(await store.getByHash('missing')).toBeNull();
+  });
+
+  it('getByHash returns hydrated record including lastUsedAt when present', async () => {
+    const createdAt = new Date('2026-04-19T00:00:00.000Z');
+    const lastUsedAt = new Date('2026-04-19T12:00:00.000Z');
+    const db: any = chain([
+      {
+        keyHash: 'h',
+        installationId: 'inst-1',
+        label: 'dev',
+        scope: ['octocat/hello'],
+        createdBy: 'u',
+        createdAt,
+        lastUsedAt,
+      },
+    ]);
+    const store = new PostgresApiKeyStore(db);
+    expect(await store.getByHash('h')).toEqual({
+      keyHash: 'h',
+      installationId: 'inst-1',
+      label: 'dev',
+      scope: ['octocat/hello'],
+      createdBy: 'u',
+      createdAt: '2026-04-19T00:00:00.000Z',
+      lastUsedAt: '2026-04-19T12:00:00.000Z',
+    });
+  });
+
+  it('getByHash omits lastUsedAt when null', async () => {
+    const db: any = chain([
+      {
+        keyHash: 'h',
+        installationId: 'inst-1',
+        label: 'dev',
+        scope: 'all',
+        createdBy: 'u',
+        createdAt: new Date('2026-04-19T00:00:00.000Z'),
+        lastUsedAt: null,
+      },
+    ]);
+    const store = new PostgresApiKeyStore(db);
+    const got = await store.getByHash('h');
+    expect(got?.lastUsedAt).toBeUndefined();
+  });
+
+  it('listByInstallation maps each row', async () => {
+    const db: any = chain([
+      {
+        keyHash: 'a',
+        installationId: 'inst-1',
+        label: 'x',
+        scope: 'all',
+        createdBy: 'u',
+        createdAt: new Date('2026-04-19T00:00:00.000Z'),
+        lastUsedAt: null,
+      },
+      {
+        keyHash: 'b',
+        installationId: 'inst-1',
+        label: 'y',
+        scope: ['o/r'],
+        createdBy: 'u',
+        createdAt: new Date('2026-04-19T00:00:00.000Z'),
+        lastUsedAt: null,
+      },
+    ]);
+    const store = new PostgresApiKeyStore(db);
+    const got = await store.listByInstallation('inst-1');
+    expect(got).toHaveLength(2);
+    expect(got[0].keyHash).toBe('a');
+    expect(got[1].keyHash).toBe('b');
+  });
+
+  it('delete removes by keyHash', async () => {
+    const db: any = chain(undefined);
+    const store = new PostgresApiKeyStore(db);
+    await store.delete('h');
+    expect(db.delete).toHaveBeenCalledWith(apiKeys);
+    expect(db.where).toHaveBeenCalled();
+  });
+
+  it('touchLastUsed sets lastUsedAt', async () => {
+    const db: any = chain(undefined);
+    const store = new PostgresApiKeyStore(db);
+    await store.touchLastUsed('h', '2026-04-19T12:00:00.000Z');
+    expect(db.update).toHaveBeenCalledWith(apiKeys);
+    expect(db.set).toHaveBeenCalledWith({
+      lastUsedAt: new Date('2026-04-19T12:00:00.000Z'),
+    });
+  });
+});

--- a/packages/storage-postgres/src/api-key-store.ts
+++ b/packages/storage-postgres/src/api-key-store.ts
@@ -1,0 +1,60 @@
+import { eq } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import type { ApiKeyRecord, IApiKeyStore } from '@mergewatch/core';
+import { apiKeys } from './schema.js';
+
+export class PostgresApiKeyStore implements IApiKeyStore {
+  constructor(private db: PostgresJsDatabase) {}
+
+  async create(record: Omit<ApiKeyRecord, 'lastUsedAt'>): Promise<void> {
+    await this.db.insert(apiKeys).values({
+      keyHash: record.keyHash,
+      installationId: record.installationId,
+      label: record.label,
+      scope: record.scope as any,
+      createdBy: record.createdBy,
+      createdAt: new Date(record.createdAt),
+    });
+  }
+
+  async getByHash(keyHash: string): Promise<ApiKeyRecord | null> {
+    const rows = await this.db
+      .select()
+      .from(apiKeys)
+      .where(eq(apiKeys.keyHash, keyHash))
+      .limit(1);
+    if (rows.length === 0) return null;
+    return toRecord(rows[0]);
+  }
+
+  async listByInstallation(installationId: string): Promise<ApiKeyRecord[]> {
+    const rows = await this.db
+      .select()
+      .from(apiKeys)
+      .where(eq(apiKeys.installationId, installationId));
+    return rows.map(toRecord);
+  }
+
+  async delete(keyHash: string): Promise<void> {
+    await this.db.delete(apiKeys).where(eq(apiKeys.keyHash, keyHash));
+  }
+
+  async touchLastUsed(keyHash: string, isoTimestamp: string): Promise<void> {
+    await this.db
+      .update(apiKeys)
+      .set({ lastUsedAt: new Date(isoTimestamp) })
+      .where(eq(apiKeys.keyHash, keyHash));
+  }
+}
+
+function toRecord(row: typeof apiKeys.$inferSelect): ApiKeyRecord {
+  return {
+    keyHash: row.keyHash,
+    installationId: row.installationId,
+    label: row.label,
+    scope: row.scope as ApiKeyRecord['scope'],
+    createdBy: row.createdBy,
+    createdAt: row.createdAt.toISOString(),
+    ...(row.lastUsedAt ? { lastUsedAt: row.lastUsedAt.toISOString() } : {}),
+  };
+}

--- a/packages/storage-postgres/src/index.ts
+++ b/packages/storage-postgres/src/index.ts
@@ -1,5 +1,7 @@
 export { PostgresInstallationStore } from './installation-store.js';
 export { PostgresReviewStore } from './review-store.js';
-export { installations, installationSettings, reviews } from './schema.js';
+export { installations, installationSettings, reviews, apiKeys, mcpSessions } from './schema.js';
 export { runMigrations } from './migrate.js';
 export { createPostgresDashboardStore } from './dashboard-store.js';
+export { PostgresApiKeyStore } from './api-key-store.js';
+export { PostgresMcpSessionStore } from './mcp-session-store.js';

--- a/packages/storage-postgres/src/mcp-session-store.test.ts
+++ b/packages/storage-postgres/src/mcp-session-store.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PostgresMcpSessionStore } from './mcp-session-store';
+import { mcpSessions } from './schema';
+
+function chain(result: any) {
+  const p: any = {
+    select: vi.fn(() => p),
+    from: vi.fn(() => p),
+    where: vi.fn(() => p),
+    limit: vi.fn(() => p),
+    insert: vi.fn(() => p),
+    values: vi.fn(() => p),
+    onConflictDoUpdate: vi.fn(() => Promise.resolve(undefined)),
+    then: (resolve: any) => Promise.resolve(result).then(resolve),
+  };
+  return p;
+}
+
+describe('PostgresMcpSessionStore', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('get returns null when no row', async () => {
+    const db: any = chain([]);
+    const store = new PostgresMcpSessionStore(db);
+    expect(await store.get('missing')).toBeNull();
+  });
+
+  it('get hydrates record and converts expiresAt -> ttl (epoch seconds)', async () => {
+    const firstBilledAt = new Date('2026-04-19T00:00:00.000Z');
+    const expiresAt = new Date('2026-04-19T00:30:00.000Z');
+    const db: any = chain([
+      {
+        sessionId: 's',
+        installationId: 'inst-1',
+        firstBilledAt,
+        maxBilledCents: 50,
+        iteration: 3,
+        expiresAt,
+      },
+    ]);
+    const store = new PostgresMcpSessionStore(db);
+    const got = await store.get('s');
+    expect(got).toEqual({
+      sessionId: 's',
+      installationId: 'inst-1',
+      firstBilledAt: '2026-04-19T00:00:00.000Z',
+      maxBilledCents: 50,
+      iteration: 3,
+      ttl: Math.floor(expiresAt.getTime() / 1000),
+    });
+  });
+
+  it('upsert maps ttl -> expiresAt and uses onConflictDoUpdate', async () => {
+    const db: any = chain(undefined);
+    const store = new PostgresMcpSessionStore(db);
+    const firstBilledAt = '2026-04-19T00:00:00.000Z';
+    const ttl = Math.floor(new Date(firstBilledAt).getTime() / 1000) + 1800;
+    await store.upsert({
+      sessionId: 's',
+      installationId: 'inst-1',
+      firstBilledAt,
+      maxBilledCents: 25,
+      iteration: 1,
+      ttl,
+    });
+    expect(db.insert).toHaveBeenCalledWith(mcpSessions);
+    expect(db.values).toHaveBeenCalledWith({
+      sessionId: 's',
+      installationId: 'inst-1',
+      firstBilledAt: new Date(firstBilledAt),
+      maxBilledCents: 25,
+      iteration: 1,
+      expiresAt: new Date(ttl * 1000),
+    });
+    expect(db.onConflictDoUpdate).toHaveBeenCalled();
+  });
+
+  it('ttl roundtrip is stable across upsert + get', async () => {
+    const firstBilledAt = '2026-04-19T00:00:00.000Z';
+    const ttl = Math.floor(new Date(firstBilledAt).getTime() / 1000) + 1800;
+    const expiresAt = new Date(ttl * 1000);
+    const db: any = chain([
+      {
+        sessionId: 's',
+        installationId: 'inst-1',
+        firstBilledAt: new Date(firstBilledAt),
+        maxBilledCents: 0,
+        iteration: 1,
+        expiresAt,
+      },
+    ]);
+    const store = new PostgresMcpSessionStore(db);
+    const got = await store.get('s');
+    expect(got?.ttl).toBe(ttl);
+  });
+});

--- a/packages/storage-postgres/src/mcp-session-store.ts
+++ b/packages/storage-postgres/src/mcp-session-store.ts
@@ -1,0 +1,50 @@
+import { eq } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import type { IMcpSessionStore, McpSessionRecord } from '@mergewatch/core';
+import { mcpSessions } from './schema.js';
+
+export class PostgresMcpSessionStore implements IMcpSessionStore {
+  constructor(private db: PostgresJsDatabase) {}
+
+  async get(sessionId: string): Promise<McpSessionRecord | null> {
+    const rows = await this.db
+      .select()
+      .from(mcpSessions)
+      .where(eq(mcpSessions.sessionId, sessionId))
+      .limit(1);
+    if (rows.length === 0) return null;
+    const row = rows[0];
+    return {
+      sessionId: row.sessionId,
+      installationId: row.installationId,
+      firstBilledAt: row.firstBilledAt.toISOString(),
+      maxBilledCents: row.maxBilledCents,
+      iteration: row.iteration,
+      ttl: Math.floor(row.expiresAt.getTime() / 1000),
+    };
+  }
+
+  async upsert(record: McpSessionRecord): Promise<void> {
+    const values = {
+      sessionId: record.sessionId,
+      installationId: record.installationId,
+      firstBilledAt: new Date(record.firstBilledAt),
+      maxBilledCents: record.maxBilledCents,
+      iteration: record.iteration,
+      expiresAt: new Date(record.ttl * 1000),
+    };
+    await this.db
+      .insert(mcpSessions)
+      .values(values)
+      .onConflictDoUpdate({
+        target: mcpSessions.sessionId,
+        set: {
+          installationId: values.installationId,
+          firstBilledAt: values.firstBilledAt,
+          maxBilledCents: values.maxBilledCents,
+          iteration: values.iteration,
+          expiresAt: values.expiresAt,
+        },
+      });
+  }
+}

--- a/packages/storage-postgres/src/schema.ts
+++ b/packages/storage-postgres/src/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, integer, jsonb, boolean, primaryKey, index } from 'drizzle-orm/pg-core';
+import { pgTable, text, integer, jsonb, boolean, timestamp, primaryKey, index } from 'drizzle-orm/pg-core';
 
 export const installations = pgTable('installations', {
   installationId: text('installation_id').notNull(),
@@ -57,3 +57,24 @@ export const reviews = pgTable('reviews', {
   installationIdx: index('reviews_installation_idx').on(t.installationId),
   prIdx: index('reviews_pr_idx').on(t.repoFullName),
 }));
+
+export const apiKeys = pgTable('api_keys', {
+  keyHash: text('key_hash').primaryKey(),
+  installationId: text('installation_id').notNull(),
+  label: text('label').notNull(),
+  scope: jsonb('scope').notNull(),
+  createdBy: text('created_by').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  lastUsedAt: timestamp('last_used_at', { withTimezone: true }),
+}, (t) => ({
+  installationIdx: index('api_keys_installation_idx').on(t.installationId),
+}));
+
+export const mcpSessions = pgTable('mcp_sessions', {
+  sessionId: text('session_id').primaryKey(),
+  installationId: text('installation_id').notNull(),
+  firstBilledAt: timestamp('first_billed_at', { withTimezone: true }).notNull(),
+  maxBilledCents: integer('max_billed_cents').notNull(),
+  iteration: integer('iteration').notNull(),
+  expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+});


### PR DESCRIPTION
## Summary
- Add `IApiKeyStore` and `IMcpSessionStore` interfaces in `@mergewatch/core` along with `ApiKeyRecord` / `McpSessionRecord` types
- Ship DynamoDB implementations (`DynamoApiKeyStore`, `DynamoMcpSessionStore`) with table names sourced from `API_KEYS_TABLE` / `SESSIONS_TABLE` env vars (fallbacks `mergewatch-api-keys`, `mergewatch-sessions`). API keys use a `ByInstallation` GSI; sessions use DynamoDB TTL via the `ttl` attribute
- Ship Postgres implementations (`PostgresApiKeyStore`, `PostgresMcpSessionStore`) with new Drizzle tables `api_keys` (indexed on installation_id) and `mcp_sessions` (uses `expires_at`; ttl epoch-seconds is computed at the edge)
- Add `ApiKeysTable` + `SessionsTable` to `infra/template.yaml` with matching IAM policy updates (`DeletionPolicy: Retain` for keys, `Delete` for sessions since they're ephemeral)
- Generate Drizzle migration `0001_volatile_zemo.sql`, hand-edited to `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS`. `pnpm run migrations:check` is clean
- Add `vitest.config.ts` + `test` script to both storage packages; exclude `**/*.test.ts` from `storage-dynamo` build

No consumers yet — this is pure infrastructure for the upcoming MCP server.

## Test plan
- [x] `pnpm --filter @mergewatch/storage-dynamo run typecheck`
- [x] `pnpm --filter @mergewatch/storage-postgres run typecheck`
- [x] `pnpm --filter @mergewatch/storage-dynamo run test` — 10 tests pass
- [x] `pnpm --filter @mergewatch/storage-postgres run test` — 11 tests pass
- [x] `pnpm --filter @mergewatch/storage-postgres run migrations:check` — `Everything's fine`
- [x] `pnpm run typecheck` at repo root — all 18 tasks pass
- [x] `pnpm --filter @mergewatch/core run test` — 280 tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)