### PR TITLE
Fix E2E-04, E2E-10, E2E-15 regressions from fixtures testing

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -416,20 +416,32 @@ Open the PR as a **draft**: `gh pr create --draft`.
 
 **Behavior**: a PR carrying a label in `rules.ignoreLabels` is skipped.
 
+> **Important**: MergeWatch only re-evaluates skip rules on `pull_request` events with action `opened` / `synchronize` / `ready_for_review` / `reopened` (see `REVIEW_TRIGGERING_ACTIONS`). The `labeled` action is **not** in that list — adding a label to an already-reviewed PR will NOT cancel the in-flight review or supersede the existing verdict. To test this fixture correctly, add the label **before** the first commit lands, or follow the label add with a synchronize event (push any commit) so the rules-skip path actually runs.
+
 **Setup**
 
-Branch: `fixture/10-skip-review-label`. Any non-trivial source change. Open the PR, then add the `skip-review` label (default `ignoreLabels` entry):
+Branch: `fixture/10-skip-review-label`. Make any non-trivial source change but **do not push yet**. Open the PR as draft → add the `skip-review` label → mark ready-for-review (which fires `ready_for_review` and re-evaluates the skip rules). Alternatively:
 
 ```bash
+# Path A: label first, then push a commit (synchronize triggers re-evaluation)
+gh pr create --title 'E2E-10' --body '...'
 gh pr edit <N> --add-label skip-review
-gh pr edit <N> --remove-label skip-review && gh pr edit <N> --add-label skip-review  # trigger synchronize
-```
+git commit --allow-empty -m 'trigger synchronize'
+git push
 
