### PR TITLE
feat(review): W9 — stable finding identity (kill the resolved+new whack-a-mole)

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -149,7 +149,7 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-20](#e2e-20-pr-description-vs-code-drift-catch) | Stale "we now use X" in PR body → reviewer flags the mismatch | 2m | 60s | feedback |
 | [E2E-21](#e2e-21-no-op-suggestion-guard-w1) | Finding whose suggested fix already exists in the file → dropped | 1m | 60s | #145 |
 | [E2E-22](#e2e-22-claim-aware-critical-verification-w2) | "Missing await" critical on code that already awaits (truncated-diff artifact) → dropped by full-file verification | 1m | 60s | #145 |
-| [E2E-23](#e2e-23-re-review-convergence--no-whack-a-mole-w9w3) | Re-review never reports the same finding as both "✅ resolved" and "🆕 new"; a triage-rebutted finding is not re-raised | 3m | 90s | #145 (target: W9+W3) |
+| [E2E-23](#e2e-23-re-review-convergence--no-whack-a-mole-w9w3) | Re-review never reports the same finding as both "✅ resolved" and "🆕 new" (W9 ✅); a triage-rebutted finding is not re-raised (W3 pending) | 3m | 90s | #145 / W9 |
 
 ---
 
@@ -916,11 +916,15 @@ PR diff should only touch the `.map(...)` / `return` lines (so the `const rows =
 
 ---
 
-### E2E-23: Re-review convergence — no whack-a-mole (W9+W3) — TARGET, currently failing
+### E2E-23: Re-review convergence — no whack-a-mole (W9+W3)
 
-**Behavior (intended, once W9+W3 land)**: across commits, the same underlying concern keeps a stable identity and a rebutted finding is not regenerated. Specifically: (a) no finding appears as both **✅ Resolved** and **🆕 new** in the same review comment; (b) a finding the author rebutted in a `## mergewatch triage` reply on a prior commit is **not** re-raised under a drifted title/line on the next commit.
+**Behavior**: across commits, the same underlying concern keeps a stable identity and a rebutted finding is not regenerated. Specifically: (a) no finding appears as both **✅ Resolved** and **🆕 new** in the same review comment; (b) a finding the author rebutted in a `## mergewatch triage` reply on a prior commit is **not** re-raised under a drifted title/line on the next commit.
 
-**Status: this fixture currently FAILS** — it is the regression guard for the W9 (stable identity key, replacing `findingKey()` = `` `${file}::${title}` `` in `review-delta.ts`) + W3 (convergence guard) work. Live evidence: **PR #145 round 2** reported `:1207 "Catch-and-continue pattern…"` as 🆕 new while the *same code* (`:1225 "Broad exception catching…"`) was listed ✅ Resolved in the same comment. Keep this card; flip the checkboxes to required once W9+W3 ship.
+**Status:**
+- **(a) — W9 SHIPPED** (PR stacked on #145): `computeReviewDelta` now union-matches on a code fingerprint (`fingerprintFromCode`, normalized cited line) OR the title, so a line-shift + LLM reword no longer reads as resolved+new. Unit-locked in `review-delta.test.ts` ("the whack-a-mole case"). Verify (a) below is now satisfied on a real re-review.
+- **(b) — W3 TARGET, still failing**: triage-aware suppression not yet implemented. `## mergewatch triage` is not parsed; a rebutted finding can still be re-raised.
+
+Live evidence this card defends: **PR #145 round 2** reported `:1207 "Catch-and-continue pattern…"` as 🆕 new while the *same code* (`:1225 "Broad exception catching…"`) was listed ✅ Resolved in the same comment.
 
 **Setup**
 
@@ -930,18 +934,18 @@ Two-commit sequence on branch `fixture/23-convergence`.
 
 **Step 2** — post a PR comment starting `## mergewatch triage` that rebuts the finding *by design* (e.g. "the catch-all is the intentional fail-safe; logging added"), then push a small commit that adds the log line (shifts subsequent line numbers).
 
-**Expected outcomes (post W9+W3)**
+**Expected outcomes**
 
-- [ ] The re-review's "📎 Previously reported" section does **not** list the same concern under both ✅ Resolved and 🆕 new
-- [ ] The rebutted finding is either **Withdrawn** or appears in a **Disputed** bucket — not re-raised as 🆕 new at the shifted line under a reworded title
-- [ ] `🆕 new` count counts only genuinely new concerns introduced by the step-2 diff
-- [ ] Verdict is allowed to converge across commits (not pinned by regenerated restatements)
+- [x] **(a) W9** The re-review's "📎 Previously reported" section does **not** list the same concern under both ✅ Resolved and 🆕 new (the catch line is unchanged → matched by fingerprint despite the reworded title and shifted line)
+- [ ] **(b) W3** The rebutted finding is either **Withdrawn** or appears in a **Disputed** bucket — not re-raised as 🆕 new under a reworded title *(pending W3)*
+- [x] **(a) W9** `🆕 new` counts only genuinely new concerns introduced by the step-2 diff (line drift alone produces zero "new")
+- [ ] **(b) W3** Verdict converges across commits once rebutted findings stop regenerating *(pending W3)*
 
-**Failure modes (current behavior — expected to fail until W9+W3)**
-- ❌ Same finding simultaneously ✅ Resolved and 🆕 new (identity key churns on title/line drift — P9)
-- ❌ A `mergewatch triage`-rebutted finding reappears verbatim-in-substance at a new line (P3/P7)
+**Failure modes**
+- ✅ FIXED (W9) — Same finding simultaneously ✅ Resolved and 🆕 new (identity churned on title/line drift — P9). Regression-locked in `review-delta.test.ts`.
+- ❌ STILL OPEN (W3) — A `mergewatch triage`-rebutted finding reappears verbatim-in-substance at a new line (P3/P7).
 
-**Note**: until W9+W3 ship, run this as a *characterization* test — record the churn so the W9/W3 PR can show the diff in behavior. This is the canonical non-convergence fixture; do not delete it when it starts passing — invert it to a regression guard.
+**Note**: W9 half is now a real regression guard (don't delete). Run the full card as a characterization test for the W3 half until triage-aware suppression ships, then flip checkbox (b).
 
 ---
 

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -36,7 +36,7 @@ import {
 } from './prompts.js';
 import type { CustomAgentDef, UXConfig } from '../config/defaults.js';
 import type { ReviewDelta } from '../review-delta.js';
-import { computeReviewDelta } from '../review-delta.js';
+import { computeReviewDelta, fingerprintFromCode } from '../review-delta.js';
 import { FILE_REQUEST_INSTRUCTION, invokeWithFileFetching } from '../context/agentic-fetcher.js';
 import type { FileFetchOptions } from '../context/agentic-fetcher.js';
 import { fetchFileContents } from '../context/file-fetcher.js';
@@ -52,6 +52,15 @@ export interface AgentFinding {
   title: string;
   description: string;
   suggestion: string;
+  /**
+   * Stable identity for cross-commit delta (W9). Derived from the normalized
+   * cited code, NOT the line number or the LLM's free-text title — both of
+   * which drift between commits and cause a finding to be reported as both
+   * "resolved" and "new" (the whack-a-mole). Set by runReviewPipeline from
+   * the fetched file contents; absent when contents couldn't be fetched, in
+   * which case delta falls back to the title key.
+   */
+  fingerprint?: string;
 }
 
 export interface OrchestratedFinding extends AgentFinding {
@@ -918,14 +927,9 @@ const FINDING_TEXT_MAX_BYTES = 4096;
  */
 const GROUNDING_WINDOW_LINES = 5;
 
-/**
- * Build a fingerprint for severity-aware delta comparison. Intentionally
- * excludes line number — the orchestrator may shift the line after a
- * fix without the underlying issue being the "same" finding.
- */
-function findingKey(f: { file: string; title: string }): string {
-  return `${f.file}::${f.title}`;
-}
+// Severity-aware delta (security-improvement scoring) reuses computeReviewDelta
+// so it shares one identity definition (W9 union-matching) — no second,
+// drifting findingKey. See the resolvedCriticals/newCriticals block below.
 
 /**
  * Extract identifier-shaped strings from a finding's text that should
@@ -1251,6 +1255,30 @@ ${content}`;
 }
 
 /**
+ * Stamp each finding with a stable code fingerprint (W9) derived from the
+ * normalized text of its cited line in the file at the PR head. This is the
+ * cross-commit identity used by computeReviewDelta — robust to line drift
+ * (keyed on code, not line number) and to the LLM rewording the title.
+ *
+ * Best-effort: when the file wasn't fetched or the anchor is out of range,
+ * the finding keeps no fingerprint and delta falls back to the title key.
+ */
+function withCodeFingerprints<T extends OrchestratedFinding>(
+  findings: T[],
+  fileContents: Record<string, string>,
+): T[] {
+  return findings.map((f) => {
+    const content = fileContents[f.file];
+    if (!content) return f;
+    const lines = content.split('\n');
+    const idx = f.line - 1;
+    if (idx < 0 || idx >= lines.length) return f;
+    const fingerprint = fingerprintFromCode(lines[idx]);
+    return fingerprint ? { ...f, fingerprint } : f;
+  });
+}
+
+/**
  * Execute the full multi-agent review pipeline.
  * All independent agents run in parallel; the orchestrator runs after they complete.
  */
@@ -1397,8 +1425,11 @@ export async function runReviewPipeline(
   // Filter findings to only those on or near actually changed lines
   const changedLines = extractChangedLines(diff);
   const CHANGED_LINE_TOLERANCE = 3;
-  const filteredFindings = groundedFindings.filter(
-    (f) => isLineNearChange(changedLines, f.file, f.line, CHANGED_LINE_TOLERANCE),
+  const filteredFindings = withCodeFingerprints(
+    groundedFindings.filter(
+      (f) => isLineNearChange(changedLines, f.file, f.line, CHANGED_LINE_TOLERANCE),
+    ),
+    groundingFileContents,
   );
 
   // Delta caption — only on re-reviews where something actually changed
@@ -1425,18 +1456,16 @@ export async function runReviewPipeline(
   );
   const noActionItems = actionFindings.length === 0;
 
-  const prevCriticalKeys = new Set(
-    (previousFindings ?? [])
-      .filter((p) => p.severity === 'critical')
-      .map(findingKey),
+  // Reuse computeReviewDelta so "resolved"/"new" criticals share the exact
+  // same identity definition (W9 union-matching) as the user-facing delta —
+  // a fixed critical that the LLM re-words must not read as new here either.
+  const currentCriticals = filteredFindings.filter((f) => f.severity === 'critical');
+  const criticalDelta = computeReviewDelta(
+    currentCriticals,
+    (previousFindings ?? []).filter((p) => p.severity === 'critical'),
   );
-  const currentCriticalKeys = new Set(
-    filteredFindings
-      .filter((f) => f.severity === 'critical')
-      .map(findingKey),
-  );
-  const resolvedCriticals = [...prevCriticalKeys].filter((k) => !currentCriticalKeys.has(k)).length;
-  const newCriticals = [...currentCriticalKeys].filter((k) => !prevCriticalKeys.has(k)).length;
+  const resolvedCriticals = criticalDelta?.resolvedCount ?? 0;
+  const newCriticals = criticalDelta ? criticalDelta.newCount : currentCriticals.length;
   // Two tiers of reward for security-improving PRs:
   //   - PURE improvement (resolved > 0, new = 0): score >= 4 (green). The PR
   //     closed criticals without introducing any new ones — clear win.

--- a/packages/core/src/review-delta.test.ts
+++ b/packages/core/src/review-delta.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { computeReviewDelta } from './review-delta.js';
+import { computeReviewDelta, fingerprintFromCode, findingMatchKeys } from './review-delta.js';
 
 function finding(file: string, title: string, line = 1) {
   return { file, title, line };
+}
+
+function fp(file: string, title: string, fingerprint: string, line = 1) {
+  return { file, title, line, fingerprint };
 }
 
 describe('computeReviewDelta', () => {
@@ -72,5 +76,77 @@ describe('computeReviewDelta', () => {
     expect(result).toMatchObject({ resolvedCount: 1, newCount: 1, carriedOverCount: 0 });
     expect(result!.resolved[0].title).toBe('Old bug');
     expect(result!.new[0].title).toBe('New bug');
+  });
+});
+
+// ─── W9: stable fingerprint identity (convergence guard) ────────────────────
+
+describe('computeReviewDelta — W9 fingerprint union-matching', () => {
+  it('the whack-a-mole case: title drifts but code is unchanged → carried, NOT resolved+new', () => {
+    // PR #145 round 2 on tape: same `} catch (err) {` line, line number
+    // shifted, LLM re-titled the finding.
+    const prev = [fp('reviewer.ts', 'Broad exception catching', '} catch (err) {', 1225)];
+    const curr = [fp('reviewer.ts', 'Catch-and-continue pattern', '} catch (err) {', 1207)];
+    const result = computeReviewDelta(curr, prev);
+    expect(result).toMatchObject({ resolvedCount: 0, newCount: 0, carriedOverCount: 1 });
+  });
+
+  it('genuinely different code AND title → resolved + new (real progress still shows)', () => {
+    const prev = [fp('a.ts', 'Missing await', 'doThing()', 10)];
+    const curr = [fp('a.ts', 'Null deref', 'x.y.z', 40)];
+    const result = computeReviewDelta(curr, prev);
+    expect(result).toMatchObject({ resolvedCount: 1, newCount: 1, carriedOverCount: 0 });
+  });
+
+  it('back-compat: prev has no fingerprint, curr does, same title → carried via title key', () => {
+    const prev = [finding('a.ts', 'Race condition', 89)]; // pre-W9 stored record
+    const curr = [fp('a.ts', 'Race condition', 'await save()', 92)];
+    const result = computeReviewDelta(curr, prev);
+    expect(result).toMatchObject({ resolvedCount: 0, newCount: 0, carriedOverCount: 1 });
+  });
+
+  it('union is conservative: same title, changed code → still carried (never phantom resolved+new)', () => {
+    const prev = [fp('a.ts', 'Broad catch', 'catch (a) {', 5)];
+    const curr = [fp('a.ts', 'Broad catch', 'catch (b) {', 5)];
+    const result = computeReviewDelta(curr, prev);
+    expect(result).toMatchObject({ resolvedCount: 0, newCount: 0, carriedOverCount: 1 });
+  });
+
+  it('different titles but same fingerprint still match (fingerprint key wins)', () => {
+    const prev = [fp('a.ts', 'A', 'const r = await f(x)', 3)];
+    const curr = [fp('a.ts', 'Z', 'const r = await f(x)', 9)];
+    const result = computeReviewDelta(curr, prev);
+    expect(result!.carriedOverCount).toBe(1);
+  });
+});
+
+describe('fingerprintFromCode', () => {
+  it('collapses whitespace and is line-number independent', () => {
+    expect(fingerprintFromCode('   const   x =  await  f(  )  ')).toBe('const x = await f( )');
+  });
+
+  it('strips a trailing line comment so adding/removing one keeps identity', () => {
+    expect(fingerprintFromCode('doThing(); // TODO later')).toBe('doThing();');
+  });
+
+  it('returns "" for too-generic anchors (closers, blank)', () => {
+    expect(fingerprintFromCode('}')).toBe('');
+    expect(fingerprintFromCode('  });')).toBe('');
+    expect(fingerprintFromCode('   ')).toBe('');
+    expect(fingerprintFromCode(undefined)).toBe('');
+  });
+
+  it('caps length at 200 chars', () => {
+    expect(fingerprintFromCode('a'.repeat(500)).length).toBe(200);
+  });
+});
+
+describe('findingMatchKeys', () => {
+  it('always yields a title key; adds a fingerprint key only when present', () => {
+    expect(findingMatchKeys({ file: 'a.ts', line: 1, title: 'T' })).toEqual(['a.ts::T::T']);
+    expect(findingMatchKeys({ file: 'a.ts', line: 1, title: 'T', fingerprint: 'code' })).toEqual([
+      'a.ts::T::T',
+      'a.ts::F::code',
+    ]);
   });
 });

--- a/packages/core/src/review-delta.ts
+++ b/packages/core/src/review-delta.ts
@@ -7,6 +7,13 @@ export interface FindingLike {
   file: string;
   line: number;
   title: string;
+  /**
+   * Stable cross-commit identity (W9): normalized cited code. When present
+   * on both sides it is preferred over the title for matching, so a finding
+   * whose wording the LLM reworded across commits is recognised as the same
+   * issue instead of being reported as both "resolved" and "new".
+   */
+  fingerprint?: string;
 }
 
 export interface ReviewDelta {
@@ -30,16 +37,50 @@ export interface ReviewDelta {
 }
 
 /**
- * Build a fingerprint key for a finding based on file + title.
- * We intentionally exclude line number since lines shift between commits.
+ * Normalize a cited code line into a stable fingerprint payload: collapse all
+ * whitespace, trim, cap length. Case is preserved (code is case-sensitive).
+ * Returns '' for blank/comment-only input so callers can decline to fingerprint
+ * (a bare `}` or `// note` is not a distinctive enough anchor).
  */
-function findingKey(f: FindingLike): string {
-  return `${f.file}::${f.title}`;
+export function fingerprintFromCode(codeLine: string | undefined): string {
+  if (!codeLine) return '';
+  const norm = codeLine.replace(/\s+/g, ' ').trim();
+  // Strip a leading line-comment marker so a finding doesn't get a different
+  // identity just because a trailing comment was added/removed on its line.
+  const codeOnly = norm.replace(/\s*\/\/.*$/, '').trim();
+  const sig = codeOnly.length >= 6 ? codeOnly : norm;
+  if (sig.replace(/[^A-Za-z0-9]/g, '').length < 4) return ''; // too generic (`}`, `});`, …)
+  return sig.slice(0, 200);
+}
+
+/**
+ * The set of identity keys a finding can match on (W9 union-matching):
+ *   - title key: `file::T::<title>` — always present (legacy / back-compat).
+ *   - fingerprint key: `file::F::<code>` — present only when the finding
+ *     carries a code fingerprint.
+ *
+ * Two findings are "the same issue" if ANY of their keys coincide. Using the
+ * union (rather than fingerprint-only) means this can only ever *reduce*
+ * spurious resolved/new churn, never introduce it: a reworded finding on
+ * unchanged code matches via the fingerprint key; a pre-W9 stored finding
+ * with no fingerprint still matches via the title key.
+ */
+export function findingMatchKeys(f: FindingLike): string[] {
+  const keys = [`${f.file}::T::${f.title}`];
+  if (f.fingerprint) keys.push(`${f.file}::F::${f.fingerprint}`);
+  return keys;
 }
 
 /**
  * Compute the delta between current findings and previous findings.
  * Returns null if there are no previous findings to compare against.
+ *
+ * Matching is union-based (see findingMatchKeys): a current finding is
+ * "carried over" if it shares any identity key with some previous finding;
+ * a previous finding is "resolved" only if NONE of its keys appear in the
+ * current set. This kills the whack-a-mole where a code edit shifts lines
+ * and the LLM rewords the title, making one unchanged issue show up as both
+ * "✅ resolved" and "🆕 new" in the same comment.
  */
 export function computeReviewDelta(
   currentFindings: FindingLike[],
@@ -49,25 +90,17 @@ export function computeReviewDelta(
     return null;
   }
 
-  const prevByKey = new Map<string, FindingLike>();
-  for (const f of previousFindings) prevByKey.set(findingKey(f), f);
-  const currByKey = new Map<string, FindingLike>();
-  for (const f of currentFindings) currByKey.set(findingKey(f), f);
+  const prevKeys = new Set<string>();
+  for (const f of previousFindings) for (const k of findingMatchKeys(f)) prevKeys.add(k);
+  const currKeys = new Set<string>();
+  for (const f of currentFindings) for (const k of findingMatchKeys(f)) currKeys.add(k);
 
-  const resolved: FindingLike[] = [];
-  for (const [key, f] of prevByKey) {
-    if (!currByKey.has(key)) resolved.push(f);
-  }
+  const matchesAny = (f: FindingLike, against: Set<string>) =>
+    findingMatchKeys(f).some((k) => against.has(k));
 
-  const added: FindingLike[] = [];
-  const carriedOver: FindingLike[] = [];
-  for (const [key, f] of currByKey) {
-    if (prevByKey.has(key)) {
-      carriedOver.push(f);
-    } else {
-      added.push(f);
-    }
-  }
+  const resolved = previousFindings.filter((f) => !matchesAny(f, currKeys));
+  const carriedOver = currentFindings.filter((f) => matchesAny(f, prevKeys));
+  const added = currentFindings.filter((f) => !matchesAny(f, prevKeys));
 
   return {
     resolvedCount: resolved.length,

--- a/packages/core/src/types/db.ts
+++ b/packages/core/src/types/db.ts
@@ -337,6 +337,12 @@ export interface ReviewFinding {
   title: string;
   description: string;
   suggestion: string;
+  /**
+   * Stable cross-commit identity (W9). Normalized cited code, not line/title.
+   * Persisted so the next review's delta can match by code, not by the LLM's
+   * (drifting) wording. Optional for back-compat with pre-W9 stored reviews.
+   */
+  fingerprint?: string;
 }
 
 // =============================================================================


### PR DESCRIPTION
**Stacked on #145** (base = `feat/claim-aware-grounding`; reuses W2's file fetch). Merge #145 first, then this.

## Problem

The cross-commit delta keyed on `` `${file}::${title}` `` (`review-delta.ts`), with a duplicate copy in `reviewer.ts`. `title` is free-text LLM output — so a code edit that shifts lines + a reworded title makes **one unchanged issue report as both "✅ resolved" and "🆕 new" in the same comment**. Caught live in **#145 round 2**: `:1225 "Broad exception catching"` listed ✅ Resolved while the *same* `} catch` reappeared as `:1207 "Catch-and-continue pattern"` 🆕 new. The verdict can never converge by fixing the PR.

This is W9 from `docs/review-quality-plan.md` (the top-priority convergence guard; W3 is the follow-up).

## Change

- `fingerprint?: string` added to `AgentFinding` / `ReviewFinding` / `FindingLike` — optional, back-compat, flows through the store's `findings` JSON (no schema/store change).
- `runReviewPipeline` stamps each finding with `fingerprintFromCode(citedLine)`: normalized cited code (whitespace-collapsed, trailing-line-comment stripped, length-capped, `""` for too-generic anchors like `}`), using the file contents W2 already fetched — **no extra fetch**.
- `computeReviewDelta` now **union-matches**: two findings are the same issue if their **fingerprint key OR exact title key** coincide. Union (not fingerprint-only) can only *reduce* spurious resolved/new, never add it, and stays back-compat with pre-W9 stored findings (title key still matches).
- Removed the duplicate `findingKey` in `reviewer.ts`; security-improvement scoring now reuses `computeReviewDelta`, so "resolved/new criticals" share one identity definition.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Code unchanged, line shifts, LLM rewords title | resolved **+** new (whack-a-mole) | **carried over** |
| Code genuinely changed + retitled | resolved + new | resolved + new (real progress still shows) |
| Pre-W9 stored finding (no fingerprint) | title match | title match (unchanged) |

## Verification

- New `review-delta.test.ts` block incl. *"the whack-a-mole case"* (the exact #145 round-2 scenario) — now `carriedOverCount: 1`, `resolved/new: 0`.
- `fingerprintFromCode` / `findingMatchKeys` unit-tested (whitespace, trailing-comment, too-generic, cap, key shape).
- `@mergewatch/core` **404 passed**; `core`/`server`/`lambda` typecheck clean; full `pnpm run build` passes.
- **E2E-23** updated: failure-mode (a) is now a shipped regression guard; (b) triage re-raise stays the **W3** target.

## Not in scope

W3 (parse `## mergewatch triage`, suppress rebutted findings on the next review) — separate follow-up PR; it builds on this stable key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)