### PR TITLE
Strengthen dashboard test-coverage opt-out in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ separate cleanup.
 
 ## Dashboard API route tests
 
-Routes under `packages/dashboard/app/api/**` do not have unit tests yet — no
-test harness is configured for the dashboard package. Do not flag missing
-test coverage for new routes here until the MCP auth work lands, which is
-when the dashboard test harness will be introduced.
+Do NOT flag missing test coverage for files under
+`packages/dashboard/app/api/**` or `packages/dashboard/app/dashboard/**`.
+The dashboard package has no test harness configured — these findings are
+not actionable until one is introduced with the MCP auth work.


### PR DESCRIPTION
## Summary
Follow-up to #113. After merging AGENTS.md, re-reviewing #109 suppressed all three `session as any` findings but still flagged 5 test-coverage findings on the same routes the rule named.

Likely cause: the first version read as a future-state note ("until the MCP auth work lands") rather than a present directive. This PR rewrites the rule in the declarative style the docs' own AGENTS.md example uses:
- Explicit `Do NOT flag` verb
- Explicit path globs for both api routes and page files
- Present-tense framing

## Test plan
- [ ] Merge, re-trigger review on #109 with `@mergewatch review`, confirm the 5 test-coverage findings drop off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)