### PR TITLE
fix(diagram): decode HTML entities outside quoted labels + de-glue `<br/>`-joined statements

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -574,11 +574,15 @@ Use names with characters like `<`, `>`, `"`, `\t`, embedded newlines in JSDoc, 
 - [ ] No raw `&lt;` / `&gt;` HTML entities visible in the rendered diagram (they're decoded by Mermaid)
 - [ ] No literal `<br/>` tags visible in node labels (they render as line breaks)
 - [ ] Tabs / lone CR characters in upstream content don't break the diagram
+- [ ] **Syntactic delimiters appear as literal `[` `]` `(` `)` `-->`** in the raw Mermaid source (view the comment markdown via "…" → "Quote reply"). The `decodeMermaidOutsideQuotes` pass converts entity forms like `B&lsqb;…&rsqb;`, `--&gt;`, `&lpar;&rpar;` back to literals before render. Inside `"…"` labels, the in-label defensive escape (`&lpar;&rpar;`, `&lt;br/&gt;`) is correct and SHOULD appear. Regression locked: PR #148 round 4.
+- [ ] **Each Mermaid statement on its own real line** in the raw source. The pre-pass converts any `<br/>` used as a *statement separator* (outside `"…"`) into a real newline. No more than one node/edge definition per line.
 
 **Failure modes**
 - ❌ "Unable to render rich display" or red error block where the diagram should be
 - ❌ Diagram truncates mid-node label
 - ❌ Quoted labels show literal escape sequences
+- ❌ Raw source shows entity-encoded brackets / arrows in unquoted positions (`B&lsqb;` / `--&gt;`) — the regression PR #149 fix
+- ❌ Multiple node/edge definitions glued onto one line by `<br/>` instead of `\n` — same PR #149 fix
 
 ---
 

--- a/packages/core/src/agents/prompts.ts
+++ b/packages/core/src/agents/prompts.ts
@@ -223,7 +223,8 @@ CRITICAL — accuracy rules:
 - Every node that references a file path MUST point to a file that actually appears in the diff. Do NOT invent paths like \`src/utils/index.ts\` or \`src/lib/helper.ts\` if they aren't in the diff.
 - Every function name in a node label MUST be a function that actually exists in the diff. Do NOT fabricate \`foo()\` if \`foo\` isn't defined or called in the changed code.
 - If you cannot verify a node from the diff, leave it out. A smaller accurate diagram is always better than a larger one with hallucinations.
-- Do not output HTML entities (\`&lt;\`, \`&gt;\`, \`&amp;\`) in labels — write the literal characters and rely on the diagram tooling to escape them. Double-encoded labels render as garbled text.
+- Do NOT output HTML entities ANYWHERE in the diagram. Content inside the \`\`\`mermaid\`\`\` code fence is parsed as Mermaid syntax, NOT as HTML — entities like \`&lt;\`, \`&gt;\`, \`&amp;\`, \`&lpar;\`, \`&rpar;\`, \`&lsqb;\`, \`&rsqb;\`, \`&lbrace;\`, \`&rbrace;\` render as literal text and break the parse when they appear in syntactic positions (a node bracket \`A&lsqb;…&rsqb;\` does not anchor a node; an arrow \`--&gt;\` is not an arrow). Write the LITERAL character (\`<\`, \`>\`, \`(\`, \`)\`, \`[\`, \`]\`, \`{\`, \`}\`) in every position.
+- Put each statement on its own REAL newline. NEVER use \`<br/>\` as a statement separator. \`<br/>\` is ONLY legal INSIDE a quoted label (e.g. \`A["line one<br/>line two"]\`) where it produces a line break inside the rendered label.
 
 ${PREVIOUS_DIAGRAM_PLACEHOLDER}
 

--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -388,6 +388,55 @@ describe('runDiagramAgent', () => {
     expect(result.diagram).not.toContain('&amp;amp;');
     expect(result.diagram).not.toContain('&amp;lt;');
   });
+
+  it('decodes HTML entities used as syntactic delimiters outside quoted labels (#148 corruption)', async () => {
+    // Live regression: PR #148's diagram had brackets/parens/arrows
+    // expressed as entities (`B&lsqb;…&rsqb;`, `--&gt;`, `&lpar;&rpar;`),
+    // and multiple statements glued onto one line by `<br/>`. None of
+    // that parses as Mermaid.
+    const mermaid = [
+      '%% W3 triage guard',
+      'flowchart TD',
+      '    A["Prior findings&lt;br/&gt;from review"] --&gt;|"findingMatchKeys&lpar;&rpar;"| B&lsqb;"Stable identity keys<br/>fingerprint + title"&rsqb;<br/>    C&lsqb;"Triage comments"&rsqb; --&gt;|"isTriageComment&lpar;&rpar;"| D["Filter to&lt;br/&gt;## mergewatch triage"]',
+    ].join('\n');
+    const llm = createMockLLM([mermaid]);
+    const result = await runDiagramAgent(sampleDiff, sampleContext, 'model-1', llm);
+
+    // Syntactic delimiters must be literal brackets / parens / arrows now.
+    expect(result.diagram).toContain('B["Stable identity keys');
+    expect(result.diagram).toContain('C["Triage comments"]');
+    expect(result.diagram).toContain('D["Filter to');
+    // No entity-form delimiters or arrows in SYNTACTIC positions. Inside
+    // `"…"` labels, `&lpar;&rpar;` etc. ARE the intentional defensive
+    // escape from escapeMermaidLabelChars — so check only the unquoted
+    // segments (alternating split, even indices).
+    const unquotedSegments = result.diagram.split(/"[^"]*"/);
+    const unquotedBody = unquotedSegments.join('');
+    expect(unquotedBody).not.toMatch(/&lsqb;|&rsqb;|&lbrace;|&rbrace;/);
+    expect(unquotedBody).not.toMatch(/--&gt;/);
+    // The `<br/>` that was glueing the two statements onto one line has
+    // become a real newline — so the parser sees two body lines, not one
+    // mangled line. (Mirrors the live #148 pattern where multiple node
+    // defs were joined by `<br/>` instead of `\n`.)
+    const bodyLines = result.diagram.split('\n').filter((l) => l.trim() && !l.startsWith('%%') && !/^flowchart/i.test(l));
+    expect(bodyLines.length).toBe(2);
+    expect(bodyLines[0]).toMatch(/^\s*A\[/);
+    expect(bodyLines[1]).toMatch(/^\s*C\[/);
+    expect(result.caption).toBe('W3 triage guard');
+  });
+
+  it('keeps `<br/>` INSIDE quoted labels (legitimate label line-break)', async () => {
+    // Decoding must NOT eat the in-label `<br/>` — Mermaid uses it for
+    // label-internal line breaks. The pass-1 escape will re-emit it as
+    // `&lt;br/&gt;` so the rendered label shows on two lines.
+    const mermaid = 'flowchart TD\n    A["line one<br/>line two"] --> B["plain"]';
+    const llm = createMockLLM([mermaid]);
+    const result = await runDiagramAgent(sampleDiff, sampleContext, 'model-1', llm);
+    // The in-label form survives through to escaped output.
+    expect(result.diagram).toContain('line one&lt;br/&gt;line two');
+    // And the diagram is still a single statement per line (not split mid-label).
+    expect(result.diagram.split('\n').filter((l) => l.trim().startsWith('A['))).toHaveLength(1);
+  });
 });
 
 // ─── runErrorHandlingAgent ──────────────────────────────────────────────────

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -409,7 +409,58 @@ function escapeMermaidLabelChars(label: string): string {
  * 2. Quotes unquoted node labels that contain reserved characters.
  * 3. Quotes unquoted edge labels (|...|) that contain reserved characters.
  */
+/**
+ * Decode HTML entities and de-glue `<br/>`-joined statements in the regions
+ * of a Mermaid diagram that are OUTSIDE double-quoted label strings.
+ *
+ * Why: the LLM sometimes assumes the diagram text will be HTML-rendered and
+ * pre-escapes Mermaid's syntactic characters as entities — but inside a
+ * ` ```mermaid ` code fence the content is parsed as Mermaid, not HTML, so
+ * those entities are read as literal text. The result (observed live on
+ * PR #148): `B&lsqb;"…"&rsqb;` instead of `B["…"]`, `--&gt;` instead of
+ * `-->`, plus multiple statements glued onto one line by `<br/>`. None of
+ * those shapes parse.
+ *
+ * Inside `"…"` labels the SAME characters are LEGITIMATE (`<br/>` is the
+ * Mermaid label line-break syntax; entities decode-and-re-encode in
+ * escapeMermaidLabelChars). So this pass only touches the unquoted regions,
+ * leaving label internals to the existing pass-1 escape.
+ */
+function decodeMermaidOutsideQuotes(diagram: string): string {
+  // Split into alternating non-quoted / quoted segments. Capturing group →
+  // odd indices are quoted regions (kept verbatim); even indices are
+  // unquoted regions (transformed). The character class `[^"]` includes
+  // newlines, so quoted regions that span lines are still a single segment.
+  const parts = diagram.split(/("[^"]*")/);
+  for (let i = 0; i < parts.length; i += 2) {
+    parts[i] = parts[i]
+      // Entity → literal. `&amp;` MUST decode LAST so we don't introduce a
+      // bare `&` that earlier replacements then re-decode through.
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&apos;/g, "'")
+      .replace(/&#39;/g, "'")
+      .replace(/&lbrace;/g, '{')
+      .replace(/&rbrace;/g, '}')
+      .replace(/&lpar;/g, '(')
+      .replace(/&rpar;/g, ')')
+      .replace(/&lsqb;/g, '[')
+      .replace(/&rsqb;/g, ']')
+      .replace(/&amp;/g, '&')
+      // Outside any label, `<br/>` is misuse-as-statement-separator: convert
+      // to a real newline so the per-statement parser actually sees them.
+      .replace(/<br\s*\/?>/gi, '\n');
+  }
+  return parts.join('');
+}
+
 function sanitizeMermaidOutput(diagram: string): string {
+  // Pass 0 — OUTSIDE quoted regions: decode HTML entities the model sometimes
+  // emits in syntactic positions, and convert any literal `<br/>` outside a
+  // label back into a statement-separating newline. See decode helper above.
+  const decoded = decodeMermaidOutsideQuotes(diagram);
+
   // Pass 1 — full-diagram scan: escape forbidden chars inside ANY double-
   // quoted region. Critically this runs BEFORE the per-line split so labels
   // that span multiple lines (an embedded real newline inside `"..."`) are
@@ -419,7 +470,7 @@ function sanitizeMermaidOutput(diagram: string): string {
   // Inside escapeMermaidLabelChars, both literal `\\n` (two chars) and real
   // newline chars are converted to `<br/>` — either way the resulting label
   // is single-line and Mermaid-safe by the time we split by lines below.
-  const preEscaped = diagram.replace(/"([^"]*)"/g, (_match, inner: string) => {
+  const preEscaped = decoded.replace(/"([^"]*)"/g, (_match, inner: string) => {
     return `"${escapeMermaidLabelChars(inner)}"`;
   });
 


### PR DESCRIPTION
## Live evidence

PR #148 rendered a broken Mermaid diagram in the bot's review comment — see [issue-comment-4493541861](https://github.com/santthosh/mergewatch.ai/pull/148#issuecomment-4493541861) context. The model's source had:

```
A["…"] --&gt;|"findingMatchKeys&lpar;&rpar;"| B&lsqb;"Stable identity keys<br/>fingerprint + title"&rsqb;<br/>    C&lsqb;"Triage comments"&rsqb; --&gt;|"isTriageComment()"| D[…]
```

Two corruptions, both *outside* the `"…"` quoted regions:

1. **Syntactic delimiters as HTML entities.** `B&lsqb;…&rsqb;` instead of `B[…]`, `--&gt;` instead of `-->`, `&lpar;&rpar;` instead of `()`. Inside a `` ```mermaid `` code fence the content is parsed as Mermaid (not HTML), so the entities are read as their literal 6-char form. No node anchor, no arrow — the whole graph fails to render.
2. **Statements glued onto one line with `<br/>`.** `<br/>` is only legal *inside* a quoted label (label-internal line break); between statements it's just label text the parser sees as nothing. Two statements on one line ⇒ one mangled line.

## Fix

- New Pass-0 in `sanitizeMermaidOutput` — `decodeMermaidOutsideQuotes`: walks the diagram in alternating quoted / unquoted regions and, **only in unquoted regions**, decodes the common entity forms (`&lt; &gt; &amp; &quot; &apos; &#39; &lbrace; &rbrace; &lpar; &rpar; &lsqb; &rsqb;`) and converts literal `<br/>` to real newlines.
- Inside `"…"` labels the same forms are either *legitimate* (`<br/>` is Mermaid's label line-break) or *the codebase's existing defense-in-depth escape* (`escapeMermaidLabelChars` deliberately re-emits in-label parens as `&lpar;&rpar;` to dodge Mermaid's lexer foot-gun) — so Pass 0 leaves them untouched.
- Stronger `DIAGRAM_PROMPT`: explicitly forbids HTML entities in ANY position (including syntactic), requires real newlines as statement separators, and reserves `<br/>` for in-label line breaks only.

## Tests

- Regression test feeds the exact #148-shaped corruption (`A["…&lt;br/&gt;…"] --&gt;|"…&lpar;&rpar;"| B&lsqb;"…<br/>…"&rsqb;<br/>    C&lsqb;…`) and asserts: literal brackets / parens / arrows in syntactic positions, no entity-form syntactic delimiters in unquoted regions, two statements on two lines, caption decoded.
- Defense test: in-label `<br/>` survives end-to-end as the correct label line-break form (re-emitted as `&lt;br/&gt;` per the existing in-label escape).

`@mergewatch/core` **383 passed** (84 in reviewer); `core`/`server`/`lambda` typecheck clean; full build passes.

## Scope

Independent fix; not stacked on the W1/W2/W9/W3 stack. Lands on `main`; subsequent deploys benefit immediately. (Once it's deployed and the bot re-reviews any PR, the diagram in the bot's comment renders.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)