### PR TITLE
Add includePatterns to opt normally-skipped PRs back into review

### DIFF
--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -145,6 +145,19 @@ export interface MergeWatchConfig {
   conventions?: string;
   /** File patterns to exclude from review (glob syntax) */
   excludePatterns: string[];
+  /**
+   * File patterns that override the internal SKIP_PATTERNS list, forcing
+   * MergeWatch to review the PR even when it would otherwise be skipped
+   * as "trivial." Use this to opt docs-only PRs (or any other normally
+   * skipped category) back into review for specific paths — for example,
+   * a critical-docs subdirectory or a top-level SECURITY markdown file.
+   *
+   * Operates at the PR-skip layer, NOT the diff-filter layer. It does
+   * not modify what's sent to the agents on a PR that's already being
+   * reviewed — that's `excludePatterns`. It only decides whether the
+   * PR gets reviewed at all when every file is otherwise trivial.
+   */
+  includePatterns: string[];
   /** Minimum severity to report: 'info' | 'warning' | 'critical' */
   minSeverity: 'info' | 'warning' | 'critical';
   /** Maximum number of findings to include in the comment */
@@ -194,6 +207,7 @@ export const DEFAULT_CONFIG: MergeWatchConfig = {
     '**/build/**',
     '**/node_modules/**',
   ],
+  includePatterns: [],
   minSeverity: 'info',
   maxFindings: 25,
   postSummaryOnClean: true,

--- a/packages/core/src/github/client.test.ts
+++ b/packages/core/src/github/client.test.ts
@@ -359,6 +359,39 @@ rules:
     expect(result?.rules).toBeUndefined();
   });
 
