### PR TITLE
Consolidate excludePatterns + rules.ignorePatterns into one field

### DIFF
--- a/packages/core/src/config/defaults.test.ts
+++ b/packages/core/src/config/defaults.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   DEFAULT_CONFIG,
   DEFAULT_RULES_CONFIG,
@@ -97,10 +97,27 @@ describe('mergeConfig', () => {
     expect(result.rules.ignoreLabels).toEqual(['wip', 'draft']);
   });
 
-  it('overrides rules.ignorePatterns array', () => {
+  it('folds deprecated rules.ignorePatterns into top-level excludePatterns', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const result = mergeConfig({ rules: { ignorePatterns: ['*.generated.ts'] } });
-    expect(result.rules.ignorePatterns).toEqual(['*.generated.ts']);
+    // The deprecated field is cleared on the merged config…
+    expect(result.rules.ignorePatterns).toEqual([]);
+    // …and its entries appended to the canonical excludePatterns list.
+    expect(result.excludePatterns).toContain('*.generated.ts');
+    // Defaults still preserved.
     expect(result.rules.maxFiles).toBe(DEFAULT_RULES_CONFIG.maxFiles);
+    // One-time deprecation warning emitted.
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('rules.ignorePatterns is deprecated'),
+    );
+    warn.mockRestore();
+  });
+
+  it('does not warn when rules.ignorePatterns is unset', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mergeConfig({});
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
   });
 
   it('leaves agentReview undefined when partial omits it', () => {

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -43,7 +43,12 @@ export const DEFAULT_UX_CONFIG: UXConfig = {
 export interface RulesConfig {
   /** Maximum number of changed files before skipping review */
   maxFiles: number;
-  /** Glob patterns for files to ignore during review */
+  /**
+   * @deprecated Use top-level `excludePatterns` instead. When set on a user
+   *   YAML, mergeConfig appends entries here into `excludePatterns` and emits
+   *   a one-time deprecation warning. The field remains in the type only so
+   *   existing `.mergewatch.yml` files continue to parse without errors.
+   */
   ignorePatterns: string[];
   /** Whether to automatically review PRs on open/synchronize */
   autoReview: boolean;
@@ -57,7 +62,11 @@ export interface RulesConfig {
 
 export const DEFAULT_RULES_CONFIG: RulesConfig = {
   maxFiles: 50,
-  ignorePatterns: ['*.lock', 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'dist/**', 'node_modules/**'],
+  // Empty by default — file-pattern exclusions live on top-level
+  // excludePatterns (the canonical field). Kept on the type for back-compat
+  // with older .mergewatch.yml files; mergeConfig folds any user-provided
+  // entries here into excludePatterns at parse time.
+  ignorePatterns: [],
   autoReview: true,
   reviewOnMention: true,
   skipDrafts: true,
@@ -229,6 +238,19 @@ export function mergeConfig(
       ...(rest.rules ?? {}),
     },
   };
+
+  // Soft-deprecation: fold rules.ignorePatterns into top-level excludePatterns
+  // so existing .mergewatch.yml files keep working. After this merge the
+  // ignorePatterns array is cleared — call sites should read excludePatterns
+  // exclusively.
+  const userIgnorePatterns = rest.rules?.ignorePatterns;
+  if (Array.isArray(userIgnorePatterns) && userIgnorePatterns.length > 0) {
+    console.warn(
+      '[mergewatch] rules.ignorePatterns is deprecated; move these entries to top-level excludePatterns. Auto-merging for now.',
+    );
+    merged.excludePatterns = [...merged.excludePatterns, ...userIgnorePatterns];
+    merged.rules.ignorePatterns = [];
+  }
   if (agentReview !== undefined) {
     const a = agentReview;
     const d = a.detection ?? {};

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -410,11 +410,9 @@ export async function handler(
     }
 
     // ── Filter excluded files from the diff ────
-    const allExcludePatterns = [
-      ...runtimeConfig.excludePatterns,
-      ...runtimeConfig.rules.ignorePatterns,
-    ];
-    const { filteredDiff, excludedFiles } = filterDiff(diff, allExcludePatterns);
+    // mergeConfig has already folded any deprecated rules.ignorePatterns
+    // entries into excludePatterns, so this single list is authoritative.
+    const { filteredDiff, excludedFiles } = filterDiff(diff, runtimeConfig.excludePatterns);
     if (excludedFiles.length > 0) {
       console.log(`Excluded ${excludedFiles.length} file(s) from diff: ${excludedFiles.join(', ')}`);
     }

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -286,11 +286,9 @@ export async function processReviewJob(
   }
 
   // ── Filter excluded files from the diff ────
-  const allExcludePatterns = [
-    ...config.excludePatterns,
-    ...config.rules.ignorePatterns,
-  ];
-  const { filteredDiff, excludedFiles } = filterDiff(diff, allExcludePatterns);
+  // mergeConfig folds the deprecated rules.ignorePatterns into excludePatterns
+  // at parse time — this is the authoritative single list.
+  const { filteredDiff, excludedFiles } = filterDiff(diff, config.excludePatterns);
   if (excludedFiles.length > 0) {
     console.log(`Excluded ${excludedFiles.length} file(s) from diff: ${excludedFiles.join(', ')}`);
   }


### PR DESCRIPTION
## Why

Two pattern lists were doing identical work. At every call site they were spread together and passed to `filterDiff()` as a single argument:

```ts
const allExcludePatterns = [
  ...config.excludePatterns,
  ...config.rules.ignorePatterns,
];
```

The duplication was history, not design. Defaults overlapped heavily (`**/*.lock`, `dist/**`, `node_modules/**` in both lists). A user reading the schema today reasonably asks "what's the difference?" and the truthful answer is "nothing — pick one."

Cleanup before adding the upcoming `skipPatterns` field for docs-only-PR opt-in. Going from two-confusing-fields to three would make this worse, not better.

## What

1. **`RulesConfig.ignorePatterns`** marked `@deprecated`. Field stays on the type so existing `.mergewatch.yml` files keep parsing without errors.
2. **`DEFAULT_RULES_CONFIG.ignorePatterns`** is now `[]`. Pattern defaults live exclusively on top-level `excludePatterns`.
3. **`mergeConfig`** folds any user-provided `rules.ignorePatterns` entries into `excludePatterns` at parse time, emits a one-time `console.warn` deprecation notice, then clears the field.
4. **Call sites** in `packages/lambda/src/handlers/review-agent.ts` and `packages/server/src/review-processor.ts` drop the spread — they pass `runtimeConfig.excludePatterns` directly to `filterDiff`. Single source of truth.

## Backward compatibility

- Users who set `rules.ignorePatterns` in YAML still get their patterns applied (folded into `excludePatterns` at merge). They see one warning per review and can migrate when convenient.
- The `RulesConfig` type still has the field, so any downstream code reading `config.rules.ignorePatterns` won't fail to compile — it'll just always be empty after merge.

## Test plan
- [x] New `mergeConfig` test verifies the fold + deprecation warning fires.
- [x] Counter-test verifies no warning when `ignorePatterns` is unset.
- [x] 311 core tests pass, 46 lambda, 50 server.
- [x] `pnpm run typecheck` clean across all 20 packages.
- [ ] After merge, eyeball one CloudWatch log for the deprecation warning when a real repo's YAML still has `rules.ignorePatterns` set.

## Next

With this landed, the schema goes from "two pattern fields, both filter from diff" to "one pattern field, filters from diff." Adding `skipPatterns` next will be unambiguous: one field per concept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)