### PR TITLE
Go silent when autoReview is off — no PR-side trace

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -147,7 +147,7 @@ export { invokeWithFileFetching, FILE_REQUEST_INSTRUCTION } from './context/agen
 export type { FileFetchOptions, AgenticInvokeResult } from './context/agentic-fetcher.js';
 
 // ─── Skip logic ─────────────────────────────────────────────────────────────
-export { shouldSkipPR, shouldSkipByRules, extractIncludePatterns, SKIP_PATTERNS } from './skip-logic.js';
+export { shouldSkipPR, shouldSkipByRules, isAutoReviewOff, extractIncludePatterns, SKIP_PATTERNS } from './skip-logic.js';
 export type { RulesSkipKind, RulesSkipResult } from './skip-logic.js';
 
 // ─── Agent-authored PR detection ────────────────────────────────────────────

--- a/packages/core/src/skip-logic.test.ts
+++ b/packages/core/src/skip-logic.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { shouldSkipPR, shouldSkipByRules, extractIncludePatterns, SKIP_PATTERNS } from './skip-logic.js';
+import { shouldSkipPR, shouldSkipByRules, isAutoReviewOff, extractIncludePatterns, SKIP_PATTERNS } from './skip-logic.js';
 import { DEFAULT_RULES_CONFIG } from './config/defaults.js';
 import type { RulesConfig } from './config/defaults.js';
 
@@ -308,5 +308,35 @@ describe('shouldSkipByRules', () => {
       mode: 'review',
     });
     expect(result).toBeNull();
+  });
+});
+
+describe('isAutoReviewOff', () => {
+  it('returns true when rules.autoReview is explicitly false', () => {
+    expect(isAutoReviewOff({ rules: { autoReview: false } as never }, false)).toBe(true);
+  });
+
+  it('returns false when mentionTriggered is true (explicit user request bypasses silence)', () => {
+    expect(isAutoReviewOff({ rules: { autoReview: false } as never }, true)).toBe(false);
+  });
+
+  it('returns false when autoReview is true', () => {
+    expect(isAutoReviewOff({ rules: { autoReview: true } as never }, false)).toBe(false);
+  });
+
+  it('returns false when YAML lacks a rules block (defaults to autoReview=true)', () => {
+    expect(isAutoReviewOff({}, false)).toBe(false);
+  });
+
+  it('returns false when yamlConfig is null (fetch failed)', () => {
+    expect(isAutoReviewOff(null, false)).toBe(false);
+  });
+
+  it('returns false when yamlConfig is undefined', () => {
+    expect(isAutoReviewOff(undefined, false)).toBe(false);
+  });
+
+  it('treats undefined mentionTriggered like false (auto-triggered)', () => {
+    expect(isAutoReviewOff({ rules: { autoReview: false } as never }, undefined)).toBe(true);
   });
 });

