### PR TITLE
Per-agent temperature: let summary + diagram breathe

### DIFF
--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -315,7 +315,11 @@ ${previousDiagram}
     diagramPrompt = diagramPrompt.replace(PREVIOUS_DIAGRAM_PLACEHOLDER, '');
   }
   const prompt = buildPrompt(diagramPrompt, diff, context, false);
-  const raw = normalizeLLMResult(await llm.invoke(modelId, prompt)).text;
+  // Slight temperature so Mermaid diagrams don't read as a carbon copy across
+  // re-reviews of the same PR. Still low enough that structure is stable.
+  const raw = normalizeLLMResult(
+    await llm.invoke(modelId, prompt, undefined, { temperature: 0.2 }),
+  ).text;
   return parseDiagramResponse(raw);
 }
 
@@ -498,7 +502,12 @@ export async function runSummaryAgent(
   agentAuthored?: boolean,
 ): Promise<string> {
   const prompt = buildPrompt(SUMMARY_PROMPT, diff, context, false, undefined, conventions, agentAuthored);
-  const raw = normalizeLLMResult(await llm.invoke(modelId, prompt)).text;
+  // Generative prose — a small bump off 0 avoids re-review summaries that
+  // read like carbon copies. The finding agents (security/bugs/style/...)
+  // stay at temperature 0 so they flag issues consistently across re-runs.
+  const raw = normalizeLLMResult(
+    await llm.invoke(modelId, prompt, undefined, { temperature: 0.3 }),
+  ).text;
   const parsed = safeParseJson<{ summary: string }>(raw, { summary: '' });
   return parsed.summary;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 // ─── Interfaces ─────────────────────────────────────────────────────────────
-export type { ILLMProvider, TokenUsage, LLMInvokeResult } from './llm/types.js';
+export type { ILLMProvider, TokenUsage, LLMInvokeResult, LLMSamplingConfig } from './llm/types.js';
 export { normalizeLLMResult } from './llm/types.js';
 export { TokenAccumulator, TrackingLLMProvider } from './llm/token-accumulator.js';
 export { estimateCost, DEFAULT_PRICING } from './llm/pricing.js';

--- a/packages/core/src/llm/types.ts
+++ b/packages/core/src/llm/types.ts
@@ -20,8 +20,29 @@ export interface LLMInvokeResult {
   usage?: TokenUsage;
 }
 
+/**
+ * Sampling controls for a single invocation. Individual providers map these
+ * to their own parameter names and silently drop anything they don't support
+ * (e.g. OpenAI-compatible endpoints have no top_k). When omitted, providers
+ * default to temperature 0 / greedy decode — the right call for structured
+ * finding agents where re-run consistency matters more than output variety.
+ */
+export interface LLMSamplingConfig {
+  /** 0 (default) = deterministic. Bump for generative agents (summary, diagram). */
+  temperature?: number;
+  /** Nucleus sampling cutoff. Provider-dependent effect; ignored by some. */
+  topP?: number;
+  /** Top-k sampling. Provider-dependent; ignored by OpenAI-spec endpoints. */
+  topK?: number;
+}
+
 export interface ILLMProvider {
-  invoke(modelId: string, prompt: string, maxTokens?: number): Promise<string | LLMInvokeResult>;
+  invoke(
+    modelId: string,
+    prompt: string,
+    maxTokens?: number,
+    sampling?: LLMSamplingConfig,
+  ): Promise<string | LLMInvokeResult>;
 }
 
 /** Normalize a string or LLMInvokeResult to always get an LLMInvokeResult. */

--- a/packages/llm-anthropic/src/anthropic-provider.ts
+++ b/packages/llm-anthropic/src/anthropic-provider.ts
@@ -1,5 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk';
-import type { ILLMProvider, LLMInvokeResult } from '@mergewatch/core';
+import type { ILLMProvider, LLMInvokeResult, LLMSamplingConfig } from '@mergewatch/core';
 
 export class AnthropicLLMProvider implements ILLMProvider {
   private client: Anthropic;
@@ -8,11 +8,18 @@ export class AnthropicLLMProvider implements ILLMProvider {
     this.client = new Anthropic({ apiKey });
   }
 
-  async invoke(modelId: string, prompt: string, maxTokens = 4096): Promise<LLMInvokeResult> {
+  async invoke(
+    modelId: string,
+    prompt: string,
+    maxTokens = 4096,
+    sampling: LLMSamplingConfig = {},
+  ): Promise<LLMInvokeResult> {
     const response = await this.client.messages.create({
       model: modelId,
       max_tokens: maxTokens,
-      temperature: 0,
+      temperature: sampling.temperature ?? 0,
+      ...(sampling.topP !== undefined ? { top_p: sampling.topP } : {}),
+      ...(sampling.topK !== undefined ? { top_k: sampling.topK } : {}),
       messages: [{ role: 'user', content: prompt }],
     });
     const block = response.content[0];

--- a/packages/llm-bedrock/src/bedrock-provider.test.ts
+++ b/packages/llm-bedrock/src/bedrock-provider.test.ts
@@ -160,6 +160,41 @@ describe('BedrockLLMProvider', () => {
     expect(provider).toBeDefined();
   });
 
+  it('forwards sampling config (temperature, top_p, top_k) to Anthropic bodies', async () => {
+    mockSend.mockResolvedValueOnce(makeResponse({
+      content: [{ type: 'text', text: 'ok' }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    }));
+
+    const provider = new BedrockLLMProvider();
+    await provider.invoke(
+      'us.anthropic.claude-sonnet-4-6',
+      'prompt',
+      2048,
+      { temperature: 0.3, topP: 0.95, topK: 40 },
+    );
+
+    const body = getLastCommandBody();
+    expect(body.temperature).toBe(0.3);
+    expect(body.top_p).toBe(0.95);
+    expect(body.top_k).toBe(40);
+  });
+
+  it('defaults sampling to temperature 0 when no config passed', async () => {
+    mockSend.mockResolvedValueOnce(makeResponse({
+      content: [{ type: 'text', text: 'ok' }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    }));
+
+    const provider = new BedrockLLMProvider();
+    await provider.invoke('us.anthropic.claude-sonnet-4-6', 'prompt');
+
+    const body = getLastCommandBody();
+    expect(body.temperature).toBe(0);
+    expect(body.top_p).toBeUndefined();
+    expect(body.top_k).toBeUndefined();
+  });
+
   it('self-heals from InvalidSignatureException with a client retry', async () => {
     const sigErr = new Error('Signature expired: 20260422T222327Z is now earlier than ...');
     sigErr.name = 'InvalidSignatureException';

--- a/packages/llm-bedrock/src/bedrock-provider.ts
+++ b/packages/llm-bedrock/src/bedrock-provider.ts
@@ -16,7 +16,7 @@ import {
   BedrockRuntimeClient,
   InvokeModelCommand,
 } from '@aws-sdk/client-bedrock-runtime';
-import type { ILLMProvider, LLMInvokeResult, TokenUsage } from '@mergewatch/core';
+import type { ILLMProvider, LLMInvokeResult, LLMSamplingConfig, TokenUsage } from '@mergewatch/core';
 
 // ─── Supported model IDs ───────────────────────────────────────────────────
 export const SUPPORTED_MODELS = {
@@ -36,27 +36,38 @@ interface ModelRequestBody {
   accept: string;
 }
 
-function buildAnthropicBody(prompt: string, maxTokens: number): ModelRequestBody {
+function buildAnthropicBody(
+  prompt: string,
+  maxTokens: number,
+  sampling: LLMSamplingConfig,
+): ModelRequestBody {
+  const body: Record<string, unknown> = {
+    anthropic_version: 'bedrock-2023-05-31',
+    max_tokens: maxTokens,
+    temperature: sampling.temperature ?? 0,
+    messages: [{ role: 'user', content: prompt }],
+  };
+  if (sampling.topP !== undefined) body.top_p = sampling.topP;
+  if (sampling.topK !== undefined) body.top_k = sampling.topK;
   return {
-    body: JSON.stringify({
-      anthropic_version: 'bedrock-2023-05-31',
-      max_tokens: maxTokens,
-      temperature: 0,
-      messages: [{ role: 'user', content: prompt }],
-    }),
+    body: JSON.stringify(body),
     contentType: 'application/json',
     accept: 'application/json',
   };
 }
 
-function buildTitanBody(prompt: string, maxTokens: number): ModelRequestBody {
+function buildTitanBody(
+  prompt: string,
+  maxTokens: number,
+  sampling: LLMSamplingConfig,
+): ModelRequestBody {
   return {
     body: JSON.stringify({
       inputText: prompt,
       textGenerationConfig: {
         maxTokenCount: maxTokens,
-        temperature: 0,
-        topP: 1,
+        temperature: sampling.temperature ?? 0,
+        topP: sampling.topP ?? 1,
       },
     }),
     contentType: 'application/json',
@@ -72,14 +83,19 @@ function isTitanModel(modelId: string): boolean {
   return modelId.includes('amazon.titan');
 }
 
-function buildRequestBody(modelId: string, prompt: string, maxTokens: number): ModelRequestBody {
+function buildRequestBody(
+  modelId: string,
+  prompt: string,
+  maxTokens: number,
+  sampling: LLMSamplingConfig,
+): ModelRequestBody {
   if (isAnthropicModel(modelId)) {
-    return buildAnthropicBody(prompt, maxTokens);
+    return buildAnthropicBody(prompt, maxTokens, sampling);
   }
   if (isTitanModel(modelId)) {
-    return buildTitanBody(prompt, maxTokens);
+    return buildTitanBody(prompt, maxTokens, sampling);
   }
-  return buildAnthropicBody(prompt, maxTokens);
+  return buildAnthropicBody(prompt, maxTokens, sampling);
 }
 
 // ─── Response parsers per model family ─────────────────────────────────────
@@ -131,8 +147,13 @@ export class BedrockLLMProvider implements ILLMProvider {
     });
   }
 
-  async invoke(modelId: string, prompt: string, maxTokens = 4096): Promise<LLMInvokeResult> {
-    const { body, contentType, accept } = buildRequestBody(modelId, prompt, maxTokens);
+  async invoke(
+    modelId: string,
+    prompt: string,
+    maxTokens = 4096,
+    sampling: LLMSamplingConfig = {},
+  ): Promise<LLMInvokeResult> {
+    const { body, contentType, accept } = buildRequestBody(modelId, prompt, maxTokens, sampling);
 
     const command = new InvokeModelCommand({
       modelId,

--- a/packages/llm-litellm/src/litellm-provider.ts
+++ b/packages/llm-litellm/src/litellm-provider.ts
@@ -1,4 +1,4 @@
-import type { ILLMProvider, LLMInvokeResult } from '@mergewatch/core';
+import type { ILLMProvider, LLMInvokeResult, LLMSamplingConfig } from '@mergewatch/core';
 
 export class LiteLLMProvider implements ILLMProvider {
   constructor(
@@ -6,7 +6,12 @@ export class LiteLLMProvider implements ILLMProvider {
     private apiKey?: string,
   ) {}
 
-  async invoke(modelId: string, prompt: string, maxTokens = 4096): Promise<LLMInvokeResult> {
+  async invoke(
+    modelId: string,
+    prompt: string,
+    maxTokens = 4096,
+    sampling: LLMSamplingConfig = {},
+  ): Promise<LLMInvokeResult> {
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
     };
@@ -15,13 +20,18 @@ export class LiteLLMProvider implements ILLMProvider {
     }
 
     const url = `${this.baseUrl.replace(/\/$/, '')}/chat/completions`;
+    // top_k is not part of the OpenAI chat-completions spec — LiteLLM proxies
+    // it through to providers that support it when present, so we forward it
+    // rather than drop it.
     const response = await fetch(url, {
       method: 'POST',
       headers,
       body: JSON.stringify({
         model: modelId,
         max_tokens: maxTokens,
-        temperature: 0,
+        temperature: sampling.temperature ?? 0,
+        ...(sampling.topP !== undefined ? { top_p: sampling.topP } : {}),
+        ...(sampling.topK !== undefined ? { top_k: sampling.topK } : {}),
         messages: [{ role: 'user', content: prompt }],
       }),
     });

--- a/packages/llm-ollama/src/ollama-provider.ts
+++ b/packages/llm-ollama/src/ollama-provider.ts
@@ -1,17 +1,28 @@
-import type { ILLMProvider, LLMInvokeResult } from '@mergewatch/core';
+import type { ILLMProvider, LLMInvokeResult, LLMSamplingConfig } from '@mergewatch/core';
 
 export class OllamaLLMProvider implements ILLMProvider {
   constructor(private baseUrl: string = 'http://localhost:11434') {}
 
-  async invoke(modelId: string, prompt: string, maxTokens = 4096): Promise<LLMInvokeResult> {
+  async invoke(
+    modelId: string,
+    prompt: string,
+    maxTokens = 4096,
+    sampling: LLMSamplingConfig = {},
+  ): Promise<LLMInvokeResult> {
     const url = `${this.baseUrl.replace(/\/$/, '')}/api/chat`;
+    const options: Record<string, unknown> = {
+      num_predict: maxTokens,
+      temperature: sampling.temperature ?? 0,
+    };
+    if (sampling.topP !== undefined) options.top_p = sampling.topP;
+    if (sampling.topK !== undefined) options.top_k = sampling.topK;
     const response = await fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         model: modelId,
         stream: false,
-        options: { num_predict: maxTokens, temperature: 0 },
+        options,
         messages: [{ role: 'user', content: prompt }],
       }),
     });


### PR DESCRIPTION
## Why

User feedback on our hardcoded `temperature: 0`: it's right for some agents and wrong for others.

- **Finding agents** (security, bugs, style, error handling, test coverage, comment accuracy) *want* temperature 0. A reviewer that flags an issue on one run and silently misses it on identical input the next run is worse than one that's steady. Re-review reproducibility is the promise.
- **Summary and diagram** are generative. Temp 0 makes their output read stale on re-reviews of the same PR — same prose, same Mermaid layout, same phrasing every time.

## What

1. `LLMSamplingConfig` in `@mergewatch/core` — optional `temperature` / `topP` / `topK`. Default is temperature 0 for backwards compatibility.
2. All four providers (Bedrock, Anthropic direct, LiteLLM, Ollama) accept the new param on `invoke()` and map to their respective API shapes:
   - Bedrock+Anthropic → `temperature`, `top_p`, `top_k`
   - Bedrock+Titan → `textGenerationConfig.{temperature, topP}` (no top_k)
   - Anthropic direct → same as Bedrock+Anthropic
   - LiteLLM → OpenAI-spec + `top_k` passthrough (the proxy forwards it to providers that accept it)
   - Ollama → `options.{temperature, top_p, top_k}`
3. Per-agent bumps inside `runReviewPipeline`:
   - Summary: `temperature: 0.3`
   - Diagram: `temperature: 0.2`
   - Everything else: default (0) — unchanged

## What stays the same

- Finding agents still get temp 0. Their test fixtures didn't need updates.
- Orchestrator stays at temp 0 — it's a structured dedup + ranking pass, not generative.
- `.mergewatch.yml` schema unchanged — no new knob for users to mis-tune. (Can add one later if there's demand.)

## Test plan
- [x] `pnpm --filter @mergewatch/llm-bedrock run test` — 14 pass (2 new: sampling-override forwarding + default-zero)
- [x] `pnpm --filter @mergewatch/core run test` — passes
- [x] `pnpm --filter @mergewatch/llm-anthropic / llm-litellm / llm-ollama run test` — all pass, existing `temperature: 0` fixtures still valid
- [x] `pnpm run typecheck` — 20/20 packages clean
- [ ] After deploy, eyeball two re-reviews of the same PR: summary should read noticeably different the second time, findings should stay consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)