### PR TITLE
feat(review): W7 — score guardrail (single unverified Critical does not block)

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -151,6 +151,7 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-22](#e2e-22-claim-aware-critical-verification-w2) | "Missing await" critical on code that already awaits (truncated-diff artifact) → dropped by full-file verification | 1m | 60s | #145 |
 | [E2E-23](#e2e-23-re-review-convergence--no-whack-a-mole-w9w3) | Re-review never reports the same finding as both "✅ resolved" and "🆕 new" (W9); a triage-rebutted finding is not re-raised (W3) | 3m | 90s | W9 / W3 |
 | [E2E-24](#e2e-24-triage-author-filter-security-boundary) | A `## mergewatch triage` from a NON-PR-author does not suppress findings (W3 security boundary) | 2m | 60s | #148 |
+| [E2E-25](#e2e-25-w7-score-guardrail--unverified-only-criticals-dont-block) | A Critical the W2 pass couldn't confirm → score clamped to 3/COMMENT (not 2/REQUEST_CHANGES), check stays advisory | 2m | 60s | W7 |
 
 ---
 
@@ -992,6 +993,55 @@ Push a small commit on the PR branch to trigger a re-review.
 - ❌ A non-author can prompt-inject through the triage body to manipulate suppression of other findings on the same PR
 
 **Note**: closes the W3 attack surface. The same fixture also acts as the live test for the data-isolation guard in `TRIAGE_MAPPING_PROMPT` — if the author-filter ever regresses, the prompt-level guard is the second line of defense.
+
+---
+
+### E2E-25: W7 score guardrail — unverified-only Criticals don't block
+
+**Behavior**: when the orchestrator emits Critical(s) but the W2 verification pass can't confirm any of them against the file contents (LLM error, unparseable response, no clear verdict, etc.), the bot:
+- keeps the findings (fail-safe, never silently drops a real Critical),
+- tags each survivor with `verification: 'unverified'`,
+- clamps the merge score to **3/5** (would have been ≤2/5),
+- so the formal PR review event is **COMMENT** (advisory), not **REQUEST_CHANGES** — and the `MergeWatch Review` check stays a non-blocker.
+
+This closes the P13 "no-exit critical" state that pinned **PR #148** at `CHANGES_REQUESTED` × 4 rounds: the bot's residual concern was unverifiable but blocked the PR every commit. Now those land as advisory.
+
+**Status:** SHIPPED in the W7 PR. Both halves regression-locked by `reconcileMergeScore` unit tests (every tier interaction is covered).
+
+**Setup**
+
+Branch: `fixture/25-w7-guardrail`. The trigger is "the orchestrator scores ≤ 2 AND every surviving Critical is `unverified`". The exact prompt that elicits an inconclusive W2 verdict is stochastic, but a reliable shape:
+
+`src/inscrutable.ts` — a small file with an obvious-looking but ambiguous "issue" that's a known false-positive bait (e.g. a parameterised query that *looks* like SQL concat, a try/catch that swallows a noop error, a non-async function the model misreads as async):
+
+```ts
+// W7 fixture: ambiguous on purpose — the inline guard at line 4 is the
+// real safety net, but the model often misses it on first pass.
+export function lookupUser(id: number): Promise<unknown> {
+  if (!Number.isInteger(id) || id <= 0) throw new Error('bad id');
+  return db.prepare('SELECT * FROM users WHERE id = ?', [id]);
+}
+
+declare const db: { prepare(sql: string, p: unknown[]): Promise<unknown> };
+```
+
+Provide `groundingFetch` (the default on SaaS / when configured) so verification *actually runs* — `verification: 'unverified'` requires that W2 was attempted but didn't return a verdict, not that it was skipped entirely.
+
+**Expected outcomes**
+
+- [ ] If a Critical surfaces, the rendered comment shows score `3/5 — Review recommended` (not `2/5 — Needs fixes` or red)
+- [ ] Score-reason line includes phrasing like *"could not be confirmed against the source"* / *"verification inconclusive"* / *"advisory"*
+- [ ] Formal PR review event = **COMMENT** (not REQUEST_CHANGES)
+- [ ] `MergeWatch Review` check status = SUCCESS (advisory), not FAILURE
+- [ ] Each surviving Critical row carries the `verification: 'unverified'` tag in the stored review (DynamoDB / Postgres). Verify via the dashboard's "View full details" link or directly in the store.
+- [ ] Push a follow-up commit that makes the same code clearly broken (e.g. remove the inline guard); the next review's verification should now confirm the Critical → no clamp → score returns to ≤ 2 + REQUEST_CHANGES. Confirms the guardrail is gated on "W2 inconclusive," not "presence of any Critical."
+
+**Failure modes**
+- ❌ Score `1/5` or `2/5` with formal review `REQUEST_CHANGES` despite every Critical being unconfirmed by W2 (the W7 clamp didn't fire — likely an `allCriticalsUnverified` regression)
+- ❌ The Critical was silently dropped (over-suppression — W7 should clamp the SCORE, never the FINDING itself; the finding stays visible as advisory)
+- ❌ A confirmed-real Critical (`verification: 'verified'`) was also clamped (the clamp should require *every* surviving Critical to be unverified — a mixed set with even one verified Critical must still block)
+
+**Note**: the verification verdict is stochastic on real models. To force the clamp in a self-hosted run, swap in an LLM whose `CRITICAL_VERIFICATION_PROMPT` response throws or returns garbage — each Critical gets tagged `unverified` and the clamp triggers deterministically.
 
 ---
 

--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -19,6 +19,7 @@ import {
   groundFinding,
   suggestionAlreadyApplied,
   verifyCriticalFindings,
+  reconcileMergeScore,
   type ReviewContext,
   type AgentFinding,
   type ReviewPipelineOptions,
@@ -1129,6 +1130,7 @@ describe('runReviewPipeline', () => {
     expect(typeof result.inputTokens).toBe('number');
     expect(typeof result.outputTokens).toBe('number');
   });
+
 });
 
 // ─── agentAuthored flag (AGENT_MODE_SUFFIX injection) ───────────────
@@ -1486,41 +1488,163 @@ describe('verifyCriticalFindings', () => {
     expect(result).toEqual([]);
   });
 
-  it('keeps a critical the model confirms', async () => {
+  it('keeps a critical the model confirms — tags it `verified` (W7 input)', async () => {
     const llm = createMockLLM(['{"valid": true, "confidence": 0.9, "reason": "genuine defect"}']);
     const result = await verifyCriticalFindings([critical], fileContents, 'light', llm);
-    expect(result).toEqual([critical]);
+    expect(result).toEqual([{ ...critical, verification: 'verified' }]);
   });
 
-  it('keeps the finding when the file could not be fetched (fail-safe)', async () => {
+  it('keeps the finding when the file could not be fetched — leaves verification UNSET (W2 didn\'t run)', async () => {
+    // No file content = verification was skipped, not attempted-and-inconclusive.
+    // Leaving the field unset preserves legacy behavior (no W7 clamp on this
+    // critical) so callers without `groundingFetch` aren't surprised.
     const llm = createMockLLM(['{"valid": false}']);
     const result = await verifyCriticalFindings([critical], {}, 'light', llm);
-    expect(result).toEqual([critical]);
-    expect(llm.calls).toHaveLength(0); // no file → no verification call
+    expect(result).toEqual([critical]); // unchanged object, no verification field
+    expect(llm.calls).toHaveLength(0);
   });
 
-  it('keeps the finding when the LLM call throws (fail-safe)', async () => {
+  it('keeps the finding when the LLM call throws — tags it `unverified`', async () => {
     const llm: ILLMProvider = {
       async invoke() {
         throw new Error('bedrock throttled');
       },
     };
     const result = await verifyCriticalFindings([critical], fileContents, 'light', llm);
-    expect(result).toEqual([critical]);
+    expect(result).toEqual([{ ...critical, verification: 'unverified' }]);
   });
 
-  it('keeps the finding on unparseable LLM output (fail-safe)', async () => {
+  it('keeps the finding on unparseable LLM output — tags it `unverified`', async () => {
     const llm = createMockLLM(['not json at all']);
     const result = await verifyCriticalFindings([critical], fileContents, 'light', llm);
-    expect(result).toEqual([critical]);
+    expect(result).toEqual([{ ...critical, verification: 'unverified' }]);
   });
 
-  it('only verifies criticals — warnings/info pass through untouched', async () => {
+  it('keeps the finding on parsed-but-no-verdict output — tags it `unverified`', async () => {
+    // Model returned valid JSON but no `valid` field (or some other shape).
+    // Fail-safe keep, tagged unverified so W7 scoring can downgrade.
+    const llm = createMockLLM(['{"confidence": 0.5, "reason": "hard to tell"}']);
+    const result = await verifyCriticalFindings([critical], fileContents, 'light', llm);
+    expect(result).toEqual([{ ...critical, verification: 'unverified' }]);
+  });
+
+  it('only verifies criticals — warnings/info pass through with NO verification tag', async () => {
     const warning = { ...critical, severity: 'warning' as const };
     const info = { ...critical, severity: 'info' as const };
     const llm = createMockLLM(['{"valid": false}']);
     const result = await verifyCriticalFindings([warning, info], fileContents, 'light', llm);
-    expect(result).toEqual([warning, info]);
+    expect(result).toEqual([warning, info]); // no verification field added
     expect(llm.calls).toHaveLength(0);
+  });
+});
+
+// ─── reconcileMergeScore (W7 score guardrail) ───────────────────────────────
+
+describe('reconcileMergeScore', () => {
+  // Minimal helpers — only the fields the function reads.
+  function critical(over: Partial<AgentFinding> & { verification?: 'verified' | 'unverified' } = {}) {
+    return {
+      file: 'a.ts', line: 1, severity: 'critical' as const,
+      category: 'security', title: 'X', description: '', suggestion: '',
+      ...over,
+    };
+  }
+  function warning(over: Partial<AgentFinding> = {}) {
+    return {
+      file: 'a.ts', line: 1, severity: 'warning' as const,
+      category: 'style', title: 'W', description: '', suggestion: '',
+      ...over,
+    };
+  }
+
+  it('returns 5 when there are no action items', () => {
+    expect(reconcileMergeScore({
+      filteredFindings: [], previousFindings: undefined,
+      orchestratorScore: 2, orchestratorReason: 'red',
+    })).toMatchObject({ mergeScore: 5 });
+  });
+
+  it('falls through to orchestrator score for confirmed criticals (W7 does NOT downgrade)', () => {
+    const r = reconcileMergeScore({
+      filteredFindings: [critical({ verification: 'verified' })],
+      previousFindings: undefined,
+      orchestratorScore: 1, orchestratorReason: 'real critical',
+    });
+    expect(r).toEqual({ mergeScore: 1, mergeScoreReason: 'real critical' });
+  });
+
+  it('back-compat: a critical with NO verification field does NOT trigger the W7 clamp', () => {
+    // The verification field is absent — W2 didn't run on this finding.
+    // Legacy behavior preserved: orchestrator score stands (can be ≤2).
+    const r = reconcileMergeScore({
+      filteredFindings: [critical()],
+      previousFindings: undefined,
+      orchestratorScore: 2, orchestratorReason: 'red',
+    });
+    expect(r.mergeScore).toBe(2);
+  });
+
+  it('W7 — clamps to 3 when EVERY surviving Critical is `unverified` and orchestrator scored ≤2', () => {
+    // The #148 P13 "no-exit critical" scenario: W2 ran on each Critical
+    // but couldn't confirm any of them — orchestrator still scored red.
+    const r = reconcileMergeScore({
+      filteredFindings: [
+        critical({ title: 'A', verification: 'unverified' }),
+        critical({ title: 'B', verification: 'unverified' }),
+      ],
+      previousFindings: undefined,
+      orchestratorScore: 1, orchestratorReason: 'two criticals',
+    });
+    expect(r.mergeScore).toBe(3);
+    expect(r.mergeScoreReason).toMatch(/could not be confirmed|verification inconclusive|advisory/i);
+  });
+
+  it('W7 does NOT clamp when even ONE surviving Critical is verified (the verified one still blocks)', () => {
+    const r = reconcileMergeScore({
+      filteredFindings: [
+        critical({ title: 'verified-real',     verification: 'verified' }),
+        critical({ title: 'unverified-maybe', verification: 'unverified' }),
+      ],
+      previousFindings: undefined,
+      orchestratorScore: 1, orchestratorReason: 'one real, one maybe',
+    });
+    expect(r.mergeScore).toBe(1); // verified Critical still blocks
+  });
+
+  it('W7 does NOT clamp when orchestrator score is already ≥ 3', () => {
+    // Guardrail only fires on the "would have been red" path; not a generic uplift.
+    const r = reconcileMergeScore({
+      filteredFindings: [critical({ verification: 'unverified' })],
+      previousFindings: undefined,
+      orchestratorScore: 3, orchestratorReason: 'yellow',
+    });
+    expect(r.mergeScore).toBe(3);
+    expect(r.mergeScoreReason).toBe('yellow'); // orchestrator reason preserved
+  });
+
+  it('pure security improvement overrides W7: ≥4 when resolved>0 and new=0', () => {
+    // Mixed tier interaction — pure-improvement check runs BEFORE W7.
+    const r = reconcileMergeScore({
+      filteredFindings: [warning()], // not a critical → no current criticals
+      previousFindings: [critical({ title: 'old' })], // had a prior critical
+      orchestratorScore: 1, orchestratorReason: 'red',
+    });
+    expect(r.mergeScore).toBeGreaterThanOrEqual(4);
+    expect(r.mergeScoreReason).toMatch(/Resolved 1 critical issue/);
+  });
+
+  it('net security improvement still hits its tier (≥3) regardless of W7 verification state', () => {
+    const r = reconcileMergeScore({
+      filteredFindings: [
+        critical({ title: 'new-A', verification: 'unverified' }),
+      ],
+      previousFindings: [
+        critical({ title: 'old-A' }),
+        critical({ title: 'old-B' }),
+      ],
+      orchestratorScore: 1, orchestratorReason: 'one critical',
+    });
+    expect(r.mergeScore).toBeGreaterThanOrEqual(3);
+    expect(r.mergeScoreReason).toMatch(/net improvement/);
   });
 });

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -62,6 +62,18 @@ export interface AgentFinding {
    * which case delta falls back to the title key.
    */
   fingerprint?: string;
+  /**
+   * Result of the W2 critical-verification pass (W7 score guardrail input):
+   *   - `verified`   — model explicitly confirmed the defect against the
+   *                    full file content (parsed.valid === true).
+   *   - `unverified` — verification was inconclusive (missing file, LLM
+   *                    error, unparseable output, no clear verdict). The
+   *                    finding was kept fail-safe but couldn't be confirmed,
+   *                    so it must not by itself BLOCK the PR (W7 clamps the
+   *                    score to ≥3 when all surviving Criticals are unverified).
+   * Absent for non-critical findings (verification only runs on criticals).
+   */
+  verification?: 'verified' | 'unverified';
 }
 
 export interface OrchestratedFinding extends AgentFinding {
@@ -1248,16 +1260,31 @@ export async function verifyCriticalFindings(
   modelId: string,
   llm: ILLMProvider,
 ): Promise<OrchestratedFinding[]> {
+  // Each task returns the disposition for one finding:
+  //   - { keep: true }                            — pass-through (non-critical).
+  //   - { keep: true,  verification: 'verified' } — model confirmed the defect.
+  //   - { keep: true,  verification: 'unverified' } — kept fail-safe; W7
+  //                                                   will treat this as
+  //                                                   advisory in scoring.
+  //   - { keep: false }                           — model said valid:false, drop.
   // Bounded concurrency, not Promise.all: a pathological PR with many
   // criticals would otherwise burst N parallel Bedrock InvokeModel calls and
   // hit the per-minute TPM quota (same reason runReviewPipeline uses
   // AGENT_CONCURRENCY). withConcurrency preserves input order, so the
   // verdicts[i] ↔ findings[i] alignment below still holds.
-  const verdicts = await withConcurrency<boolean>(
+  type Verdict = { keep: boolean; verification?: 'verified' | 'unverified' };
+  const verdicts = await withConcurrency<Verdict>(
     findings.map((f) => async () => {
-      if (f.severity !== 'critical') return true;
+      if (f.severity !== 'critical') return { keep: true };
       const content = fileContents[f.file];
-      if (!content) return true; // Couldn't fetch the file — can't disprove it.
+      if (!content) {
+        // No file content for this path — verification was SKIPPED (not
+        // attempted-and-inconclusive). Keep the finding with NO verification
+        // tag so legacy callers without `groundingFetch` don't get the W7
+        // score clamp applied. The clamp is opt-in: it fires only when W2
+        // explicitly ran and couldn't confirm (see the LLM branches below).
+        return { keep: true };
+      }
 
       const prompt = `${CRITICAL_VERIFICATION_PROMPT}
 
@@ -1277,7 +1304,7 @@ ${content}`;
         ).text;
         // Sentinel default `{}` (not `{ valid: true }`) so an unparseable
         // or verdict-less response is distinguishable from an explicit
-        // pass — the fail-safe "keep" is then logged, not silent.
+        // pass — the fail-safe "keep" is then logged AND tagged 'unverified'.
         const parsed = safeParseJson<{ valid?: boolean; reason?: string }>(raw, {});
         if (parsed.valid === false) {
           console.warn(
@@ -1287,32 +1314,41 @@ ${content}`;
             f.line,
             (parsed.reason ?? '').slice(0, 200),
           );
-          return false;
+          return { keep: false };
         }
-        if (parsed.valid !== true) {
-          console.warn(
-            '[critical-verify] no usable verdict for "%s" (%s:%d) — keeping finding (fail-safe)',
-            f.title,
-            f.file,
-            f.line,
-          );
+        if (parsed.valid === true) {
+          return { keep: true, verification: 'verified' };
         }
-        return true;
+        // Ambiguous: parsed but no usable verdict.
+        console.warn(
+          '[critical-verify] no usable verdict for "%s" (%s:%d) — keeping finding (unverified, advisory)',
+          f.title,
+          f.file,
+          f.line,
+        );
+        return { keep: true, verification: 'unverified' };
       } catch (err) {
         console.warn(
-          '[critical-verify] verification call failed for "%s" (%s:%d) — keeping finding:',
+          '[critical-verify] verification call failed for "%s" (%s:%d) — keeping finding (unverified, advisory):',
           f.title,
           f.file,
           f.line,
           err,
         );
-        return true;
+        return { keep: true, verification: 'unverified' };
       }
     }),
     AGENT_CONCURRENCY,
   );
 
-  return findings.filter((_, i) => verdicts[i]);
+  // Drop the explicit-invalid ones; tag the survivors with their verdict.
+  const result: OrchestratedFinding[] = [];
+  for (let i = 0; i < findings.length; i++) {
+    const v = verdicts[i];
+    if (!v.keep) continue;
+    result.push(v.verification ? { ...findings[i], verification: v.verification } : findings[i]);
+  }
+  return result;
 }
 
 /**
@@ -1337,6 +1373,95 @@ function withCodeFingerprints<T extends OrchestratedFinding>(
     const fingerprint = fingerprintFromCode(lines[idx]);
     return fingerprint ? { ...f, fingerprint } : f;
   });
+}
+
+/**
+ * Reconcile the orchestrator's raw 1–5 score with the post-grounding /
+ * post-line-filter / post-triage finding set. Pure function — extracted
+ * from runReviewPipeline so the tiered scoring rules are directly
+ * unit-testable (no agent / LLM mocking required).
+ *
+ * Tiers, in priority order:
+ *   1. **No action items** → 5. `info`-only or empty.
+ *   2. **Pure security improvement** (resolved criticals > 0, new = 0) →
+ *      ≥4. The PR closed criticals without introducing new ones.
+ *   3. **Net security improvement** (resolved > new, both > 0) → ≥3.
+ *      Closed more than opened; reviewer still gets signal about the new.
+ *   4. **W7 guardrail — unverified-only criticals** → 3 (clamped from
+ *      ≤2). Every surviving Critical was tagged `verification: 'unverified'`
+ *      by the W2 pass — kept fail-safe but couldn't be confirmed against
+ *      the source. A single un-confirmable Critical must not BLOCK the
+ *      PR; mergeScoreToReviewEvent maps 3 → COMMENT, so the check stays
+ *      advisory. Verified Criticals (or any mix containing a verified
+ *      one) still hit the orchestrator's full score (which can be ≤2).
+ *      Back-compat: an absent `verification` field is treated as "W2
+ *      didn't run on this finding" and does NOT trigger the clamp.
+ *   5. **Default** → orchestrator's raw score (can be red).
+ */
+export function reconcileMergeScore(input: {
+  filteredFindings: OrchestratedFinding[];
+  previousFindings: PreviousFinding[] | undefined;
+  orchestratorScore: number;
+  orchestratorReason: string;
+}): { mergeScore: number; mergeScoreReason: string } {
+  const { filteredFindings, previousFindings, orchestratorScore, orchestratorReason } = input;
+
+  const actionFindings = filteredFindings.filter(
+    (f) => f.severity === 'critical' || f.severity === 'warning',
+  );
+  const noActionItems = actionFindings.length === 0;
+
+  // Reuse computeReviewDelta so "resolved"/"new" criticals share the exact
+  // same identity definition (W9 union-matching) as the user-facing delta —
+  // a fixed critical that the LLM re-words must not read as new here either.
+  const currentCriticals = filteredFindings.filter((f) => f.severity === 'critical');
+  const criticalDelta = computeReviewDelta(
+    currentCriticals,
+    (previousFindings ?? []).filter((p) => p.severity === 'critical'),
+  );
+  const resolvedCriticals = criticalDelta?.resolvedCount ?? 0;
+  const newCriticals = criticalDelta ? criticalDelta.newCount : currentCriticals.length;
+
+  const isPureSecurityImprovement = resolvedCriticals > 0 && newCriticals === 0;
+  const isNetSecurityImprovement = resolvedCriticals > newCriticals && newCriticals > 0;
+
+  // W7 — opt-in: a Critical with NO verification field (pre-W7 record OR
+  // a path where W2 didn't run) is treated as "verification didn't run"
+  // and does NOT count toward the clamp. Only explicit `unverified` does.
+  const hasAnyConfirmedOrUntaggedCritical = currentCriticals.some(
+    (f) => f.verification !== 'unverified',
+  );
+  const allCriticalsUnverified =
+    currentCriticals.length > 0 && !hasAnyConfirmedOrUntaggedCritical;
+
+  if (noActionItems) {
+    return {
+      mergeScore: 5,
+      mergeScoreReason: filteredFindings.length === 0
+        ? 'No issues found on changed lines.'
+        : 'No action items — only informational notes.',
+    };
+  }
+  if (isPureSecurityImprovement) {
+    return {
+      mergeScore: Math.max(4, orchestratorScore),
+      mergeScoreReason: `Resolved ${resolvedCriticals} critical issue${resolvedCriticals === 1 ? '' : 's'} from prior review, no new criticals introduced.`,
+    };
+  }
+  if (isNetSecurityImprovement) {
+    return {
+      mergeScore: Math.max(3, orchestratorScore),
+      mergeScoreReason: `Resolved ${resolvedCriticals} critical issue${resolvedCriticals === 1 ? '' : 's'} from prior review; introduced ${newCriticals} new — net improvement, but review the new findings.`,
+    };
+  }
+  if (allCriticalsUnverified && orchestratorScore <= 2) {
+    const n = currentCriticals.length;
+    return {
+      mergeScore: 3,
+      mergeScoreReason: `${n} critical finding${n === 1 ? '' : 's'} could not be confirmed against the source (W2 verification inconclusive). Downgraded to advisory — review carefully, but the PR is not blocked on unverified concerns.`,
+    };
+  }
+  return { mergeScore: orchestratorScore, mergeScoreReason: orchestratorReason };
 }
 
 /**
@@ -1519,61 +1644,12 @@ export async function runReviewPipeline(
     : null;
 
   // Reconcile the orchestrator's verdict with the post-filter findings.
-  // Three cases force the score upward:
-  //   1. No findings at all → 5/5. Genuinely clean.
-  //   2. Only info findings → 5/5. Comment-formatter renders "All clear!"
-  //      since info findings aren't action items; the score should match.
-  //   3. PR closes critical findings from a prior review and introduces
-  //      none → score is clamped to >= 4. The orchestrator scores based
-  //      on the current finding count alone and doesn't reward "fixed 3
-  //      criticals, still have 2 warnings". Without this, a security-
-  //      improvement PR gets the same orange face as the broken commit
-  //      it fixed (per the feedback: "fixing things should not get the
-  //      same emoji as ignoring them").
-  const actionFindings = filteredFindings.filter(
-    (f) => f.severity === 'critical' || f.severity === 'warning',
-  );
-  const noActionItems = actionFindings.length === 0;
-
-  // Reuse computeReviewDelta so "resolved"/"new" criticals share the exact
-  // same identity definition (W9 union-matching) as the user-facing delta —
-  // a fixed critical that the LLM re-words must not read as new here either.
-  const currentCriticals = filteredFindings.filter((f) => f.severity === 'critical');
-  const criticalDelta = computeReviewDelta(
-    currentCriticals,
-    (previousFindings ?? []).filter((p) => p.severity === 'critical'),
-  );
-  const resolvedCriticals = criticalDelta?.resolvedCount ?? 0;
-  const newCriticals = criticalDelta ? criticalDelta.newCount : currentCriticals.length;
-  // Two tiers of reward for security-improving PRs:
-  //   - PURE improvement (resolved > 0, new = 0): score >= 4 (green). The PR
-  //     closed criticals without introducing any new ones — clear win.
-  //   - NET improvement (resolved > new, both > 0): score >= 3 (yellow). The
-  //     PR closed more than it opened, but the LLM did flag some new
-  //     concerns on the fix code. Prevents the cliff from green → red just
-  //     because the agent picked at the fix; reviewer still gets signal
-  //     that something new is worth a look.
-  //   - Otherwise: fall through to orchestrator's verdict (can be red).
-  const isPureSecurityImprovement = resolvedCriticals > 0 && newCriticals === 0;
-  const isNetSecurityImprovement = resolvedCriticals > newCriticals && newCriticals > 0;
-
-  let mergeScore: number;
-  let mergeScoreReason: string;
-  if (noActionItems) {
-    mergeScore = 5;
-    mergeScoreReason = filteredFindings.length === 0
-      ? 'No issues found on changed lines.'
-      : 'No action items — only informational notes.';
-  } else if (isPureSecurityImprovement) {
-    mergeScore = Math.max(4, orchestratorResult.mergeScore);
-    mergeScoreReason = `Resolved ${resolvedCriticals} critical issue${resolvedCriticals === 1 ? '' : 's'} from prior review, no new criticals introduced.`;
-  } else if (isNetSecurityImprovement) {
-    mergeScore = Math.max(3, orchestratorResult.mergeScore);
-    mergeScoreReason = `Resolved ${resolvedCriticals} critical issue${resolvedCriticals === 1 ? '' : 's'} from prior review; introduced ${newCriticals} new — net improvement, but review the new findings.`;
-  } else {
-    mergeScore = orchestratorResult.mergeScore;
-    mergeScoreReason = orchestratorResult.mergeScoreReason;
-  }
+  const { mergeScore, mergeScoreReason } = reconcileMergeScore({
+    filteredFindings,
+    previousFindings,
+    orchestratorScore: orchestratorResult.mergeScore,
+    orchestratorReason: orchestratorResult.mergeScoreReason,
+  });
 
   return {
     summary,

--- a/packages/core/src/types/db.ts
+++ b/packages/core/src/types/db.ts
@@ -343,6 +343,14 @@ export interface ReviewFinding {
    * (drifting) wording. Optional for back-compat with pre-W9 stored reviews.
    */
   fingerprint?: string;
+  /**
+   * Result of the W2 critical-verification pass (W7 score-guardrail input).
+   * `verified` = the verifier model confirmed the defect against the full
+   * file; `unverified` = inconclusive / fail-safe-kept. Persisted so a
+   * later re-review can still reason about the prior verification result.
+   * Optional / back-compat with pre-W7 stored reviews.
+   */
+  verification?: 'verified' | 'unverified';
 }
 
 // =============================================================================


### PR DESCRIPTION
## Problem — the "no-exit critical" state on PR #148

PR #148 hit pattern **P13** (logged in `docs/review-quality-plan.md` Example 7): four rounds of bot review pinning the PR at `CHANGES_REQUESTED` / check `FAILURE` on a residual Critical that nothing the author could do would clear. The pieces:

- The bot's residual concern (prompt injection through the triage-mapping LLM call) had no code-level "fix" left to apply — the author-filter + prompt data-isolation guard + tests *were* the fix.
- W3 suppresses **rebutted** findings on the *next* review, but can't retro-clear a stuck check on the *current* one.
- A single Critical at orchestrator score `≤2` ⇒ `REQUEST_CHANGES` via `mergeScoreToReviewEvent`, no matter how confident or confirmable that Critical was.

The fix per the plan's W7: **a Critical the bot itself couldn't confirm against the source must not block the PR.**

## Change

### Verification tagging (`verifyCriticalFindings`)
Each surviving Critical now carries a `verification` field set by W2:
| Outcome | Tag |
|---|---|
| `parsed.valid === true` | `verification: 'verified'` |
| `parsed.valid === false` | dropped (existing) |
| LLM error / unparseable / no clear verdict | `verification: 'unverified'` (kept fail-safe; tagged so W7 can downgrade) |
| No file content for this path | **NO tag** — verification was *skipped*, not attempted-and-inconclusive |

The "no tag on no-file" rule is deliberate: callers without `groundingFetch` keep legacy behavior. W7 is opt-in via W2 actually attempting the call. `ReviewFinding` in `types/db.ts` adds the optional field so the verdict round-trips through storage.

### Score reconciliation extracted + W7 tier (`reconcileMergeScore`)
The score-tier logic moved out of `runReviewPipeline` into a pure exported function so every interaction is directly unit-testable. New tier slots between net-security-improvement and the orchestrator default:

> If **every** surviving Critical has `verification === 'unverified'` AND `orchestratorScore ≤ 2` → clamp `mergeScore = 3`, with a reason that says the criticals couldn't be confirmed and the PR is "not blocked on unverified concerns."

`mergeScoreToReviewEvent` (already in place) maps `3 → COMMENT`, so the formal PR review is advisory and the check stays green.

### What still blocks
- A **single verified** Critical (`verification: 'verified'`) → the orchestrator's red score stands.
- A **mixed set** containing any verified Critical → still blocks. The clamp requires *every* survivor to be unverified.
- Criticals with **no `verification` field** → also still block (back-compat).

## Tests

- Existing `verifyCriticalFindings` tests updated to assert the new tagging contract.
- New `reconcileMergeScore` suite covers: no-action items, verified-blocks-as-before, back-compat-untagged-does-not-clamp, all-unverified-clamps, mixed-still-blocks, orchestrator-≥3-no-uplift, pure-security-improvement-overrides-W7, net-security-improvement-still-applies. Every tier branch is exercised directly without agent / LLM mocking.
- `@mergewatch/core` **430 passed**; `core` / `server` / `lambda` typecheck clean; full `pnpm run build` passes.

## E2E-25 fixture card
Added to `e2e/RUNBOOK.md` (deduped per the runbook protocol — new card, not a duplicate of E2E-23 which covers the W3 triage-suppression path). Includes the over-clamp regression-check step: push a follow-up commit that makes the same code clearly broken → next review's verification confirms → no clamp → blocks again. Confirms the guardrail is gated on "W2 inconclusive," not "presence of any Critical."

## Not in scope (follow-ups)

- **W3-rebutted Criticals.** The plan's W7 text includes triage-rebutted findings as a third clamp trigger. W3 already *suppresses* those before scoring (they don't reach `currentCriticals`), so the clamp path isn't exercised by them. If we later want a "Disputed" visible bucket instead of silent suppression, that'd surface those findings to scoring with `verification` semantics consistent with this PR.
- **W11 design-opinion classification** (second clamp trigger in the plan) isn't shipped; the W7 implementation here is forward-compatible (it ORs over `verification === 'unverified'`; W11 can add another tag value later).

🤖 Generated with [Claude Code](https://claude.com/claude-code)