### PR TITLE
Reconcile mergeScore for info-only PRs

### DIFF
--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -749,6 +749,55 @@ describe('runReviewPipeline', () => {
     expect(result.mergeScoreReason).toBe('One warning.');
   });
 
+  it('overrides mergeScore to 5 when only info-severity findings remain (no critical or warning action items)', async () => {
+    // Repro of the comment-rendering contradiction: orchestrator returns
+    // info-only findings + a 4/5 verdict. The action-items section renders
+    // "All clear!" (because action items = critical + warning are empty),
+    // but the merge score line still says "4/5 — Generally safe" based on
+    // info findings. Reconciliation should force 5/5 so the two agree.
+    const agentResponse = JSON.stringify({ findings: [] });
+    const summaryResponse = JSON.stringify({ summary: 'Some notes.' });
+    const diagramResponse = '%% overview\nflowchart TD\n  A-->B';
+    const orchestratorResponse = JSON.stringify({
+      findings: [{
+        file: 'foo.ts',
+        line: 3,
+        severity: 'info',
+        category: 'style',
+        title: 'Nit',
+        description: 'Minor stylistic note.',
+        suggestion: 'Consider renaming.',
+      }],
+      mergeScore: 4,
+      mergeScoreReason: 'Generally safe with minor notes.',
+    });
+    const llm = createMockLLM([
+      agentResponse, agentResponse, agentResponse,
+      agentResponse, agentResponse, agentResponse,
+      summaryResponse, diagramResponse, orchestratorResponse,
+    ]);
+
+    const result = await runReviewPipeline(
+      {
+        diff: sampleDiff,
+        context: sampleContext,
+        modelId: 'heavy-model',
+        lightModelId: 'light-model',
+        maxFindings: 25,
+        enabledAgents: allAgentsEnabled,
+        previousFindings: [
+          { file: 'foo.ts', line: 3, title: 'Nit', severity: 'info', category: 'style' },
+        ],
+      },
+      { llm },
+    );
+
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].severity).toBe('info');
+    expect(result.mergeScore).toBe(5);
+    expect(result.mergeScoreReason).toContain('informational');
+  });
+
   it('calls LLM for all enabled agents plus orchestrator', async () => {
     // With all agents enabled and no findings, the orchestrator is skipped (0 findings).
     // So we expect 8 LLM calls: 6 finding agents + summary + diagram

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -986,11 +986,20 @@ export async function runReviewPipeline(
   // The orchestrator scores based on pre-filter findings (and stays
   // conservative when prior findings exist via carry-forward context) — so
   // a 3/5 verdict can land next to an "All clear!" message when the
-  // changed-line filter strips every finding. Force 5/5 in that case so
-  // the score and the findings list agree.
-  const mergeScore = filteredFindings.length === 0 ? 5 : orchestratorResult.mergeScore;
-  const mergeScoreReason = filteredFindings.length === 0
-    ? 'No issues found on changed lines.'
+  // changed-line filter strips every finding. Force 5/5 in two cases:
+  //   1. No findings at all → genuinely clean.
+  //   2. Only info findings → comment-formatter renders "All clear!" because
+  //      info findings aren't action items. Info is advisory; it shouldn't
+  //      drag the merge score down or contradict the rendered verdict.
+  const actionFindings = filteredFindings.filter(
+    (f) => f.severity === 'critical' || f.severity === 'warning',
+  );
+  const noActionItems = actionFindings.length === 0;
+  const mergeScore = noActionItems ? 5 : orchestratorResult.mergeScore;
+  const mergeScoreReason = noActionItems
+    ? filteredFindings.length === 0
+      ? 'No issues found on changed lines.'
+      : 'No action items — only informational notes.'
     : orchestratorResult.mergeScoreReason;
 
   return {


### PR DESCRIPTION
## Summary
Fixes the contradiction users saw on PRs with only info-severity findings:

- Top: 🟢 4/5 — Generally safe
- Bottom: 🎉 All clear! No issues found

PR #131 forced `mergeScore = 5` only when `filteredFindings.length === 0`. Info-only PRs fell through: the comment-formatter renders "All clear!" when action items (critical + warning) are zero, but the merge-score badge still reflected the orchestrator's score derived from info findings.

Info findings are advisory — they shouldn't drag the merge score down or contradict the rendered verdict.

## The fix
`packages/core/src/agents/reviewer.ts` — extend the reconciliation. Force `mergeScore = 5` when `actionFindings.length === 0`, covering:
- No findings at all → reason: "No issues found on changed lines."
- Only info findings → reason: "No action items — only informational notes."

## Test plan
- [x] New unit test in `reviewer.test.ts`: info-only orchestrator output with score 4 → reconciled to 5 with the info-specific reason
- [x] Existing reconciliation test (no findings case) still passes
- [x] Existing "preserves score when warnings remain" test still passes
- [x] `pnpm run typecheck` clean across all 20 packages
- [x] `pnpm test` in core: 351 tests pass (+1 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)