### PR TITLE
Clear eyes reaction + silence test-coverage on no-op diffs

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -44,6 +44,38 @@ cat > src/utils.ts <<'EOF'
 export function add(a: number, b: number): number {
   return a + b;
 }
+
+export function multiply(a: number, b: number): number {
+  return a * b;
+}
+EOF
+# Seed co-located tests so the test-coverage agent sees existing coverage.
+# Without this, ANY change to src/utils.ts trips "new public function lacks
+# tests" even on JSDoc-only diffs — the agent can't tell pre-existing from new.
+cat > src/utils.test.ts <<'EOF'
+import { describe, it, expect } from 'vitest';
+import { add, multiply } from './utils';
+
+describe('add', () => {
+  it('sums two positive numbers', () => {
+    expect(add(2, 3)).toBe(5);
+  });
+  it('handles negatives', () => {
+    expect(add(-1, -2)).toBe(-3);
+  });
+  it('handles zero', () => {
+    expect(add(0, 0)).toBe(0);
+  });
+});
+
+describe('multiply', () => {
+  it('multiplies two positive numbers', () => {
+    expect(multiply(2, 3)).toBe(6);
+  });
+  it('handles zero', () => {
+    expect(multiply(5, 0)).toBe(0);
+  });
+});
 EOF
 cat > README.md <<'EOF'
 # mergewatch-fixtures
@@ -124,7 +156,8 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 
 Branch: `fixture/01-clean-pr`
 
-`src/utils.ts` — change `add` to add a JSDoc comment:
+`src/utils.ts` — change `add` to add a JSDoc comment (the function body stays
+identical so the diff is comment-only):
 
 ```ts
 /**
@@ -135,7 +168,9 @@ export function add(a: number, b: number): number {
 }
 ```
 
-No `.mergewatch.yml` needed (default config).
+No `.mergewatch.yml` needed (default config). The seed commit already
+includes `src/utils.test.ts` with coverage for `add`, so the test-coverage
+agent has signal that `add` is pre-existing and covered.
 
 **Expected outcomes**
 
@@ -145,15 +180,18 @@ No `.mergewatch.yml` needed (default config).
   - [ ] MergeWatch wordmark image at top (~48px tall)
   - [ ] `🟢 5/5 — Safe to merge` verdict line
   - [ ] `🎉 All clear! No issues found` action-items section
