### PR TITLE
Self-heal BedrockLLMProvider on InvalidSignatureException

### DIFF
--- a/packages/llm-bedrock/src/bedrock-provider.test.ts
+++ b/packages/llm-bedrock/src/bedrock-provider.test.ts
@@ -160,6 +160,37 @@ describe('BedrockLLMProvider', () => {
     expect(provider).toBeDefined();
   });
 
+  it('self-heals from InvalidSignatureException with a client retry', async () => {
+    const sigErr = new Error('Signature expired: 20260422T222327Z is now earlier than ...');
+    sigErr.name = 'InvalidSignatureException';
+    mockSend
+      .mockRejectedValueOnce(sigErr)
+      .mockResolvedValueOnce(makeResponse({
+        content: [{ type: 'text', text: 'after retry' }],
+        usage: { input_tokens: 1, output_tokens: 1 },
+      }));
+
+    const provider = new BedrockLLMProvider();
+    const result = await provider.invoke(
+      'us.anthropic.claude-sonnet-4-20250514-v1:0', 'prompt',
+    );
+
+    expect(result.text).toBe('after retry');
+    expect(mockSend).toHaveBeenCalledTimes(2);
+  });
+
+  it('rethrows non-signature errors without retry', async () => {
+    const err = new Error('ThrottlingException: Rate exceeded');
+    err.name = 'ThrottlingException';
+    mockSend.mockRejectedValueOnce(err);
+
+    const provider = new BedrockLLMProvider();
+    await expect(
+      provider.invoke('us.anthropic.claude-sonnet-4-20250514-v1:0', 'prompt'),
+    ).rejects.toThrow('ThrottlingException: Rate exceeded');
+    expect(mockSend).toHaveBeenCalledTimes(1);
+  });
+
   it('handles Anthropic response with missing usage gracefully', async () => {
     mockSend.mockResolvedValueOnce(makeResponse({
       content: [{ type: 'text', text: 'no usage' }],

--- a/packages/llm-bedrock/src/bedrock-provider.ts
+++ b/packages/llm-bedrock/src/bedrock-provider.ts
@@ -113,11 +113,15 @@ function parseResponse(modelId: string, raw: string): ParsedResponse {
 
 export class BedrockLLMProvider implements ILLMProvider {
   private client: BedrockRuntimeClient;
+  private readonly region: string;
 
   constructor(region?: string) {
-    this.client = new BedrockRuntimeClient({
-      region: region ?? process.env.AWS_REGION ?? 'us-east-1',
-    });
+    this.region = region ?? process.env.AWS_REGION ?? 'us-east-1';
+    this.client = this.createClient();
+  }
+
+  private createClient(): BedrockRuntimeClient {
+    return new BedrockRuntimeClient({ region: this.region });
   }
 
   async invoke(modelId: string, prompt: string, maxTokens = 4096): Promise<LLMInvokeResult> {
@@ -130,9 +134,23 @@ export class BedrockLLMProvider implements ILLMProvider {
       accept,
     });
 
-    const response = await this.client.send(command);
+    const response = await this.sendWithSignatureRecovery(command);
     const rawResponse = new TextDecoder().decode(response.body);
     const parsed = parseResponse(modelId, rawResponse);
     return { text: parsed.text, usage: parsed.usage };
+  }
+
+  // Recover from SDK v3's poisoned systemClockOffset in long-lived warm Lambdas.
+  private async sendWithSignatureRecovery(command: InvokeModelCommand) {
+    try {
+      return await this.client.send(command);
+    } catch (err) {
+      if (err instanceof Error && err.name === 'InvalidSignatureException') {
+        console.warn('[bedrock] InvalidSignatureException — recreating client and retrying');
+        this.client = this.createClient();
+        return await this.client.send(command);
+      }
+      throw err;
+    }
   }
 }


### PR DESCRIPTION
## Root cause

PR #112 review failed repeatedly with `InvalidSignatureException: Signature expired: 20260422T222327Z is now earlier than ... (20260422T222828Z - 5 min.)`. CloudWatch logs from `/aws/lambda/mergewatch-review-agent-prod` revealed:

- Multiple Bedrock requests in one invocation all stamped with the exact same 22:23:27 signing time
- Lambda wall clock at 22:28:28 (correct)
- `attempts: 1, totalRetryDelay: 0` on each — not a retry storm
- All from the same warm container (`6de303fdf8c946e2ae42a629a7683fae`)

The Lambda clock was fine; the SDK was subtracting ~5 min from every signature. That's AWS SDK v3's `systemClockOffset` clock-skew-correction — it gets set after any clock-skew response from AWS and persists on the client. Since `BedrockLLMProvider` is a module-level singleton in `packages/lambda/src/handlers/review-agent.ts:70`, a poisoned offset sticks to the warm container and every `@mergewatch review` retrigger hits it again.

## Fix

Catch `InvalidSignatureException` in `invoke()`, rebuild the Bedrock client, and retry once. Non-signature errors propagate unchanged. Fast path is unaffected.

## Test plan
- [x] `pnpm --filter @mergewatch/llm-bedrock run test` — 12 pass (2 new: self-heal retry + non-signature rethrow)
- [x] `pnpm --filter @mergewatch/llm-bedrock run typecheck` clean
- [x] `pnpm --filter @mergewatch/lambda run typecheck` clean
- [ ] After merge + manual `pnpm run deploy`, confirm PR #112's `@mergewatch review` comment produces a review instead of erroring

## Unblocks
#112 and any other PR whose review hits a warm container with a poisoned offset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)