### PR TITLE
Surface autoReview=false as a user-actionable check run

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -148,6 +148,7 @@ export type { FileFetchOptions, AgenticInvokeResult } from './context/agentic-fe
 
 // ─── Skip logic ─────────────────────────────────────────────────────────────
 export { shouldSkipPR, shouldSkipByRules, extractIncludePatterns, SKIP_PATTERNS } from './skip-logic.js';
+export type { RulesSkipKind, RulesSkipResult } from './skip-logic.js';
 
 // ─── Agent-authored PR detection ────────────────────────────────────────────
 export { classifyPrSource } from './agent-detection.js';

--- a/packages/core/src/skip-logic.test.ts
+++ b/packages/core/src/skip-logic.test.ts
@@ -188,8 +188,8 @@ describe('shouldSkipByRules', () => {
   // ─── skipDrafts ───────────────────────────────────────────────────────────
   it('skips draft PRs when skipDrafts is true (default)', () => {
     const result = shouldSkipByRules(defaults, { isDraft: true });
-    expect(result).not.toBeNull();
-    expect(result).toContain('Draft PR');
+    expect(result?.kind).toBe('draft');
+    expect(result?.reason).toContain('Draft PR');
   });
 
   it('does not skip draft PRs when skipDrafts is false', () => {
@@ -205,9 +205,9 @@ describe('shouldSkipByRules', () => {
   // ─── maxFiles ─────────────────────────────────────────────────────────────
   it('skips PRs exceeding maxFiles', () => {
     const result = shouldSkipByRules({ ...defaults, maxFiles: 10 }, { changedFileCount: 15 });
-    expect(result).not.toBeNull();
-    expect(result).toContain('15');
-    expect(result).toContain('max: 10');
+    expect(result?.kind).toBe('maxFiles');
+    expect(result?.reason).toContain('15');
+    expect(result?.reason).toContain('max: 10');
   });
 
   it('does not skip PRs at or below maxFiles', () => {
@@ -222,8 +222,8 @@ describe('shouldSkipByRules', () => {
   // ─── ignoreLabels ────────────────────────────────────────────────────────
   it('skips PRs with a matching ignore label', () => {
     const result = shouldSkipByRules(defaults, { labels: ['skip-review'] });
-    expect(result).not.toBeNull();
-    expect(result).toContain('skip-review');
+    expect(result?.kind).toBe('labelIgnored');
+    expect(result?.reason).toContain('skip-review');
   });
 
   it('matches labels case-insensitively', () => {
@@ -231,8 +231,8 @@ describe('shouldSkipByRules', () => {
       { ...defaults, ignoreLabels: ['WIP'] },
       { labels: ['wip'] },
     );
-    expect(result).not.toBeNull();
-    expect(result).toContain('wip');
+    expect(result?.kind).toBe('labelIgnored');
+    expect(result?.reason).toContain('wip');
   });
 
   it('does not skip when no labels match', () => {
@@ -256,8 +256,8 @@ describe('shouldSkipByRules', () => {
   // ─── autoReview ──────────────────────────────────────────────────────────
   it('skips auto-triggered reviews when autoReview is false', () => {
     const result = shouldSkipByRules({ ...defaults, autoReview: false }, { mode: 'review' });
-    expect(result).not.toBeNull();
-    expect(result).toContain('Automatic reviews disabled');
+    expect(result?.kind).toBe('autoReviewOff');
+    expect(result?.reason).toContain('Automatic reviews disabled');
   });
 
   it('does not skip mention-triggered reviews when autoReview is false', () => {
@@ -268,13 +268,13 @@ describe('shouldSkipByRules', () => {
   // ─── reviewOnMention ─────────────────────────────────────────────────────
   it('skips mention-triggered reviews when reviewOnMention is false', () => {
     const result = shouldSkipByRules({ ...defaults, reviewOnMention: false }, { mode: 'summary', mentionTriggered: true });
-    expect(result).not.toBeNull();
-    expect(result).toContain('Mention-triggered reviews disabled');
+    expect(result?.kind).toBe('reviewOnMentionOff');
+    expect(result?.reason).toContain('Mention-triggered reviews disabled');
   });
 
   it('skips respond mode when reviewOnMention is false', () => {
     const result = shouldSkipByRules({ ...defaults, reviewOnMention: false }, { mode: 'respond', mentionTriggered: true });
-    expect(result).not.toBeNull();
+    expect(result?.kind).toBe('reviewOnMentionOff');
   });
 
   it('does not skip auto-triggered reviews when reviewOnMention is false', () => {
@@ -296,7 +296,8 @@ describe('shouldSkipByRules', () => {
       { ...defaults, autoReview: false },
       { isDraft: true, mode: 'review' },
     );
-    expect(result).toContain('Automatic reviews disabled');
+    expect(result?.kind).toBe('autoReviewOff');
+    expect(result?.reason).toContain('Automatic reviews disabled');
   });
 
   it('returns null when all rules pass', () => {

--- a/packages/core/src/skip-logic.ts
+++ b/packages/core/src/skip-logic.ts
@@ -118,39 +118,73 @@ export function shouldSkipPR(
 }
 
 /**
+ * Discriminator for the kind of rule-based skip. Callers branch on this when
+ * they want category-specific UX (e.g. posting a "how to enable" check run
+ * for `autoReviewOff` only) without string-matching the human-readable reason.
+ */
+export type RulesSkipKind =
+  | 'autoReviewOff'
+  | 'reviewOnMentionOff'
+  | 'draft'
+  | 'maxFiles'
+  | 'labelIgnored';
+
+export interface RulesSkipResult {
+  kind: RulesSkipKind;
+  /** Human-readable reason, used for logging and stored on the review record. */
+  reason: string;
+}
+
+/**
  * Check whether a PR should be skipped based on the rules config.
- * Returns a skip reason string if skipped, or null if the PR should be reviewed.
+ * Returns a result object describing the skip kind + reason if skipped, or
+ * null if the PR should be reviewed.
  */
 export function shouldSkipByRules(
   rules: RulesConfig,
   pr: { isDraft?: boolean; labels?: string[]; changedFileCount?: number; mode?: string; mentionTriggered?: boolean },
-): string | null {
+): RulesSkipResult | null {
   // mentionTriggered is the authoritative signal for whether a user explicitly
   // requested this review via an @mergewatch comment.  When true, the review
   // is treated as a force-review that bypasses autoReview/reviewOnMention gates.
   const isMentionTriggered = pr.mentionTriggered === true;
 
   if (!rules.autoReview && !isMentionTriggered) {
-    return 'Automatic reviews disabled — use @mergewatch to trigger manually';
+    return {
+      kind: 'autoReviewOff',
+      reason: 'Automatic reviews disabled — use @mergewatch to trigger manually',
+    };
   }
 
   if (!rules.reviewOnMention && isMentionTriggered) {
-    return 'Mention-triggered reviews disabled via reviewOnMention: false';
+    return {
+      kind: 'reviewOnMentionOff',
+      reason: 'Mention-triggered reviews disabled via reviewOnMention: false',
+    };
   }
 
   if (rules.skipDrafts && pr.isDraft) {
-    return 'Draft PR — set rules.skipDrafts: false to review drafts';
+    return {
+      kind: 'draft',
+      reason: 'Draft PR — set rules.skipDrafts: false to review drafts',
+    };
   }
 
   if (pr.changedFileCount != null && pr.changedFileCount > rules.maxFiles) {
-    return `PR has ${pr.changedFileCount} changed files (max: ${rules.maxFiles})`;
+    return {
+      kind: 'maxFiles',
+      reason: `PR has ${pr.changedFileCount} changed files (max: ${rules.maxFiles})`,
+    };
   }
 
   if (pr.labels && rules.ignoreLabels.length > 0) {
     const ignoreLabelSet = new Set(rules.ignoreLabels.map((l) => l.toLowerCase()));
     const matchedLabel = pr.labels.find((l) => ignoreLabelSet.has(l.toLowerCase()));
     if (matchedLabel) {
-      return `PR has label "${matchedLabel}" which is in ignoreLabels`;
+      return {
+        kind: 'labelIgnored',
+        reason: `PR has label "${matchedLabel}" which is in ignoreLabels`,
+      };
     }
   }
 

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -394,31 +394,38 @@ export async function handler(
     const runtimeConfig = mergeConfig({ ...(yamlConfig ?? {}), ...settingsOverrides });
 
     // ── Rules-based skip (skipDrafts, maxFiles, ignoreLabels, autoReview, reviewOnMention) ────
-    const rulesSkipReason = shouldSkipByRules(runtimeConfig.rules, {
+    const rulesSkip = shouldSkipByRules(runtimeConfig.rules, {
       isDraft: event.isDraft,
       labels: event.prLabels,
       changedFileCount: event.changedFileCount ?? prContext?.files?.length,
       mode,
       mentionTriggered: event.mentionTriggered,
     });
-    if (rulesSkipReason) {
-      console.log(`Rules skip ${repoFullName}#${prNumber}: ${rulesSkipReason}`);
+    if (rulesSkip) {
+      console.log(`Rules skip ${repoFullName}#${prNumber} (${rulesSkip.kind}): ${rulesSkip.reason}`);
 
       await reviewStore.updateStatus(repoFullName, prNumberCommitSha, 'skipped', {
         completedAt: new Date().toISOString(),
-        skipReason: rulesSkipReason,
+        skipReason: rulesSkip.reason,
       });
 
+      // Surface autoReview=false as a user-actionable check run with the
+      // mention-trigger instructions; other skip kinds keep the generic title.
+      const checkRunCopy = rulesSkip.kind === 'autoReviewOff'
+        ? {
+            title: 'Auto-review is disabled for this repository',
+            summary: 'Comment `@mergewatch review` on this PR to run a review.',
+          }
+        : { title: 'Review skipped', summary: rulesSkip.reason };
       await createCheckRun(octokit, owner, repo, headSha, {
         status: 'completed',
         conclusion: 'neutral',
-        title: 'Review skipped',
-        summary: rulesSkipReason,
+        ...checkRunCopy,
       });
 
       return {
         statusCode: 200,
-        body: JSON.stringify({ message: 'Skipped', reason: rulesSkipReason }),
+        body: JSON.stringify({ message: 'Skipped', reason: rulesSkip.reason, kind: rulesSkip.kind }),
       };
     }
 

--- a/packages/server/src/review-processor.test.ts
+++ b/packages/server/src/review-processor.test.ts
@@ -172,7 +172,7 @@ describe('processReviewJob — check runs', () => {
   });
 
   it('creates neutral check run on rules skip', async () => {
-    (shouldSkipByRules as any).mockReturnValue('Draft PR skipped');
+    (shouldSkipByRules as any).mockReturnValue({ kind: 'draft', reason: 'Draft PR skipped' });
     const deps = makeDeps();
     await processReviewJob(makeJob(), deps);
 
@@ -183,6 +183,25 @@ describe('processReviewJob — check runs', () => {
         conclusion: 'neutral',
         title: 'Review skipped',
         summary: 'Draft PR skipped',
+      }),
+    );
+  });
+
+  it('creates user-actionable check run on autoReviewOff skip', async () => {
+    (shouldSkipByRules as any).mockReturnValue({
+      kind: 'autoReviewOff',
+      reason: 'Automatic reviews disabled — use @mergewatch to trigger manually',
+    });
+    const deps = makeDeps();
+    await processReviewJob(makeJob(), deps);
+
+    expect(createCheckRun).toHaveBeenCalledWith(
+      mockOctokit, 'test', 'repo', basePRContext.headSha,
+      expect.objectContaining({
+        status: 'completed',
+        conclusion: 'neutral',
+        title: 'Auto-review is disabled for this repository',
+        summary: expect.stringContaining('@mergewatch review'),
       }),
     );
   });

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -279,22 +279,29 @@ export async function processReviewJob(
   });
 
   // ── Rules-based skip (skipDrafts, maxFiles, ignoreLabels, autoReview, reviewOnMention) ────
-  const rulesSkipReason = shouldSkipByRules(config.rules, {
+  const rulesSkip = shouldSkipByRules(config.rules, {
     isDraft: job.isDraft,
     labels: job.prLabels,
     changedFileCount: job.changedFileCount ?? prContext?.files?.length,
     mode,
     mentionTriggered: job.mentionTriggered,
   });
-  if (rulesSkipReason) {
-    await deps.reviewStore.updateStatus(repoFullName, prNumberCommitSha, 'skipped', { completedAt: now, skipReason: rulesSkipReason });
+  if (rulesSkip) {
+    await deps.reviewStore.updateStatus(repoFullName, prNumberCommitSha, 'skipped', { completedAt: now, skipReason: rulesSkip.reason });
+    // Surface autoReview=false as a user-actionable check run with the
+    // mention-trigger instructions; other skip kinds keep the generic title.
+    const checkRunCopy = rulesSkip.kind === 'autoReviewOff'
+      ? {
+          title: 'Auto-review is disabled for this repository',
+          summary: 'Comment `@mergewatch review` on this PR to run a review.',
+        }
+      : { title: 'Review skipped', summary: rulesSkip.reason };
     await createCheckRun(octokit, owner, repo, headSha, {
       status: 'completed',
       conclusion: 'neutral',
-      title: 'Review skipped',
-      summary: rulesSkipReason,
+      ...checkRunCopy,
     }).catch((err) => console.warn('Failed to create rules skip check run:', err));
-    console.log(`Rules skip ${repoFullName}#${prNumber}: ${rulesSkipReason}`);
+    console.log(`Rules skip ${repoFullName}#${prNumber} (${rulesSkip.kind}): ${rulesSkip.reason}`);
     return;
   }
 


### PR DESCRIPTION
## Why

`rules.autoReview: false` already worked at the skip-logic level — the review pipeline bypassed PR opens / synchronizes when the flag was off, and only ran on `@mergewatch review` mentions. But there was **no user-visible signal** that auto-review was off. PR authors saw nothing in the merge box, then waited for a review that never came.

## What

When `shouldSkipByRules` returns the `autoReviewOff` skip kind, the check run posted to the PR now uses user-actionable copy:

```
✓ Auto-review is disabled for this repository
   Comment `@mergewatch review` on this PR to run a review.
```

Other skip kinds (`draft`, `maxFiles`, `labelIgnored`, `reviewOnMentionOff`) keep the existing generic "Review skipped" title with their detailed reason as summary — those are intentional skips that don't need user-facing instructions.

## Type-level change

`shouldSkipByRules` previously returned `string | null` (the human-readable reason). Now it returns:

```ts
type RulesSkipResult = { kind: RulesSkipKind; reason: string } | null;
type RulesSkipKind =
  | 'autoReviewOff'
  | 'reviewOnMentionOff'
  | 'draft'
  | 'maxFiles'
  | 'labelIgnored';
```

Callers branch on `.kind` instead of substring-matching the reason. Both transports (Lambda + Express) and their tests are updated.

## Per the agreed shape

- ✅ Check run only — no comment posted on auto-skip
- ✅ Wording: "Auto-review is disabled for this repository. Comment `@mergewatch review` on this PR to run a review."
- ✅ Only `autoReviewOff` gets the new copy; other skips unchanged
- ✅ When the user does `@mergewatch review`, the normal review pipeline posts a fresh comment — no placeholder to update

## Test plan
- [x] `pnpm --filter @mergewatch/core run test` — 334 pass (assertions migrated to `.kind` + `.reason`)
- [x] `pnpm --filter @mergewatch/lambda run test` — 54 pass
- [x] `pnpm --filter @mergewatch/server run test` — 57 pass (1 new: autoReviewOff check-run wording)
- [x] `pnpm run typecheck` — all 20 packages clean
- [ ] After deploy, set `autoReview: false` in a test repo's `.mergewatch.yml`, push a commit, and confirm the new check run appears with the mention-trigger instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)