### PR TITLE
Classify agent-authored PRs on webhook; pass agentAuthored to pipeline

### DIFF
--- a/packages/core/src/agent-detection.test.ts
+++ b/packages/core/src/agent-detection.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Octokit } from '@octokit/rest';
+import { classifyPrSource } from './agent-detection.js';
+import type { GitHubPullRequest } from './types/github.js';
+import type { AgentReviewConfig } from './config/defaults.js';
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────
+
+function makePr(overrides?: Partial<GitHubPullRequest>): GitHubPullRequest {
+  return {
+    number: 42,
+    title: 'Add feature',
+    body: null,
+    state: 'open',
+    html_url: 'https://github.com/octo/repo/pull/42',
+    head: {
+      label: 'octo:feature/foo',
+      ref: 'feature/foo',
+      sha: 'abc123',
+      repo: {
+        id: 1,
+        name: 'repo',
+        full_name: 'octo/repo',
+        owner: { login: 'octo', id: 1, avatar_url: '', type: 'User' },
+        private: false,
+        html_url: '',
+        default_branch: 'main',
+      },
+    },
+    base: {
+      label: 'octo:main',
+      ref: 'main',
+      sha: 'def456',
+      repo: {
+        id: 1,
+        name: 'repo',
+        full_name: 'octo/repo',
+        owner: { login: 'octo', id: 1, avatar_url: '', type: 'User' },
+        private: false,
+        html_url: '',
+        default_branch: 'main',
+      },
+    },
+    user: { login: 'alice', id: 1, avatar_url: '', type: 'User' },
+    created_at: '2026-04-01T00:00:00Z',
+    updated_at: '2026-04-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides?: Partial<AgentReviewConfig>): AgentReviewConfig {
+  return {
+    enabled: true,
+    strictChecks: true,
+    autoIterate: true,
+    maxIterations: 3,
+    passThreshold: 'noCritical',
+    detection: {
+      commitTrailers: ['Co-authored-by: Claude'],
+      branchPrefixes: ['claude/', 'cursor/'],
+      labels: ['ai-generated', 'claude-authored'],
+    },
+    ...overrides,
+  };
+}
+
+function makeOctokit(listCommitsImpl?: (args: unknown) => unknown): Octokit {
+  const impl = listCommitsImpl ?? (() => ({ data: [] }));
+  return {
+    pulls: {
+      listCommits: vi.fn(impl),
+    },
+  } as unknown as Octokit;
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('classifyPrSource', () => {
+  it('returns human when config is undefined', async () => {
+    const result = await classifyPrSource(makePr(), makeOctokit(), undefined);
+    expect(result).toEqual({ source: 'human' });
+  });
+
+  it('returns human when detection is disabled', async () => {
+    const result = await classifyPrSource(
+      makePr({ labels: [{ name: 'ai-generated' }] }),
+      makeOctokit(),
+      makeConfig({ enabled: false }),
+    );
+    expect(result).toEqual({ source: 'human' });
+  });
+
+  it('classifies as agent when a configured label is present', async () => {
+    const result = await classifyPrSource(
+      makePr({ labels: [{ name: 'ai-generated' }] }),
+      makeOctokit(),
+      makeConfig(),
+    );
+    expect(result.source).toBe('agent');
+    expect(result.matchedRule).toBe('label');
+    // 'ai-generated' does not include claude/cursor/codex → fallback 'other'
+    expect(result.agentKind).toBe('other');
+  });
+
+  it('derives agentKind=claude from a claude-* label', async () => {
+    const result = await classifyPrSource(
+      makePr({ labels: [{ name: 'claude-authored' }] }),
+      makeOctokit(),
+      makeConfig(),
+    );
+    expect(result.source).toBe('agent');
+    expect(result.agentKind).toBe('claude');
+    expect(result.matchedRule).toBe('label');
+  });
+
+  it('is case-insensitive on label match', async () => {
+    const result = await classifyPrSource(
+      makePr({ labels: [{ name: 'AI-Generated' }] }),
+      makeOctokit(),
+      makeConfig(),
+    );
+    expect(result.source).toBe('agent');
+    expect(result.matchedRule).toBe('label');
+  });
+
+  it('classifies as agent when head branch starts with a configured prefix', async () => {
+    const result = await classifyPrSource(
+      makePr({ head: { ...makePr().head, ref: 'claude/fix-bug' } }),
+      makeOctokit(),
+      makeConfig(),
+    );
+    expect(result.source).toBe('agent');
+    expect(result.matchedRule).toBe('branch');
+    expect(result.agentKind).toBe('claude');
+  });
+
+  it('derives agentKind=cursor from cursor/ prefix', async () => {
+    const result = await classifyPrSource(
+      makePr({ head: { ...makePr().head, ref: 'cursor/refactor' } }),
+      makeOctokit(),
+      makeConfig(),
+    );
+    expect(result.agentKind).toBe('cursor');
+  });
+
+  it('calls listCommits only when commitTrailers is non-empty', async () => {
+    const octokit = makeOctokit();
+    await classifyPrSource(
+      makePr(),
+      octokit,
+      makeConfig({ detection: { commitTrailers: [], branchPrefixes: [], labels: [] } }),
+    );
+    expect((octokit.pulls.listCommits as any)).not.toHaveBeenCalled();
+  });
+
+  it('classifies as agent when a configured commit trailer is found', async () => {
+    const octokit = makeOctokit(() => ({
+      data: [
+        { commit: { message: 'chore: bump deps\n\nCo-authored-by: Claude <noreply@anthropic.com>' } },
+      ],
+    }));
+    const result = await classifyPrSource(makePr(), octokit, makeConfig());
+    expect(result.source).toBe('agent');
+    expect(result.matchedRule).toBe('trailer');
+    expect(result.agentKind).toBe('claude');
+  });
+
+  it('returns human when no rules match', async () => {
+    const octokit = makeOctokit(() => ({
+      data: [{ commit: { message: 'Unrelated commit message' } }],
+    }));
+    const result = await classifyPrSource(makePr(), octokit, makeConfig());
+    expect(result).toEqual({ source: 'human' });
+  });
+
+  it('falls back to human when listCommits throws', async () => {
+    const octokit = makeOctokit(() => {
+      throw new Error('API rate limit exceeded');
+    });
+    // Silence the warn log
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = await classifyPrSource(makePr(), octokit, makeConfig());
+    expect(result).toEqual({ source: 'human' });
+    spy.mockRestore();
+  });
+
+  it('label match wins over branch match (order matters)', async () => {
+    const result = await classifyPrSource(
+      makePr({
+        labels: [{ name: 'ai-generated' }],
+        head: { ...makePr().head, ref: 'claude/fix' },
+      }),
+      makeOctokit(),
+      makeConfig(),
+    );
+    expect(result.matchedRule).toBe('label');
+    expect(result.agentKind).toBe('other');
+  });
+
+  it('branch match wins over trailer match (order matters)', async () => {
+    const listCommits = vi.fn(() => ({
+      data: [{ commit: { message: 'Co-authored-by: Claude' } }],
+    }));
+    const octokit = {
+      pulls: { listCommits },
+    } as unknown as Octokit;
+    const result = await classifyPrSource(
+      makePr({ head: { ...makePr().head, ref: 'cursor/refactor' } }),
+      octokit,
+      makeConfig(),
+    );
+    expect(result.matchedRule).toBe('branch');
+    expect(result.agentKind).toBe('cursor');
+    // listCommits should not have been invoked since branch matched first
+    expect(listCommits).not.toHaveBeenCalled();
+  });
+
+  it('defaults agentKind to "other" when no kind keyword is in the matched string', async () => {
+    const result = await classifyPrSource(
+      makePr({ head: { ...makePr().head, ref: 'bot/something' } }),
+      makeOctokit(),
+      makeConfig({
+        detection: {
+          commitTrailers: [],
+          branchPrefixes: ['bot/'],
+          labels: [],
+        },
+      }),
+    );
+    expect(result.source).toBe('agent');
+    expect(result.agentKind).toBe('other');
+  });
+});

--- a/packages/core/src/agent-detection.ts
+++ b/packages/core/src/agent-detection.ts
@@ -1,0 +1,114 @@
+/**
+ * PR-source classification: agent-authored vs human-authored.
+ *
+ * Called on the webhook path before enqueuing a review job so that downstream
+ * runtimes (Lambda review-agent, Express review-processor) know whether to
+ * inject the agent-mode prompt suffix and persist `source` / `agentKind` on
+ * the ReviewItem.
+ *
+ * Detection is best-effort — if the Octokit call for commit trailers fails
+ * we fall back to 'human' rather than failing the whole webhook delivery.
+ *
+ * Rule ordering (label > branch > trailer) is important: labels are the
+ * cheapest and most explicit signal, branch prefixes are zero-API, and commit
+ * trailers require a paged API call so they run last.
+ */
+import type { Octokit } from '@octokit/rest';
+import type { GitHubPullRequest } from './types/github.js';
+import type { AgentReviewConfig } from './config/defaults.js';
+
+export type AgentKind = 'claude' | 'cursor' | 'codex' | 'other';
+
+export interface ClassificationResult {
+  source: 'agent' | 'human';
+  agentKind?: AgentKind;
+  /** Which rule matched (for logging / debugging). */
+  matchedRule?: 'trailer' | 'branch' | 'label';
+}
+
+/**
+ * Map a matched string (label name, branch prefix, or trailer fragment) to an
+ * AgentKind via lowercase substring match. Falls back to 'other' so we always
+ * tag the review with *something* when a detection rule fires.
+ */
+function kindFromString(value: string): AgentKind {
+  const lower = value.toLowerCase();
+  if (lower.includes('claude')) return 'claude';
+  if (lower.includes('cursor')) return 'cursor';
+  if (lower.includes('codex')) return 'codex';
+  return 'other';
+}
+
+function kindFromLabel(label: string): AgentKind {
+  return kindFromString(label);
+}
+
+function kindFromBranch(prefix: string): AgentKind {
+  return kindFromString(prefix);
+}
+
+function kindFromTrailer(trailer: string): AgentKind {
+  return kindFromString(trailer);
+}
+
+/**
+ * Classify a PR as agent- or human-authored using the configured detection
+ * heuristics. Returns 'human' when detection is disabled or no rule matches.
+ */
+export async function classifyPrSource(
+  pr: GitHubPullRequest,
+  octokit: Octokit,
+  config: AgentReviewConfig | undefined,
+): Promise<ClassificationResult> {
+  if (!config || !config.enabled) return { source: 'human' };
+
+  // 1. Label check — cheapest signal, no API call.
+  const labelNames = (pr.labels ?? []).map((l) => l.name.toLowerCase());
+  for (const match of config.detection.labels) {
+    if (labelNames.includes(match.toLowerCase())) {
+      return { source: 'agent', agentKind: kindFromLabel(match), matchedRule: 'label' };
+    }
+  }
+
+  // 2. Branch prefix check — also zero API call.
+  const head = pr.head?.ref ?? '';
+  const headLower = head.toLowerCase();
+  for (const prefix of config.detection.branchPrefixes) {
+    if (headLower.startsWith(prefix.toLowerCase())) {
+      return { source: 'agent', agentKind: kindFromBranch(prefix), matchedRule: 'branch' };
+    }
+  }
+
+  // 3. Commit trailers — one API call. Skipped when no trailers configured.
+  if (config.detection.commitTrailers.length > 0) {
+    try {
+      const { data: commits } = await octokit.pulls.listCommits({
+        owner: pr.base.repo.owner.login,
+        repo: pr.base.repo.name,
+        pull_number: pr.number,
+        per_page: 100,
+      });
+      for (const commit of commits) {
+        const msg = commit.commit.message ?? '';
+        for (const trailer of config.detection.commitTrailers) {
+          if (msg.includes(trailer)) {
+            return { source: 'agent', agentKind: kindFromTrailer(trailer), matchedRule: 'trailer' };
+          }
+        }
+      }
+    } catch (err) {
+      // Best-effort: if the API call fails, treat as human rather than crashing
+      // the whole webhook. We log so operators can diagnose quota / auth issues.
+      console.warn(
+        'classifyPrSource: listCommits failed for %s/%s#%d — falling back to human:',
+        pr.base.repo.owner.login,
+        pr.base.repo.name,
+        pr.number,
+        err,
+      );
+      return { source: 'human' };
+    }
+  }
+
+  return { source: 'human' };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -146,6 +146,10 @@ export type { FileFetchOptions, AgenticInvokeResult } from './context/agentic-fe
 // ─── Skip logic ─────────────────────────────────────────────────────────────
 export { shouldSkipPR, shouldSkipByRules, SKIP_PATTERNS } from './skip-logic.js';
 
+// ─── Agent-authored PR detection ────────────────────────────────────────────
+export { classifyPrSource } from './agent-detection.js';
+export type { AgentKind, ClassificationResult } from './agent-detection.js';
+
 // ─── Diff filtering ─────────────────────────────────────────────────────────
 export { filterDiff, extractChangedLines, isLineNearChange } from './diff-filter.js';
 

--- a/packages/core/src/types/github.ts
+++ b/packages/core/src/types/github.ts
@@ -256,4 +256,12 @@ export interface ReviewJobPayload {
    * root to reconstruct conversation context.
    */
   inlineReplyCommentId?: number;
+  /**
+   * PR source classification populated by the webhook handler via
+   * classifyPrSource. When 'agent', the review agent injects the agent-mode
+   * prompt suffix and persists source/agentKind onto the ReviewItem.
+   */
+  source?: 'agent' | 'human';
+  /** Agent kind when source='agent' (derived from whichever detection rule matched). */
+  agentKind?: 'claude' | 'cursor' | 'codex' | 'other';
 }

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -278,6 +278,8 @@ export async function handler(
       baseBranch: prContext.baseBranch,
       installationId: String(installationId),
       skipReason,
+      source: event.source,
+      agentKind: event.agentKind,
     };
     await reviewStore.upsert(skippedRecord);
 
@@ -329,6 +331,8 @@ export async function handler(
     headBranch: prContext.headBranch,
     baseBranch: prContext.baseBranch,
     installationId: String(installationId),
+    source: event.source,
+    agentKind: event.agentKind,
   };
   const claimed = await reviewStore.claimReview(reviewRecord);
   if (!claimed) {
@@ -476,6 +480,7 @@ export async function handler(
       previousDiagram,
       previousFindings: prevComplete?.findings,
       conventions: conventionsResult?.content,
+      agentAuthored: event.source === 'agent',
     }, { llm });
 
     const reviewDetailUrl = `${DASHBOARD_BASE_URL}/dashboard/reviews/${encodeURIComponent(`${repoFullName}:${prNumberCommitSha}`)}`;

--- a/packages/lambda/src/handlers/webhook.test.ts
+++ b/packages/lambda/src/handlers/webhook.test.ts
@@ -1,8 +1,58 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createHmac } from 'node:crypto';
-import { verifySignature, parseReviewMode, shouldHandleReviewCommentEvent } from './webhook.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before importing the handler so the module sees
+// mocked versions of @mergewatch/core, the AWS SDKs, and the SSM auth provider.
+// ---------------------------------------------------------------------------
+
+const mockEnqueue = vi.fn().mockResolvedValue({});
+const mockFindExistingBotComment = vi.fn().mockResolvedValue(null);
+const mockFetchRepoConfig = vi.fn();
+const mockClassifyPrSource = vi.fn();
+const mockGetInstallationOctokit = vi.fn();
+
+vi.mock('@mergewatch/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@mergewatch/core')>();
+  return {
+    ...actual,
+    findExistingBotComment: (...args: unknown[]) => mockFindExistingBotComment(...args),
+    fetchRepoConfig: (...args: unknown[]) => mockFetchRepoConfig(...args),
+    classifyPrSource: (...args: unknown[]) => mockClassifyPrSource(...args),
+  };
+});
+
+vi.mock('@aws-sdk/client-lambda', () => ({
+  LambdaClient: class {
+    send(cmd: unknown) { return mockEnqueue(cmd); }
+  },
+  InvokeCommand: class {
+    input: unknown;
+    constructor(input: unknown) { this.input = input; }
+  },
+  InvocationType: { Event: 'Event' },
+}));
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: class { send() { return Promise.resolve({}); } },
+}));
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: () => ({ send: () => Promise.resolve({}) }),
+  },
+  PutCommand: class { input: unknown; constructor(input: unknown) { this.input = input; } },
+}));
+
+vi.mock('../github-auth-ssm.js', () => ({
+  SSMGitHubAuthProvider: class {
+    getInstallationOctokit(id: number) { return mockGetInstallationOctokit(id); }
+  },
+  getWebhookSecret: () => Promise.resolve('test-secret'),
+}));
+
+import { verifySignature, parseReviewMode, shouldHandleReviewCommentEvent, handler } from './webhook.js';
 import { REVIEW_TRIGGERING_ACTIONS, COMMENT_LOOKUP_ACTIONS } from '@mergewatch/core';
