### PR TITLE
Add AGENTS.md with repo conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# Repo conventions
+
+MergeWatch auto-discovers this file and injects it into every review agent's
+prompt. Keep rules focused and brief — these are opt-outs and house patterns
+that override generic best-practice suggestions.
+
+## NextAuth session typing
+
+The dashboard accesses `accessToken` / `githubUserId` via `(session as any)`.
+This is the established pattern across ~24 call sites and is stamped on in
+`packages/dashboard/lib/auth.ts`. Do not flag individual `session as any`
+casts — the fix is a single NextAuth module augmentation, tracked as a
+separate cleanup.
+
+## Dashboard API route tests
+
+Routes under `packages/dashboard/app/api/**` do not have unit tests yet — no
+test harness is configured for the dashboard package. Do not flag missing
+test coverage for new routes here until the MCP auth work lands, which is
+when the dashboard test harness will be introduced.


### PR DESCRIPTION
## Summary
- MergeWatch auto-discovers `AGENTS.md` at repo root and injects it into every agent's prompt (no `.mergewatch.yml` change needed).
- Documents two opt-out rules that came up as noise on #109:
  - NextAuth `(session as any)` is the established dashboard pattern (~24 call sites, stamped on in `lib/auth.ts`) — the fix is a single module augmentation, not per-route edits.
  - Dashboard API routes under `packages/dashboard/app/api/**` have no test harness yet; missing-coverage findings there aren't actionable until MCP auth introduces one.

## Test plan
- [ ] Merge, then open a trivial dashboard PR and verify MergeWatch no longer flags `session as any` or missing dashboard API tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)