### PR TITLE
feat(review): W8 — location accuracy (snap to call site, not function definition)

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -152,6 +152,7 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-23](#e2e-23-re-review-convergence--no-whack-a-mole-w9w3) | Re-review never reports the same finding as both "✅ resolved" and "🆕 new" (W9); a triage-rebutted finding is not re-raised (W3) | 3m | 90s | W9 / W3 |
 | [E2E-24](#e2e-24-triage-author-filter-security-boundary) | A `## mergewatch triage` from a NON-PR-author does not suppress findings (W3 security boundary) | 2m | 60s | #148 |
 | [E2E-25](#e2e-25-w7-score-guardrail--unverified-only-criticals-dont-block) | A Critical the W2 pass couldn't confirm → score clamped to 3/COMMENT (not 2/REQUEST_CHANGES), check stays advisory | 2m | 60s | W7 |
+| [E2E-26](#e2e-26-w8-location-accuracy--snap-to-call-site-not-definition) | A call-site finding cited at a function definition line snaps to the actual call site (W8) | 2m | 60s | W8 |
 
 ---
 
@@ -1042,6 +1043,50 @@ Provide `groundingFetch` (the default on SaaS / when configured) so verification
 - ❌ A confirmed-real Critical (`verification: 'verified'`) was also clamped (the clamp should require *every* surviving Critical to be unverified — a mixed set with even one verified Critical must still block)
 
 **Note**: the verification verdict is stochastic on real models. To force the clamp in a self-hosted run, swap in an LLM whose `CRITICAL_VERIFICATION_PROMPT` response throws or returns garbage — each Critical gets tagged `unverified` and the clamp triggers deterministically.
+
+---
+
+### E2E-26: W8 location accuracy — snap to call site, not definition
+
+**Behavior**: when a finding references a function by name, `groundFinding` walks every occurrence of the identifier in the file and snaps to the **call site** closest to the LLM's anchor — never to the function's *definition* line when at least one use-site exists. Verifies the PR #39 failure mode: the bot cited `rag.ts:330` (the `function searchViaPostgres(…)` definition) for a finding about the call at line 410.
+
+**Setup**
+
+Branch: `fixture/26-call-site-snap`. Add `src/svc.ts`:
+
+```ts
+// Line 1: the function DEFINITION.
+export async function searchViaPostgres(q: number[]): Promise<unknown[]> {
+  // Line 3: body.
+  return globalThis.db.query(q);
+}
+
+// Some unrelated code so the def and the call are not on consecutive lines.
+function unrelated() {
+  return 42;
+}
+
+// Line 12: the call SITE — this is what a finding about
+// `searchViaPostgres` should anchor at.
+export async function loadResults(): Promise<unknown[]> {
+  return await searchViaPostgres([1, 2, 3]);
+}
+```
+
+Craft the PR so the diff touches both the definition area and the call site (e.g., add the call site in this PR, or modify both regions). The bait: the LLM may try to anchor a finding about the call at the function's signature line.
+
+**Expected outcomes**
+
+- [ ] If a finding about `searchViaPostgres` lands in the rendered comment, its `line` field points at the **call site** (`return await searchViaPostgres([...])` line), NOT at the `export async function searchViaPostgres(…)` line
+- [ ] In the inline-comment thread, the comment is anchored on the call line and matches the summary table / Critical block line exactly (single canonical location across all three renderings)
+- [ ] If the finding is genuinely about the *definition* (e.g., "function takes too many parameters"), the snap correctly stays on the def line — the W8 heuristic only drops definitions when a **use-site** exists for the same identifier
+
+**Failure modes**
+- ❌ Finding rendered at the `function searchViaPostgres(…)` line when a call site exists elsewhere in the same file (the PR #39 regression)
+- ❌ Inline-comment line differs from the summary table line for the same finding (#37 reported `:38` in summary but `:39` inline)
+- ❌ A finding about the function's signature gets *incorrectly* snapped away to a call site (over-snap — the W8 fallback should keep def-only findings on the def line; the regression test guards both directions)
+
+**Note**: the snap is deterministic given the file contents and finding text. To force the def-line failure pre-W8, inject `{ "file": "src/svc.ts", "line": 1, "severity": "critical", "title": "Missing await on \`searchViaPostgres\` call" }` into the orchestrator response and confirm post-W8 it snaps to the call line.
 
 ---
 

--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -1322,8 +1322,11 @@ describe('groundFinding', () => {
     expect(groundFinding(f, file)).toEqual(f);
   });
 
-  it('keeps the finding when the cited line is within ±5 of the identifier', () => {
-    // anchor line 5, identifier at line 7 — within window
+  it('snaps to the actual call line even when the anchor is within ±5 of the identifier (W8)', () => {
+    // anchor line 5 (a comment line), the actual call is at line 7 — within
+    // window. Pre-W8 grounded conservatively (kept anchor at 5 because the
+    // identifier WAS near the anchor); W8 always picks the best use-site, so
+    // the finding moves to line 7 where the code actually lives.
     const file = [
       'function handle() {',
       '  // line 2',
@@ -1336,6 +1339,19 @@ describe('groundFinding', () => {
       '}',
     ].join('\n');
     const f = { ...baseFinding, line: 5 };
+    const result = groundFinding(f, file);
+    expect(result).not.toBeNull();
+    expect(result!.line).toBe(7);
+  });
+
+  it('keeps the anchor when the cited line IS the call site (distance 0 wins the tie)', () => {
+    // The LLM was right; no snap needed.
+    const file = [
+      'function handle() {',
+      '  await createChatSession();',
+      '}',
+    ].join('\n');
+    const f = { ...baseFinding, line: 2 };
     expect(groundFinding(f, file)).toEqual(f);
   });
 
@@ -1396,6 +1412,101 @@ describe('groundFinding', () => {
       suggestion: 'Add await before migrationRunner: const run = await migrationRunner({',
     };
     expect(groundFinding(f, file)).toBeNull();
+  });
+
+  // ─── W8: snap prefers call site over definition ───────────────────────────
+
+  it('W8 — snaps a call-site finding off the function definition line and onto the call site (PR #39 case)', () => {
+    // Mimics the PR #39 failure: the model cited line 1 (the function
+    // definition) for a finding that's really about the call site at line 4.
+    // Before W8 the snap returned the first occurrence (the def). W8 walks
+    // every occurrence, drops definitions when any use-site exists, and
+    // picks the closest remaining one to the anchor.
+    const file = [
+      'export async function searchViaPostgres(q: string) {',
+      '  return db.query(q);',
+      '}',
+      'return await searchViaPostgres(queryEmbedding);',
+    ].join('\n');
+    const f = {
+      ...baseFinding,
+      line: 1,
+      title: 'Missing await on async `searchViaPostgres` call',
+      description: 'The call to `searchViaPostgres` returns a Promise that may be unawaited.',
+      suggestion: 'Ensure the result is awaited.',
+    };
+    const result = groundFinding(f, file);
+    expect(result).not.toBeNull();
+    expect(result!.line).toBe(4); // the actual call site, not the def at line 1
+  });
+
+  it('W8 — falls back to the definition line when NO use-site exists in the file', () => {
+    // The file only declares the function and never calls it (e.g., a
+    // module that exports for an external caller). The def is the only
+    // signal we have, so the snap lands there rather than dropping the
+    // finding — better something than nothing on a real concern.
+    const file = [
+      'export async function searchViaPostgres(q: string) {',
+      '  return db.query(q);',
+      '}',
+    ].join('\n');
+    const f = {
+      ...baseFinding,
+      line: 1,
+      title: 'Exported `searchViaPostgres` should validate input',
+      description: 'The function `searchViaPostgres` accepts q without validation.',
+    };
+    const result = groundFinding(f, file);
+    expect(result).not.toBeNull();
+    expect(result!.line).toBe(1);
+  });
+
+  it('W8 — among multiple call sites, picks the one closest to the LLM\'s anchor', () => {
+    // Two distinct call sites; the LLM was approximately right but pointed
+    // a few lines off. We should land on the closer call.
+    const lines = [
+      'function handle() {',        // 1
+      '  doThing();',                // 2  ← call site A (distance from anchor 8 = 6)
+      '  // …',                      // 3
+      '  // …',                      // 4
+      '  // …',                      // 5
+      '  // …',                      // 6
+      '  // …',                      // 7
+      '  // anchor was here',        // 8  ← LLM's anchor
+      '  // …',                      // 9
+      '  doThing();',                // 10 ← call site B (distance 2)
+      '}',                           // 11
+    ];
+    const f = {
+      ...baseFinding,
+      line: 8,
+      title: 'Duplicate `doThing` invocation',
+      description: 'The call `doThing` runs twice within `handle`.',
+    };
+    const result = groundFinding(f, lines.join('\n'));
+    expect(result).not.toBeNull();
+    expect(result!.line).toBe(10);
+  });
+
+  it('W8 — does NOT mis-classify a use-site as a definition (return / await / assignment)', () => {
+    // Stress the "before the identifier name" definition heuristic against
+    // common JS/TS surface forms. None should be classified as defs, so
+    // the snap targets the call site, not the def at line 1.
+    const file = [
+      'export async function createChatSession(): Promise<{ id: string }> {', // def at line 1
+      '  return { id: "x" };',
+      '}',
+      'const session = await createChatSession();', // use at line 4
+    ].join('\n');
+    const f = {
+      ...baseFinding,
+      line: 2,
+      title: 'await on `createChatSession`',
+      description: 'The call `createChatSession` returns a Promise.',
+    };
+    const result = groundFinding(f, file);
+    expect(result).not.toBeNull();
+    expect(result!.line).toBe(4);
   });
 });
 

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -1151,21 +1151,14 @@ export function groundFinding(
   const identifiers = extractFindingIdentifiers(`${f.title} ${f.description} ${f.suggestion}`);
   if (identifiers.length === 0) return f; // No identifier to verify against — pass through.
 
-  // ±GROUNDING_WINDOW_LINES around the anchor (inclusive).
-  const start = Math.max(0, zeroBased - GROUNDING_WINDOW_LINES);
-  const end = Math.min(lines.length, zeroBased + GROUNDING_WINDOW_LINES + 1);
-  const window = lines.slice(start, end).join('\n');
-
-  // Identifier appears near anchor — finding is grounded.
-  if (identifiers.some((id) => window.includes(id))) return f;
-
-  // Identifier appears somewhere else in the file — snap to first occurrence.
-  // This handles the common "anchor is on a comment line, actual code is 1-3
-  // lines below" failure mode without dropping otherwise-correct findings.
-  for (let i = 0; i < lines.length; i++) {
-    if (identifiers.some((id) => lines[i].includes(id))) {
-      return { ...f, line: i + 1 };
-    }
+  // W8 — find the best anchor line for this finding. Prefers call sites
+  // over definitions (the #39 failure mode was a finding about a call site
+  // anchored at the function's `function searchViaPostgres(…)` definition
+  // line; the actual `return await searchViaPostgres(q)` was elsewhere).
+  // Ties broken by proximity to the LLM's original anchor.
+  const snapped = findBestAnchorLine(lines, identifiers, zeroBased);
+  if (snapped !== null) {
+    return snapped === zeroBased ? f : { ...f, line: snapped + 1 };
   }
 
   // Identifier nowhere in file. The orchestrator likely hallucinated the
@@ -1174,6 +1167,86 @@ export function groundFinding(
   if (f.severity === 'critical') return null;
   if (f.severity === 'warning') return { ...f, severity: 'info' };
   return null;
+}
+
+/**
+ * On-line definition-keyword shape: matches the part of a line *immediately
+ * before the identifier name*, looking for a JS/TS declaration keyword that
+ * makes the next token a *defining* occurrence rather than a *use* of the
+ * identifier. Tracks the common surface forms:
+ *   `function foo(`            ← classic FunctionDeclaration
+ *   `async function foo(`      ← async variant (the `async ` is part of the
+ *                                 same word stream; the regex above only
+ *                                 inspects the chars immediately preceding
+ *                                 the name, so the `\bfunction\s+$` clause
+ *                                 still matches when `async ` is two tokens
+ *                                 back)
+ *   `export function foo(`     ← same as above with an `export` modifier;
+ *                                 the regex anchors on the last non-name
+ *                                 keyword before the identifier, which is
+ *                                 still `function`
+ *   `class Foo`, `interface Foo`, `type Foo` ← named type declarations
+ *   `public foo(`, `private foo(`, `protected foo(`, `static foo(`
+ *                                ← class method shorthand
+ * Use-site forms (`return foo()`, `await foo()`, `const r = foo()`,
+ * `foo.bar()`) deliberately do NOT match — the chars right before the
+ * identifier on those lines are `return `, `await `, `= `, `.`, none of
+ * which are declaration keywords.
+ */
+const W8_DEFINITION_BEFORE = /\b(function|class|interface|type|method|public|private|protected|static)\s+$/;
+
+/**
+ * Find the best line to anchor a finding to, given the identifiers we
+ * extracted from its text and the LLM's original anchor (zero-based). The
+ * scoring is two-pass:
+ *
+ *   1. Bucket every occurrence as **call-site / use** or **definition**
+ *      based on whether `W8_DEFINITION_BEFORE` matches the chars immediately
+ *      before the identifier name on that line.
+ *   2. If there's at least one use-site, drop the definitions — a call-site
+ *      finding anchored at the definition line is the canonical P8 failure
+ *      and never the right answer. If there are NO use-sites, fall back to
+ *      the definitions (they're the only signal we have).
+ *   3. Within the chosen pool, pick the line CLOSEST to the LLM's original
+ *      anchor. The LLM is usually approximately right; the distance tie-
+ *      break stops us from snapping across the entire file when there are
+ *      multiple call sites.
+ *
+ * Returns the zero-based line index, or `null` when the identifier appears
+ * nowhere in the file (caller drops/downgrades).
+ */
+function findBestAnchorLine(
+  lines: string[],
+  identifiers: string[],
+  anchorIdx: number,
+): number | null {
+  const candidates: Array<{ lineIdx: number; isDef: boolean }> = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    for (const id of identifiers) {
+      const idx = line.indexOf(id);
+      if (idx < 0) continue;
+      const before = line.slice(0, idx);
+      const isDef = W8_DEFINITION_BEFORE.test(before);
+      candidates.push({ lineIdx: i, isDef });
+      break; // one match per line is enough
+    }
+  }
+  if (candidates.length === 0) return null;
+
+  const useSites = candidates.filter((c) => !c.isDef);
+  const pool = useSites.length > 0 ? useSites : candidates;
+
+  let best = pool[0];
+  let bestDist = Math.abs(best.lineIdx - anchorIdx);
+  for (let i = 1; i < pool.length; i++) {
+    const dist = Math.abs(pool[i].lineIdx - anchorIdx);
+    if (dist < bestDist) {
+      best = pool[i];
+      bestDist = dist;
+    }
+  }
+  return best.lineIdx;
 }
 
 /**


### PR DESCRIPTION
## Problem — the PR #39 anchor failure

The W9/W3 review of voice-bot PR #39 (Example 4 in the plan) anchored a "missing await on async \`searchViaPostgres\`" finding at \`rag.ts:325/330\`. The author's triage called this out explicitly:

> *"The cited line numbers (325, 330) don't match the call site at all — 330 is the function definition."*

`groundFinding`'s snap loop returned the **first occurrence** of the extracted identifier in the file. For an identifier shaped \`searchViaPostgres\`, that's almost always the \`function searchViaPostgres(…)\` *declaration* — not the actual call site. Result: an inline comment anchored on a signature, the reader has to hunt for the real code, and (worse) the next re-review primes on the same wrong line.

## Change

New helper \`findBestAnchorLine\` replaces the old "first occurrence wins" snap loop:

1. **Walk every occurrence** of every extracted identifier in the file.
2. **Classify each as definition or use** by inspecting the chars immediately before the identifier name. \`\\b(function|class|interface|type|method|public|private|protected|static)\\s+$\` ⇒ def; anything else (\`return\`, \`await\`, \`=\`, \`.\`, \`,\`, …) ⇒ use.
3. **Drop definitions when ≥1 use-site exists** — a call-site finding anchored at the def line is never right when there's a real call elsewhere in the same file.
4. **Pick the closest occurrence to the LLM's anchor** within the chosen pool. Distance-0 wins ties, so the snap is a no-op when the LLM was right.
5. No occurrence anywhere → existing fail path (drop critical / downgrade warning).

## Behavior matrix

| Scenario | Pre-W8 snap | Post-W8 snap |
|---|---|---|
| Anchor on def line, call elsewhere in file | def line (wrong) | **call line** ✓ |
| Anchor on def, call within ±5 window | kept on def (the conservative early-return) | **call line** ✓ |
| Multiple call sites | first occurrence | **closest to LLM anchor** ✓ |
| Anchor IS the call site | kept | kept (distance 0 wins) |
| Only the def exists in the file (no use-site) | def line | def line (fallback — better than dropping) |
| `return foo()`, `await foo()`, `= foo()`, `.foo()` | treated as occurrence | correctly classified as **use**, not def |
| Identifier appears nowhere | dropped (critical) / downgraded (warning) | unchanged |

## Tests

- **Existing test** "keeps the finding when the cited line is within ±5 of the identifier" reframed and updated — the W8 behavior is strictly more accurate (anchor on a comment near the actual call now snaps to the call, where it should).
- **New W8 cases** in `reviewer.test.ts`:
  - "snaps a call-site finding off the function definition line and onto the call site (PR #39 case)"
  - "falls back to the definition line when NO use-site exists in the file" (def-only file — better signal than dropping)
  - "among multiple call sites, picks the one closest to the LLM's anchor"
  - "does NOT mis-classify a use-site as a definition (return / await / assignment)"
  - "keeps the anchor when the cited line IS the call site (distance 0 wins the tie)"
- `@mergewatch/core` **426 passed**; `core` / `server` / `lambda` typecheck clean; full `pnpm run build` passes.

## E2E-26 fixture card
Added per the runbook update protocol — deduped (new behavior, not a duplicate of E2E-17 which covers anchor-on-comment-line). Includes the over-snap regression check: a def-only file with a finding about the signature must NOT be incorrectly snapped away — guards both directions.

## Stack-aware notes

- Branched off `main` (`feat/w8-location-accuracy`). Does NOT stack on #152 (W7) — these touch different code paths (\`findBestAnchorLine\` is new; W7's \`reconcileMergeScore\` extraction is independent).
- One minor mergebook with #152: both PRs add a new E2E card and a table row. Whichever lands second gets a 2-line conflict in `e2e/RUNBOOK.md` (E2E-26 was chosen to avoid the E2E-25 slot W7 claimed). The card content itself doesn't conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)