### PR TITLE
Reconcile mergeScore with post-filter findings

### DIFF
--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -602,6 +602,103 @@ describe('runReviewPipeline', () => {
     return responses;
   }
 
+  it('overrides mergeScore to 5 when the orchestrator scored low but every finding was line-filtered', async () => {
+    // Reproduces a real prod confusion: orchestrator returns findings + a
+    // mergeScore of 3, but the line-proximity filter removes every finding
+    // because they live on lines not touched by this PR. The comment then
+    // renders "All clear!" alongside a "3/5 — Review recommended" verdict.
+    // This test locks in the post-filter score reconciliation.
+    const agentResponse = JSON.stringify({ findings: [] });
+    const summaryResponse = JSON.stringify({ summary: 'Refactor.' });
+    const diagramResponse = '%% overview\nflowchart TD\n  A-->B';
+    // Orchestrator returns ONE finding on a line not in the diff (sampleDiff
+    // only touches lines 1-3 of foo.ts), with a conservative mergeScore.
+    const orchestratorResponse = JSON.stringify({
+      findings: [{
+        file: 'foo.ts',
+        line: 100,
+        severity: 'warning',
+        category: 'style',
+        title: 'Nit on unrelated line',
+        description: '…',
+        suggestion: '…',
+      }],
+      mergeScore: 3,
+      mergeScoreReason: 'Multiple warnings.',
+    });
+    const llm = createMockLLM([
+      agentResponse, agentResponse, agentResponse, // security, bug, style
+      agentResponse, agentResponse, agentResponse, // errorHandling, testCoverage, commentAccuracy
+      summaryResponse, diagramResponse, orchestratorResponse,
+    ]);
+
+    const result = await runReviewPipeline(
+      {
+        diff: sampleDiff,
+        context: sampleContext,
+        modelId: 'heavy-model',
+        lightModelId: 'light-model',
+        maxFindings: 25,
+        enabledAgents: allAgentsEnabled,
+        // Force orchestrator to run by feeding it raw findings via previousFindings —
+        // when all current findings are empty but previousFindings is set, it runs.
+        previousFindings: [
+          { file: 'foo.ts', line: 100, title: 'Nit on unrelated line', severity: 'warning', category: 'style' },
+        ],
+      },
+      { llm },
+    );
+
+    expect(result.findings).toEqual([]);
+    expect(result.mergeScore).toBe(5);
+    expect(result.mergeScoreReason).toContain('No issues');
+  });
+
+  it('preserves the orchestrator mergeScore when there are visible findings post-filter', async () => {
+    // Orchestrator returns a finding on a CHANGED line (line 3 — within
+    // sampleDiff's range) with score 3. Filter keeps it. Score stays.
+    const agentResponse = JSON.stringify({ findings: [] });
+    const summaryResponse = JSON.stringify({ summary: 'Refactor.' });
+    const diagramResponse = '%% overview\nflowchart TD\n  A-->B';
+    const orchestratorResponse = JSON.stringify({
+      findings: [{
+        file: 'foo.ts',
+        line: 3,
+        severity: 'warning',
+        category: 'bug',
+        title: 'Real concern',
+        description: '…',
+        suggestion: '…',
+      }],
+      mergeScore: 3,
+      mergeScoreReason: 'One warning.',
+    });
+    const llm = createMockLLM([
+      agentResponse, agentResponse, agentResponse,
+      agentResponse, agentResponse, agentResponse,
+      summaryResponse, diagramResponse, orchestratorResponse,
+    ]);
+
+    const result = await runReviewPipeline(
+      {
+        diff: sampleDiff,
+        context: sampleContext,
+        modelId: 'heavy-model',
+        lightModelId: 'light-model',
+        maxFindings: 25,
+        enabledAgents: allAgentsEnabled,
+        previousFindings: [
+          { file: 'foo.ts', line: 3, title: 'Real concern', severity: 'warning', category: 'bug' },
+        ],
+      },
+      { llm },
+    );
+
+    expect(result.findings).toHaveLength(1);
+    expect(result.mergeScore).toBe(3);
+    expect(result.mergeScoreReason).toBe('One warning.');
+  });
+
   it('calls LLM for all enabled agents plus orchestrator', async () => {
     // With all agents enabled and no findings, the orchestrator is skipped (0 findings).
     // So we expect 8 LLM calls: 6 finding agents + summary + diagram

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -964,14 +964,25 @@ export async function runReviewPipeline(
     ? await runDeltaCaptionAgent(delta, lightModelId, llm)
     : null;
 
+  // Reconcile the orchestrator's verdict with the post-filter findings.
+  // The orchestrator scores based on pre-filter findings (and stays
+  // conservative when prior findings exist via carry-forward context) — so
+  // a 3/5 verdict can land next to an "All clear!" message when the
+  // changed-line filter strips every finding. Force 5/5 in that case so
+  // the score and the findings list agree.
+  const mergeScore = filteredFindings.length === 0 ? 5 : orchestratorResult.mergeScore;
+  const mergeScoreReason = filteredFindings.length === 0
+    ? 'No issues found on changed lines.'
+    : orchestratorResult.mergeScoreReason;
+
   return {
     summary,
     findings: filteredFindings,
     changedLines,
     diagram: diagramResult.diagram,
     diagramCaption: diagramResult.caption,
-    mergeScore: orchestratorResult.mergeScore,
-    mergeScoreReason: orchestratorResult.mergeScoreReason,
+    mergeScore,
+    mergeScoreReason,
     suppressedCount: Math.max(0, totalRawFindings - filteredFindings.length),
     enabledAgentCount,
     inputTokens: accumulator.totalInputTokens,


### PR DESCRIPTION
## The contradiction

Spotted on [PR #130's comment](https://github.com/santthosh/mergewatch.ai/pull/130#issuecomment-4427047531) — the same comment said all of:

```
✅ 2 resolved
📝 Resolved two code quality suggestions...
🟡 3/5 — Review recommended
🎉 All clear! No issues found
```

Score and findings disagree.

## Why it happened

`runReviewPipeline` returns `mergeScore: orchestratorResult.mergeScore` **without reconciling against the post-filter findings list**. Two ways the contradiction lands:

1. **Filter removed all findings.** The orchestrator returned findings + a low score; the changed-line proximity filter stripped them because they lived on lines this PR didn't touch. Score reflects the pre-filter count.
2. **Conservative LLM verdict.** The orchestrator returned 0 findings (resolved everything from carry-forward) but scored 3/5 because the LLM stays cautious when given prior-finding context. Score doesn't reflect the resolved state.

Either way: the score and the rendered "All clear!" message contradict.

## Fix

After the changed-line filter runs, if `filteredFindings.length === 0`, force `mergeScore` to `5/5` and `mergeScoreReason` to `"No issues found on changed lines."`. The orchestrator's verdict is preserved when at least one finding survives the filter.

## Test plan
- [x] **New**: orchestrator returns 1 finding at `line=100`, sample diff touches lines 1-3 → filter removes the finding → `result.mergeScore === 5` ✓
- [x] **New**: orchestrator returns 1 finding at `line=3` → filter keeps it → `result.mergeScore === 3` (orchestrator verdict preserved) ✓
- [x] 342 core tests, full typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)