-import type { PullRequestReviewCommentEvent } from '@mergewatch/core';
+import type { PullRequestReviewCommentEvent, PullRequestEvent } from '@mergewatch/core';
 
 // ---------------------------------------------------------------------------
 // verifySignature
@@ -161,5 +211,169 @@ describe('shouldHandleReviewCommentEvent', () => {
     const evt = makeEvent();
     evt.installation = undefined;
     expect(shouldHandleReviewCommentEvent(evt)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handler — agent-source classification on pull_request events
+// ---------------------------------------------------------------------------
+
+function signBody(body: string, secret = 'test-secret'): string {
+  return 'sha256=' + createHmac('sha256', secret).update(body).digest('hex');
+}
+
+function makePullRequestEvent(overrides: Partial<PullRequestEvent> = {}): PullRequestEvent {
+  return {
+    action: 'opened',
+    number: 7,
+    pull_request: {
+      number: 7,
+      title: 'Automated change',
+      body: null,
+      state: 'open',
+      html_url: 'https://github.com/octo/repo/pull/7',
+      head: {
+        label: 'octo:claude/fix-bug',
+        ref: 'claude/fix-bug',
+        sha: 'abc123',
+        repo: {
+          id: 1,
+          name: 'repo',
+          full_name: 'octo/repo',
+          owner: { login: 'octo', id: 1, avatar_url: '', type: 'User' },
+          private: false,
+          html_url: '',
+          default_branch: 'main',
+        },
+      },
+      base: {
+        label: 'octo:main',
+        ref: 'main',
+        sha: 'def456',
+        repo: {
+          id: 1,
+          name: 'repo',
+          full_name: 'octo/repo',
+          owner: { login: 'octo', id: 1, avatar_url: '', type: 'User' },
+          private: false,
+          html_url: '',
+          default_branch: 'main',
+        },
+      },
+      user: { login: 'alice', id: 1, avatar_url: '', type: 'User' },
+      draft: false,
+      labels: [],
+      created_at: '2026-04-01T00:00:00Z',
+      updated_at: '2026-04-01T00:00:00Z',
+    },
+    repository: {
+      id: 1,
+      name: 'repo',
+      full_name: 'octo/repo',
+      owner: { login: 'octo', id: 1, avatar_url: '', type: 'User' },
+      private: false,
+      html_url: '',
+      default_branch: 'main',
+    },
+    installation: { id: 999 },
+    sender: { login: 'alice', id: 1, avatar_url: '', type: 'User' },
+    ...overrides,
+  };
+}
+
+function makeApiGatewayEvent(body: string): any {
+  return {
+    body,
+    headers: {
+      'x-hub-signature-256': signBody(body),
+      'x-github-event': 'pull_request',
+    },
+  };
+}
+
+describe('handler — agent-source classification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetInstallationOctokit.mockResolvedValue({});
+    mockFetchRepoConfig.mockResolvedValue(null);
+  });
+
+  it('propagates source=agent and agentKind into the enqueued payload', async () => {
+    mockFetchRepoConfig.mockResolvedValue({
+      agentReview: { enabled: true, detection: { branchPrefixes: ['claude/'] } },
+    });
+    mockClassifyPrSource.mockResolvedValue({
+      source: 'agent',
+      agentKind: 'claude',
+      matchedRule: 'branch',
+    });
+
+    const body = JSON.stringify(makePullRequestEvent());
+    const res = await handler(makeApiGatewayEvent(body));
+
+    expect(res.statusCode).toBe(200);
+    expect(mockClassifyPrSource).toHaveBeenCalledTimes(1);
+    expect(mockEnqueue).toHaveBeenCalledTimes(1);
+    const invokeInput = (mockEnqueue.mock.calls[0][0] as { input: { Payload: Buffer } }).input;
+    const payload = JSON.parse(invokeInput.Payload.toString());
+    expect(payload.source).toBe('agent');
+    expect(payload.agentKind).toBe('claude');
+  });
+
+  it('passes undefined agentReview config when repo YAML has no agentReview block', async () => {
+    mockFetchRepoConfig.mockResolvedValue(null);
+    mockClassifyPrSource.mockResolvedValue({ source: 'human' });
+
+    const body = JSON.stringify(makePullRequestEvent());
+    await handler(makeApiGatewayEvent(body));
+
+    expect(mockClassifyPrSource).toHaveBeenCalledTimes(1);
+    // Third argument to classifyPrSource is the agentReview config.
+    const callArgs = mockClassifyPrSource.mock.calls[0];
+    expect(callArgs[2]).toBeUndefined();
+  });
+
+  it('populates agentReview config when repo YAML opts in', async () => {
+    mockFetchRepoConfig.mockResolvedValue({
+      agentReview: { enabled: true },
+    });
+    mockClassifyPrSource.mockResolvedValue({ source: 'human' });
+
+    const body = JSON.stringify(makePullRequestEvent());
+    await handler(makeApiGatewayEvent(body));
+
+    const callArgs = mockClassifyPrSource.mock.calls[0];
+    expect(callArgs[2]).toBeDefined();
+    expect(callArgs[2].enabled).toBe(true);
+    // mergeConfig fills the detection block with defaults.
+    expect(callArgs[2].detection).toBeDefined();
+  });
+
+  it('propagates source=human when classifier returns human', async () => {
+    mockFetchRepoConfig.mockResolvedValue(null);
+    mockClassifyPrSource.mockResolvedValue({ source: 'human' });
+
+    const body = JSON.stringify(makePullRequestEvent());
+    await handler(makeApiGatewayEvent(body));
+
+    const invokeInput = (mockEnqueue.mock.calls[0][0] as { input: { Payload: Buffer } }).input;
+    const payload = JSON.parse(invokeInput.Payload.toString());
+    expect(payload.source).toBe('human');
+    expect(payload.agentKind).toBeUndefined();
+  });
+
+  it('runs classification on synchronize events (not only opened)', async () => {
+    mockFetchRepoConfig.mockResolvedValue(null);
+    mockClassifyPrSource.mockResolvedValue({ source: 'human' });
+    mockFindExistingBotComment.mockResolvedValue(123);
+
+    const body = JSON.stringify(makePullRequestEvent({ action: 'synchronize' }));
+    await handler(makeApiGatewayEvent(body));
+
+    expect(mockClassifyPrSource).toHaveBeenCalledTimes(1);
+    const invokeInput = (mockEnqueue.mock.calls[0][0] as { input: { Payload: Buffer } }).input;
+    const payload = JSON.parse(invokeInput.Payload.toString());
+    expect(payload.source).toBe('human');
+    expect(payload.existingCommentId).toBe(123);
   });
 });