+  - [ ] No "Requires your attention" table (zero critical + zero warning)
 - [ ] Formal PR review submitted with state = **Approved**
 - [ ] **The Approved review has NO body text** (only the verdict state — #132 dropped the verdict body)
 - [ ] Completed check run "MergeWatch Review" lands with conclusion = success
 - [ ] +1 👍 reaction on the PR (success signal)
+- [ ] 👀 reaction is **removed** once review completes — only 👍 remains
 
 **Failure modes to watch for**
 - ❌ PR review has a body that says "X/5 — verdict — view details" (regression of #132)
 - ❌ Multiple summary comments instead of one edited-in-place
-- ❌ 👀 reaction still present (should have been removed when review completed)
+- ❌ 👀 reaction still present after review completes (regression of #138 eyes-cleanup)
+- ❌ "Requires your attention" table with a "no test coverage" warning — that's the test-coverage agent firing on an unchanged public function (regression of the #138 prompt tightening)
 
 ---
 

--- a/packages/core/src/agents/prompts.ts
+++ b/packages/core/src/agents/prompts.ts
@@ -290,6 +290,8 @@ DO NOT report:
 - Configuration file changes (tsconfig, eslint, package.json)
 - Test files themselves (do not review tests for test coverage)
 - Generated code or auto-generated types
+- Diffs that are exclusively comments, JSDoc, or whitespace — these do not change runtime behavior, so they cannot introduce uncovered code paths. Return [] without further analysis when the entire diff falls into this category.
+- Pre-existing public functions that are unchanged in the diff. Only flag functions that are NEW or whose SIGNATURE/BEHAVIOR changed in this PR. If a function appears in the diff context but no `+` lines modify its declaration or body, treat it as pre-existing and do not flag missing tests for it.
 
 Return a JSON object with this exact shape:
 {

--- a/packages/core/src/github/client.test.ts
+++ b/packages/core/src/github/client.test.ts
@@ -1,11 +1,14 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   mergeScoreToReviewEvent,
   buildInlineComments,
   extractInlineCommentTitle,
   BOT_COMMENT_MARKER,
   parseRepoConfigYaml,
+  addPRReaction,
+  removePRReaction,
 } from './client.js';
+import type { Octokit } from '@octokit/rest';
 
 // ---------------------------------------------------------------------------
 // mergeScoreToReviewEvent
@@ -463,5 +466,67 @@ agentReview:
     const result = parseRepoConfigYaml(yaml);
     expect(result?.agentReview).toBeDefined();
     expect(result!.agentReview!.detection).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addPRReaction
+// ---------------------------------------------------------------------------
+
+describe('addPRReaction', () => {
+  it('returns the reaction ID from a successful API call', async () => {
+    const createForIssue = vi.fn().mockResolvedValue({ data: { id: 99 } });
+    const octokit = { reactions: { createForIssue } } as unknown as Octokit;
+    const id = await addPRReaction(octokit, 'o', 'r', 42, 'eyes');
+    expect(id).toBe(99);
+    expect(createForIssue).toHaveBeenCalledWith({
+      owner: 'o',
+      repo: 'r',
+      issue_number: 42,
+      content: 'eyes',
+    });
+  });
+
+  it('returns null and logs a warning when the API call fails', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const createForIssue = vi.fn().mockRejectedValue(new Error('rate limit'));
+    const octokit = { reactions: { createForIssue } } as unknown as Octokit;
+    const id = await addPRReaction(octokit, 'o', 'r', 42, 'eyes');
+    expect(id).toBeNull();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('does not throw on failure — reactions are non-critical', async () => {
+    const createForIssue = vi.fn().mockRejectedValue(new Error('boom'));
+    const octokit = { reactions: { createForIssue } } as unknown as Octokit;
+    await expect(addPRReaction(octokit, 'o', 'r', 42, '+1')).resolves.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removePRReaction
+// ---------------------------------------------------------------------------
+
+describe('removePRReaction', () => {
+  it('deletes the reaction by ID via Octokit', async () => {
+    const deleteForIssue = vi.fn().mockResolvedValue({});
+    const octokit = { reactions: { deleteForIssue } } as unknown as Octokit;
+    await removePRReaction(octokit, 'o', 'r', 42, 12345);
+    expect(deleteForIssue).toHaveBeenCalledWith({
+      owner: 'o',
+      repo: 'r',
+      issue_number: 42,
+      reaction_id: 12345,
+    });
+  });
+
+  it('swallows API errors and logs a warning so finally blocks never re-throw', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const deleteForIssue = vi.fn().mockRejectedValue(new Error('not found'));
+    const octokit = { reactions: { deleteForIssue } } as unknown as Octokit;
+    await expect(removePRReaction(octokit, 'o', 'r', 42, 12345)).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
   });
 });

--- a/packages/core/src/github/client.ts
+++ b/packages/core/src/github/client.ts
@@ -117,6 +117,10 @@ export async function getPRContext(
 /**
  * Add a reaction to a PR (which is an issue in GitHub's API).
  * Used to signal review start (eyes) and completion (thumbs up).
+ *
+ * Returns the reaction ID so callers can later remove it (e.g. clearing the
+ * "eyes" reaction once the review completes). Returns null when the request
+ * fails — reactions are non-critical and never block a review.
  */
 export async function addPRReaction(
   octokit: Octokit,
@@ -124,17 +128,43 @@ export async function addPRReaction(
   repo: string,
   prNumber: number,
   reaction: '+1' | '-1' | 'laugh' | 'confused' | 'heart' | 'hooray' | 'rocket' | 'eyes',
-): Promise<void> {
+): Promise<number | null> {
   try {
-    await octokit.reactions.createForIssue({
+    const { data } = await octokit.reactions.createForIssue({
       owner,
       repo,
       issue_number: prNumber,
       content: reaction,
     });
+    return data.id;
   } catch (err) {
     // Non-critical — don't fail the review if reaction fails
     console.warn('Failed to add %s reaction to %s/%s#%d:', reaction, owner, repo, prNumber, err);
+    return null;
+  }
+}
+
+/**
+ * Remove a previously-added reaction from a PR. Used to clear the eyes
+ * reaction once review completes, so the PR doesn't stay in a "MergeWatch
+ * is still looking" state forever.
+ */
+export async function removePRReaction(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  reactionId: number,
+): Promise<void> {
+  try {
+    await octokit.reactions.deleteForIssue({
+      owner,
+      repo,
+      issue_number: prNumber,
+      reaction_id: reactionId,
+    });
+  } catch (err) {
+    console.warn('Failed to remove reaction %d from %s/%s#%d:', reactionId, owner, repo, prNumber, err);
   }
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -83,6 +83,7 @@ export {
   getPRDiff,
   getPRContext,
   addPRReaction,
+  removePRReaction,
   postReviewComment,
   updateReviewComment,
   findExistingBotComment,

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -19,6 +19,7 @@ import {
   postReviewComment,
   updateReviewComment,
   addPRReaction,
+  removePRReaction,
   getCommentReactions,
   postReplyComment,
   createCheckRun,
@@ -367,7 +368,9 @@ export async function handler(
     };
   }
 
-  await addPRReaction(octokit, owner, repo, prNumber, 'eyes');
+  // Capture the eyes reaction ID so we can clear it once the review completes,
+  // so the PR doesn't stay in a "MergeWatch is still looking" state forever.
+  const eyesReactionId = await addPRReaction(octokit, owner, repo, prNumber, 'eyes');
 
   await createCheckRun(octokit, owner, repo, headSha, {
     status: 'in_progress',
@@ -770,5 +773,11 @@ export async function handler(
         error: error instanceof Error ? error.message : String(error),
       }),
     };
+  } finally {
+    // Always clear the eyes reaction — success or failure — so the PR doesn't
+    // get stuck looking like MergeWatch is still mid-review.
+    if (eyesReactionId != null) {
+      await removePRReaction(octokit, owner, repo, prNumber, eyesReactionId);
+    }
   }
 }

--- a/packages/server/src/review-processor.test.ts
+++ b/packages/server/src/review-processor.test.ts
@@ -12,7 +12,8 @@ vi.mock('@mergewatch/core', async (importOriginal) => {
     ...actual,
     getPRContext: vi.fn(),
     getPRDiff: vi.fn(),
-    addPRReaction: vi.fn().mockResolvedValue(undefined),
+    addPRReaction: vi.fn().mockResolvedValue(12345),
+    removePRReaction: vi.fn().mockResolvedValue(undefined),
     createCheckRun: vi.fn().mockResolvedValue(undefined),
     shouldSkipPR: vi.fn().mockReturnValue(null),
     shouldSkipByRules: vi.fn().mockReturnValue(null),
@@ -48,6 +49,7 @@ vi.mock('@mergewatch/core', async (importOriginal) => {
 import {
   getPRContext, getPRDiff, createCheckRun, shouldSkipPR, shouldSkipByRules,
   runReviewPipeline, postReplyComment, fetchRepoConfig, handleInlineReply,
+  addPRReaction, removePRReaction,
 } from '@mergewatch/core';
 import { processReviewJob } from './review-processor.js';
 
@@ -230,6 +232,50 @@ describe('processReviewJob — check runs', () => {
         summary: 'MergeWatch encountered an error while reviewing this PR. Please try again or contact support if the issue persists.',
       }),
     );
+  });
+
+  describe('eyes reaction cleanup', () => {
+    it('clears the eyes reaction after a successful review', async () => {
+      const deps = makeDeps();
+      await processReviewJob(makeJob(), deps);
+
+      expect(addPRReaction).toHaveBeenCalledWith(mockOctokit, 'test', 'repo', 1, 'eyes');
+      expect(removePRReaction).toHaveBeenCalledWith(mockOctokit, 'test', 'repo', 1, 12345);
+    });
+
+    it('clears the eyes reaction even when the pipeline throws', async () => {
+      (runReviewPipeline as any).mockRejectedValue(new Error('LLM timeout'));
+      const deps = makeDeps();
+
+      await expect(processReviewJob(makeJob(), deps)).rejects.toThrow('LLM timeout');
+
+      // finally block must fire — eyes shouldn't get stuck on a failed review
+      expect(removePRReaction).toHaveBeenCalledWith(mockOctokit, 'test', 'repo', 1, 12345);
+    });
+
+    it('clears the eyes reaction on smart skip', async () => {
+      (shouldSkipPR as any).mockReturnValue('Only docs changed');
+      const deps = makeDeps();
+      await processReviewJob(makeJob(), deps);
+
+      expect(removePRReaction).toHaveBeenCalledWith(mockOctokit, 'test', 'repo', 1, 12345);
+    });
+
+    it('clears the eyes reaction on rules skip', async () => {
+      (shouldSkipByRules as any).mockReturnValue({ kind: 'draft', reason: 'Draft PR' });
+      const deps = makeDeps();
+      await processReviewJob(makeJob(), deps);
+
+      expect(removePRReaction).toHaveBeenCalledWith(mockOctokit, 'test', 'repo', 1, 12345);
+    });
+
+    it('does not attempt to remove the reaction when addPRReaction returned null', async () => {
+      (addPRReaction as any).mockResolvedValueOnce(null);
+      const deps = makeDeps();
+      await processReviewJob(makeJob(), deps);
+
+      expect(removePRReaction).not.toHaveBeenCalled();
+    });
   });
 
   describe('completion check run', () => {

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -1,6 +1,6 @@
 import type { ReviewJobPayload, IInstallationStore, IReviewStore, IGitHubAuthProvider, ILLMProvider, FileFetchOptions, ReviewDelta, MergeWatchConfig } from '@mergewatch/core';
 import {
-  getPRDiff, getPRContext, addPRReaction, postReviewComment, updateReviewComment,
+  getPRDiff, getPRContext, addPRReaction, removePRReaction, postReviewComment, updateReviewComment,
   findExistingBotComment, getCommentReactions, createCheckRun,
   formatReviewComment, runReviewPipeline, shouldSkipPR, shouldSkipByRules, isAutoReviewOff, extractIncludePatterns,
   filterDiff,
@@ -223,8 +223,15 @@ export async function processReviewJob(
     return;
   }
 
-  // Add eyes reaction
-  await addPRReaction(octokit, owner, repo, prNumber, 'eyes').catch(() => {});
+  // Add eyes reaction — capture the ID so we can clear it in every exit path
+  // (smart skip, rules skip, success, error) and the PR doesn't get stuck in
+  // a "MergeWatch is still looking" state.
+  const eyesReactionId = await addPRReaction(octokit, owner, repo, prNumber, 'eyes');
+  const clearEyes = async () => {
+    if (eyesReactionId != null) {
+      await removePRReaction(octokit, owner, repo, prNumber, eyesReactionId);
+    }
+  };
 
   // In-progress check run
   await createCheckRun(octokit, owner, repo, headSha, {
@@ -250,6 +257,7 @@ export async function processReviewJob(
       summary: skipReason,
     }).catch((err) => console.warn('Failed to create skip check run:', err));
     console.log(`Skipped ${repoFullName}#${prNumber}: ${skipReason}`);
+    await clearEyes();
     return;
   }
 
@@ -309,6 +317,7 @@ export async function processReviewJob(
       summary: rulesSkip.reason,
     }).catch((err) => console.warn('Failed to create rules skip check run:', err));
     console.log(`Rules skip ${repoFullName}#${prNumber} (${rulesSkip.kind}): ${rulesSkip.reason}`);
+    await clearEyes();
     return;
   }
 
@@ -588,5 +597,7 @@ export async function processReviewJob(
       summary: 'MergeWatch encountered an error while reviewing this PR. Please try again or contact support if the issue persists.',
     }).catch((checkErr) => console.warn('Failed to create error check run:', checkErr));
     throw err;
+  } finally {
+    await clearEyes();
   }
 }


### PR DESCRIPTION
## Summary
E2E-01 (clean PR fixture) surfaced two real bugs:

1. **👀 reaction never removed** — \`addPRReaction\` returned \`void\`, so the success path had no way to know which reaction to delete. The reaction stayed on the PR forever, making it look like MergeWatch was still mid-review.
2. **Test-coverage agent fired on a JSDoc-only diff** — the agent flagged \"New public function 'add' has no test coverage\" even though \`add\` was pre-existing and unchanged. The LLM only saw the diff hunk and had no signal the function was old.

Both fixed here.

## Changes

**packages/core**
- \`github/client.ts\`: \`addPRReaction\` now returns \`Promise<number | null>\` (reaction ID or null on failure). New \`removePRReaction(octokit, owner, repo, prNumber, reactionId)\` helper deletes by ID.
- \`agents/prompts.ts\`: \`TEST_COVERAGE_REVIEWER_PROMPT\` gains two DO NOT report rules:
  - Comment-only / JSDoc-only / whitespace-only diffs.
  - Pre-existing public functions unchanged in the diff (only flag NEW functions or those with signature/behavior changes).

**packages/lambda/src/handlers/review-agent.ts**
- Capture eyes reaction ID; clear it in a \`finally\` block so success AND error paths clean up.

**packages/server/src/review-processor.ts**
- Same pattern via a \`clearEyes()\` closure called from every exit path: smart-skip return, rules-skip return, main pipeline success, main pipeline error.

**e2e/RUNBOOK.md**
- Seed \`src/utils.test.ts\` in the fixtures setup so the test-coverage agent has visible coverage for \`add\` and \`multiply\` — no more false-positive warnings.
- E2E-01 expected outcomes: new checkbox for \"👀 reaction is removed once review completes\".
- E2E-01 failure modes: explicit regression tests for both bugs fixed here.

## Tests
- 5 new server-side tests cover eyes cleanup on: successful review, errored pipeline (finally fires), smart-skip return, rules-skip return, and the \`addPRReaction\` returns null case (skip cleanup).
- All 20 packages green: core 357 / server **71** (+5) / lambda 57.
- \`pnpm run typecheck\` clean across the workspace.

## Behavior after this lands
- Every successful or skipped review leaves only the 👍 reaction on the PR — 👀 is removed.
- A JSDoc-only PR that touches an existing function gets a clean 5/5 (E2E-01 fixture works as designed).
- Real-world JSDoc / comment / whitespace PRs in customer repos stop tripping the test-coverage agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)