--- a/packages/core/src/skip-logic.ts
+++ b/packages/core/src/skip-logic.ts
@@ -136,6 +136,27 @@ export interface RulesSkipResult {
 }
 
 /**
+ * Predicate for the *silent* skip path: returns true when the repo has
+ * `rules.autoReview: false` in `.mergewatch.yml` AND the review wasn't
+ * mention-triggered. The runtime handlers consult this BEFORE any GitHub
+ * side effect (eyes reaction, check run, PR review) so a parked install
+ * leaves no trace on the PR. Other skip kinds (draft, maxFiles, labels)
+ * still surface a check run via `shouldSkipByRules`; only autoReviewOff
+ * goes silent.
+ *
+ * Accepts the partial YAML shape directly (no DEFAULT merge needed) since
+ * we only care about the explicit user opt-out signal — a missing
+ * `rules.autoReview` falls back to the default `true` and returns false here.
+ */
+export function isAutoReviewOff(
+  yamlConfig: Partial<MergeWatchConfig> | null | undefined,
+  mentionTriggered: boolean | undefined,
+): boolean {
+  if (mentionTriggered === true) return false;
+  return yamlConfig?.rules?.autoReview === false;
+}
+
+/**
  * Check whether a PR should be skipped based on the rules config.
  * Returns a result object describing the skip kind + reason if skipped, or
  * null if the PR should be reviewed.

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -28,6 +28,7 @@ import {
   shouldSkipPR,
   extractIncludePatterns,
   shouldSkipByRules,
+  isAutoReviewOff,
   filterDiff,
   RESPOND_PROMPT,
   BOT_COMMENT_MARKER,
@@ -255,20 +256,32 @@ export async function handler(
 
   // ── Handle "review" / "summary" modes ──────────────────────────────────
 
-  const prContext = await getPRContext(octokit, owner, repo, prNumber);
-  const headSha = prContext.headSha;
-  const shortSha = headSha.slice(0, 7);
-  const prNumberCommitSha = `${prNumber}#${shortSha}`;
-
-  // Load .mergewatch.yml once. Used both for the smart-skip includePatterns
-  // override and later when building the full runtimeConfig — avoids two
-  // GitHub fetches per review.
+  // Load .mergewatch.yml first so we can evaluate autoReview before any
+  // GitHub-visible side effect (eyes reaction, in-progress check run, PR
+  // review). A repo with `rules.autoReview: false` is a parked install —
+  // we go fully silent: no reactions, no check runs, no storage write.
+  // Other skip kinds (draft, maxFiles, labels) still surface a check run
+  // via shouldSkipByRules below; only autoReviewOff goes silent.
   const yamlConfig = await fetchRepoConfig(octokit, owner, repo).catch((err) => {
     // Static format string; user-controlled values pass as separate args
     // to avoid feeding repo names through Node's printf-style formatter.
     console.warn('Failed to fetch .mergewatch.yml — proceeding without YAML config:', `${repoFullName}#${prNumber}`, err);
     return null;
   });
+
+  if (isAutoReviewOff(yamlConfig, event.mentionTriggered)) {
+    console.log(`autoReview off — silently skipping ${repoFullName}#${prNumber}`);
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ message: 'Skipped silently (autoReview off)' }),
+    };
+  }
+
+  const prContext = await getPRContext(octokit, owner, repo, prNumber);
+  const headSha = prContext.headSha;
+  const shortSha = headSha.slice(0, 7);
+  const prNumberCommitSha = `${prNumber}#${shortSha}`;
+
   const includePatterns = extractIncludePatterns(yamlConfig);
 
   // ── Smart skip — bypass when user explicitly requested a review via @mergewatch ────
@@ -408,18 +421,14 @@ export async function handler(
         skipReason: rulesSkip.reason,
       });
 
-      // Surface autoReview=false as a user-actionable check run with the
-      // mention-trigger instructions; other skip kinds keep the generic title.
-      const checkRunCopy = rulesSkip.kind === 'autoReviewOff'
-        ? {
-            title: 'Auto-review is disabled for this repository',
-            summary: 'Comment `@mergewatch review` on this PR to run a review.',
-          }
-        : { title: 'Review skipped', summary: rulesSkip.reason };
+      // autoReviewOff is handled silently earlier (before any GitHub side
+      // effect). Any rulesSkip seen here is a visible-skip kind: draft,
+      // maxFiles, labelIgnored, reviewOnMentionOff.
       await createCheckRun(octokit, owner, repo, headSha, {
         status: 'completed',
         conclusion: 'neutral',
-        ...checkRunCopy,
+        title: 'Review skipped',
+        summary: rulesSkip.reason,
       });
 
       return {

--- a/packages/server/src/review-processor.test.ts
+++ b/packages/server/src/review-processor.test.ts
@@ -129,6 +129,9 @@ describe('processReviewJob — check runs', () => {
     (shouldSkipPR as any).mockReturnValue(null);
     (shouldSkipByRules as any).mockReturnValue(null);
     (runReviewPipeline as any).mockResolvedValue(basePipelineResult);
+    // vi.clearAllMocks() doesn't reset .mockResolvedValue implementations
+    // set by previous tests, so explicitly restore the default.
+    (fetchRepoConfig as any).mockResolvedValue(null);
   });
 
   it('creates in-progress check run after eyes reaction', async () => {
@@ -186,23 +189,30 @@ describe('processReviewJob — check runs', () => {
     );
   });
 
-  it('creates user-actionable check run on autoReviewOff skip', async () => {
-    (shouldSkipByRules as any).mockReturnValue({
-      kind: 'autoReviewOff',
-      reason: 'Automatic reviews disabled — use @mergewatch to trigger manually',
-    });
+  it('goes fully silent when autoReview is off in .mergewatch.yml (no reactions, no check runs, no storage writes)', async () => {
+    (fetchRepoConfig as any).mockResolvedValueOnce({ rules: { autoReview: false } });
     const deps = makeDeps();
     await processReviewJob(makeJob(), deps);
 
-    expect(createCheckRun).toHaveBeenCalledWith(
-      mockOctokit, 'test', 'repo', basePRContext.headSha,
-      expect.objectContaining({
-        status: 'completed',
-        conclusion: 'neutral',
-        title: 'Auto-review is disabled for this repository',
-        summary: expect.stringContaining('@mergewatch review'),
-      }),
-    );
+    // No GitHub-visible side effects
+    expect(createCheckRun).not.toHaveBeenCalled();
+    // PR context is never fetched on the silent path — saves a round-trip
+    expect(getPRContext).not.toHaveBeenCalled();
+    expect(getPRDiff).not.toHaveBeenCalled();
+    // No storage write — parked repos don't accumulate skipped records
+    expect(deps.reviewStore.claimReview).not.toHaveBeenCalled();
+    expect(deps.reviewStore.updateStatus).not.toHaveBeenCalled();
+  });
+
+  it('still runs review when autoReview is off but mentionTriggered is true (@mergewatch override)', async () => {
+    (fetchRepoConfig as any).mockResolvedValueOnce({ rules: { autoReview: false } });
+    (runReviewPipeline as any).mockResolvedValue(basePipelineResult);
+    const deps = makeDeps();
+    await processReviewJob(makeJob({ mentionTriggered: true }), deps);
+
+    // PR context fetched + review pipeline ran — the silent gate honors mention overrides
+    expect(getPRContext).toHaveBeenCalled();
+    expect(runReviewPipeline).toHaveBeenCalled();
   });
 
   it('creates failure check run on error', async () => {
@@ -330,6 +340,7 @@ describe('processReviewJob — respond mode', () => {
     vi.clearAllMocks();
     (getPRContext as any).mockResolvedValue(basePRContext);
     (getPRDiff as any).mockResolvedValue('diff content');
+    (fetchRepoConfig as any).mockResolvedValue(null);
   });
 
   it('calls LLM and posts reply for respond mode', async () => {
@@ -406,6 +417,7 @@ describe('processReviewJob — config merging', () => {
     (shouldSkipPR as any).mockReturnValue(null);
     (shouldSkipByRules as any).mockReturnValue(null);
     (runReviewPipeline as any).mockResolvedValue(basePipelineResult);
+    (fetchRepoConfig as any).mockResolvedValue(null);
   });
 
   it('maps dashboard severity threshold to minSeverity', async () => {
@@ -569,6 +581,7 @@ describe('processReviewJob — agent-authored wiring', () => {
     (shouldSkipPR as any).mockReturnValue(null);
     (shouldSkipByRules as any).mockReturnValue(null);
     (runReviewPipeline as any).mockResolvedValue(basePipelineResult);
+    (fetchRepoConfig as any).mockResolvedValue(null);
   });
 
   it('persists source and agentKind on the claimed review record', async () => {

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -2,7 +2,7 @@ import type { ReviewJobPayload, IInstallationStore, IReviewStore, IGitHubAuthPro
 import {
   getPRDiff, getPRContext, addPRReaction, postReviewComment, updateReviewComment,
   findExistingBotComment, getCommentReactions, createCheckRun,
-  formatReviewComment, runReviewPipeline, shouldSkipPR, shouldSkipByRules, extractIncludePatterns,
+  formatReviewComment, runReviewPipeline, shouldSkipPR, shouldSkipByRules, isAutoReviewOff, extractIncludePatterns,
   filterDiff,
   DEFAULT_CONFIG, mergeConfig,
   BOT_COMMENT_MARKER, submitPRReview, dismissStaleReviews, mergeScoreToReviewEvent,
@@ -175,6 +175,24 @@ export async function processReviewJob(
     return handleInlineReplyJob(octokit, job, deps);
   }
 
+  // Load .mergewatch.yml first so we can evaluate autoReview before any
+  // GitHub-visible side effect (eyes reaction, in-progress check run, PR
+  // review). A repo with `rules.autoReview: false` is a parked install —
+  // we go fully silent: no reactions, no check runs, no storage write.
+  // Other skip kinds (draft, maxFiles, labels) still surface a check run
+  // via shouldSkipByRules below; only autoReviewOff goes silent.
+  const yamlConfig = await fetchRepoConfig(octokit, owner, repo).catch((err) => {
+    // Static format string; user-controlled values pass as separate args
+    // to avoid feeding repo names through Node's printf-style formatter.
+    console.warn('Failed to fetch .mergewatch.yml — proceeding without YAML config:', `${repoFullName}#${prNumber}`, err);
+    return null;
+  });
+
+  if (isAutoReviewOff(yamlConfig, job.mentionTriggered)) {
+    console.log(`autoReview off — silently skipping ${repoFullName}#${prNumber}`);
+    return;
+  }
+
   // Fetch PR context and diff
   const prContext = await getPRContext(octokit, owner, repo, prNumber);
   const diff = await getPRDiff(octokit, owner, repo, prNumber);
@@ -215,15 +233,8 @@ export async function processReviewJob(
     summary: `MergeWatch is reviewing PR #${prNumber}...`,
   }).catch((err) => console.warn('Failed to create in-progress check run:', err));
 
-  // Load .mergewatch.yml once. Used for the smart-skip includePatterns
-  // override and reused below when building the full runtimeConfig — avoids
-  // a second GitHub round-trip per review.
-  const yamlConfig = await fetchRepoConfig(octokit, owner, repo).catch((err) => {
-    // Static format string; user-controlled values pass as separate args
-    // to avoid feeding repo names through Node's printf-style formatter.
-    console.warn('Failed to fetch .mergewatch.yml — proceeding without YAML config:', `${repoFullName}#${prNumber}`, err);
-    return null;
-  });
+  // yamlConfig was fetched earlier for the autoReview silent-skip gate and
+  // is reused below for includePatterns + runtimeConfig — no second round-trip.
   const includePatterns = extractIncludePatterns(yamlConfig);
 
   // Smart skip check — bypass when user explicitly requested a review via @mergewatch
@@ -288,18 +299,14 @@ export async function processReviewJob(
   });
   if (rulesSkip) {
     await deps.reviewStore.updateStatus(repoFullName, prNumberCommitSha, 'skipped', { completedAt: now, skipReason: rulesSkip.reason });
-    // Surface autoReview=false as a user-actionable check run with the
-    // mention-trigger instructions; other skip kinds keep the generic title.
-    const checkRunCopy = rulesSkip.kind === 'autoReviewOff'
-      ? {
-          title: 'Auto-review is disabled for this repository',
-          summary: 'Comment `@mergewatch review` on this PR to run a review.',
-        }
-      : { title: 'Review skipped', summary: rulesSkip.reason };
+    // autoReviewOff is handled silently earlier (before any GitHub side
+    // effect). Any rulesSkip seen here is a visible-skip kind: draft,
+    // maxFiles, labelIgnored, reviewOnMentionOff.
     await createCheckRun(octokit, owner, repo, headSha, {
       status: 'completed',
       conclusion: 'neutral',
-      ...checkRunCopy,
+      title: 'Review skipped',
+      summary: rulesSkip.reason,
     }).catch((err) => console.warn('Failed to create rules skip check run:', err));
     console.log(`Rules skip ${repoFullName}#${prNumber} (${rulesSkip.kind}): ${rulesSkip.reason}`);
     return;


### PR DESCRIPTION
## Summary
When a repo has `rules.autoReview: false` in `.mergewatch.yml`, MergeWatch was still leaving a visible footprint on every PR — 👀 reaction, in-progress check run, and a "Auto-review is disabled" check run. The last was originally intended as discoverability UX; it now reads as noise on parked installs.

This change makes parked installs **fully silent**: no reactions, no check runs, no formal PR review, no storage write.

## Behavior
| autoReview | mentionTriggered | Behavior |
|---|---|---|
| `true` (default) | n/a | normal review |
| `false` | `false` | **fully silent** — early-return before any side effect |
| `false` | `true` (`@mergewatch review`) | normal review (mention override) |
| `true` + other skip kind (draft/maxFiles/label/reviewOnMention) | n/a | unchanged — visible "Review skipped" check run |

## Files
- `packages/core/src/skip-logic.ts` — new `isAutoReviewOff(yamlConfig, mentionTriggered)` predicate. YAML-only signal — autoReview is not surfaced in the dashboard. Missing rules block → defaults to `true` (safer).
- `packages/lambda/src/handlers/review-agent.ts` — hoist `fetchRepoConfig` + add early-return gate before `getPRContext` / `claimReview` / `addPRReaction` / `createCheckRun`. Drop the now-dead `autoReviewOff`-specific check run copy.
- `packages/server/src/review-processor.ts` — mirror the same hoist + early return + dead-code removal.

## Tests
- **Core**: 7 new unit tests on `isAutoReviewOff` (off → true; on → false; mention → false; no rules block → false; null/undefined config → false; undefined mentionTriggered treated as auto-triggered).
- **Express**: integration tests that the silent path makes zero `getPRContext` / `getPRDiff` / `createCheckRun` / `reviewStore` calls; mention-triggered override still proceeds with full pipeline.
- Replaces the obsolete \"creates user-actionable check run on autoReviewOff skip\" test since that behavior is intentionally gone.
- `vi.clearAllMocks()` doesn't reset `.mockResolvedValue` implementations, so each `beforeEach` now restores `fetchRepoConfig` to null to prevent cross-test bleed.

## Test plan
- [x] `pnpm run typecheck` clean across 20 packages
- [x] `pnpm test` — core 364 / server 66 / lambda 57, all green
- [x] Manual: pushed a test commit with `rules.autoReview: false` → no PR reaction, no check run, no review

🤖 Generated with [Claude Code](https://claude.com/claude-code)