### PR TITLE
Add E2E test runbook

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -1,0 +1,622 @@
+# MergeWatch End-to-End Test Runbook
+
+A curated set of fixture PRs that exercise every user-visible behavior MergeWatch ships. Run this after every production deploy to catch regressions before users see them.
+
+> **Status**: manual checklist. A future iteration will script branch creation + assertions (see [Future Automation](#future-automation) at the end).
+
+## Why this exists
+
+Unit tests prove pieces work in isolation. They cannot prove:
+
+- The Lambda actually fires webhooks against the deployed handler.
+- The right comment body renders in the GitHub UI (HTML escaping, marker handling, Mermaid).
+- Check runs land where they should and link to the right place.
+- Reactions appear / don't appear.
+- Edit-in-place actually edits rather than re-posts.
+- Real Bedrock / Anthropic API calls succeed under prod IAM.
+
+This runbook gives you ~30 minutes of structured manual testing that surfaces real-world breakage.
+
+---
+
+## Setup (one-time)
+
+### 1. Create the fixtures repository
+
+Create a public scratch repository — call it `mergewatch-fixtures` — under the same GitHub account that owns the MergeWatch App installation. Keep it separate from the main `mergewatch.ai` repo so test PR noise doesn't pollute production history.
+
+```bash
+gh repo create mergewatch-fixtures --public --description "E2E fixtures for MergeWatch"
+git clone https://github.com/<owner>/mergewatch-fixtures.git
+cd mergewatch-fixtures
+```
+
+Seed it with a minimal source tree so PRs have a place to land:
+
+```bash
+mkdir -p src docs
+cat > src/app.ts <<'EOF'
+export function greet(name: string): string {
+  return `Hello, ${name}!`;
+}
+EOF
+cat > src/utils.ts <<'EOF'
+export function add(a: number, b: number): number {
+  return a + b;
+}
+EOF
+cat > README.md <<'EOF'
+# mergewatch-fixtures
+
+Scratch repo for MergeWatch E2E tests. See [e2e/RUNBOOK.md](https://github.com/<owner>/mergewatch.ai/blob/main/e2e/RUNBOOK.md).
+EOF
+git add . && git commit -m "Seed fixtures repo" && git push origin main
+```
+
+### 2. Install MergeWatch on the fixtures repo
+
+- SaaS: visit the [MergeWatch GitHub App](https://github.com/apps/mergewatch) and install on `mergewatch-fixtures`.
+- Self-hosted: configure your local instance's webhook to point at this repo, or install the dev App on it.
+
+### 3. Verify install
+
+Open any new PR (e.g., trivial commit + `gh pr create`). Within ~30s you should see the eyes 👀 reaction land. Close that PR — setup is done.
+
+### 4. Tag commits (optional, recommended)
+
+Add a `e2e-baseline` tag to the seed commit so every fixture can be re-created with `git reset --hard e2e-baseline`. This keeps the repo small and the fixture branches reproducible.
+
+```bash
+git tag e2e-baseline && git push --tags
+```
+
+---
+
+## Test procedure (every fixture)
+
+Each fixture follows this loop:
+
+1. **Reset to baseline**: `git checkout main && git pull && git reset --hard e2e-baseline` (only if fixture state drifted).
+2. **Create the fixture branch**: `git checkout -b fixture/<NN-name>`.
+3. **Apply the setup** — copy the `.mergewatch.yml` snippet + create the source files listed in the fixture card.
+4. **Push the branch**: `git push -u origin fixture/<NN-name>`.
+5. **Open the PR**: `gh pr create --title "<fixture name>" --body "E2E fixture E2E-NN"`.
+6. **Wait** for MergeWatch (~30–60s).
+7. **Verify** against the fixture's "Expected outcomes" checklist below.
+8. **Reset between runs**: close the PR, delete the remote branch (`git push origin :fixture/<NN-name>`), delete local branch.
+
+For re-runs on the same fixture, you can amend + force-push (cheap) instead of creating a new PR.
+
+---
+
+## Full regression checklist
+
+Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
+
+| ID | Behavior tested | Setup time | Wait | Verifies PR # |
+|---|---|---|---|---|
+| [E2E-01](#e2e-01-clean-pr--full-review) | Happy path: clean PR → 5/5 + APPROVE + empty review body | 1m | 60s | #132 |
+| [E2E-02](#e2e-02-info-only-findings) | Info-only findings → 5/5, "All clear" + Info collapsible | 1m | 60s | #134 |
+| [E2E-03](#e2e-03-critical-finding--inline-comment) | Critical finding → inline comment + REQUEST_CHANGES | 1m | 60s | core |
+| [E2E-04](#e2e-04-autoreview-off--silent) | `autoReview: false` → zero PR trace | 1m | 30s | #136 |
+| [E2E-05](#e2e-05-autoreview-off--mergewatch-override) | `autoReview: false` + `@mergewatch review` → review runs | 1m | 60s | #136 |
+| [E2E-06](#e2e-06-smart-skip--docs-only) | Docs-only PR → visible "Review skipped" check run | 30s | 30s | core |
+| [E2E-07](#e2e-07-smart-skip-bypass-via-includepatterns) | Docs-only + `includePatterns` → review runs | 1m | 60s | core |
+| [E2E-08](#e2e-08-smart-skip-bypass-via-mention) | Docs-only + `@mergewatch review` → review runs | 1m | 60s | core |
+| [E2E-09](#e2e-09-draft-pr-skip) | Draft PR → "Review skipped — Draft PR" | 30s | 30s | core |
+| [E2E-10](#e2e-10-ignorelabels-skip) | `skip-review` label → "Review skipped — label" | 30s | 30s | core |
+| [E2E-11](#e2e-11-re-review-on-synchronize) | Push new commit → old review dismissed + comment edited in place | 2m | 90s | core |
+| [E2E-12](#e2e-12-re-run-check-via-github-ui) | Click "Re-run" on the check → new review fires | 30s | 60s | core |
+| [E2E-13](#e2e-13-inline-reply-engages-on-mergewatch-thread) | Human replies in a MergeWatch inline thread → MergeWatch responds | 2m | 60s | #133 |
+| [E2E-14](#e2e-14-inline-reply-skips-third-party-bot-thread) | Human replies in a non-MergeWatch inline thread → no engagement | 2m | 60s | #133 |
+| [E2E-15](#e2e-15-mermaid-diagram-renders) | Complex diff produces a renderable Mermaid diagram | 2m | 60s | #128–#130 |
+| [E2E-16](#e2e-16-agent-authored-pr-detection) | PR from `claude/*` branch → flagged as agent-authored | 1m | 60s | core |
+
+---
+
+## Fixture cards
+
+### E2E-01: Clean PR → full review
+
+**Behavior**: a PR with no issues should produce 5/5 "Safe to merge", an APPROVE on the formal PR review (with empty body — verdict block removed in #132), and a summary comment with "All clear!".
+
+**Setup**
+
+Branch: `fixture/01-clean-pr`
+
+`src/utils.ts` — change `add` to add a JSDoc comment:
+
+```ts
+/**
+ * Add two numbers together.
+ */
+export function add(a: number, b: number): number {
+  return a + b;
+}
+```
+
+No `.mergewatch.yml` needed (default config).
+
+**Expected outcomes**
+
+- [ ] 👀 reaction lands within ~10s on the PR
+- [ ] In-progress check run titled "Review in progress" appears
+- [ ] Summary comment posted with:
+  - [ ] MergeWatch wordmark image at top (~48px tall)
+  - [ ] `🟢 5/5 — Safe to merge` verdict line
+  - [ ] `🎉 All clear! No issues found` action-items section
+- [ ] Formal PR review submitted with state = **Approved**
+- [ ] **The Approved review has NO body text** (only the verdict state — #132 dropped the verdict body)
+- [ ] Completed check run "MergeWatch Review" lands with conclusion = success
+- [ ] +1 👍 reaction on the PR (success signal)
+
+**Failure modes to watch for**
+- ❌ PR review has a body that says "X/5 — verdict — view details" (regression of #132)
+- ❌ Multiple summary comments instead of one edited-in-place
+- ❌ 👀 reaction still present (should have been removed when review completed)
+
+---
+
+### E2E-02: Info-only findings
+
+**Behavior**: a PR that produces ONLY info-severity findings should reconcile to 5/5 (not the orchestrator's lower score) — fix from #134.
+
+**Setup**
+
+Branch: `fixture/02-info-only`
+
+Edit `src/utils.ts` to use slightly verbose but functionally correct code that's likely to trip info-severity style observations:
+
+```ts
+export function add(a: number, b: number): number {
+  // verify both inputs are valid numbers
+  const valA = a;
+  const valB = b;
+  const result = valA + valB;
+  return result;
+}
+```
+
+No `.mergewatch.yml` needed.
+
+**Expected outcomes**
+
+- [ ] Summary comment with `🟢 5/5 — Safe to merge` (NOT 3/5 or 4/5)
+- [ ] Verdict reason line says something like "No action items — only informational notes" (NOT "Multiple warnings")
+- [ ] Action-items section reads `🎉 All clear! No issues found`
+- [ ] An "Info (N)" collapsible section IS present below with at least 1 finding
+- [ ] Formal PR review state = **Approved** (not Comment, not Request changes)
+
+**Failure modes**
+- ❌ Score shows 3/5 or 4/5 with "All clear!" — that's the bug #134 fixed reappearing
+- ❌ "Requires your attention" table appears — only action items (critical/warning) should populate it
+
+---
+
+### E2E-03: Critical finding → inline comment
+
+**Behavior**: a critical finding on a changed line should produce an inline review comment + REQUEST_CHANGES formal review.
+
+**Setup**
+
+Branch: `fixture/03-critical-finding`
+
+`src/sql.ts` — new file:
+
+```ts
+import { Pool } from 'pg';
+const pool = new Pool();
+
+export async function findUser(userId: string) {
+  // SQL injection — concatenating user input directly into the query string
+  const result = await pool.query(`SELECT * FROM users WHERE id = '${userId}'`);
+  return result.rows[0];
+}
+```
+
+No `.mergewatch.yml` needed.
+
+**Expected outcomes**
+
+- [ ] Inline review comment lands on the `pool.query(...)` line
+- [ ] Inline comment body starts with `**🔴 <title>**` and includes a Suggestion section
+- [ ] Inline comment includes the hidden `<!-- mergewatch-inline -->` marker (verify via "View source" or curl `gh api .../pulls/N/comments` — needed for thread-root gating in E2E-13/14)
+- [ ] Summary comment shows `🟠 2/5 — Needs fixes` or `🔴 1/5 — Do not merge`
+- [ ] "Requires your attention" table lists the SQL Injection row with 🔴
+- [ ] Formal PR review state = **Changes requested**
+- [ ] Review comment has a body (REQUEST_CHANGES requires non-empty body — different from APPROVE)
+
+---
+
+### E2E-04: autoReview off → silent
+
+**Behavior**: when `rules.autoReview: false`, MergeWatch leaves no trace on the PR (no reaction, no check run, no review, no comment). Ships in #136.
+
+**Setup**
+
+Branch: `fixture/04-auto-review-off`
+
+`.mergewatch.yml`:
+
+```yaml
+rules:
+  autoReview: false
+```
+
+`src/utils.ts` — any trivial change (e.g., rename a variable inside `add`).
+
+**Expected outcomes**
+
+- [ ] No 👀 reaction on the PR
+- [ ] No "MergeWatch Review" check run on the PR (visible in the Checks tab)
+- [ ] No summary comment
+- [ ] No formal PR review
+- [ ] No inline comments
+- [ ] CloudWatch (SaaS) or stdout (self-hosted) shows a single log line: `autoReview off — silently skipping <owner>/<repo>#<N>`
+- [ ] DynamoDB `mergewatch-reviews` table (or Postgres `reviews`) has NO row for this commit SHA
+
+**Failure modes**
+- ❌ "Auto-review is disabled for this repository" check run appears — that's the pre-#136 behavior the user explicitly asked to remove
+- ❌ 👀 reaction lands then disappears — the reaction shouldn't have been added at all
+
+---
+
+### E2E-05: autoReview off + @mergewatch override
+
+**Behavior**: even with `autoReview: false`, a `@mergewatch review` comment must force a full review. The silent gate must honor `mentionTriggered`.
+
+**Setup**
+
+Same branch as E2E-04 (`fixture/04-auto-review-off`) with the same `.mergewatch.yml`. Don't re-open a fresh PR — use the existing E2E-04 PR.
+
+After confirming E2E-04 produced zero trace, post a comment on the PR:
+
+```
+@mergewatch review
+```
+
+**Expected outcomes**
+
+- [ ] 👀 reaction lands within ~10s after the comment
+- [ ] In-progress check run appears
+- [ ] Summary comment is posted as normal
+- [ ] Formal PR review submitted
+- [ ] All the trace that was absent in E2E-04 is now present
+
+**Failure modes**
+- ❌ No reaction / no review — silent gate isn't honoring mentionTriggered (regression of skip-logic.ts)
+
+---
+
+### E2E-06: Smart skip — docs only
+
+**Behavior**: a PR touching only docs/lock files should skip review and post a visible "Review skipped" check run.
+
+**Setup**
+
+Branch: `fixture/06-docs-only`
+
+Edit `README.md` only (any change, e.g., add a paragraph).
+
+No `.mergewatch.yml` needed.
+
+**Expected outcomes**
+
+- [ ] 👀 reaction lands briefly
+- [ ] **Visible** check run titled "Review skipped" with summary like `Only docs changed`
+- [ ] No summary comment
+- [ ] No formal PR review
+- [ ] (Auto-review IS on here — this is the smart-skip path, NOT the silent path)
+
+---
+
+### E2E-07: Smart skip bypass via includePatterns
+
+**Behavior**: `includePatterns` lets a docs-only PR opt itself back into review.
+
+**Setup**
+
+Branch: `fixture/07-include-patterns`
+
+`.mergewatch.yml`:
+
+```yaml
+includePatterns:
+  - "docs/**"
+```
+
+Add `docs/architecture.md` with some content.
+
+**Expected outcomes**
+
+- [ ] Full review runs (👀 reaction → in-progress check run → summary comment → APPROVE)
+- [ ] Summary comment treats the markdown file as a normal source file (no "skipped — only docs" message)
+
+---
+
+### E2E-08: Smart skip bypass via mention
+
+**Behavior**: same as E2E-07 but proves `@mergewatch review` overrides smart-skip even without `includePatterns`.
+
+**Setup**
+
+Same as E2E-06 (docs-only PR, no override config). After the "Review skipped" check run appears, post:
+
+```
+@mergewatch review
+```
+
+**Expected outcomes**
+
+- [ ] Review runs full pipeline despite docs-only content
+- [ ] Summary comment posted
+- [ ] (Check run from initial skip remains in history — that's fine)
+
+---
+
+### E2E-09: Draft PR skip
+
+**Behavior**: draft PRs are skipped by default (`skipDrafts: true`) with a visible check run.
+
+**Setup**
+
+Branch: `fixture/09-draft-pr`. Make any non-trivial source change (e.g., `src/app.ts`).
+
+Open the PR as a **draft**: `gh pr create --draft`.
+
+**Expected outcomes**
+
+- [ ] Visible "Review skipped" check run with summary mentioning "Draft PR"
+- [ ] No summary comment
+- [ ] No formal PR review
+
+**Bonus**: convert to ready-for-review (`gh pr ready`). MergeWatch should now run a full review (synchronize-equivalent event).
+
+---
+
+### E2E-10: ignoreLabels skip
+
+**Behavior**: a PR carrying a label in `rules.ignoreLabels` is skipped.
+
+**Setup**
+
+Branch: `fixture/10-skip-review-label`. Any non-trivial source change. Open the PR, then add the `skip-review` label (default `ignoreLabels` entry):
+
+```bash
+gh pr edit <N> --add-label skip-review
+gh pr edit <N> --remove-label skip-review && gh pr edit <N> --add-label skip-review  # trigger synchronize
+```
+
+Or push a fresh commit after adding the label.
+
+**Expected outcomes**
+
+- [ ] Visible "Review skipped" check run with summary like `PR has label "skip-review" which is in ignoreLabels`
+
+---
+
+### E2E-11: Re-review on synchronize
+
+**Behavior**: pushing a new commit to an open PR should:
+- Dismiss any prior formal PR reviews
+- Edit the existing summary comment in place (not post a new one)
+- Track the delta between commits (delta caption)
+
+**Setup**
+
+Use any active fixture PR (E2E-01 works). After the first review completes:
+
+```bash
+git checkout fixture/01-clean-pr
+echo "// added in commit 2" >> src/utils.ts
+git commit -am "Second commit"
+git push
+```
+
+**Expected outcomes**
+
+- [ ] Original formal PR review now shows as **Dismissed** (struck-through in the GitHub UI)
+- [ ] Single summary comment (not two) — comment was edited in place via `BOT_COMMENT_MARKER` lookup
+- [ ] Comment body's commit SHA reference at the bottom updates to the new SHA
+- [ ] If findings changed, a delta caption appears ("Resolved X, introduced Y")
+- [ ] Updated commit-hash link in the comment footer points at the new commit
+
+---
+
+### E2E-12: Re-run check via GitHub UI
+
+**Behavior**: clicking the "Re-run" button on the MergeWatch check should trigger a fresh review on the same commit.
+
+**Setup**
+
+Open any completed fixture PR. In the Checks tab, click the ⋯ menu next to "MergeWatch Review" → "Re-run".
+
+**Expected outcomes**
+
+- [ ] Within ~30s a new "in progress" check run appears
+- [ ] Summary comment is updated in place
+- [ ] Behavior identical to a synchronize event
+
+---
+
+### E2E-13: Inline-reply engages on MergeWatch thread
+
+**Behavior**: replying to a MergeWatch inline comment should trigger a focused conversational response.
+
+**Setup**
+
+Use the E2E-03 PR (which produced an inline comment from MergeWatch on the SQL injection finding). In the GitHub UI, reply to that inline comment with:
+
+```
+Can you elaborate on the parameterized query suggestion?
+```
+
+**Expected outcomes**
+
+- [ ] 👀 reaction appears on YOUR reply within ~10s
+- [ ] MergeWatch posts a follow-up reply in the same inline thread within ~30s
+- [ ] 👀 reaction is removed once the reply lands
+- [ ] Reply is reasonably on-topic about parameterized queries
+- [ ] Reply does NOT contain the `<!-- mergewatch-inline -->` marker visibly (it's HTML-comment hidden)
+
+**Verify the resolve fast-path**: post `/resolve` as a reply. MergeWatch should resolve the thread via GraphQL within ~10s without invoking the LLM.
+
+---
+
+### E2E-14: Inline-reply skips third-party bot thread
+
+**Behavior**: MergeWatch must NOT engage when a human replies to a thread NOT rooted in a MergeWatch comment (e.g., CopilotAI's or a human's inline finding). Fix from #133.
+
+**Setup**
+
+You can't easily simulate CopilotAI from a fixtures repo. Two ways:
+
+1. **Manual fake**: have a human (you) leave a top-level inline review comment on a PR file. Then have a different human (or the same one) reply in that thread.
+2. **CopilotAI test**: install GitHub Copilot Code Review on `mergewatch-fixtures`, let it post an inline finding on a PR, then reply yourself.
+
+For E2E-14a (manual fake — easiest):
+
+Branch: `fixture/14-third-party-thread`. Make a non-trivial change so MergeWatch produces its own review. Once that completes, leave a NEW top-level inline comment on a different line of the diff (use the GitHub UI's "+ Add comment" gutter button on a line that MergeWatch DID NOT comment on). Then reply to that inline comment yourself with `@mergewatch what do you think?` or just `looks fine` — but on the human-rooted thread.
+
+**Expected outcomes**
+
+- [ ] MergeWatch does NOT post a reply in the human-rooted thread
+- [ ] MergeWatch DOES still respond if you reply in its own thread on the same PR (sanity check)
+- [ ] Logs show `thread root is not a MergeWatch comment` skip reason (CloudWatch / stdout)
+
+**Failure modes**
+- ❌ MergeWatch replies in a thread it didn't start — this is the interference the user explicitly called out
+
+---
+
+### E2E-15: Mermaid diagram renders
+
+**Behavior**: complex PRs should produce a Mermaid `flowchart TD` diagram that renders correctly in the GitHub UI (no parse errors). Multiple sanitizer fixes shipped in #128–#130.
+
+**Setup**
+
+Branch: `fixture/15-mermaid-stress`. Add a multi-file change that touches at least 5 files with distinct names containing characters that historically broke Mermaid:
+
+```
+src/auth/oauth-callback.ts      (with a function named `[handle/callback]`)
+src/utils/string-helpers.ts     (with content containing real newlines in identifiers)
+src/db/migrations/0042-add.sql  (slashes + numbers)
+src/api/v1/users.ts             (multi-segment path)
+src/components/<Title>.tsx      (angle brackets in the path)
+```
+
+Use names with characters like `<`, `>`, `"`, `\t`, embedded newlines in JSDoc, etc.
+
+**Expected outcomes**
+
+- [ ] Diagram block in the summary comment renders inline in the GitHub PR view (no `mermaid parse error` shown)
+- [ ] Diagram includes labeled boxes for each touched file
+- [ ] No raw `&lt;` / `&gt;` HTML entities visible in the rendered diagram (they're decoded by Mermaid)
+- [ ] No literal `<br/>` tags visible in node labels (they render as line breaks)
+- [ ] Tabs / lone CR characters in upstream content don't break the diagram
+
+**Failure modes**
+- ❌ "Unable to render rich display" or red error block where the diagram should be
+- ❌ Diagram truncates mid-node label
+- ❌ Quoted labels show literal escape sequences
+
+---
+
+### E2E-16: Agent-authored PR detection
+
+**Behavior**: a PR from a `claude/*`-prefixed branch should be classified as agent-authored and trigger agent-mode prompt suffixes / persist `source: 'agent', agentKind: 'claude'`.
+
+**Setup**
+
+`.mergewatch.yml`:
+
+```yaml
+agentReview:
+  enabled: true
+  detection:
+    branchPrefixes: ["claude/", "cursor/", "codex/"]
+```
+
+Branch: `claude/fix-greet-bug`. Make a non-trivial change to `src/app.ts`.
+
+**Expected outcomes**
+
+- [ ] CloudWatch / stdout log: `Classified <owner>/<repo>#<N> as agent (claude) via branch`
+- [ ] Summary comment renders normally (no visible difference yet — verification is internal)
+- [ ] DynamoDB review record (or Postgres `reviews.source`) has `source: 'agent', agentKind: 'claude'`
+- [ ] If `agentReview.strictChecks: true` (default), the prompt-mode suffix is applied → review tone may be terser on logic findings
+
+To inspect the stored record (SaaS):
+
+```bash
+aws dynamodb get-item --table-name mergewatch-reviews \
+  --key '{"repoFullName":{"S":"<owner>/mergewatch-fixtures"},"prNumberCommitSha":{"S":"<N>#<shortSha>"}}' \
+  --profile mergewatch
+```
+
+---
+
+## Quick smoke test (5 minutes)
+
+When you just want to confirm the deploy didn't immediately break things:
+
+1. Run **E2E-01** (clean PR → APPROVE).
+2. Run **E2E-04** (autoReview off → silent).
+3. Run **E2E-06** (docs-only → visible skip).
+
+If all three pass, the deploy is at least minimally healthy. Full run gives much higher confidence.
+
+---
+
+## Troubleshooting
+
+**MergeWatch didn't react at all within 60s**
+- Check the App is installed on the fixtures repo (GitHub → Settings → Apps).
+- Check webhook delivery: GitHub → fixtures repo → Settings → Webhooks → look for failed deliveries.
+- SaaS: `pnpm run logs:webhook` (root) — search for the PR number.
+- Self-hosted: `docker logs mergewatch-server`.
+
+**Review took longer than 3 minutes**
+- Bedrock TPM throttling — check CloudWatch metrics for `InvokeModelInvocationsThrottled`.
+- Check `withConcurrency` is capped at 3 (in `packages/core/src/agents/reviewer.ts`).
+
+**Summary comment appears but no formal PR review**
+- Check `submitPRReview` IAM permissions (App needs `Pull requests: write`).
+- Check the dismissStaleReviews call didn't throw — look for `dismissStaleReviews failed` in logs.
+
+**Multiple summary comments instead of one edited**
+- `findExistingBotComment` is failing — check `BOT_COMMENT_MARKER` matching logic.
+- Could be a DynamoDB lookup issue if the cached comment ID is stale.
+
+---
+
+## Future automation
+
+When this runbook stops feeling like fun, build the harness:
+
+1. A `e2e/fixtures/` directory with one subdirectory per fixture (`01-clean-pr/`, etc.), each containing:
+   - `mergewatch.yml` (the config)
+   - `diff.patch` (the change to apply)
+   - `expected.json` (asserted outcomes — check runs by name, comment body substrings, reactions, PR review state)
+2. A `e2e/run.ts` script that:
+   - Takes a fixture name
+   - Resets the fixtures repo to `e2e-baseline`
+   - Applies the patch, opens a PR via `gh pr create`
+   - Polls for `n` seconds waiting for `expected.json` conditions
+   - Reports pass/fail
+3. A GitHub Action on the main repo that runs `e2e/run.ts` against every fixture nightly + after every deploy.
+
+The main flakiness risk is webhook timing (asynchronous Lambda invokes can take 30-90s). Build in generous timeouts with retries.
+
+---
+
+## Update protocol
+
+When you ship a new user-visible behavior:
+
+1. Add a new fixture card to this file in the same PR.
+2. Add the fixture to the regression checklist table.
+3. Increment any related fixture's expected outcomes if the change affects them (e.g., a new comment section).
+4. Note the PR number in the "Verifies PR #" column so future maintainers know why the fixture exists.
+
+Keep the runbook as the source of truth for "what MergeWatch promises to do on a PR."


### PR DESCRIPTION
## Summary
Adds \`e2e/RUNBOOK.md\` — a manual end-to-end test checklist with 16 fixture PRs that cover every user-visible MergeWatch behavior. Run after every production deploy to catch regressions before users hit them.

## What's inside
- **16 fixture cards** with setup, trigger, and a checklist of expected outcomes — covering happy-path review, info-only reconciliation (#134), critical findings + inline comments, silent autoReview-off (#136) + @mergewatch override, smart skip (docs-only, includePatterns, mention bypass), rules skip (draft, ignoreLabels), re-review on synchronize, re-run-from-UI, inline-reply engagement on MergeWatch threads (#133), inline-reply rejection on third-party-bot threads (#133), Mermaid sanitizer stress, and agent-authored PR detection.
- **5-minute smoke test** triplet (E2E-01, E2E-04, E2E-06) for quick post-deploy confidence.
- **Setup section** for creating a sibling \`mergewatch-fixtures\` repo so test PR noise stays out of the main repo.
- **Troubleshooting** for the most common breakage modes (no reaction, slow review, multiple comments, missing PR review).
- **Update protocol** so new behaviors get fixtures in the same PR they ship in.
- **Automation sketch** at the end describing a future \`e2e/run.ts\` harness.

## Why a doc and not code
Per the original discussion: option A (manual runbook) is one afternoon of work and immediately useful; option B (scripted harness) is ~1-2 days and introduces flakiness around async webhook timing. This lands the value now and leaves the harness as a follow-up the runbook can graduate into.

## Test plan
- [x] Markdown renders cleanly on GitHub (no broken anchors in the regression table)
- [x] Every fixture references a real recent PR or core behavior
- [x] No dependency on internal-only tooling — \`gh\`, \`git\`, and a public scratch repo are enough

🤖 Generated with [Claude Code](https://claude.com/claude-code)