### PR TITLE
Restore REQUEST_CHANGES formal review for critical findings

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -261,8 +261,14 @@ No `.mergewatch.yml` needed.
 - [ ] Inline comment includes the hidden `<!-- mergewatch-inline -->` marker (verify via "View source" or curl `gh api .../pulls/N/comments` — needed for thread-root gating in E2E-13/14)
 - [ ] Summary comment shows `🟠 2/5 — Needs fixes` or `🔴 1/5 — Do not merge`
 - [ ] "Requires your attention" table lists the SQL Injection row with 🔴
-- [ ] Formal PR review state = **Changes requested**
-- [ ] Review comment has a body (REQUEST_CHANGES requires non-empty body — different from APPROVE)
+- [ ] Formal PR review state = **Changes requested** (single review event — NOT multiple COMMENTED reviews)
+- [ ] Review body is a single line that points at the summary comment (e.g. `🔴 Critical issues found — see the full review in the summary comment above.`)
+- [ ] Check run conclusion = `failure` with a title like "N critical issues found"
+
+**Failure modes to watch for**
+- ❌ Formal review state is `COMMENTED` instead of `CHANGES_REQUESTED` (regression of #139 — was the bug observed in mergewatch-fixtures PR #3)
+- ❌ Multiple COMMENTED reviews (one per inline comment) instead of one CHANGES_REQUESTED review with bundled inlines
+- ❌ Review body is empty or matches the old multi-section verdict block — both are wrong; a one-line pointer is the target
 
 ---
 

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -36,7 +36,6 @@ import {
   submitPRReview,
   dismissStaleReviews,
   mergeScoreToReviewEvent,
-  createStandaloneReviewComment,
   buildInlineComments,
   extractInlineCommentTitle,
   fetchRepoConfig,
@@ -617,32 +616,22 @@ export async function handler(
     // ── Step C: Surface verdict + inline findings ──────────────────────────
     // Branching policy:
     //   APPROVE (score 4-5) → submit a Review with NO body so the timeline
-    //     shows a clean "approved these changes" event with no comment
-    //     block. Inline comments are bundled under the Review as before.
-    //   REQUEST_CHANGES / COMMENT (score 1-3) → skip the Review entirely.
-    //     The check run already carries the failure conclusion and the
-    //     edit-in-place summary comment has the full verdict body. Inline
-    //     comments still ship — they're posted as standalone PR review
-    //     comments so reviewers see them on the Files Changed tab without
-    //     a noisy "mergewatch reviewed" event firing each commit.
+    //     shows a clean "approved these changes" event. Inline comments are
+    //     bundled under the Review.
+    //   REQUEST_CHANGES / COMMENT (score 1-3) → submit a Review with a
+    //     minimal one-line body pointing at the summary comment. GitHub
+    //     requires a body for these events; a single sentence is far less
+    //     noisy than the multi-section verdict block we had before #132
+    //     and consolidates inline comments into a SINGLE Review event
+    //     (rather than N×COMMENTED reviews from standalone inline comments).
+    const reviewBody = reviewEvent === 'APPROVE'
+      ? ''
+      : reviewEvent === 'REQUEST_CHANGES'
+        ? '🔴 Critical issues found — see the full review in the summary comment above.'
+        : '🟡 Review recommended — see the full review in the summary comment above.';
     try {
       await dismissStaleReviews(octokit, owner, repo, prNumber);
-
-      if (reviewEvent === 'APPROVE') {
-        await submitPRReview(octokit, owner, repo, prNumber, '', reviewEvent, inlineComments);
-      } else {
-        for (const c of inlineComments) {
-          await createStandaloneReviewComment(octokit, owner, repo, prNumber, {
-            path: c.path,
-            line: c.line,
-            side: c.side,
-            body: c.body,
-            commitId: prContext.headSha,
-          }).catch((err) => {
-            console.warn('Standalone inline comment failed:', err);
-          });
-        }
-      }
+      await submitPRReview(octokit, owner, repo, prNumber, reviewBody, reviewEvent, inlineComments);
     } catch (err) {
       console.warn('PR review submission failed — issue comment has the full review:', err);
     }

--- a/packages/server/src/review-processor.test.ts
+++ b/packages/server/src/review-processor.test.ts
@@ -49,7 +49,7 @@ vi.mock('@mergewatch/core', async (importOriginal) => {
 import {
   getPRContext, getPRDiff, createCheckRun, shouldSkipPR, shouldSkipByRules,
   runReviewPipeline, postReplyComment, fetchRepoConfig, handleInlineReply,
-  addPRReaction, removePRReaction,
+  addPRReaction, removePRReaction, submitPRReview, mergeScoreToReviewEvent,
 } from '@mergewatch/core';
 import { processReviewJob } from './review-processor.js';
 
@@ -373,6 +373,87 @@ describe('processReviewJob — check runs', () => {
       const calls = (createCheckRun as any).mock.calls;
       const completionCall = calls[calls.length - 1];
       expect(completionCall[4].title).toBe('1 critical issue found');
+    });
+  });
+
+  describe('formal PR review submission', () => {
+    // mergeScoreToReviewEvent is mocked at module level; reset it per test.
+    beforeEach(() => {
+      (mergeScoreToReviewEvent as any).mockReset();
+    });
+
+    it('submits APPROVE with empty body for high merge scores', async () => {
+      (mergeScoreToReviewEvent as any).mockReturnValue('APPROVE');
+      const deps = makeDeps();
+      await processReviewJob(makeJob(), deps);
+
+      expect(submitPRReview).toHaveBeenCalledWith(
+        mockOctokit, 'test', 'repo', 1,
+        '', // empty body — clean "approved these changes" event
+        'APPROVE',
+        [],
+      );
+    });
+
+    it('submits REQUEST_CHANGES with a non-empty body for low scores (critical findings)', async () => {
+      (mergeScoreToReviewEvent as any).mockReturnValue('REQUEST_CHANGES');
+      (runReviewPipeline as any).mockResolvedValue({
+        ...basePipelineResult,
+        findings: [
+          { file: 'a.ts', line: 1, severity: 'critical', category: 'security', title: 'SQLi', description: '', suggestion: '' },
+        ],
+        mergeScore: 1,
+      });
+      const deps = makeDeps();
+      await processReviewJob(makeJob(), deps);
+
+      const call = (submitPRReview as any).mock.calls[0];
+      const [, , , , body, event] = call;
+      expect(event).toBe('REQUEST_CHANGES');
+      expect(body).toBeTruthy();
+      expect(body.length).toBeGreaterThan(0);
+      // GitHub requires a body for REQUEST_CHANGES; we point at the summary.
+      expect(body.toLowerCase()).toContain('summary comment');
+    });
+
+    it('submits COMMENT with a non-empty body for middle scores', async () => {
+      (mergeScoreToReviewEvent as any).mockReturnValue('COMMENT');
+      const deps = makeDeps();
+      await processReviewJob(makeJob(), deps);
+
+      const call = (submitPRReview as any).mock.calls[0];
+      const [, , , , body, event] = call;
+      expect(event).toBe('COMMENT');
+      expect(body).toBeTruthy();
+      expect(body.length).toBeGreaterThan(0);
+    });
+
+    it('uses a critical-flavored body for REQUEST_CHANGES vs review-recommended for COMMENT', async () => {
+      // First run: REQUEST_CHANGES
+      (mergeScoreToReviewEvent as any).mockReturnValue('REQUEST_CHANGES');
+      const deps1 = makeDeps();
+      await processReviewJob(makeJob(), deps1);
+      const requestBody = (submitPRReview as any).mock.calls[0][4];
+
+      vi.clearAllMocks();
+      (getPRContext as any).mockResolvedValue(basePRContext);
+      (getPRDiff as any).mockResolvedValue('diff content');
+      (shouldSkipPR as any).mockReturnValue(null);
+      (shouldSkipByRules as any).mockReturnValue(null);
+      (runReviewPipeline as any).mockResolvedValue(basePipelineResult);
+      (fetchRepoConfig as any).mockResolvedValue(null);
+      (addPRReaction as any).mockResolvedValue(12345);
+
+      // Second run: COMMENT
+      (mergeScoreToReviewEvent as any).mockReturnValue('COMMENT');
+      const deps2 = makeDeps();
+      await processReviewJob(makeJob(), deps2);
+      const commentBody = (submitPRReview as any).mock.calls[0][4];
+
+      expect(requestBody).not.toBe(commentBody);
+      // Critical findings are flagged in red; "review recommended" is yellow.
+      expect(requestBody).toContain('🔴');
+      expect(commentBody).toContain('🟡');
     });
   });
 });

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -6,7 +6,7 @@ import {
   filterDiff,
   DEFAULT_CONFIG, mergeConfig,
   BOT_COMMENT_MARKER, submitPRReview, dismissStaleReviews, mergeScoreToReviewEvent,
-  createStandaloneReviewComment, buildInlineComments, extractInlineCommentTitle,
+  buildInlineComments, extractInlineCommentTitle,
   fetchRepoConfig, fetchConventions,
   buildWorkDoneSection, computeReviewDelta,
   RESPOND_PROMPT, postReplyComment,
@@ -489,28 +489,21 @@ export async function processReviewJob(
     // ── Step C: Surface verdict + inline findings ──────────────────────────
     // Branching policy (mirrors Lambda):
     //   APPROVE (score 4-5) → submit a Review with NO body so the timeline
-    //     shows a clean "approved these changes" event with no comment block.
-    //     Inline comments bundle under the Review.
-    //   REQUEST_CHANGES / COMMENT (score 1-3) → skip the Review entirely.
-    //     The check run carries the failure conclusion; the edit-in-place
-    //     summary comment has the full body. Inline comments still ship via
-    //     standalone PR review comments.
+    //     shows a clean "approved these changes" event. Inline comments
+    //     bundle under the Review.
+    //   REQUEST_CHANGES / COMMENT (score 1-3) → submit a Review with a
+    //     minimal one-line body pointing at the summary comment. GitHub
+    //     requires a body for these events; a single sentence consolidates
+    //     all inline comments into a single Review event instead of N
+    //     separate COMMENTED reviews from standalone inline comments.
+    const reviewBody = reviewEvent === 'APPROVE'
+      ? ''
+      : reviewEvent === 'REQUEST_CHANGES'
+        ? '🔴 Critical issues found — see the full review in the summary comment above.'
+        : '🟡 Review recommended — see the full review in the summary comment above.';
     try {
       await dismissStaleReviews(octokit, owner, repo, prNumber);
-
-      if (reviewEvent === 'APPROVE') {
-        await submitPRReview(octokit, owner, repo, prNumber, '', reviewEvent, inlineComments);
-      } else {
-        for (const c of inlineComments) {
-          await createStandaloneReviewComment(octokit, owner, repo, prNumber, {
-            path: c.path,
-            line: c.line,
-            side: c.side,
-            body: c.body,
-            commitId: prContext.headSha,
-          }).catch((err) => console.warn('Standalone inline comment failed:', err));
-        }
-      }
+      await submitPRReview(octokit, owner, repo, prNumber, reviewBody, reviewEvent, inlineComments);
     } catch (err) {
       console.warn('PR review submission failed — issue comment has the full review:', err);
     }


### PR DESCRIPTION
## Summary
E2E-03 (critical finding → REQUEST_CHANGES) regressed in production. Observed on https://github.com/santthosh/mergewatch-fixtures/pull/3:

- Formal review state was **COMMENTED ×3** instead of a single **CHANGES_REQUESTED**
- All review bodies were empty

## Root cause
PR #132 (\"drop verdict body\") overshot — instead of just emptying the body for APPROVE, it skipped \`submitPRReview\` entirely for non-APPROVE scores and used \`createStandaloneReviewComment\` in a loop. Each standalone inline comment counts as its own COMMENTED review on the timeline, so a PR with 3 inline findings produced 3 COMMENTED reviews and never a REQUEST_CHANGES event.

## Fix
Restore the branching policy to:

| Score | Event | Body |
|---|---|---|
| 4-5 | APPROVE | empty (clean \"approved\" event — unchanged from #132) |
| 1-2 | REQUEST_CHANGES | one-line: 🔴 Critical issues found — see the full review in the summary comment above |
| 3 | COMMENT | one-line: 🟡 Review recommended — see the full review in the summary comment above |

Inline comments are now always bundled under a single Review event instead of fanning out as N separate standalone comments. GitHub requires a body for REQUEST_CHANGES and COMMENT; a one-line pointer is far less noisy than the multi-section verdict block #132 dropped, and avoids the timeline pollution from standalone inline comments.

## Files
- \`packages/lambda/src/handlers/review-agent.ts\` — replace the per-comment loop with a single \`submitPRReview\` call; minimal body picked by event type.
- \`packages/server/src/review-processor.ts\` — mirror.
- \`packages/server/src/review-processor.test.ts\` — 4 new tests covering APPROVE/REQUEST_CHANGES/COMMENT body handling.
- \`e2e/RUNBOOK.md\` — E2E-03 expected outcomes updated; failure modes now explicitly call out COMMENTED-instead-of-CHANGES_REQUESTED so this regression gets caught next time.

\`createStandaloneReviewComment\` is no longer called by either runtime; unused imports cleaned up. The helper stays exported from \`@mergewatch/core\` for potential future use.

## Test plan
- [x] \`pnpm run typecheck\` clean across 20 packages
- [x] \`pnpm test\` — core 363 / server **75** (+4) / lambda 57, all green
- [ ] Manual verification on mergewatch-fixtures PR #3 after deploy: re-run via Checks UI, confirm a single CHANGES_REQUESTED review with the one-line body lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)