-Or push a fresh commit after adding the label.
+# Path B: open as draft, label, then mark ready
+gh pr create --draft --title 'E2E-10' --body '...'
+gh pr edit <N> --add-label skip-review
+gh pr ready <N>
+```
 
 **Expected outcomes**
 
 - [ ] Visible "Review skipped" check run with summary like `PR has label "skip-review" which is in ignoreLabels`
+- [ ] If a prior MergeWatch review was already submitted, it is **dismissed** by the new skip evaluation
+
+**Known gap**
+- ❌ Adding the `skip-review` label to a PR that's already mid-review (or already reviewed) does **not** cancel/supersede the existing review. The webhook only fires for the actions listed above. Tracked as a deliberate limitation — opening a code-side fix would require handling `labeled` / `unlabeled` actions specifically and is non-trivial.
 
 ---
 

--- a/packages/core/src/agents/prompts.ts
+++ b/packages/core/src/agents/prompts.ts
@@ -219,6 +219,12 @@ Guidelines:
 - Use subgraphs to group related files or modules when helpful.
 - If the diff is too trivial for a useful diagram (e.g. a one-line config change, a typo fix, or a single variable rename), return EMPTY (nothing at all).
 
+CRITICAL — accuracy rules:
+- Every node that references a file path MUST point to a file that actually appears in the diff. Do NOT invent paths like \`src/utils/index.ts\` or \`src/lib/helper.ts\` if they aren't in the diff.
+- Every function name in a node label MUST be a function that actually exists in the diff. Do NOT fabricate \`foo()\` if \`foo\` isn't defined or called in the changed code.
+- If you cannot verify a node from the diff, leave it out. A smaller accurate diagram is always better than a larger one with hallucinations.
+- Do not output HTML entities (\`&lt;\`, \`&gt;\`, \`&amp;\`) in labels — write the literal characters and rely on the diagram tooling to escape them. Double-encoded labels render as garbled text.
+
 ${PREVIOUS_DIAGRAM_PLACEHOLDER}
 
 Return ONLY raw Mermaid code — no JSON, no fences, no explanation.

--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -361,6 +361,31 @@ describe('runDiagramAgent', () => {
     // defense-in-depth substitution.
     expect(result.diagram).toMatch(/A\["invoke&lpar;&rpar;"\]/);
   });
+
+  it('does not double-escape pre-encoded HTML entities from the LLM', async () => {
+    // Repro for E2E-15a: when the LLM emits `&lt;Title&gt;` already escaped,
+    // the previous escape function ran `&` → `&amp;` first and turned the
+    // entity into `&amp;lt;Title&amp;gt;`. After idempotency, we should
+    // re-emit clean `&lt;Title&gt;`.
+    const mermaid = 'flowchart TD\n  A["&lt;Title&gt;"]';
+    const llm = createMockLLM([mermaid]);
+    const result = await runDiagramAgent(sampleDiff, sampleContext, 'model-1', llm);
+    expect(result.diagram).toContain('&lt;Title&gt;');
+    expect(result.diagram).not.toContain('&amp;lt;');
+    expect(result.diagram).not.toContain('&amp;gt;');
+  });
+
+  it('is idempotent — running through the escape twice produces the same output', async () => {
+    // Round-tripping a label that mixes raw and pre-encoded chars should
+    // not progressively mangle the output.
+    const mermaid = 'flowchart TD\n  A["Foo &amp; <Bar>"]';
+    const llm = createMockLLM([mermaid]);
+    const result = await runDiagramAgent(sampleDiff, sampleContext, 'model-1', llm);
+    // After decode + re-encode: `&` → `&amp;`, `<` → `&lt;`, `>` → `&gt;`.
+    expect(result.diagram).toContain('Foo &amp; &lt;Bar&gt;');
+    expect(result.diagram).not.toContain('&amp;amp;');
+    expect(result.diagram).not.toContain('&amp;lt;');
+  });
 });
 
 // ─── runErrorHandlingAgent ──────────────────────────────────────────────────

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -336,7 +336,29 @@ ${previousDiagram}
  * confused JSON-escape and Mermaid line-break syntax) into `<br/>`.
  */
 function escapeMermaidLabelChars(label: string): string {
-  // Order matters in two places:
+  // Step 1: decode any pre-existing HTML entities. LLMs sometimes emit
+  // already-escaped Mermaid (e.g. `&lt;Title&gt;`) thinking the output will
+  // be HTML-rendered. Without this decode pass, the `&` → `&amp;` step
+  // below would re-escape those entities into `&amp;lt;Title&amp;gt;`,
+  // which Mermaid then renders as literal `&lt;Title&gt;` instead of
+  // `<Title>`. Decoding first makes the function idempotent.
+  //
+  // `&amp;` MUST decode LAST — otherwise `&amp;lt;` would prematurely become
+  // `&lt;` and get re-decoded to `<` on the next pass, dropping the literal
+  // `&` that was actually in the source.
+  const decoded = label
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&lbrace;/g, '{')
+    .replace(/&rbrace;/g, '}')
+    .replace(/&lpar;/g, '(')
+    .replace(/&rpar;/g, ')')
+    .replace(/&lsqb;/g, '[')
+    .replace(/&rsqb;/g, ']')
+    .replace(/&amp;/g, '&');
+
+  // Step 2: encode. Order matters in two places:
   //   1. `&amp;` MUST run first — otherwise the `&` we introduce in every
   //      other replacement gets re-escaped to `&amp;…;`.
   //   2. `\\n → <br/>` MUST run AFTER the angle-bracket escapes, so the
@@ -348,7 +370,7 @@ function escapeMermaidLabelChars(label: string): string {
   // reliably suppress shape-delimiter interpretation inside `"..."` regions,
   // so escaping them all is the only durable fix. `"` is also escaped so
   // an embedded quote can't break out of the quoted-label region.
-  return label
+  return decoded
     .replace(/&/g, '&amp;')
     .replace(/"/g, '&quot;')
     .replace(/</g, '&lt;')

--- a/packages/core/src/github/client.ts
+++ b/packages/core/src/github/client.ts
@@ -904,16 +904,24 @@ export function parseRepoConfigYaml(content: string): Partial<MergeWatchConfig> 
   return config;
 }
 
