### PR TITLE
Mitigate Bedrock TPM throttling: longer retries + concurrency cap

### DIFF
--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -66,6 +66,41 @@ export interface ReviewContext {
   prBody?: string;
 }
 
+// ─── Concurrency control ───────────────────────────────────────────────────
+
+/**
+ * Cap on concurrent LLM calls inside the review pipeline. Bursting 8 parallel
+ * Bedrock InvokeModel calls on a large diff exceeds the per-minute TPM quota
+ * for claude-sonnet-4, producing "Too many tokens" throttling that the SDK's
+ * 3-attempt retry can't smooth over. Three parallel is a conservative default
+ * that still keeps end-to-end latency within typical targets.
+ */
+const AGENT_CONCURRENCY = 3;
+
+/**
+ * Run task factories with a bounded concurrency. Results are returned in the
+ * same order as the input. Any rejected task rejects the whole call — match
+ * Promise.all semantics so existing error handling still fires.
+ */
+async function withConcurrency<T>(
+  tasks: Array<() => Promise<T>>,
+  limit: number,
+): Promise<T[]> {
+  if (tasks.length === 0) return [];
+  const results: T[] = new Array(tasks.length);
+  let next = 0;
+  const workerCount = Math.min(limit, tasks.length);
+  const worker = async () => {
+    while (true) {
+      const i = next++;
+      if (i >= tasks.length) return;
+      results[i] = await tasks[i]();
+    }
+  };
+  await Promise.all(Array.from({ length: workerCount }, worker));
+  return results;
+}
+
 // ─── Helpers ───────────────────────────────────────────────────────────────
 
 /**
@@ -714,50 +749,55 @@ export async function runReviewPipeline(
   const accumulator = new TokenAccumulator();
   const llm = new TrackingLLMProvider(deps.llm, accumulator);
 
-  // Launch all enabled agents in parallel
+  // Launch all enabled agents with bounded concurrency (see AGENT_CONCURRENCY).
   // Note: summary and diagram agents don't get file fetching (they benefit less from deep context)
   const [
     securityFindings, bugFindings, styleFindings,
     errorHandlingFindings, testCoverageFindings, commentAccuracyFindings,
     summary, diagramResult,
-  ] = await Promise.all([
-    enabledAgents.security
+  ] = await withConcurrency<AgentFinding[] | string | DiagramResult>([
+    () => enabledAgents.security
       ? runSecurityAgent(diff, context, modelId, llm, fileFetchOptions, tone, conventions, agentAuthored)
       : Promise.resolve([]),
-    enabledAgents.bugs
+    () => enabledAgents.bugs
       ? runBugAgent(diff, context, modelId, llm, fileFetchOptions, tone, conventions, agentAuthored)
       : Promise.resolve([]),
-    enabledAgents.style
+    () => enabledAgents.style
       ? runStyleAgent(diff, context, modelId, llm, customStyleRules, fileFetchOptions, tone, conventions, agentAuthored)
       : Promise.resolve([]),
-    enabledAgents.errorHandling
+    () => enabledAgents.errorHandling
       ? runErrorHandlingAgent(diff, context, modelId, llm, fileFetchOptions, tone, conventions, agentAuthored)
       : Promise.resolve([]),
-    enabledAgents.testCoverage
+    () => enabledAgents.testCoverage
       ? runTestCoverageAgent(diff, context, modelId, llm, fileFetchOptions, tone, conventions, agentAuthored)
       : Promise.resolve([]),
-    enabledAgents.commentAccuracy
+    () => enabledAgents.commentAccuracy
       ? runCommentAccuracyAgent(diff, context, lightModelId, llm, fileFetchOptions, tone, conventions, agentAuthored)
       : Promise.resolve([]),
-    enabledAgents.summary
+    () => enabledAgents.summary
       ? runSummaryAgent(diff, context, lightModelId, llm, conventions, agentAuthored)
       : Promise.resolve(''),
-    enabledAgents.diagram
+    () => enabledAgents.diagram
       ? runDiagramAgent(diff, context, lightModelId, llm, previousDiagram)
       : Promise.resolve({ diagram: '', caption: '' } as DiagramResult),
-  ]);
+  ], AGENT_CONCURRENCY) as [
+    AgentFinding[], AgentFinding[], AgentFinding[],
+    AgentFinding[], AgentFinding[], AgentFinding[],
+    string, DiagramResult,
+  ];
 
-  // Run enabled custom agents in parallel
+  // Run enabled custom agents with the same concurrency cap.
   const enabledCustomAgents = customAgents.filter((a) => a.enabled);
   const customResults = enabledCustomAgents.length > 0
-    ? await Promise.all(
-        enabledCustomAgents.map((agentDef) =>
+    ? await withConcurrency<AgentFinding[]>(
+        enabledCustomAgents.map((agentDef) => () =>
           runCustomAgent(agentDef, diff, context, modelId, llm, fileFetchOptions, conventions, agentAuthored)
             .catch((err) => {
               console.warn(`Custom agent "${agentDef.name}" failed:`, err);
               return [] as AgentFinding[];
             })
         ),
+        AGENT_CONCURRENCY,
       )
     : [];
 

--- a/packages/llm-bedrock/src/bedrock-provider.ts
+++ b/packages/llm-bedrock/src/bedrock-provider.ts
@@ -121,7 +121,14 @@ export class BedrockLLMProvider implements ILLMProvider {
   }
 
   private createClient(): BedrockRuntimeClient {
-    return new BedrockRuntimeClient({ region: this.region });
+    // maxAttempts: 10 with standard retry mode yields cumulative exponential
+    // backoff of ~30-45s (with jitter) across a 429 burst — enough to span a
+    // Bedrock TPM window where the SDK default of 3 attempts / ~0.6s is not.
+    return new BedrockRuntimeClient({
+      region: this.region,
+      maxAttempts: 10,
+      retryMode: 'standard',
+    });
   }
 
   async invoke(modelId: string, prompt: string, maxTokens = 4096): Promise<LLMInvokeResult> {


### PR DESCRIPTION
## Context

After #115 landed the InvalidSignatureException self-heal, the underlying cause surfaced directly: Bedrock `ThrottlingException: Too many tokens, please wait before trying again.` on #112.

Lambda log from the most recent failed invocation:

```
attempts: 3, totalRetryDelay: 630ms → ThrottlingException (HTTP 429)
Total Lambda duration: 8.3s before failing
```

Two independent problems, both fixed here:

## Fix 1 — Retry config

SDK default is 3 attempts with ~630ms total backoff. Nowhere near enough for a Bedrock per-minute TPM window. Raise `maxAttempts` to 10 under `standard` retry mode; cumulative exponential backoff lands around 30–45s with jitter, which actually spans a quota window.

## Fix 2 — Concurrency cap

`runReviewPipeline` fanned out 6–8 agents through `Promise.all()` — that bursts 6–8 InvokeModel calls within milliseconds and instantaneously exceeds TPM regardless of retry policy. Add a small worker-pool helper and cap parallelism at 3. Custom agents use the same cap. End-to-end latency roughly 2.5x the fastest agent instead of 8x, which is fine (reviews already run ~20–30s, so this keeps us in single-minute territory).

The concurrency helper preserves `Promise.all` semantics: same result order for destructuring, same rejection propagation so existing `.catch()` paths fire unchanged.

## Test plan
- [x] `pnpm --filter @mergewatch/core run test` — 310 pass
- [x] `pnpm --filter @mergewatch/llm-bedrock run test` — 12 pass
- [x] `pnpm run typecheck` — all 18 packages clean
- [ ] After merge + `pnpm run deploy`, confirm #112 review succeeds on `@mergewatch review`

## Orthogonal
Quota raise via AWS Support is in flight separately and should land in hours/days. These code-side fixes keep reviews working even without the raise, and stay correct once the quota is higher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)