### PR TITLE
Tier-1 reviewer trust fixes: grounding + delta-aware verdict + hide confidence

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -143,6 +143,10 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-14](#e2e-14-inline-reply-skips-third-party-bot-thread) | Human replies in a non-MergeWatch inline thread → no engagement | 2m | 60s | #133 |
 | [E2E-15](#e2e-15-mermaid-diagram-renders) | Complex diff produces a renderable Mermaid diagram | 2m | 60s | #128–#130 |
 | [E2E-16](#e2e-16-agent-authored-pr-detection) | PR from `claude/*` branch → flagged as agent-authored | 1m | 60s | core |
+| [E2E-17](#e2e-17-finding-grounding-drops-hallucinated-anchors) | Critical finding anchored at a comment line gets dropped or snapped | 2m | 60s | tier-1 |
+| [E2E-18](#e2e-18-delta-aware-verdict-on-security-improvement) | PR that resolves prior criticals → green verdict (≥4/5), not orange | 3m | 90s | tier-1 |
+| [E2E-19](#e2e-19-confidence-scores-hidden-by-default) | New install sees no `85%` etc. badges in finding rows | 30s | 60s | tier-1 |
+| [E2E-20](#e2e-20-pr-description-vs-code-drift-catch) | Stale "we now use X" in PR body → reviewer flags the mismatch | 2m | 60s | feedback |
 
 ---
 
@@ -609,6 +613,210 @@ aws dynamodb get-item --table-name mergewatch-reviews \
   --key '{"repoFullName":{"S":"<owner>/mergewatch-fixtures"},"prNumberCommitSha":{"S":"<N>#<shortSha>"}}' \
   --profile mergewatch
 ```
+
+---
+
+### E2E-17: Finding grounding drops hallucinated anchors
+
+**Behavior**: a finding whose cited anchor line doesn't actually contain the code it describes is dropped (critical) or downgraded (warning → info). The grounding step in `runReviewPipeline` re-fetches the file at the PR's headSha and verifies that an identifier from the finding's description appears within ±5 lines of the anchor; if not, it snaps to the first matching line in the file or drops the finding.
+
+Verifies the regression flagged in user feedback: "the bot anchored a critical 'race condition' at lines 89–91 (which are comment lines), when the actual `await createChatSession()` was on line 92."
+
+**Setup**
+
+Branch: `fixture/17-grounding-hallucinated-anchor`. Add a file deliberately crafted so the LLM is likely to anchor a finding at a comment line:
+
+`src/race-trap.ts`:
+
+```ts
+// This function persists chat state to two stores.
+// IMPORTANT: the writes happen serially below — the comment block
+// runs from line 1 to line 8 and contains words like "await",
+// "race condition", and "fire-and-forget" so the reviewer might be
+// tempted to anchor a finding inside this comment region.
+//
+// The actual code is below.
+
+export async function persistChat(userId: string, msg: string): Promise<void> {
+  const session = await createChatSession(userId);
+  await addChatMessage(session.id, msg);
+}
+
+declare function createChatSession(userId: string): Promise<{ id: string }>;
+declare function addChatMessage(id: string, msg: string): Promise<void>;
+```
+
+No `.mergewatch.yml` needed.
+
+**Expected outcomes**
+
+- [ ] If a critical finding is produced about race conditions or fire-and-forget writes, its `line` field points at line **10 or 11** (the `await createChatSession` / `await addChatMessage` lines) — NOT at lines 1–8
+- [ ] If the orchestrator emitted such a finding anchored in the comment region (1–8), the grounding pass snapped the line to the actual code OR dropped the finding entirely
+- [ ] No finding's anchor line is on a `//`-only line in the rendered "Requires your attention" table
+- [ ] The dashboard review record (or DynamoDB `findings`) shows snapped line numbers, not the original orchestrator output
+
+**Failure modes to watch for**
+- ❌ Critical finding rendered at lines 1–8 (anchor still on a comment line)
+- ❌ Critical finding describing functions that don't appear in `src/race-trap.ts` at all (full hallucination — the grounding pass should have dropped it)
+
+**Note**: this fixture is stochastic — the LLM may not always anchor on a comment line on a small file. To force the failure mode pre-fix, you can manually inject `{ "file": "src/race-trap.ts", "line": 3, "severity": "critical", "title": "Race condition", "description": "createChatSession() and addChatMessage() are not awaited together." }` into the orchestrator response in a local self-hosted run.
+
+---
+
+### E2E-18: Delta-aware verdict on security improvement
+
+**Behavior**: a PR that resolves critical findings from a prior review without introducing new criticals should produce a green verdict (≥4/5 "Generally safe" / "Safe to merge"), not the same orange "Needs fixes" face the original buggy commit got. Verifies the reconciliation rule added with the grounding fix.
+
+User feedback motivating this: "PR #18 had real exploitable issues, PR #19 closed them — both landed at 2/5. When a PR is a security improvement, the verdict should reflect that."
+
+**Setup**
+
+Use a two-PR sequence on the fixtures repo.
+
+**Step 1** — open a PR that produces critical findings:
+
+Branch: `fixture/18a-introduce-criticals`. Add `src/admin-api.ts`:
+
+```ts
+import type { NextRequest } from 'next/server';
+
+// No authentication — anyone can hit this admin endpoint.
+export async function GET(_req: NextRequest) {
+  const transcripts = await fetchAllTranscripts();
+  return Response.json({ transcripts });
+}
+
+// User-controlled SQL.
+export async function POST(req: NextRequest) {
+  const { id } = await req.json();
+  const result = await db.raw(`SELECT * FROM users WHERE id = '${id}'`);
+  return Response.json(result);
+}
+
+declare const db: { raw(sql: string): Promise<unknown> };
+declare function fetchAllTranscripts(): Promise<unknown[]>;
+```
+
+Open the PR, let MergeWatch review. Confirm it produces ≥1 critical findings and lands at 1/5 or 2/5 (orange/red). **Do not merge.**
+
+**Step 2** — push a follow-up commit that fixes the criticals:
+
+```ts
+import type { NextRequest } from 'next/server';
+import { requireAdmin } from '@/auth';
+
+export async function GET(req: NextRequest) {
+  await requireAdmin(req);
+  const transcripts = await fetchAllTranscripts();
+  return Response.json({ transcripts });
+}
+
+export async function POST(req: NextRequest) {
+  await requireAdmin(req);
+  const { id } = await req.json();
+  // Parameterized query.
+  const result = await db.prepare('SELECT * FROM users WHERE id = ?', [id]);
+  return Response.json(result);
+}
+
+declare const db: { prepare(sql: string, params: unknown[]): Promise<unknown> };
+declare function fetchAllTranscripts(): Promise<unknown[]>;
+declare function requireAdmin(req: NextRequest): Promise<void>;
+```
+
+Push to the same branch. MergeWatch will re-review with the fix-commit context.
+
+**Expected outcomes (on the second review)**
+
+- [ ] The "📎 Previously reported findings" section shows the ≥1 criticals from step 1 marked as **✅ Resolved**
+- [ ] No new critical findings are introduced
+- [ ] Verdict line shows `🟢 4/5 — Generally safe` or `🟢 5/5 — Safe to merge` — NOT `🟠 2/5 — Needs fixes`
+- [ ] Verdict reason mentions resolved criticals: something like `Resolved N critical issues from prior review, no new criticals introduced.`
+- [ ] Formal PR review state = **Approved** (empty body — APPROVE event)
+- [ ] Delta caption summarises the resolution: e.g., "Replaced unauthenticated admin endpoints with `requireAdmin` guards and parameterized the SQL query."
+
+**Failure modes**
+- ❌ Score still orange/red despite zero new criticals (delta-aware reconciliation regressed)
+- ❌ Resolved criticals counted as still-open in the verdict reason
+
+---
+
+### E2E-19: Confidence scores hidden by default
+
+**Behavior**: a fresh MergeWatch install should NOT render `XX%` confidence badges next to findings. The flag still exists (`InstallationSettings.summary.confidenceScore`) and users can opt back in via the dashboard, but the default is off because LLM-self-reported confidence has been observed to be miscalibrated against actual hit rate.
+
+**Setup**
+
+Branch: `fixture/19-confidence-default-off`. Make any change that's likely to produce a finding with non-empty confidence (e.g., add code with a clearly-named TODO that triggers the bug agent):
+
+`src/cache.ts`:
+
+```ts
+export function getCached<T>(key: string): T | null {
+  // TODO: this currently returns stale data after invalidation — fix me.
+  return cache.get(key) ?? null;
+}
+
+declare const cache: Map<string, unknown>;
+```
+
+No `.mergewatch.yml`. Don't touch any dashboard settings.
+
+**Expected outcomes**
+
+- [ ] Summary comment includes a "Requires your attention" or "Info" section with at least one finding
+- [ ] **No finding row contains a `XX%` badge** — neither in the action-items table nor in the collapsible Info section
+- [ ] If you turn the setting back on (Settings → Summary → "Show confidence scores"), the next review's findings DO show the badge
+
+**Failure modes**
+- ❌ `85%`, `90%`, etc. badges appear in finding rows on a default install (regression of the default flip)
+- ❌ The setting toggle in the dashboard doesn't have any effect
+
+---
+
+### E2E-20: PR description vs code drift catch
+
+**Behavior**: when a PR's description claims behavior that the diff has since dropped or changed, the reviewer flags the discrepancy. This is a genuine catch the bot got right in user testing ("PR #18 description still said 'localStorage persistence' after I'd dropped it in commit c1e3a06").
+
+This is more of a *spot-check* than a hard pass/fail — the LLM doesn't always catch description drift, but it should at least notice on obvious cases.
+
+**Setup**
+
+Branch: `fixture/20-description-drift`. Make TWO commits:
+
+**Commit 1** — implement the behavior the description will describe:
+
+`src/persistence.ts`:
+
+```ts
+export function savePref(key: string, value: string): void {
+  localStorage.setItem(`pref:${key}`, value);
+}
+```
+
+**Commit 2** — drop the localStorage usage in favor of an in-memory map:
+
+```ts
+const memCache = new Map<string, string>();
+export function savePref(key: string, value: string): void {
+  memCache.set(`pref:${key}`, value);
+}
+```
+
+Open the PR with this body — **deliberately stale**:
+
+```markdown
+This PR adds preference persistence using `localStorage.setItem` so
+user choices survive page reloads. The key format is `pref:<name>`.
+```
+
+**Expected outcomes** (spot-check, not strict pass/fail)
+
+- [ ] At least one info or warning finding mentions that the PR description references `localStorage` but the diff has dropped it
+- [ ] The mismatch surfaces in the summary text or the "Requires your attention" table
+- [ ] Bonus: the reviewer's verdict reason or summary notes the description should be updated
+
+**Note**: this is the only fixture where a miss isn't necessarily a bug. PR-description drift detection is best-effort. If MergeWatch never catches it, that's a quality-bar to raise; if it catches some but not all, log the misses for prompt tuning.
 
 ---
 

--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -15,6 +15,8 @@ import {
   runOrchestratorAgent,
   runDeltaCaptionAgent,
   runReviewPipeline,
+  extractFindingIdentifiers,
+  groundFinding,
   type ReviewContext,
   type AgentFinding,
   type ReviewPipelineOptions,
@@ -1067,5 +1069,118 @@ describe('agentAuthored flag', () => {
     const llm = createMockLLM([emptyAgentResponse]);
     await runCustomAgent(agentDef, sampleDiff, sampleContext, 'model-1', llm, undefined, undefined, true);
     expect(llm.calls[0].prompt).toContain(AGENT_MODE_SUFFIX);
+  });
+});
+
+// ─── extractFindingIdentifiers ──────────────────────────────────────────────
+
+describe('extractFindingIdentifiers', () => {
+  it('extracts function-call identifiers from prose', () => {
+    const ids = extractFindingIdentifiers('Race condition: `createChatSession()` and `addChatMessage()` are not awaited together.');
+    expect(ids).toContain('createChatSession(');
+    expect(ids).toContain('addChatMessage(');
+  });
+
+  it('extracts backtick-quoted identifiers', () => {
+    const ids = extractFindingIdentifiers('The `userId` field is not validated.');
+    expect(ids).toContain('userId');
+  });
+
+  it('ignores JS syntax keywords that look like calls', () => {
+    const ids = extractFindingIdentifiers('Use `if (x)` instead of `for (y)`.');
+    expect(ids).not.toContain('if(');
+    expect(ids).not.toContain('for(');
+  });
+
+  it('returns empty for prose with no identifiers', () => {
+    const ids = extractFindingIdentifiers('Consider adding error handling.');
+    expect(ids).toEqual([]);
+  });
+
+  it('skips very short identifiers (likely noise)', () => {
+    // 2-char ids are common false positives in prose
+    const ids = extractFindingIdentifiers('Method `do()` is wrong.');
+    expect(ids).not.toContain('do(');
+  });
+});
+
+// ─── groundFinding ──────────────────────────────────────────────────────────
+
+describe('groundFinding', () => {
+  const baseFinding = {
+    file: 'src/chat-handler.ts',
+    line: 89,
+    severity: 'critical' as const,
+    confidence: 85,
+    category: 'concurrency',
+    title: 'Race condition in chat session persistence',
+    description: 'The call to `createChatSession()` is not awaited before `addChatMessage()` runs.',
+    suggestion: 'await both calls in order.',
+  };
+
+  it('passes findings through unchanged when no file content is available', () => {
+    expect(groundFinding(baseFinding, undefined)).toEqual(baseFinding);
+  });
+
+  it('passes findings through when no identifiers can be extracted', () => {
+    const f = { ...baseFinding, line: 1, title: 'Style issue', description: 'Consider refactoring.', suggestion: '' };
+    const file = '// line 1\n// line 2';
+    expect(groundFinding(f, file)).toEqual(f);
+  });
+
+  it('keeps the finding when the cited line is within ±5 of the identifier', () => {
+    // anchor line 5, identifier at line 7 — within window
+    const file = [
+      'function handle() {',
+      '  // line 2',
+      '  // line 3',
+      '  // line 4',
+      '  // line 5 (anchor)',
+      '  prepare();',
+      '  await createChatSession();',
+      '  return ok;',
+      '}',
+    ].join('\n');
+    const f = { ...baseFinding, line: 5 };
+    expect(groundFinding(f, file)).toEqual(f);
+  });
+
+  it('snaps the line number when the identifier exists in the file but outside the ±5 window', () => {
+    // anchor line 2 (a comment), identifier 10 lines down
+    const lines = [
+      '// header comment',
+      '// anchor comment line', // line 2
+      '', '', '', '', '', '', '', '',
+      'const s = await createChatSession();', // line 11
+    ];
+    const result = groundFinding({ ...baseFinding, line: 2 }, lines.join('\n'));
+    expect(result).not.toBeNull();
+    expect(result!.line).toBe(11);
+  });
+
+  it('drops a critical finding when the identifier nowhere appears in the file', () => {
+    // Reproduces the prod hallucination: line 89-91 are comments, file
+    // never even calls createChatSession() — drop the critical.
+    const file = ['// only comments here', 'const x = 1;', 'export default x;'].join('\n');
+    const result = groundFinding(baseFinding, file);
+    expect(result).toBeNull();
+  });
+
+  it('downgrades a warning to info when the identifier is missing (less destructive than dropping)', () => {
+    const file = 'const a = 1;\nconst b = 2;';
+    const warning = { ...baseFinding, severity: 'warning' as const, line: 1 };
+    const result = groundFinding(warning, file);
+    expect(result?.severity).toBe('info');
+  });
+
+  it('drops an info finding when the identifier is missing', () => {
+    const file = 'const a = 1;';
+    const info = { ...baseFinding, severity: 'info' as const, line: 1 };
+    expect(groundFinding(info, file)).toBeNull();
+  });
+
+  it('drops a critical when the anchor is past EOF', () => {
+    const file = 'one\ntwo\nthree';
+    expect(groundFinding({ ...baseFinding, line: 999 }, file)).toBeNull();
   });
 });

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -886,6 +886,39 @@ const SYNTAX_KEYWORDS = new Set([
 ]);
 
 /**
+ * Minimum identifier length (≥3 chars). Excludes 1-2 char names that
+ * commonly appear as false-positive matches against arbitrary file content
+ * (e.g. `id`, `fn`, `x`). The +1 in the regex (`{2,}`) follows the first
+ * required character — total identifier length is 3 or more.
+ */
+const MIN_IDENTIFIER_LENGTH = 3;
+
+/**
+ * Hard cap on finding-text length fed to regex extraction. Defense against
+ * ReDoS in case a future agent emits pathological backtick-heavy prose.
+ * Finding titles/descriptions/suggestions are bounded by the orchestrator
+ * prompt but we don't rely on that — 4KB covers any legitimate finding.
+ */
+const FINDING_TEXT_MAX_BYTES = 4096;
+
+/**
+ * Number of lines on either side of the cited anchor to check for the
+ * extracted identifier. Tuned to catch off-by-N anchors where the LLM
+ * placed the finding on a comment line near the actual code, without
+ * being so wide that unrelated code coincidentally matches.
+ */
+const GROUNDING_WINDOW_LINES = 5;
+
+/**
+ * Build a fingerprint for severity-aware delta comparison. Intentionally
+ * excludes line number — the orchestrator may shift the line after a
+ * fix without the underlying issue being the "same" finding.
+ */
+function findingKey(f: { file: string; title: string }): string {
+  return `${f.file}::${f.title}`;
+}
+
+/**
  * Extract identifier-shaped strings from a finding's text that should
  * appear in the cited code for the finding to be grounded. We look for:
  *   - Function/method calls: `someFunc(`
@@ -895,12 +928,19 @@ const SYNTAX_KEYWORDS = new Set([
  * as easy false-positive matches against arbitrary file content.
  */
 export function extractFindingIdentifiers(text: string): string[] {
+  // Cap input length defensively before regex processing — protects against
+  // ReDoS on pathological inputs even though the regexes here are linear.
+  const bounded = text.length > FINDING_TEXT_MAX_BYTES
+    ? text.slice(0, FINDING_TEXT_MAX_BYTES)
+    : text;
   const ids = new Set<string>();
 
-  // Function calls: capture `name(` patterns.
-  const callPattern = /\b([a-zA-Z_$][\w$]{2,})\(/g;
+  // Function calls: capture `name(` patterns. The {n,} clause is one shorter
+  // than MIN_IDENTIFIER_LENGTH because the first `[a-zA-Z_$]` already accounts
+  // for one character.
+  const callPattern = new RegExp(`\\b([a-zA-Z_$][\\w$]{${MIN_IDENTIFIER_LENGTH - 1},})\\(`, 'g');
   let m: RegExpExecArray | null;
-  while ((m = callPattern.exec(text)) !== null) {
+  while ((m = callPattern.exec(bounded)) !== null) {
     if (!SYNTAX_KEYWORDS.has(m[1].toLowerCase())) {
       ids.add(m[1] + '(');
     }
@@ -908,9 +948,13 @@ export function extractFindingIdentifiers(text: string): string[] {
 
   // Backtick-quoted identifiers — strip the ticks and require an identifier-shape.
   const tickPattern = /`([^`\n]+)`/g;
-  while ((m = tickPattern.exec(text)) !== null) {
+  while ((m = tickPattern.exec(bounded)) !== null) {
     const inner = m[1].trim();
-    if (inner.length >= 4 && /^[a-zA-Z_$][\w$.]*\(?\)?$/.test(inner) && !SYNTAX_KEYWORDS.has(inner.toLowerCase())) {
+    if (
+      inner.length >= MIN_IDENTIFIER_LENGTH + 1 &&
+      /^[a-zA-Z_$][\w$.]*\(?\)?$/.test(inner) &&
+      !SYNTAX_KEYWORDS.has(inner.toLowerCase())
+    ) {
       ids.add(inner);
     }
   }
@@ -952,10 +996,9 @@ export function groundFinding(
   const identifiers = extractFindingIdentifiers(`${f.title} ${f.description} ${f.suggestion}`);
   if (identifiers.length === 0) return f; // No identifier to verify against — pass through.
 
-  // ±5 lines around the anchor (inclusive).
-  const WINDOW = 5;
-  const start = Math.max(0, zeroBased - WINDOW);
-  const end = Math.min(lines.length, zeroBased + WINDOW + 1);
+  // ±GROUNDING_WINDOW_LINES around the anchor (inclusive).
+  const start = Math.max(0, zeroBased - GROUNDING_WINDOW_LINES);
+  const end = Math.min(lines.length, zeroBased + GROUNDING_WINDOW_LINES + 1);
   const window = lines.slice(start, end).join('\n');
 
   // Identifier appears near anchor — finding is grounded.
@@ -1006,7 +1049,21 @@ export async function groundFindings(
       fileFetchOptions.maxContextKB,
     );
   } catch (err) {
-    console.warn('Finding grounding: file fetch failed — passing findings through', err);
+    // Deliberate catch-all: grounding is best-effort defense-in-depth. A
+    // transient GitHub API failure (network, rate limit, auth refresh
+    // mid-review) must NOT silently delete findings — passing them
+    // through unchanged is the safe fallback. The warning surfaces in
+    // CloudWatch / stdout for triage; we include enough context (repo,
+    // ref, file count) for monitoring filters to spot a real outage.
+    console.warn(
+      'Finding grounding: file fetch failed — passing %d findings through unchanged for %s/%s@%s (%d unique files)',
+      findings.length,
+      fileFetchOptions.owner,
+      fileFetchOptions.repo,
+      fileFetchOptions.ref,
+      uniqueFiles.length,
+      err,
+    );
     return findings;
   }
 
@@ -1174,12 +1231,12 @@ export async function runReviewPipeline(
   const prevCriticalKeys = new Set(
     (previousFindings ?? [])
       .filter((p) => p.severity === 'critical')
-      .map((p) => `${p.file}::${p.title}`),
+      .map(findingKey),
   );
   const currentCriticalKeys = new Set(
     filteredFindings
       .filter((f) => f.severity === 'critical')
-      .map((f) => `${f.file}::${f.title}`),
+      .map(findingKey),
   );
   const resolvedCriticals = [...prevCriticalKeys].filter((k) => !currentCriticalKeys.has(k)).length;
   const newCriticals = [...currentCriticalKeys].filter((k) => !prevCriticalKeys.has(k)).length;

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -38,6 +38,7 @@ import type { ReviewDelta } from '../review-delta.js';
 import { computeReviewDelta } from '../review-delta.js';
 import { FILE_REQUEST_INSTRUCTION, invokeWithFileFetching } from '../context/agentic-fetcher.js';
 import type { FileFetchOptions } from '../context/agentic-fetcher.js';
+import { fetchFileContents } from '../context/file-fetcher.js';
 import { extractChangedLines, isLineNearChange } from '../diff-filter.js';
 
 // ─── Types ─────────────────────────────────────────────────────────────────
@@ -871,6 +872,149 @@ export interface ReviewPipelineResult {
   deltaCaption: string | null;
 }
 
+// ─── Finding grounding ─────────────────────────────────────────────────────
+
+/**
+ * Words that look like function-call identifiers but are syntax keywords.
+ * Used by extractFindingIdentifiers to avoid producing useless verification
+ * targets like `if(` or `for(`.
+ */
+const SYNTAX_KEYWORDS = new Set([
+  'if', 'for', 'while', 'switch', 'catch', 'try', 'function', 'return',
+  'do', 'else', 'finally', 'throw', 'typeof', 'instanceof', 'new',
+  'async', 'await', 'yield', 'super', 'in', 'of', 'void', 'delete',
+]);
+
+/**
+ * Extract identifier-shaped strings from a finding's text that should
+ * appear in the cited code for the finding to be grounded. We look for:
+ *   - Function/method calls: `someFunc(`
+ *   - Backtick-quoted code names: `` `someIdentifier` ``
+ *
+ * Common English words and JS keywords are filtered out so they don't act
+ * as easy false-positive matches against arbitrary file content.
+ */
+export function extractFindingIdentifiers(text: string): string[] {
+  const ids = new Set<string>();
+
+  // Function calls: capture `name(` patterns.
+  const callPattern = /\b([a-zA-Z_$][\w$]{2,})\(/g;
+  let m: RegExpExecArray | null;
+  while ((m = callPattern.exec(text)) !== null) {
+    if (!SYNTAX_KEYWORDS.has(m[1].toLowerCase())) {
+      ids.add(m[1] + '(');
+    }
+  }
+
+  // Backtick-quoted identifiers — strip the ticks and require an identifier-shape.
+  const tickPattern = /`([^`\n]+)`/g;
+  while ((m = tickPattern.exec(text)) !== null) {
+    const inner = m[1].trim();
+    if (inner.length >= 4 && /^[a-zA-Z_$][\w$.]*\(?\)?$/.test(inner) && !SYNTAX_KEYWORDS.has(inner.toLowerCase())) {
+      ids.add(inner);
+    }
+  }
+
+  return Array.from(ids);
+}
+
+/**
+ * Verify a single finding against the actual file contents at the PR head.
+ * Returns null when the finding can't be grounded (drop critical / warning;
+ * keep info pass-through when no identifiers were extractable so we don't
+ * silently delete advisory notes).
+ *
+ * When the identifier appears in the file but not within ±5 lines of the
+ * cited anchor, the finding is "snapped" — its `line` is updated to point
+ * at the first occurrence. This salvages findings the orchestrator got
+ * mostly right but anchored to a comment line near the actual code.
+ */
+export function groundFinding(
+  f: OrchestratedFinding,
+  fileContent: string | undefined,
+): OrchestratedFinding | null {
+  // No file content available — pass through. The grounding check is an
+  // optional defense-in-depth layer, not a hard gate; we never want a
+  // GitHub API hiccup to silently delete real findings.
+  if (!fileContent) return f;
+
+  const lines = fileContent.split('\n');
+  const zeroBased = f.line - 1;
+
+  // Out-of-range anchor — definitely wrong. Drop critical, downgrade
+  // warning to info, drop info outright.
+  if (zeroBased < 0 || zeroBased >= lines.length) {
+    if (f.severity === 'critical') return null;
+    if (f.severity === 'warning') return { ...f, severity: 'info' };
+    return null;
+  }
+
+  const identifiers = extractFindingIdentifiers(`${f.title} ${f.description} ${f.suggestion}`);
+  if (identifiers.length === 0) return f; // No identifier to verify against — pass through.
+
+  // ±5 lines around the anchor (inclusive).
+  const WINDOW = 5;
+  const start = Math.max(0, zeroBased - WINDOW);
+  const end = Math.min(lines.length, zeroBased + WINDOW + 1);
+  const window = lines.slice(start, end).join('\n');
+
+  // Identifier appears near anchor — finding is grounded.
+  if (identifiers.some((id) => window.includes(id))) return f;
+
+  // Identifier appears somewhere else in the file — snap to first occurrence.
+  // This handles the common "anchor is on a comment line, actual code is 1-3
+  // lines below" failure mode without dropping otherwise-correct findings.
+  for (let i = 0; i < lines.length; i++) {
+    if (identifiers.some((id) => lines[i].includes(id))) {
+      return { ...f, line: i + 1 };
+    }
+  }
+
+  // Identifier nowhere in file. The orchestrator likely hallucinated the
+  // finding (e.g. described `createChatSession()` on a file that doesn't
+  // call it). Drop critical, downgrade warning, drop info.
+  if (f.severity === 'critical') return null;
+  if (f.severity === 'warning') return { ...f, severity: 'info' };
+  return null;
+}
+
+/**
+ * Ground every finding against the actual file at the PR head, dropping or
+ * downgrading those whose anchor doesn't survive a ±5-line check. Reduces
+ * the highest-trust-damage class of false positive: a critical-severity
+ * finding cited at a line that doesn't even contain the code it describes.
+ *
+ * Best-effort: when fileFetchOptions isn't provided (e.g. self-hosted with
+ * no octokit available, or a fetch fails), the findings pass through
+ * unchanged. We never block on grounding errors.
+ */
+export async function groundFindings(
+  findings: OrchestratedFinding[],
+  fileFetchOptions: FileFetchOptions | undefined,
+): Promise<OrchestratedFinding[]> {
+  if (!fileFetchOptions || findings.length === 0) return findings;
+
+  const uniqueFiles = Array.from(new Set(findings.map((f) => f.file)));
+  let fileContents: Record<string, string> = {};
+  try {
+    fileContents = await fetchFileContents(
+      fileFetchOptions.octokit,
+      fileFetchOptions.owner,
+      fileFetchOptions.repo,
+      fileFetchOptions.ref,
+      uniqueFiles,
+      fileFetchOptions.maxContextKB,
+    );
+  } catch (err) {
+    console.warn('Finding grounding: file fetch failed — passing findings through', err);
+    return findings;
+  }
+
+  return findings
+    .map((f) => groundFinding(f, fileContents[f.file]))
+    .filter((f): f is OrchestratedFinding => f !== null);
+}
+
 /**
  * Execute the full multi-agent review pipeline.
  * All independent agents run in parallel; the orchestrator runs after they complete.
@@ -990,10 +1134,16 @@ export async function runReviewPipeline(
   ];
   const enabledAgentCount = findingAgentFlags.filter(Boolean).length + enabledCustomAgents.length;
 
+  // Ground each finding against the actual file at the PR head, dropping
+  // hallucinated criticals whose cited line doesn't contain the code they
+  // describe. Runs before the line-proximity filter so snapped lines benefit
+  // from filtering too.
+  const groundedFindings = await groundFindings(orchestratorResult.findings, fileFetchOptions);
+
   // Filter findings to only those on or near actually changed lines
   const changedLines = extractChangedLines(diff);
   const CHANGED_LINE_TOLERANCE = 3;
-  const filteredFindings = orchestratorResult.findings.filter(
+  const filteredFindings = groundedFindings.filter(
     (f) => isLineNearChange(changedLines, f.file, f.line, CHANGED_LINE_TOLERANCE),
   );
 
@@ -1005,24 +1155,50 @@ export async function runReviewPipeline(
     : null;
 
   // Reconcile the orchestrator's verdict with the post-filter findings.
-  // The orchestrator scores based on pre-filter findings (and stays
-  // conservative when prior findings exist via carry-forward context) — so
-  // a 3/5 verdict can land next to an "All clear!" message when the
-  // changed-line filter strips every finding. Force 5/5 in two cases:
-  //   1. No findings at all → genuinely clean.
-  //   2. Only info findings → comment-formatter renders "All clear!" because
-  //      info findings aren't action items. Info is advisory; it shouldn't
-  //      drag the merge score down or contradict the rendered verdict.
+  // Three cases force the score upward:
+  //   1. No findings at all → 5/5. Genuinely clean.
+  //   2. Only info findings → 5/5. Comment-formatter renders "All clear!"
+  //      since info findings aren't action items; the score should match.
+  //   3. PR closes critical findings from a prior review and introduces
+  //      none → score is clamped to >= 4. The orchestrator scores based
+  //      on the current finding count alone and doesn't reward "fixed 3
+  //      criticals, still have 2 warnings". Without this, a security-
+  //      improvement PR gets the same orange face as the broken commit
+  //      it fixed (per the feedback: "fixing things should not get the
+  //      same emoji as ignoring them").
   const actionFindings = filteredFindings.filter(
     (f) => f.severity === 'critical' || f.severity === 'warning',
   );
   const noActionItems = actionFindings.length === 0;
-  const mergeScore = noActionItems ? 5 : orchestratorResult.mergeScore;
-  const mergeScoreReason = noActionItems
-    ? filteredFindings.length === 0
+
+  const prevCriticalKeys = new Set(
+    (previousFindings ?? [])
+      .filter((p) => p.severity === 'critical')
+      .map((p) => `${p.file}::${p.title}`),
+  );
+  const currentCriticalKeys = new Set(
+    filteredFindings
+      .filter((f) => f.severity === 'critical')
+      .map((f) => `${f.file}::${f.title}`),
+  );
+  const resolvedCriticals = [...prevCriticalKeys].filter((k) => !currentCriticalKeys.has(k)).length;
+  const newCriticals = [...currentCriticalKeys].filter((k) => !prevCriticalKeys.has(k)).length;
+  const isSecurityImprovement = resolvedCriticals > 0 && newCriticals === 0;
+
+  let mergeScore: number;
+  let mergeScoreReason: string;
+  if (noActionItems) {
+    mergeScore = 5;
+    mergeScoreReason = filteredFindings.length === 0
       ? 'No issues found on changed lines.'
-      : 'No action items — only informational notes.'
-    : orchestratorResult.mergeScoreReason;
+      : 'No action items — only informational notes.';
+  } else if (isSecurityImprovement) {
+    mergeScore = Math.max(4, orchestratorResult.mergeScore);
+    mergeScoreReason = `Resolved ${resolvedCriticals} critical issue${resolvedCriticals === 1 ? '' : 's'} from prior review, no new criticals introduced.`;
+  } else {
+    mergeScore = orchestratorResult.mergeScore;
+    mergeScoreReason = orchestratorResult.mergeScoreReason;
+  }
 
   return {
     summary,

--- a/packages/core/src/types/db.ts
+++ b/packages/core/src/types/db.ts
@@ -159,7 +159,12 @@ export const DEFAULT_INSTALLATION_SETTINGS: InstallationSettings = {
   maxComments: 10,
   summary: {
     prSummary: true,
-    confidenceScore: true,
+    // Confidence scores are LLM-self-reported and not well-calibrated against
+    // actual hit rate. A "85% confidence" finding has been observed to be 0%
+    // true in production. Hidden by default; users who want them can opt in
+    // via the dashboard. The score is still stored on each finding for
+    // internal sorting / future threshold-based filtering.
+    confidenceScore: false,
     issuesTable: true,
     diagram: true,
   },


### PR DESCRIPTION
## Summary
Addresses the three highest-impact items from the reviewer-trust feedback. Tier-2 (per-repo memory, public-by-design allowlist) and Tier-3 (refactor-tracing, schema-derived isolation) are deferred to follow-ups.

## 1. Finding grounding (biggest trust win)
**Reproduces** the user's "critical race condition anchored at lines 89-91 (comment-only lines), actual `await createChatSession` on line 92" failure mode. A critical finding that doesn't survive opening the file is the single most damaging false positive.

**Fix**: new \`groundFindings()\` step between orchestrator and changed-line filter. For each finding:
1. Extract identifier-shaped strings from title/description/suggestion (function calls + backtick-quoted names; JS keywords filtered out).
2. Fetch the file at the PR's headSha (size-bounded, dedup'd by file via existing \`fetchFileContents\`).
3. Verify at least one identifier appears within ±5 lines of the cited anchor.

| Outcome | Action |
|---|---|
| Identifier within window | Keep finding |
| Identifier elsewhere in file | Snap \`line\` to first occurrence (salvages off-by-N anchors) |
| Identifier nowhere | Drop critical, downgrade warning → info, drop info |
| Anchor past EOF | Same fate by severity |
| No identifiers extractable | Pass through (advisory findings) |
| File fetch failed | Pass through (best-effort, never block) |

## 2. Delta-aware mergeScore reconciliation
**Reproduces**: "PR #18 had real criticals, PR #19 fixed them, both landed at 2/5 orange."

**Fix**: when previousFindings has N criticals that are no longer present AND no new criticals were introduced, force \`mergeScore >= 4\` with a reason like \`Resolved N critical issues from prior review, no new criticals introduced.\`

Mirrors the existing #134 info-only reconciliation pattern.

## 3. Confidence scores hidden by default
\`DEFAULT_INSTALLATION_SETTINGS.summary.confidenceScore\`: \`true → false\`. The flag and rendering remain; users can opt back in via the dashboard. Rationale documented inline — LLM-self-reported confidence has been observed to be miscalibrated against actual hit rate.

## E2E RUNBOOK additions
Four new fixture cards:
- **E2E-17**: grounding drops hallucinated anchors (deliberately-crafted file with comment-laden lines that tempt mis-anchoring)
- **E2E-18**: delta-aware verdict on security improvement (two-step PR: introduce criticals → fix them; second review should land green)
- **E2E-19**: no \`XX%\` badges on a fresh install
- **E2E-20**: PR description vs code drift catch (best-effort spot-check)

## Test plan
- [x] 13 new core unit tests covering identifier extraction + grounding edge cases (8 groundFinding scenarios + 5 extractFindingIdentifiers)
- [x] \`pnpm run typecheck\` clean across 20 packages
- [x] \`pnpm test\` — core **378** (+13), server 75, lambda 57; all 20 packages green
- [ ] Manual verification post-deploy: run E2E-17 + E2E-18 + E2E-19 from RUNBOOK.md

## Deferred (Tier 2 / 3)
- Per-repo finding memory (#2 + #3 in feedback): extending \`previousFindings\` to a cross-PR query keyed by \`(file, finding-title)\` — separate PR.
- Public-by-design allowlist (#6 first half): security-prompt addendum for \`NEXT_PUBLIC_*\`, Cognito IDs, Stripe \`pk_*\` — separate PR.
- Refactor-tracing (#4): hard to enforce without another LLM call; punted.
- Mermaid signal-to-noise (#7a): already config-toggleable; defaults left untouched per the trade-off discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)