+/**
+ * Fetch `.mergewatch.yml` from a repo. When `ref` is provided, reads the file
+ * at that commit / branch — required for the silent autoReview-off gate to
+ * honor changes made on the PR branch, since GitHub's default is to read from
+ * the repo's default branch.
+ */
 export async function fetchRepoConfig(
   octokit: Octokit,
   owner: string,
   repo: string,
+  ref?: string,
 ): Promise<Partial<MergeWatchConfig> | null> {
   try {
     const { data } = await octokit.repos.getContent({
       owner,
       repo,
       path: '.mergewatch.yml',
+      ...(ref ? { ref } : {}),
     });
 
     if (Array.isArray(data) || data.type !== 'file' || !data.content) {

--- a/packages/core/src/types/github.ts
+++ b/packages/core/src/types/github.ts
@@ -279,6 +279,15 @@ export interface ReviewJobPayload {
   changedFileCount?: number;
   /** True when triggered by an @mergewatch comment (force-bypasses skip logic). */
   mentionTriggered?: boolean;
+  /**
+   * Head commit SHA of the PR. Passed from the webhook so the review-agent
+   * can fetch `.mergewatch.yml` at the PR's head (not the repo's default
+   * branch) — required for the silent autoReview-off gate to honor config
+   * changes made on the PR branch. Optional because pre-existing job payloads
+   * in flight won't carry it; the silent-skip fetch falls back to the default
+   * branch in that case.
+   */
+  headSha?: string;
   /** For "respond" mode: the user's comment body that triggered the response. */
   userComment?: string;
   /** For "respond" mode: the login of the user who commented. */

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -263,7 +263,11 @@ export async function handler(
   // we go fully silent: no reactions, no check runs, no storage write.
   // Other skip kinds (draft, maxFiles, labels) still surface a check run
   // via shouldSkipByRules below; only autoReviewOff goes silent.
-  const yamlConfig = await fetchRepoConfig(octokit, owner, repo).catch((err) => {
+  //
+  // Read at the PR's headSha when we have it, so config changes on the PR
+  // branch take effect. Falls back to the default branch when headSha is
+  // absent (e.g. legacy job payloads in flight from before this change).
+  const yamlConfig = await fetchRepoConfig(octokit, owner, repo, event.headSha).catch((err) => {
     // Static format string; user-controlled values pass as separate args
     // to avoid feeding repo names through Node's printf-style formatter.
     console.warn('Failed to fetch .mergewatch.yml — proceeding without YAML config:', `${repoFullName}#${prNumber}`, err);

--- a/packages/lambda/src/handlers/webhook.ts
+++ b/packages/lambda/src/handlers/webhook.ts
@@ -196,6 +196,7 @@ async function handlePullRequestEvent(
     changedFileCount: pr.changed_files,
     source: classification.source,
     agentKind: classification.agentKind,
+    headSha: pr.head?.sha,
   });
 
   console.log(
@@ -381,6 +382,7 @@ async function handleCheckRunEvent(event: CheckRunEvent): Promise<void> {
     changedFileCount: pr.changed_files,
     source: classification.source,
     agentKind: classification.agentKind,
+    headSha: pr.head?.sha,
   });
 
   console.log(

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -181,7 +181,11 @@ export async function processReviewJob(
   // we go fully silent: no reactions, no check runs, no storage write.
   // Other skip kinds (draft, maxFiles, labels) still surface a check run
   // via shouldSkipByRules below; only autoReviewOff goes silent.
-  const yamlConfig = await fetchRepoConfig(octokit, owner, repo).catch((err) => {
+  //
+  // Read at the PR's headSha when we have it, so config changes on the PR
+  // branch take effect. Falls back to the default branch when headSha is
+  // absent (e.g. legacy job payloads in flight from before this change).
+  const yamlConfig = await fetchRepoConfig(octokit, owner, repo, job.headSha).catch((err) => {
     // Static format string; user-controlled values pass as separate args
     // to avoid feeding repo names through Node's printf-style formatter.
     console.warn('Failed to fetch .mergewatch.yml — proceeding without YAML config:', `${repoFullName}#${prNumber}`, err);

--- a/packages/server/src/webhook-handler.ts
+++ b/packages/server/src/webhook-handler.ts
@@ -118,6 +118,7 @@ async function handlePullRequest(payload: PullRequestEvent, deps: WebhookDeps) {
     changedFileCount: pull_request.changed_files,
     source,
     agentKind,
+    headSha: pull_request.head?.sha,
   };
 
   // Process in background
@@ -240,6 +241,7 @@ async function handleCheckRun(payload: CheckRunEvent, deps: WebhookDeps) {
     changedFileCount: pr.changed_files,
     source: classification.source,
     agentKind: classification.agentKind,
+    headSha: pr.head?.sha,
   };
 
   processReviewJob(job, deps).catch((err) => {


### PR DESCRIPTION
## Summary
Bundle of fixes for three real regressions and one runbook gap surfaced by running E2E fixtures on mergewatch-fixtures PRs #4, #8, #10. E2E-16 is also addressed by the in-flight #139 — noted below, no extra code needed.

## Bugs fixed

### E2E-04 — silent autoReview gate read from default branch
**Symptom**: \`.mergewatch.yml\` with \`rules.autoReview: false\` on a PR branch was ignored; MergeWatch ran the full pipeline.

**Root cause**: \`fetchRepoConfig\` called \`octokit.repos.getContent\` without a \`ref\` param. GitHub's default is the repo's default branch, so the gate evaluated against main's config rather than the PR's.

**Fix**:
- \`fetchRepoConfig\` accepts an optional \`ref\` parameter
- \`ReviewJobPayload\` gains an optional \`headSha\` field
- Lambda + Express webhook handlers fill \`headSha\` from \`event.pull_request.head.sha\` (and \`pr.head.sha\` on check_run.rerequested)
- Both review pipelines pass \`job.headSha\` into the silent-skip \`fetchRepoConfig\` call
- Falls back to default branch when headSha is absent (legacy in-flight jobs)

### E2E-15a — Mermaid double-encoded HTML entities
**Symptom**: \`<Title>\` rendered in node labels as literal text \`&lt;Title&gt;\` (visible to users). Raw bytes showed \`&amp;lt;Title&amp;gt;\` — double-encoded.

**Root cause**: when the LLM emitted pre-escaped Mermaid (\`&lt;Title&gt;\`), \`escapeMermaidLabelChars\` ran \`&\` → \`&amp;\` first, mangling the existing entity.

**Fix**: decode HTML entities first, then re-encode. Function is now idempotent; \`escape(escape(x)) === escape(x)\`. Two new tests cover the case.

### E2E-15b — Hallucinated nodes in diagrams
**Symptom**: reviewer invented file paths (\`src/utils/index.ts (add())\`) that don't exist in the diff.

**Fix**: tighten \`DIAGRAM_PROMPT\` with explicit accuracy rules — nodes must reference real files/functions from the diff. Also tells the LLM not to pre-encode HTML entities (defense-in-depth with the sanitizer fix above).

### E2E-10 — Label-add doesn't re-trigger review
**Symptom**: adding \`skip-review\` to an already-reviewed PR didn't cancel or supersede the existing verdict.

**Root cause**: \`REVIEW_TRIGGERING_ACTIONS\` includes only opened/synchronize/ready_for_review/reopened — not labeled.

**Fix**: documentation only. Runbook E2E-10 now spells out the limitation and the two valid test patterns (label-then-push, or draft-label-ready). Code-side handling of \`labeled\` webhooks is non-trivial and deferred.

## E2E-16 — agent PRs missing formal review
Same root cause as **PR #139** (REQUEST_CHANGES regression). Agent PRs often score 3/5, which the pre-#139 code routed through \`createStandaloneReviewComment\` without ever calling \`submitPRReview\`. Resolves once #139 lands; **no code change needed in this PR**.

## Test plan
- [x] \`pnpm run typecheck\` clean across 20 packages
- [x] \`pnpm test\` — core 365 (+2 idempotent-escape tests), server 75, lambda 57 — all green
- [ ] Manual verification against mergewatch-fixtures PRs #4, #8, #10 after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)