--- a/packages/lambda/src/handlers/webhook.ts
+++ b/packages/lambda/src/handlers/webhook.ts
@@ -18,6 +18,9 @@ import {
   findExistingBotComment,
   REVIEW_TRIGGERING_ACTIONS,
   COMMENT_LOOKUP_ACTIONS,
+  classifyPrSource,
+  fetchRepoConfig,
+  mergeConfig,
 } from '@mergewatch/core';
 import type {
   PullRequestEvent,
@@ -26,6 +29,7 @@ import type {
   InstallationEvent,
   ReviewMode,
   ReviewJobPayload,
+  AgentReviewConfig,
 } from '@mergewatch/core';
 import { SSMGitHubAuthProvider, getWebhookSecret } from '../github-auth-ssm.js';
 
@@ -155,14 +159,27 @@ async function handlePullRequestEvent(
   const repo = repository.name;
   const prNumber = pr.number;
 
+  // We always need an Octokit now for classification (and, for re-open /
+  // synchronize actions, also for the existing-comment lookup).
+  const octokit = await authProvider.getInstallationOctokit(installationId);
+
   let existingCommentId: number | undefined;
   if ((COMMENT_LOOKUP_ACTIONS as readonly string[]).includes(action)) {
-    const octokit = await authProvider.getInstallationOctokit(installationId);
     const commentId = await findExistingBotComment(octokit, owner, repo, prNumber);
     if (commentId) {
       existingCommentId = commentId;
     }
   }
+
+  // Resolve agentReview config (repo YAML overrides defaults) and classify
+  // the PR source. Only opt-in via .mergewatch.yml triggers detection —
+  // when the repo has no agentReview block we pass undefined, which short-
+  // circuits the classifier to 'human'.
+  const yamlConfig = await fetchRepoConfig(octokit, owner, repo).catch(() => null);
+  const agentReviewConfig: AgentReviewConfig | undefined = yamlConfig?.agentReview
+    ? mergeConfig(yamlConfig).agentReview
+    : undefined;
+  const classification = await classifyPrSource(pr, octokit, agentReviewConfig);
 
   await enqueueReviewJob({
     installationId,
@@ -174,8 +191,13 @@ async function handlePullRequestEvent(
     isDraft: pr.draft ?? false,
     prLabels: pr.labels?.map((l) => l.name) ?? [],
     changedFileCount: pr.changed_files,
+    source: classification.source,
+    agentKind: classification.agentKind,
   });
 
+  console.log(
+    `Classified ${owner}/${repo}#${prNumber} as ${classification.source}${classification.agentKind ? ' (' + classification.agentKind + ')' : ''} via ${classification.matchedRule ?? 'default'}`,
+  );
   console.log(
     `Enqueued review job: ${owner}/${repo}#${prNumber} (action=${action}, existingComment=${existingCommentId ?? "none"})`
   );

--- a/packages/server/src/review-processor.test.ts
+++ b/packages/server/src/review-processor.test.ts
@@ -538,3 +538,58 @@ describe('processReviewJob — inline_reply mode', () => {
     expect(runReviewPipeline).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// agent-authored PR wiring — source/agentKind persisted + agentAuthored passed
+// ---------------------------------------------------------------------------
+
+describe('processReviewJob — agent-authored wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getPRContext as any).mockResolvedValue(basePRContext);
+    (getPRDiff as any).mockResolvedValue('diff content');
+    (shouldSkipPR as any).mockReturnValue(null);
+    (shouldSkipByRules as any).mockReturnValue(null);
+    (runReviewPipeline as any).mockResolvedValue(basePipelineResult);
+  });
+
+  it('persists source and agentKind on the claimed review record', async () => {
+    const deps = makeDeps();
+    await processReviewJob(
+      makeJob({ source: 'agent', agentKind: 'claude' }),
+      deps,
+    );
+
+    expect(deps.reviewStore.claimReview).toHaveBeenCalledTimes(1);
+    const claimed = (deps.reviewStore.claimReview as any).mock.calls[0][0];
+    expect(claimed.source).toBe('agent');
+    expect(claimed.agentKind).toBe('claude');
+  });
+
+  it('passes agentAuthored=true into runReviewPipeline when source is agent', async () => {
+    const deps = makeDeps();
+    await processReviewJob(
+      makeJob({ source: 'agent', agentKind: 'claude' }),
+      deps,
+    );
+
+    const pipelineOptions = (runReviewPipeline as any).mock.calls[0][0];
+    expect(pipelineOptions.agentAuthored).toBe(true);
+  });
+
+  it('passes agentAuthored=false into runReviewPipeline when source is human', async () => {
+    const deps = makeDeps();
+    await processReviewJob(makeJob({ source: 'human' }), deps);
+
+    const pipelineOptions = (runReviewPipeline as any).mock.calls[0][0];
+    expect(pipelineOptions.agentAuthored).toBe(false);
+  });
+
+  it('passes agentAuthored=false when source is missing (back-compat)', async () => {
+    const deps = makeDeps();
+    await processReviewJob(makeJob(), deps);
+
+    const pipelineOptions = (runReviewPipeline as any).mock.calls[0][0];
+    expect(pipelineOptions.agentAuthored).toBe(false);
+  });
+});

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -197,6 +197,8 @@ export async function processReviewJob(
     headBranch: prContext.headBranch,
     baseBranch: prContext.baseBranch,
     installationId: instId,
+    source: job.source,
+    agentKind: job.agentKind,
   });
   if (!claimed) {
     console.log(`Review already in progress for ${repoFullName}#${prNumber}@${shortSha}, skipping`);
@@ -353,6 +355,7 @@ export async function processReviewJob(
         previousDiagram,
         previousFindings: prevComplete?.findings,
         conventions: conventionsResult?.content,
+        agentAuthored: job.source === 'agent',
       },
       { llm: deps.llm },
     );

--- a/packages/server/src/webhook-handler.test.ts
+++ b/packages/server/src/webhook-handler.test.ts
@@ -1,6 +1,30 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createHmac } from 'crypto';
-import { verifySignature, parseReviewMode } from './webhook-handler.js';
+
+// Mock the review-processor BEFORE importing the webhook handler so we can
+// capture the ReviewJobPayload it's handed without actually running a review.
+const mockProcessReviewJob = vi.fn().mockResolvedValue(undefined);
+vi.mock('./review-processor.js', () => ({
+  processReviewJob: (...args: unknown[]) => mockProcessReviewJob(...args),
+}));
+
+const mockFindExistingBotComment = vi.fn().mockResolvedValue(null);
+const mockFetchRepoConfig = vi.fn().mockResolvedValue(null);
+const mockClassifyPrSource = vi.fn().mockResolvedValue({ source: 'human' });
+
+vi.mock('@mergewatch/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@mergewatch/core')>();
+  return {
+    ...actual,
+    findExistingBotComment: (...args: unknown[]) => mockFindExistingBotComment(...args),
+    fetchRepoConfig: (...args: unknown[]) => mockFetchRepoConfig(...args),
+    classifyPrSource: (...args: unknown[]) => mockClassifyPrSource(...args),
+  };
+});
+
+import { verifySignature, parseReviewMode, createWebhookHandler } from './webhook-handler.js';
+import type { WebhookDeps } from './webhook-handler.js';
+import type { IInstallationStore, IReviewStore, IGitHubAuthProvider, ILLMProvider, PullRequestEvent } from '@mergewatch/core';
 
 // ---------------------------------------------------------------------------
 // verifySignature