+  // ─── includePatterns parsing ─────────────────────────────────────────────
+  it('parses includePatterns as a string array', () => {
+    const yaml = `
+includePatterns:
+  - "docs/runbooks/**"
+  - "**/SECURITY.md"
+`;
+    const result = parseRepoConfigYaml(yaml);
+    expect(result?.includePatterns).toEqual(['docs/runbooks/**', '**/SECURITY.md']);
+  });
+
+  it('filters non-string entries from includePatterns', () => {
+    const yaml = `
+includePatterns:
+  - "docs/**"
+  - 42
+  - null
+  - "RUNBOOK.md"
+`;
+    const result = parseRepoConfigYaml(yaml);
+    expect(result?.includePatterns).toEqual(['docs/**', 'RUNBOOK.md']);
+  });
+
+  it('ignores includePatterns when not an array', () => {
+    const result = parseRepoConfigYaml('includePatterns: "docs/**"');
+    expect(result?.includePatterns).toBeUndefined();
+  });
+
+  it('returns no includePatterns when field is absent', () => {
+    const result = parseRepoConfigYaml('model: my-model');
+    expect(result?.includePatterns).toBeUndefined();
+  });
+
   // ─── UX parsing ──────────────────────────────────────────────────────────
   it('parses ux config', () => {
     const yaml = `

--- a/packages/core/src/github/client.ts
+++ b/packages/core/src/github/client.ts
@@ -765,6 +765,9 @@ export function parseRepoConfigYaml(content: string): Partial<MergeWatchConfig> 
     if (Array.isArray(parsed.excludePatterns)) {
       config.excludePatterns = parsed.excludePatterns.filter((p: unknown) => typeof p === 'string');
     }
+    if (Array.isArray(parsed.includePatterns)) {
+      config.includePatterns = parsed.includePatterns.filter((p: unknown) => typeof p === 'string');
+    }
     if (parsed.agents && typeof parsed.agents === 'object') {
       const a = parsed.agents as Record<string, unknown>;
       config.agents = {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -145,7 +145,7 @@ export { invokeWithFileFetching, FILE_REQUEST_INSTRUCTION } from './context/agen
 export type { FileFetchOptions, AgenticInvokeResult } from './context/agentic-fetcher.js';
 
 // ─── Skip logic ─────────────────────────────────────────────────────────────
-export { shouldSkipPR, shouldSkipByRules, SKIP_PATTERNS } from './skip-logic.js';
+export { shouldSkipPR, shouldSkipByRules, extractIncludePatterns, SKIP_PATTERNS } from './skip-logic.js';
 
 // ─── Agent-authored PR detection ────────────────────────────────────────────
 export { classifyPrSource } from './agent-detection.js';

--- a/packages/core/src/skip-logic.test.ts
+++ b/packages/core/src/skip-logic.test.ts
@@ -115,6 +115,36 @@ describe('shouldSkipPR', () => {
     expect(SKIP_PATTERNS).toBeDefined();
     expect(SKIP_PATTERNS.length).toBeGreaterThan(0);
   });
+
+  // ─── includePatterns override ────────────────────────────────────────────
+  it('reviews a docs-only PR when includePatterns matches', () => {
+    const result = shouldSkipPR(['docs/architecture.md'], ['docs/**']);
+    expect(result).toBeNull();
+  });
+
+  it('still skips docs that do not match any includePatterns entry', () => {
+    const result = shouldSkipPR(['CHANGELOG.md'], ['docs/critical/**']);
+    expect(result).not.toBeNull();
+    expect(result).toContain('docs');
+  });
+
+  it('reviews a mixed lock + matching-include PR', () => {
+    const result = shouldSkipPR(
+      ['package-lock.json', 'docs/runbooks/oncall.md'],
+      ['docs/runbooks/**'],
+    );
+    expect(result).toBeNull();
+  });
+
+  it('empty includePatterns falls back to default skip behaviour', () => {
+    const result = shouldSkipPR(['README.md'], []);
+    expect(result).not.toBeNull();
+  });
+
+  it('omitted includePatterns argument falls back to default skip behaviour', () => {
+    const result = shouldSkipPR(['README.md']);
+    expect(result).not.toBeNull();
+  });
 });
 
 describe('shouldSkipByRules', () => {

--- a/packages/core/src/skip-logic.test.ts
+++ b/packages/core/src/skip-logic.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { shouldSkipPR, shouldSkipByRules, SKIP_PATTERNS } from './skip-logic.js';
+import { shouldSkipPR, shouldSkipByRules, extractIncludePatterns, SKIP_PATTERNS } from './skip-logic.js';
 import { DEFAULT_RULES_CONFIG } from './config/defaults.js';
 import type { RulesConfig } from './config/defaults.js';
 
@@ -144,6 +144,41 @@ describe('shouldSkipPR', () => {
   it('omitted includePatterns argument falls back to default skip behaviour', () => {
     const result = shouldSkipPR(['README.md']);
     expect(result).not.toBeNull();
+  });
+});
+
+describe('extractIncludePatterns', () => {
+  it('returns [] when yamlConfig is null', () => {
+    expect(extractIncludePatterns(null)).toEqual([]);
+  });
+
+  it('returns [] when yamlConfig is undefined', () => {
+    expect(extractIncludePatterns(undefined)).toEqual([]);
+  });
+
+  it('returns [] when includePatterns field is missing', () => {
+    expect(extractIncludePatterns({})).toEqual([]);
+  });
+
+  it('returns [] when includePatterns is not an array (string)', () => {
+    expect(extractIncludePatterns({ includePatterns: 'docs/**' } as never)).toEqual([]);
+  });
+
+  it('returns [] when includePatterns is not an array (number)', () => {
+    expect(extractIncludePatterns({ includePatterns: 42 } as never)).toEqual([]);
+  });
+
+  it('returns the array unchanged when all entries are strings', () => {
+    expect(
+      extractIncludePatterns({ includePatterns: ['docs/**', '**/SECURITY.md'] }),
+    ).toEqual(['docs/**', '**/SECURITY.md']);
+  });
+
+  it('filters out non-string entries from a mixed array', () => {
+    const out = extractIncludePatterns({
+      includePatterns: ['docs/**', 42, null, true, '**/RUNBOOK.md'] as never,
+    });
+    expect(out).toEqual(['docs/**', '**/RUNBOOK.md']);
   });
 });
 

--- a/packages/core/src/skip-logic.ts
+++ b/packages/core/src/skip-logic.ts
@@ -9,7 +9,7 @@
  */
 
 import { minimatch } from 'minimatch';
-import type { RulesConfig } from './config/defaults.js';
+import type { MergeWatchConfig, RulesConfig } from './config/defaults.js';
 
 /**
  * File patterns that indicate a trivial PR not worth reviewing.
@@ -70,6 +70,20 @@ export const SKIP_PATTERNS = [
  * (real glob `**` star-star) and a PR that only touches that path will be
  * reviewed even though all-markdown is otherwise considered trivial.
  */
+/**
+ * Extract a sanitized `includePatterns` list from a possibly-null parsed
+ * YAML config. Centralized here so the Lambda and Express transports share
+ * one defensive parse — string-only entries, empty fallback when the field
+ * is missing or malformed.
+ */
+export function extractIncludePatterns(
+  yamlConfig: Partial<MergeWatchConfig> | null | undefined,
+): string[] {
+  const raw = (yamlConfig as { includePatterns?: unknown } | null | undefined)?.includePatterns;
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((p): p is string => typeof p === 'string');
+}
+
 export function shouldSkipPR(
   files: string[],
   includePatterns: string[] = [],

--- a/packages/core/src/skip-logic.ts
+++ b/packages/core/src/skip-logic.ts
@@ -91,7 +91,6 @@ export function shouldSkipPR(
   if (files.length === 0) return 'No changed files';
 
   const isForceIncluded = (file: string) =>
-    includePatterns.length > 0 &&
     includePatterns.some((pattern) => minimatch(file, pattern));
 
   const nonTrivialFiles = files.filter(

--- a/packages/core/src/skip-logic.ts
+++ b/packages/core/src/skip-logic.ts
@@ -62,12 +62,28 @@ export const SKIP_PATTERNS = [
 /**
  * Check if a PR should be skipped because all changed files are trivial.
  * Returns a skip reason string if skipped, or null if the PR should be reviewed.
+ *
+ * `includePatterns` is the user-configured override list: any file matching
+ * one of these patterns is treated as non-trivial regardless of whether it
+ * also matches SKIP_PATTERNS. This is how a docs-only PR can opt itself
+ * back into review — set `includePatterns: ["docs/architecture/star-star"]`
+ * (real glob `**` star-star) and a PR that only touches that path will be
+ * reviewed even though all-markdown is otherwise considered trivial.
  */
-export function shouldSkipPR(files: string[]): string | null {
+export function shouldSkipPR(
+  files: string[],
+  includePatterns: string[] = [],
+): string | null {
   if (files.length === 0) return 'No changed files';
 
+  const isForceIncluded = (file: string) =>
+    includePatterns.length > 0 &&
+    includePatterns.some((pattern) => minimatch(file, pattern));
+
   const nonTrivialFiles = files.filter(
-    (file) => !SKIP_PATTERNS.some((pattern) => minimatch(file, pattern)),
+    (file) =>
+      isForceIncluded(file) ||
+      !SKIP_PATTERNS.some((pattern) => minimatch(file, pattern)),
   );
 
   if (nonTrivialFiles.length === 0) {

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -265,7 +265,9 @@ export async function handler(
   // override and later when building the full runtimeConfig — avoids two
   // GitHub fetches per review.
   const yamlConfig = await fetchRepoConfig(octokit, owner, repo).catch((err) => {
-    console.warn(`Failed to fetch .mergewatch.yml for ${repoFullName}#${prNumber} — proceeding without YAML config:`, err);
+    // Static format string; user-controlled values pass as separate args
+    // to avoid feeding repo names through Node's printf-style formatter.
+    console.warn('Failed to fetch .mergewatch.yml — proceeding without YAML config:', `${repoFullName}#${prNumber}`, err);
     return null;
   });
   const includePatterns = extractIncludePatterns(yamlConfig);

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -26,6 +26,7 @@ import {
   formatReviewComment,
   mergeConfig,
   shouldSkipPR,
+  extractIncludePatterns,
   shouldSkipByRules,
   filterDiff,
   RESPOND_PROMPT,
@@ -264,9 +265,7 @@ export async function handler(
   // override and later when building the full runtimeConfig — avoids two
   // GitHub fetches per review.
   const yamlConfig = await fetchRepoConfig(octokit, owner, repo).catch(() => null);
-  const includePatterns = Array.isArray(yamlConfig?.includePatterns)
-    ? yamlConfig.includePatterns.filter((p): p is string => typeof p === 'string')
-    : [];
+  const includePatterns = extractIncludePatterns(yamlConfig);
 
   // ── Smart skip — bypass when user explicitly requested a review via @mergewatch ────
   const skipReason = event.mentionTriggered ? null : shouldSkipPR(prContext.files, includePatterns);

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -264,7 +264,10 @@ export async function handler(
   // Load .mergewatch.yml once. Used both for the smart-skip includePatterns
   // override and later when building the full runtimeConfig — avoids two
   // GitHub fetches per review.
-  const yamlConfig = await fetchRepoConfig(octokit, owner, repo).catch(() => null);
+  const yamlConfig = await fetchRepoConfig(octokit, owner, repo).catch((err) => {
+    console.warn(`Failed to fetch .mergewatch.yml for ${repoFullName}#${prNumber} — proceeding without YAML config:`, err);
+    return null;
+  });
   const includePatterns = extractIncludePatterns(yamlConfig);
 
   // ── Smart skip — bypass when user explicitly requested a review via @mergewatch ────

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -260,8 +260,16 @@ export async function handler(
   const shortSha = headSha.slice(0, 7);
   const prNumberCommitSha = `${prNumber}#${shortSha}`;
 
+  // Load .mergewatch.yml once. Used both for the smart-skip includePatterns
+  // override and later when building the full runtimeConfig — avoids two
+  // GitHub fetches per review.
+  const yamlConfig = await fetchRepoConfig(octokit, owner, repo).catch(() => null);
+  const includePatterns = Array.isArray(yamlConfig?.includePatterns)
+    ? yamlConfig.includePatterns.filter((p): p is string => typeof p === 'string')
+    : [];
+
   // ── Smart skip — bypass when user explicitly requested a review via @mergewatch ────
-  const skipReason = event.mentionTriggered ? null : shouldSkipPR(prContext.files);
+  const skipReason = event.mentionTriggered ? null : shouldSkipPR(prContext.files, includePatterns);
   if (skipReason) {
     console.log(`Skipping ${repoFullName}#${prNumber}: ${skipReason}`);
 
@@ -377,7 +385,8 @@ export async function handler(
         : [],
     };
 
-    const yamlConfig = await fetchRepoConfig(octokit, owner, repo);
+    // yamlConfig was loaded earlier for the smart-skip includePatterns
+    // override; reuse it here instead of paying another GitHub round-trip.
     const runtimeConfig = mergeConfig({ ...(yamlConfig ?? {}), ...settingsOverrides });
 
     // ── Rules-based skip (skipDrafts, maxFiles, ignoreLabels, autoReview, reviewOnMention) ────

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -219,7 +219,9 @@ export async function processReviewJob(
   // override and reused below when building the full runtimeConfig — avoids
   // a second GitHub round-trip per review.
   const yamlConfig = await fetchRepoConfig(octokit, owner, repo).catch((err) => {
-    console.warn(`Failed to fetch .mergewatch.yml for ${repoFullName}#${prNumber} — proceeding without YAML config:`, err);
+    // Static format string; user-controlled values pass as separate args
+    // to avoid feeding repo names through Node's printf-style formatter.
+    console.warn('Failed to fetch .mergewatch.yml — proceeding without YAML config:', `${repoFullName}#${prNumber}`, err);
     return null;
   });
   const includePatterns = extractIncludePatterns(yamlConfig);

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -215,8 +215,18 @@ export async function processReviewJob(
     summary: `MergeWatch is reviewing PR #${prNumber}...`,
   }).catch((err) => console.warn('Failed to create in-progress check run:', err));
 
+  // Load .mergewatch.yml once. Used for the smart-skip includePatterns
+  // override and reused below when building the full runtimeConfig — avoids
+  // a second GitHub round-trip per review.
+  const yamlConfig = await fetchRepoConfig(octokit, owner, repo).catch(() => null);
+  const includePatterns = Array.isArray(yamlConfig?.includePatterns)
+    ? yamlConfig.includePatterns.filter((p): p is string => typeof p === 'string')
+    : [];
+
   // Smart skip check — bypass when user explicitly requested a review via @mergewatch
-  const skipReason = job.mentionTriggered ? null : shouldSkipPR(prContext.files || []);
+  const skipReason = job.mentionTriggered
+    ? null
+    : shouldSkipPR(prContext.files || [], includePatterns);
   if (skipReason) {
     await deps.reviewStore.updateStatus(repoFullName, prNumberCommitSha, 'skipped', { completedAt: now, skipReason });
     await createCheckRun(octokit, owner, repo, headSha, {
@@ -255,8 +265,8 @@ export async function processReviewJob(
       : [],
   };
 
-  // Merge config: YAML provides base, dashboard settings override, env var model overrides all
-  const yamlConfig = await fetchRepoConfig(octokit, owner, repo);
+  // Merge config: YAML provides base, dashboard settings override, env var model overrides all.
+  // yamlConfig was fetched earlier for the smart-skip includePatterns override; reuse it here.
   const modelOverride = process.env.LLM_MODEL;
   const config = mergeConfig({
     ...(yamlConfig ?? {}),

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -2,7 +2,7 @@ import type { ReviewJobPayload, IInstallationStore, IReviewStore, IGitHubAuthPro
 import {
   getPRDiff, getPRContext, addPRReaction, postReviewComment, updateReviewComment,
   findExistingBotComment, getCommentReactions, createCheckRun,
-  formatReviewComment, runReviewPipeline, shouldSkipPR, shouldSkipByRules,
+  formatReviewComment, runReviewPipeline, shouldSkipPR, shouldSkipByRules, extractIncludePatterns,
   filterDiff,
   DEFAULT_CONFIG, mergeConfig,
   BOT_COMMENT_MARKER, submitPRReview, dismissStaleReviews, mergeScoreToReviewEvent,
@@ -219,9 +219,7 @@ export async function processReviewJob(
   // override and reused below when building the full runtimeConfig — avoids
   // a second GitHub round-trip per review.
   const yamlConfig = await fetchRepoConfig(octokit, owner, repo).catch(() => null);
-  const includePatterns = Array.isArray(yamlConfig?.includePatterns)
-    ? yamlConfig.includePatterns.filter((p): p is string => typeof p === 'string')
-    : [];
+  const includePatterns = extractIncludePatterns(yamlConfig);
 
   // Smart skip check — bypass when user explicitly requested a review via @mergewatch
   const skipReason = job.mentionTriggered

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -218,7 +218,10 @@ export async function processReviewJob(
   // Load .mergewatch.yml once. Used for the smart-skip includePatterns
   // override and reused below when building the full runtimeConfig — avoids
   // a second GitHub round-trip per review.
-  const yamlConfig = await fetchRepoConfig(octokit, owner, repo).catch(() => null);
+  const yamlConfig = await fetchRepoConfig(octokit, owner, repo).catch((err) => {
+    console.warn(`Failed to fetch .mergewatch.yml for ${repoFullName}#${prNumber} — proceeding without YAML config:`, err);
+    return null;
+  });
   const includePatterns = extractIncludePatterns(yamlConfig);
 
   // Smart skip check — bypass when user explicitly requested a review via @mergewatch


### PR DESCRIPTION
## What

A new top-level `includePatterns: string[]` field. When a file matches an entry, the PR is **kept reviewable** even if every other file would mark it trivial under the internal `SKIP_PATTERNS` list. Default is `[]` — existing behavior unchanged.

```yaml
# .mergewatch.yml
includePatterns:
  - "docs/runbooks/**"        # review docs PRs that touch runbooks
  - "docs/architecture/**"    # ...or architecture docs
  - "**/SECURITY.md"          # ...or any SECURITY.md
```

A PR with only `docs/runbooks/oncall.md` would have been skipped before. Now it's reviewed.

## Why this name (and not `skipPatterns`)

`includePatterns` keeps the user mental model focused on the **override**. Users don't need to copy the ~30 internal skip patterns just to add one carve-out — they list only what they want kept reviewable.

The trade-off: `includePatterns` reads as the symmetric opposite of `excludePatterns`, but they operate at **different layers**:
- `excludePatterns` — filter files out of the diff sent to agents (per-file, mid-review)
- `includePatterns` — keep the PR alive when it'd otherwise be skipped as trivial (whole-PR, pre-review)

JSDoc on the field explains the layer distinction so the difference isn't a footgun.

## Semantics

- `shouldSkipPR(files, includePatterns?)` — a file matched by `includePatterns` short-circuits the `SKIP_PATTERNS` check.
- PR is skipped iff **every** file is in `SKIP_PATTERNS` **and not** in `includePatterns`.
- Empty / omitted `includePatterns` → identical to the prior behavior.

## Implementation

- New field on `MergeWatchConfig` with default `[]`, plumbed through `parseRepoConfigYaml` and `mergeConfig`.
- `shouldSkipPR` signature accepts the override list (defaulted to `[]` for back-compat).
- Lambda `review-agent.ts` and Express `review-processor.ts` hoist `fetchRepoConfig` to before `shouldSkipPR` so `includePatterns` can be applied. The same `yamlConfig` is reused when building `runtimeConfig` later — same number of GitHub round-trips, just resequenced.

## Test plan
- [x] `pnpm --filter @mergewatch/core run test` — 316 pass (5 new `shouldSkipPR` cases)
- [x] `pnpm --filter @mergewatch/lambda / @mergewatch/server run test` — 110 pass total
- [x] `pnpm run typecheck` — all 20 packages clean
- [ ] After deploy, set `includePatterns: ["docs/architecture/**"]` on a test repo and confirm a docs-only PR touching that path gets reviewed

## Layered-config picture (post-merge)

| Field | Layer | Default |
|---|---|---|
| `excludePatterns` | filter files from diff at review time | 8 entries (lock, min, dist, build, node_modules) |
| `includePatterns` | force PR review past the skip gate | `[]` |
| `SKIP_PATTERNS` | internal default skip list (~30 entries) | not user-configurable |

Three concepts, three names, each with a clear job. After the prior consolidation PR (#123), `rules.ignorePatterns` is still readable but deprecated and folded into `excludePatterns`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)