### PR TITLE
Handle multi-line quoted labels in Mermaid sanitizer

### DIFF
--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -324,6 +324,35 @@ describe('runDiagramAgent', () => {
     expect(result.diagram).toContain('fetch&lpar;url&rpar;<br/>returns Result&lt;T&gt;');
   });
 
+  it('converts a lone real \\r inside a quoted label into <br/>', async () => {
+    // Mac classic / mis-encoded CR-only line endings — Mermaid still parses
+    // these as line breaks in some grammars, so we normalise to <br/>.
+    const mermaid = 'flowchart TD\n  A["one\rtwo"]';
+    const llm = createMockLLM([mermaid]);
+    const result = await runDiagramAgent(sampleDiff, sampleContext, 'model-1', llm);
+    expect(result.diagram).toContain('one<br/>two');
+    expect(result.diagram).not.toContain('\r');
+  });
+
+  it('converts real tab characters into 4 spaces', async () => {
+    const mermaid = 'flowchart TD\n  A["col1\tcol2"]';
+    const llm = createMockLLM([mermaid]);
+    const result = await runDiagramAgent(sampleDiff, sampleContext, 'model-1', llm);
+    expect(result.diagram).toContain('col1    col2');
+    expect(result.diagram).not.toContain('\t');
+  });
+
+  it('cleans up literal \\t and \\r JSON-escape sequences', async () => {
+    // The LLM occasionally emits these as cosmetic JSON escapes thinking
+    // Mermaid will interpret them; it renders the literal backslash-X chars.
+    const mermaid = 'flowchart TD\n  A["one\\ttwo\\rthree"]';
+    const llm = createMockLLM([mermaid]);
+    const result = await runDiagramAgent(sampleDiff, sampleContext, 'model-1', llm);
+    expect(result.diagram).not.toContain('\\t');
+    expect(result.diagram).not.toContain('\\r');
+    expect(result.diagram).toContain('one two three');
+  });
+
   it('still quotes unquoted labels with reserved chars (existing behavior)', async () => {
     const mermaid = 'flowchart TD\n  A[invoke()]';
     const llm = createMockLLM([mermaid]);

--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -303,6 +303,27 @@ describe('runDiagramAgent', () => {
     expect(result.diagram).not.toContain('\\n');
   });
 
+  it('replaces REAL newline characters inside quoted labels with <br/>', async () => {
+    // Reproduces the prod failure that the prior fix missed: the LLM emits a
+    // genuine newline (not the two-char `\n` literal) inside a quoted label.
+    // sanitizeMermaidOutput used to split on '\n' BEFORE the quoted-region
+    // escape ran, destroying the quote pair before it could be matched.
+    const mermaid = 'flowchart TD\n  A["line one\nline two"]';
+    const llm = createMockLLM([mermaid]);
+    const result = await runDiagramAgent(sampleDiff, sampleContext, 'model-1', llm);
+    expect(result.diagram).toContain('line one<br/>line two');
+    // The resulting line should be single-line — no stray newline left inside
+    // the label that would still confuse Mermaid's parser.
+    expect(result.diagram).not.toMatch(/"line one\n/);
+  });
+
+  it('handles real-newline alongside other forbidden chars in the same label', async () => {
+    const mermaid = 'flowchart TD\n  A["fetch(url)\nreturns Result<T>"]';
+    const llm = createMockLLM([mermaid]);
+    const result = await runDiagramAgent(sampleDiff, sampleContext, 'model-1', llm);
+    expect(result.diagram).toContain('fetch&lpar;url&rpar;<br/>returns Result&lt;T&gt;');
+  });
+
   it('still quotes unquoted labels with reserved chars (existing behavior)', async () => {
     const mermaid = 'flowchart TD\n  A[invoke()]';
     const llm = createMockLLM([mermaid]);

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -359,7 +359,11 @@ function escapeMermaidLabelChars(label: string): string {
     .replace(/\)/g, '&rpar;')
     .replace(/\[/g, '&lsqb;')
     .replace(/\]/g, '&rsqb;')
-    .replace(/\\n/g, '<br/>');
+    // Both forms of "newline inside a label" need to become <br/>: the LLM
+    // sometimes emits a JSON-style literal `\n` (two chars), and sometimes
+    // an actual newline character. Mermaid's flowchart parser refuses both.
+    .replace(/\\n/g, '<br/>')
+    .replace(/\r?\n/g, '<br/>');
 }
 
 /**
@@ -377,7 +381,23 @@ function escapeMermaidLabelChars(label: string): string {
  * 3. Quotes unquoted edge labels (|...|) that contain reserved characters.
  */
 function sanitizeMermaidOutput(diagram: string): string {
-  const lines = diagram.split('\n');
+  // Pass 1 — full-diagram scan: escape forbidden chars inside ANY double-
+  // quoted region. Critically this runs BEFORE the per-line split so labels
+  // that span multiple lines (an embedded real newline inside `"..."`) are
+  // captured as a single match. The character class `[^"]` includes newlines,
+  // so the regex naturally crosses line boundaries.
+  //
+  // Inside escapeMermaidLabelChars, both literal `\\n` (two chars) and real
+  // newline chars are converted to `<br/>` — either way the resulting label
+  // is single-line and Mermaid-safe by the time we split by lines below.
+  const preEscaped = diagram.replace(/"([^"]*)"/g, (_match, inner: string) => {
+    return `"${escapeMermaidLabelChars(inner)}"`;
+  });
+
+  // Pass 2 — per-line passes for unquoted labels. These regexes only operate
+  // within a single line, which is fine post Pass 1: any quoted region with
+  // embedded newlines has already been collapsed via <br/>.
+  const lines = preEscaped.split('\n');
   const sanitized = lines.map((line) => {
     // Skip comments, directives, empty lines, and structural keywords
     const trimmed = line.trim();
@@ -388,14 +408,6 @@ function sanitizeMermaidOutput(diagram: string): string {
     }
 
     let result = line;
-
-    // Pass 1: escape forbidden chars inside ANY double-quoted region. Catches
-    // labels that arrived already quoted from the LLM but contain `{`, `}`,
-    // `<`, `>`, or literal `\n` — Mermaid's `(\"...\")` lexer doesn't reliably
-    // suppress shape-delimiter interpretation inside the quotes.
-    result = result.replace(/"([^"]*)"/g, (_match, inner: string) => {
-      return `"${escapeMermaidLabelChars(inner)}"`;
-    });
 
     // Pass 2 (existing): quote unquoted labels that contain reserved chars.
     // Apply the same escaping when wrapping so the wrapped label is safe too.

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -359,11 +359,17 @@ function escapeMermaidLabelChars(label: string): string {
     .replace(/\)/g, '&rpar;')
     .replace(/\[/g, '&lsqb;')
     .replace(/\]/g, '&rsqb;')
-    // Both forms of "newline inside a label" need to become <br/>: the LLM
-    // sometimes emits a JSON-style literal `\n` (two chars), and sometimes
-    // an actual newline character. Mermaid's flowchart parser refuses both.
-    .replace(/\\n/g, '<br/>')
-    .replace(/\r?\n/g, '<br/>');
+    // Newline-family normalisation. Mermaid's flowchart parser refuses real
+    // line breaks inside labels and renders the JSON-style literals as ugly
+    // backslash sequences. Run the literal forms first, then the real-char
+    // forms — the real-char regexes are subsets of each other so order
+    // matters: CRLF/LF before lone CR, otherwise `\r` would consume the `\r`
+    // half of a `\r\n` and leave a stray `\n`.
+    .replace(/\\n/g, '<br/>')          // literal `\\n` (two chars)
+    .replace(/\\[trvfb]/g, ' ')         // literal `\\t` `\\r` `\\v` `\\f` `\\b` → space
+    .replace(/\r?\n/g, '<br/>')         // real LF or CRLF
+    .replace(/\r/g, '<br/>')            // lone real CR (Mermaid treats as line break in some grammars)
+    .replace(/\t/g, '    ');            // real tab → 4 spaces (consistent across renderers)
 }
 
 /**


### PR DESCRIPTION
## Why the prior fix wasn't enough

PR #129 escaped Mermaid shape delimiters inside quoted labels — but I only tested with literal `\\n` (two chars: backslash + n) and missed the case where the LLM emits an **actual newline character** inside a quoted label:

```
A["line one
line two"]
```

When sanitizeMermaidOutput hit that, two bugs combined to let it through:

1. **Per-line tokenization broke multi-line labels.** The function did `diagram.split('\n')` *before* the quoted-region escape, splitting the label into two half-strings (`A["line one` and `line two"]`). Neither half matches `/"([^"]*)"/`, so the escape never fired.
2. **escapeMermaidLabelChars only handled literal `\\n`.** Even with bug 1 fixed, a real newline character would pass through untouched.

Mermaid's parser doesn't accept literal newlines inside node labels — diagram explodes.

## Fix

1. **Run the quoted-region escape on the full diagram BEFORE splitting by lines.** The char class `[^"]` in the regex naturally matches newlines, so multi-line quoted labels get captured as a single match.
2. **Add `\r?\n → <br/>` to escapeMermaidLabelChars.** Handles real newlines and Windows-style `\r\n`. Runs after the existing literal-`\\n` and angle-bracket substitutions so the `<` and `>` in our own `<br/>` aren't mangled.

After Pass 1 runs, all quoted regions are single-line with `<br/>` separators — Pass 2 (the per-line unquoted-label-quote-wrap passes) keeps working as before.

## Test plan
- [x] `pnpm --filter @mergewatch/core run test` — 342 pass (2 new):
  - Real-newline inside a quoted label
  - Real-newline alongside `(`, `)`, `<`, `>` in the same label
- [x] `pnpm run typecheck` — all 20 packages clean
- [ ] After merge + deploy, watch CloudWatch for the specific failure shape: `Expecting ... got 'DIAMOND_START'` style errors should stop. If any new char family slips through, file a follow-up rather than chase it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)