@@ -72,5 +96,189 @@ describe('parseReviewMode', () => {
 
   it('trims whitespace before checking', () => {
     expect(parseReviewMode('  @mergewatch summary  ')).toEqual({ mode: 'summary' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createWebhookHandler — agent-source classification on pull_request events
+// ---------------------------------------------------------------------------
+
+function makePullRequestEvent(overrides: Partial<PullRequestEvent> = {}): PullRequestEvent {
+  return {
+    action: 'opened',
+    number: 7,
+    pull_request: {
+      number: 7,
+      title: 'Automated change',
+      body: null,
+      state: 'open',
+      html_url: 'https://github.com/octo/repo/pull/7',
+      head: {
+        label: 'octo:claude/fix-bug',
+        ref: 'claude/fix-bug',
+        sha: 'abc123',
+        repo: {
+          id: 1,
+          name: 'repo',
+          full_name: 'octo/repo',
+          owner: { login: 'octo', id: 1, avatar_url: '', type: 'User' },
+          private: false,
+          html_url: '',
+          default_branch: 'main',
+        },
+      },
+      base: {
+        label: 'octo:main',
+        ref: 'main',
+        sha: 'def456',
+        repo: {
+          id: 1,
+          name: 'repo',
+          full_name: 'octo/repo',
+          owner: { login: 'octo', id: 1, avatar_url: '', type: 'User' },
+          private: false,
+          html_url: '',
+          default_branch: 'main',
+        },
+      },
+      user: { login: 'alice', id: 1, avatar_url: '', type: 'User' },
+      draft: false,
+      labels: [],
+      created_at: '2026-04-01T00:00:00Z',
+      updated_at: '2026-04-01T00:00:00Z',
+    },
+    repository: {
+      id: 1,
+      name: 'repo',
+      full_name: 'octo/repo',
+      owner: { login: 'octo', id: 1, avatar_url: '', type: 'User' },
+      private: false,
+      html_url: '',
+      default_branch: 'main',
+    },
+    installation: { id: 999 },
+    sender: { login: 'alice', id: 1, avatar_url: '', type: 'User' },
+    ...overrides,
+  };
+}
+
+function makeDeps(): WebhookDeps {
+  return {
+    webhookSecret: 'test-secret',
+    installationStore: {
+      get: vi.fn(),
+      getSettings: vi.fn(),
+      upsert: vi.fn(),
+    } as unknown as IInstallationStore,
+    reviewStore: {
+      claimReview: vi.fn(),
+      updateStatus: vi.fn(),
+      queryByPR: vi.fn(),
+      upsert: vi.fn(),
+    } as unknown as IReviewStore,
+    authProvider: {
+      getInstallationOctokit: vi.fn().mockResolvedValue({}),
+    } as unknown as IGitHubAuthProvider,
+    llm: { invoke: vi.fn() } as unknown as ILLMProvider,
+    dashboardBaseUrl: 'https://mergewatch.ai',
+  };
+}
+
+function signBody(body: string, secret = 'test-secret'): string {
+  return 'sha256=' + createHmac('sha256', secret).update(body).digest('hex');
+}
+
+function makeReqRes(rawBody: string, event = 'pull_request') {
+  const req = {
+    headers: {
+      'x-hub-signature-256': signBody(rawBody),
+      'x-github-event': event,
+    },
+    body: JSON.parse(rawBody),
+    rawBody,
+  } as any;
+  const status = vi.fn().mockReturnThis();
+  const json = vi.fn().mockReturnThis();
+  const res = { status, json } as any;
+  return { req, res };
+}
+
+describe('createWebhookHandler — pull_request classification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchRepoConfig.mockResolvedValue(null);
+    mockClassifyPrSource.mockResolvedValue({ source: 'human' });
+    mockFindExistingBotComment.mockResolvedValue(null);
+  });
+
+  it('propagates source=agent and agentKind into the review job', async () => {
+    mockFetchRepoConfig.mockResolvedValue({
+      agentReview: { enabled: true, detection: { branchPrefixes: ['claude/'] } },
+    });
+    mockClassifyPrSource.mockResolvedValue({
+      source: 'agent',
+      agentKind: 'claude',
+      matchedRule: 'branch',
+    });
+
+    const deps = makeDeps();
+    const handler = createWebhookHandler(deps);
+    const body = JSON.stringify(makePullRequestEvent());
+    const { req, res } = makeReqRes(body);
+
+    await handler(req, res);
+    // processReviewJob is called fire-and-forget; await a microtask so the
+    // awaited classification chain completes before we assert.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(mockClassifyPrSource).toHaveBeenCalledTimes(1);
+    expect(mockProcessReviewJob).toHaveBeenCalledTimes(1);
+    const job = mockProcessReviewJob.mock.calls[0][0];
+    expect(job.source).toBe('agent');
+    expect(job.agentKind).toBe('claude');
+  });
+
+  it('passes source=human when classifier returns human', async () => {
+    const deps = makeDeps();
+    const handler = createWebhookHandler(deps);
+    const body = JSON.stringify(makePullRequestEvent());
+    const { req, res } = makeReqRes(body);
+
+    await handler(req, res);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const job = mockProcessReviewJob.mock.calls[0][0];
+    expect(job.source).toBe('human');
+    expect(job.agentKind).toBeUndefined();
+  });
+
+  it('passes undefined agentReview config when YAML lacks agentReview', async () => {
+    mockFetchRepoConfig.mockResolvedValue(null);
+    const deps = makeDeps();
+    const handler = createWebhookHandler(deps);
+    const body = JSON.stringify(makePullRequestEvent());
+    const { req, res } = makeReqRes(body);
+
+    await handler(req, res);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const callArgs = mockClassifyPrSource.mock.calls[0];
+    expect(callArgs[2]).toBeUndefined();
+  });
+
+  it('populates agentReview config when YAML opts in', async () => {
+    mockFetchRepoConfig.mockResolvedValue({ agentReview: { enabled: true } });
+    const deps = makeDeps();
+    const handler = createWebhookHandler(deps);
+    const body = JSON.stringify(makePullRequestEvent());
+    const { req, res } = makeReqRes(body);
+
+    await handler(req, res);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const callArgs = mockClassifyPrSource.mock.calls[0];
+    expect(callArgs[2]).toBeDefined();
+    expect(callArgs[2].enabled).toBe(true);
+    expect(callArgs[2].detection).toBeDefined();
   });
 });

--- a/packages/server/src/webhook-handler.ts
+++ b/packages/server/src/webhook-handler.ts
@@ -1,8 +1,8 @@
 import { createHmac, timingSafeEqual } from 'crypto';
 import type { Request, Response } from 'express';
-import type { IInstallationStore, IReviewStore, IGitHubAuthProvider, ILLMProvider } from '@mergewatch/core';
+import type { IInstallationStore, IReviewStore, IGitHubAuthProvider, ILLMProvider, AgentReviewConfig } from '@mergewatch/core';
 import type { ReviewJobPayload, ReviewMode, PullRequestEvent, IssueCommentEvent, PullRequestReviewCommentEvent, InstallationEvent } from '@mergewatch/core';
-import { REVIEW_TRIGGERING_ACTIONS, COMMENT_LOOKUP_ACTIONS, findExistingBotComment } from '@mergewatch/core';
+import { REVIEW_TRIGGERING_ACTIONS, COMMENT_LOOKUP_ACTIONS, findExistingBotComment, classifyPrSource, fetchRepoConfig, mergeConfig } from '@mergewatch/core';
 import { processReviewJob } from './review-processor.js';
 
 export interface WebhookDeps {
@@ -64,30 +64,58 @@ async function handlePullRequest(payload: PullRequestEvent, deps: WebhookDeps) {
   const { action, pull_request, repository, installation } = payload;
   if (!installation || !(REVIEW_TRIGGERING_ACTIONS as readonly string[]).includes(action)) return;
 
-  // Look for existing bot comment to update (not on first open)
+  const owner = repository.owner.login;
+  const repo = repository.name;
+  const prNumber = pull_request.number;
+
+  // Resolve an Octokit up front — we need it for classification and,
+  // conditionally, for the existing-comment lookup on re-open / sync.
+  let octokit: Awaited<ReturnType<IGitHubAuthProvider['getInstallationOctokit']>> | null = null;
+  try {
+    octokit = await deps.authProvider.getInstallationOctokit(installation.id);
+  } catch (err) {
+    console.warn('Failed to obtain installation Octokit for classification:', err);
+  }
+
   let existingCommentId: number | undefined;
-  if ((COMMENT_LOOKUP_ACTIONS as readonly string[]).includes(action)) {
+  if (octokit && (COMMENT_LOOKUP_ACTIONS as readonly string[]).includes(action)) {
     try {
-      const octokit = await deps.authProvider.getInstallationOctokit(installation.id);
-      const commentId = await findExistingBotComment(
-        octokit, repository.owner.login, repository.name, pull_request.number,
-      );
+      const commentId = await findExistingBotComment(octokit, owner, repo, prNumber);
       if (commentId) existingCommentId = commentId;
     } catch (err) {
       console.warn('Failed to look up existing bot comment:', err);
     }
   }
 
+  // Classify PR source when we have an Octokit. The classifier itself handles
+  // API failures internally and falls back to 'human'.
+  let source: 'agent' | 'human' | undefined;
+  let agentKind: ReviewJobPayload['agentKind'];
+  if (octokit) {
+    const yamlConfig = await fetchRepoConfig(octokit, owner, repo).catch(() => null);
+    const agentReviewConfig: AgentReviewConfig | undefined = yamlConfig?.agentReview
+      ? mergeConfig(yamlConfig).agentReview
+      : undefined;
+    const classification = await classifyPrSource(pull_request, octokit, agentReviewConfig);
+    source = classification.source;
+    agentKind = classification.agentKind;
+    console.log(
+      `Classified ${owner}/${repo}#${prNumber} as ${classification.source}${classification.agentKind ? ' (' + classification.agentKind + ')' : ''} via ${classification.matchedRule ?? 'default'}`,
+    );
+  }
+
   const job: ReviewJobPayload = {
     installationId: installation.id,
-    owner: repository.owner.login,
-    repo: repository.name,
-    prNumber: pull_request.number,
+    owner,
+    repo,
+    prNumber,
     mode: 'review',
     existingCommentId,
     isDraft: pull_request.draft ?? false,
     prLabels: pull_request.labels?.map((l) => l.name) ?? [],
     changedFileCount: pull_request.changed_files,
+    source,
+    agentKind,
   };
 
   // Process in background


### PR DESCRIPTION
## Summary
- Adds `@mergewatch/core` helper `classifyPrSource(pr, octokit, config)` that classifies a PR as agent- vs human-authored using the `agentReview.detection` heuristics (label > branch prefix > commit trailer), with graceful fallback to `human` on Octokit errors.
- Wires classification through the SaaS (Lambda) and self-hosted (Express) webhook paths. The result is persisted on `ReviewItem.source` / `ReviewItem.agentKind` and surfaced as `agentAuthored` on `runReviewPipeline` options so the agent-mode prompt suffix is injected when appropriate.
- Only opts in when `.mergewatch.yml` defines an `agentReview` block — otherwise `classifyPrSource` is called with `undefined` config and short-circuits to `human`.

## Implementation notes
- `classifyPrSource` calls `octokit.pulls.listCommits` **only** when `detection.commitTrailers` is non-empty; labels and branch prefixes are zero-API.
- Rule ordering is deliberate and tested: label wins over branch, branch wins over trailer.
- `agentKind` is derived from a substring match on the rule's configured string (`claude` / `cursor` / `codex`), falling back to `other`.

## Test plan
- [x] `pnpm --filter @mergewatch/core run test` — 310 tests pass (14 new cases in `agent-detection.test.ts`).
- [x] `pnpm --filter @mergewatch/lambda run test` — 32 tests pass (5 new `handler — agent-source classification` cases covering label, branch, trailer, synchronize, and undefined-YAML paths).
- [x] `pnpm --filter @mergewatch/server run test` — 50 tests pass (4 new webhook-handler cases + 4 new review-processor cases).
- [x] `pnpm run typecheck` across core / lambda / server — clean.
- [x] `pnpm run build` across core / lambda / server — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)