### PR TITLE
feat(review): W11 — scope awareness (test-coverage suppression + layering & scope rules)

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -153,6 +153,7 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-24](#e2e-24-triage-author-filter-security-boundary) | A `## mergewatch triage` from a NON-PR-author does not suppress findings (W3 security boundary) | 2m | 60s | #148 |
 | [E2E-25](#e2e-25-w7-score-guardrail--unverified-only-criticals-dont-block) | A Critical the W2 pass couldn't confirm → score clamped to 3/COMMENT (not 2/REQUEST_CHANGES), check stays advisory | 2m | 60s | W7 |
 | [E2E-26](#e2e-26-w8-location-accuracy--snap-to-call-site-not-definition) | A call-site finding cited at a function definition line snaps to the actual call site (W8) | 2m | 60s | W8 |
+| [E2E-27](#e2e-27-w11-scope-awareness--test-coverage-suppression-when-the-repo-documents-no-harness) | Repo AGENTS.md declares "no test harness" → N "lacks coverage" findings collapse into one info note (W11) | 2m | 60s | W11 |
 
 ---
 
@@ -1087,6 +1088,55 @@ Craft the PR so the diff touches both the definition area and the call site (e.g
 - ❌ A finding about the function's signature gets *incorrectly* snapped away to a call site (over-snap — the W8 fallback should keep def-only findings on the def line; the regression test guards both directions)
 
 **Note**: the snap is deterministic given the file contents and finding text. To force the def-line failure pre-W8, inject `{ "file": "src/svc.ts", "line": 1, "severity": "critical", "title": "Missing await on \`searchViaPostgres\` call" }` into the orchestrator response and confirm post-W8 it snaps to the call line.
+
+---
+
+### E2E-27: W11 scope awareness — test-coverage suppression when the repo documents no harness
+
+**Behavior**: when the repo's conventions document (AGENTS.md / CLAUDE.md / configured conventions file) declares no test harness — e.g. *"No unit test suite currently"* — the review pipeline collapses N "lacks test coverage" findings from the test-coverage agent into a **single info-level note**, anchored at the first test-coverage finding's file. Verified the P5 nag-wave observed on voice-bot #31 and orca #37–#39 (≥5 "X lacks coverage" warnings on infra/enablement PRs in repos that explicitly weren't going to have tests yet).
+
+**Setup**
+
+Branch: `fixture/27-no-harness`. First add an `AGENTS.md` with an explicit declaration:
+
+```md
+# Repo notes
+
+No unit test suite currently — tests are deferred until Phase 2.
+```
+
+Then add a multi-file change that the test-coverage agent will reliably flag:
+
+```ts
+// src/kb-store.ts
+export async function searchCandidates(q: number[], k: number): Promise<unknown[]> { /* … */ }
+
+// src/migrations.ts
+export async function runMigrations(): Promise<void> { /* … */ }
+export async function startKbPostgres(): Promise<void> { /* … */ }
+
+// src/server.ts
+export async function startKbPostgres(): Promise<void> { /* … */ }
+```
+
+The test-coverage agent will naturally raise "lacks coverage" on each new public function.
+
+**Expected outcomes**
+
+- [ ] In the rendered comment, the "Info" collapsible has exactly **one** entry titled *"Test-coverage findings suppressed — repo documents no test harness"* (or close paraphrase)
+- [ ] The Info note's description states the suppressed count (e.g. *"4 test-coverage findings rolled up into this note"*) and points back at the conventions document
+- [ ] The "Warnings" section contains **no** "lacks test coverage"-class findings
+- [ ] `Suppressed N` in the Review details collapsible reflects the rollup (N includes the suppressed test-coverage count)
+- [ ] Agent log includes `[scope-awareness] suppressed N test-coverage finding(s)…`
+- [ ] **Regression check**: remove the "No unit test suite" line from AGENTS.md, push another commit; the next review should restore per-function coverage findings (suppression is opt-in via the declaration, not permanent)
+
+**Failure modes**
+- ❌ The "Warnings" section still contains per-function "lacks coverage" findings despite the AGENTS.md declaration (`detectNoTestHarness` regression — the phrase didn't match)
+- ❌ A non-coverage warning (security / bug / style) was incorrectly suppressed (over-filter — the suppression must scope to `category === 'test-coverage'` only)
+- ❌ The aggregate info note appears even when there were zero coverage findings to suppress (no-op-on-empty regression)
+- ❌ Removing the declaration in a follow-up commit does NOT restore per-function findings (suppression became sticky)
+
+**Note**: `detectNoTestHarness` is deliberately conservative — it requires an explicit declaration ("No unit test suite", "tests are out of scope", "no test harness", etc.). A casual mention of "tests" anywhere in AGENTS.md does NOT trigger suppression. If the test-coverage agent is still nagging on a repo that genuinely has no harness, the fix is to add the declaration to AGENTS.md, not to widen the regex.
 
 ---
 

--- a/packages/core/src/agents/prompts.ts
+++ b/packages/core/src/agents/prompts.ts
@@ -55,7 +55,11 @@ IMPORTANT — Verify before reporting:
 - Before claiming a comment or name is "wrong" or "misleading", quote the EXACT text from the diff. If you cannot quote it verbatim, do not report the finding.
 - Do NOT report an issue based on what you ASSUME the code says — only report issues based on what the diff ACTUALLY shows. If the diff does not contain enough context to confirm the issue, lower your confidence accordingly or skip the finding entirely.
 - If you are less than 75% confident that a finding is a real issue and not a misreading of the diff, do NOT include it.
-- IMPORTANT: The "line" field in your findings MUST point to a line that was actually added or modified in the diff (a line starting with "+"). Do NOT report findings where the "line" points to an unchanged context line. If a change introduces a downstream issue on a nearby unchanged line, point the finding to the nearest changed line instead.`;
+- IMPORTANT: The "line" field in your findings MUST point to a line that was actually added or modified in the diff (a line starting with "+"). Do NOT report findings where the "line" points to an unchanged context line. If a change introduces a downstream issue on a nearby unchanged line, point the finding to the nearest changed line instead.
+
+Layering & responsibility (W11):
+- A LIBRARY / DATA-ACCESS function that correctly THROWS on an error is NOT a bug for "not handling" errors that belong to the caller. Error handling for a low-level function call belongs at the boundary that decides what to do on failure — usually the orchestrator / request handler / service entry-point — not inside the data-access function itself. Do not flag "missing try/catch around DB query" / "should swallow / log the error here" on a function whose contract is "throw on failure." Flag the actual gap (an UNHANDLED call site) instead, if one exists.
+- Respect the PR description's stated SCOPE. If the description says a concern is "out of scope", "deferred to TX/the next PR", "tracked elsewhere", "follow-up issue: …", or "intentionally not addressed in this PR" — and the diff does not introduce or worsen that concern — do NOT raise it as a new finding on this PR. Treat the description as authoritative for what this PR is and isn't trying to do.`;
 
 // ─── Security agent ────────────────────────────────────────────────────────
 export const SECURITY_REVIEWER_PROMPT = `${SHARED_PREAMBLE}

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -38,6 +38,7 @@ import type { CustomAgentDef, UXConfig } from '../config/defaults.js';
 import type { ReviewDelta } from '../review-delta.js';
 import { computeReviewDelta, fingerprintFromCode } from '../review-delta.js';
 import { partitionDisputed } from '../triage.js';
+import { detectNoTestHarness, suppressTestCoverageFindings } from '../scope-awareness.js';
 import { FILE_REQUEST_INSTRUCTION, invokeWithFileFetching } from '../context/agentic-fetcher.js';
 import type { FileFetchOptions } from '../context/agentic-fetcher.js';
 import { fetchFileContents } from '../context/file-fetcher.js';
@@ -1650,6 +1651,27 @@ export async function runReviewPipeline(
     conventions,
     agentAuthored,
   );
+
+  // W11 — scope/architecture awareness: when the repo's conventions
+  // document explicitly declares no test harness, collapse the per-
+  // function "lacks coverage" findings into a single info-level note.
+  // This kills the P5 nag-wave observed on infra/enablement PRs in repos
+  // whose own CLAUDE.md/AGENTS.md says tests aren't part of the project
+  // yet (voice-bot #31, orca #37/#38/#39). The suppressed count rolls
+  // into the existing `suppressedCount` calculation downstream.
+  if (detectNoTestHarness(conventions)) {
+    const { findings: collapsed, suppressedCount } = suppressTestCoverageFindings(
+      orchestratorResult.findings,
+    );
+    if (suppressedCount > 0) {
+      console.warn(
+        '[scope-awareness] suppressed %d test-coverage finding%s (repo conventions declare no test harness)',
+        suppressedCount,
+        suppressedCount === 1 ? '' : 's',
+      );
+      orchestratorResult.findings = collapsed;
+    }
+  }
 
   // Count enabled finding agents (exclude summary + diagram)
   const findingAgentFlags = [

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -126,6 +126,9 @@ export {
 } from './triage.js';
 export type { TriagePriorFinding } from './triage.js';
 
+// ─── Scope/architecture awareness (W11) ─────────────────────────────────────
+export { detectNoTestHarness, suppressTestCoverageFindings } from './scope-awareness.js';
+
 // ─── Config ─────────────────────────────────────────────────────────────────
 export {
   DEFAULT_CONFIG,

--- a/packages/core/src/scope-awareness.test.ts
+++ b/packages/core/src/scope-awareness.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import type { AgentFinding } from './agents/reviewer.js';
+import { detectNoTestHarness, suppressTestCoverageFindings } from './scope-awareness.js';
+
+describe('detectNoTestHarness', () => {
+  it('matches the canonical phrases used by the example repos in the plan', () => {
+    // The exact wording observed in real conventions docs (voice-bot / orca).
+    expect(detectNoTestHarness('No unit test suite currently')).toBe(true);
+    expect(detectNoTestHarness('# Repo notes\n\n- No test harness yet — coverage is deferred')).toBe(true);
+    expect(detectNoTestHarness('Tests are out of scope for this phase.')).toBe(true);
+    expect(detectNoTestHarness('No tests yet; tracking in #FOLLOWUP.')).toBe(true);
+    expect(detectNoTestHarness('Tests are not implemented for this repo.')).toBe(true);
+    expect(detectNoTestHarness('Note: no co-located tests.')).toBe(true);
+  });
+
+  it('is case-insensitive', () => {
+    expect(detectNoTestHarness('NO UNIT TEST SUITE')).toBe(true);
+    expect(detectNoTestHarness('No Test Harness')).toBe(true);
+  });
+
+  it('does NOT match casual mentions of tests', () => {
+    // Conservative direction: under-match (keep nagging) rather than
+    // over-match (silently hide real coverage gaps).
+    expect(detectNoTestHarness('Run `pnpm test` before pushing.')).toBe(false);
+    expect(detectNoTestHarness('Tests live in `tests/` and run on CI.')).toBe(false);
+    expect(detectNoTestHarness('Please add tests for new public functions.')).toBe(false);
+    expect(detectNoTestHarness('We use vitest. See AGENTS.md for the test pattern.')).toBe(false);
+  });
+
+  it('returns false for empty / undefined input', () => {
+    expect(detectNoTestHarness(undefined)).toBe(false);
+    expect(detectNoTestHarness('')).toBe(false);
+    expect(detectNoTestHarness('   \n  \t  ')).toBe(false);
+  });
+});
+
+describe('suppressTestCoverageFindings', () => {
+  function f(over: Partial<AgentFinding> & { category: string }): AgentFinding & { category: string } {
+    return {
+      file: 'src/x.ts', line: 1, severity: 'warning',
+      title: 'T', description: 'D', suggestion: '',
+      ...over,
+    };
+  }
+
+  it('collapses every test-coverage finding into a single info-level note', () => {
+    const findings = [
+      f({ category: 'test-coverage', title: 'foo() lacks coverage' }),
+      f({ category: 'test-coverage', title: 'bar() lacks coverage' }),
+      f({ category: 'test-coverage', title: 'baz() lacks coverage' }),
+      f({ category: 'security', title: 'Real warning' }),
+    ];
+    const { findings: out, suppressedCount } = suppressTestCoverageFindings(findings);
+
+    expect(suppressedCount).toBe(3);
+
+    const coverage = out.filter((x) => x.category === 'test-coverage');
+    expect(coverage).toHaveLength(1);
+    expect(coverage[0].severity).toBe('info');
+    expect(coverage[0].title).toMatch(/suppressed.*no test harness/i);
+    expect(coverage[0].description).toMatch(/^3 test-coverage finding/);
+
+    // Non-coverage findings pass through unchanged.
+    expect(out.filter((x) => x.category === 'security')).toHaveLength(1);
+  });
+
+  it('is a no-op when there are no test-coverage findings', () => {
+    const findings = [
+      f({ category: 'security', title: 'A' }),
+      f({ category: 'bug', title: 'B' }),
+    ];
+    const { findings: out, suppressedCount } = suppressTestCoverageFindings(findings);
+    expect(suppressedCount).toBe(0);
+    expect(out).toEqual(findings); // no aggregate note added
+  });
+
+  it('handles a single test-coverage finding (1 → 1 note, not 0)', () => {
+    const findings = [f({ category: 'test-coverage', title: 'only one' })];
+    const { findings: out, suppressedCount } = suppressTestCoverageFindings(findings);
+    expect(suppressedCount).toBe(1);
+    expect(out).toHaveLength(1);
+    expect(out[0].severity).toBe('info');
+    expect(out[0].description).toMatch(/^1 test-coverage finding /); // singular
+  });
+
+  it('preserves the original file path on the aggregate note', () => {
+    // So the aggregate note anchors somewhere meaningful in the rendered comment.
+    const findings = [
+      f({ category: 'test-coverage', file: 'packages/voice-bot/src/kb-migrate.ts', line: 27 }),
+      f({ category: 'test-coverage', file: 'packages/voice-bot/src/kb-store.ts',   line: 35 }),
+    ];
+    const { findings: out } = suppressTestCoverageFindings(findings);
+    const note = out[out.length - 1];
+    expect(note.file).toBe('packages/voice-bot/src/kb-migrate.ts');
+    expect(note.line).toBe(1);
+  });
+});

--- a/packages/core/src/scope-awareness.ts
+++ b/packages/core/src/scope-awareness.ts
@@ -1,0 +1,78 @@
+/**
+ * W11 — scope & architecture awareness.
+ *
+ * Concrete sub-feature: **context-aware test-coverage suppression.** When
+ * the target repository's conventions document (AGENTS.md / CLAUDE.md /
+ * the configured conventions file) explicitly declares that the repo has
+ * no test harness — e.g. *"No unit test suite currently"* — the review
+ * pipeline collapses the test-coverage agent's N "lacks tests" findings
+ * into a single non-blocking info note. Otherwise the pipeline used to
+ * nag with five "X lacks test coverage" warnings on infra/enablement PRs
+ * in repos that explicitly weren't going to have tests yet — exactly the
+ * P5 wave the plan called out from voice-bot #31, orca #37, and #39.
+ *
+ * The detection is deliberately conservative: a documented "no tests"
+ * declaration is the signal, NOT absence of test files. Many repos have
+ * non-co-located tests, deferred coverage, or are mid-migration. We only
+ * suppress when the maintainer wrote it down.
+ */
+
+import type { AgentFinding } from './agents/reviewer.js';
+
+/**
+ * Phrases that signal the repo deliberately has no test harness today.
+ * Case-insensitive; matched against the conventions text. False negatives
+ * are acceptable here (under-detection means we keep nagging, which is
+ * the legacy behavior) — false positives are NOT (we'd hide real coverage
+ * findings), so the patterns are written to require an explicit
+ * declaration, not a casual mention of "tests".
+ */
+const NO_TEST_HARNESS_SIGNALS: RegExp[] = [
+  /\bno\s+(unit\s+)?test\s+(suite|harness|infrastructure|framework)\b/i,
+  /\b(unit\s+)?tests?\s+(are\s+)?(not\s+(present|implemented|available|set\s+up)|out\s+of\s+scope)\b/i,
+  /\bno\s+co-?located\s+tests?\b/i,
+  /\bno\s+tests?\s+(yet|currently)\b/i,
+];
+
+/**
+ * Returns true when the conventions text explicitly documents the absence
+ * of a test harness. Empty / undefined conventions return false (no signal
+ * → preserve legacy nagging behavior; the test-coverage suppression must
+ * be opt-in via an explicit declaration).
+ */
+export function detectNoTestHarness(conventions: string | undefined): boolean {
+  if (!conventions || !conventions.trim()) return false;
+  return NO_TEST_HARNESS_SIGNALS.some((re) => re.test(conventions));
+}
+
+/**
+ * Replace every `category: 'test-coverage'` finding with a single info-
+ * level aggregate note. The note carries the count and a pointer back to
+ * the conventions document so a reader can see WHY the per-function nag
+ * was suppressed and how to re-enable it (remove the no-harness
+ * declaration from AGENTS.md / CLAUDE.md / etc.).
+ *
+ * Returns the post-suppression finding set plus the number of suppressed
+ * findings (so the pipeline can roll them into its `suppressedCount`).
+ * No-op when there are zero test-coverage findings — never emits a note
+ * just for the sake of it.
+ */
+export function suppressTestCoverageFindings<T extends AgentFinding & { category?: string }>(
+  findings: T[],
+): { findings: T[]; suppressedCount: number } {
+  const testCoverage = findings.filter((f) => f.category === 'test-coverage');
+  if (testCoverage.length === 0) return { findings, suppressedCount: 0 };
+
+  const others = findings.filter((f) => f.category !== 'test-coverage');
+  const anchor = testCoverage[0];
+  const note = {
+    ...anchor,
+    severity: 'info' as const,
+    title: 'Test-coverage findings suppressed — repo documents no test harness',
+    description: `${testCoverage.length} test-coverage finding${testCoverage.length === 1 ? '' : 's'} rolled up into this note. The repository's conventions document (AGENTS.md / CLAUDE.md / .mergewatch/conventions.md) declares that this repo currently has no test harness, so per-function "lacks coverage" warnings are not actionable on this PR.`,
+    suggestion: 'To re-enable per-PR test-coverage findings, remove the "no test harness" declaration from the conventions document.',
+    line: 1,
+  } as T;
+
+  return { findings: [...others, note], suppressedCount: testCoverage.length };
+}


### PR DESCRIPTION
## Problem — the P5 nag-wave + the design-opinion Criticals

Three live failure modes that the W1–W9 stack didn't address:

- **Test-coverage nag-wave (P5).** Voice-bot #31, orca #37, #38, #39 each got ≥5 "X lacks test coverage" warnings on infra/enablement PRs. The repos' own conventions docs say *"No unit test suite currently"* — the test-coverage agent ignored that despite the existing "Respect the repository conventions above" prompt instruction.
- **Layering/responsibility mis-framing (P11).** Orca #38's sole 🔴 Critical was *"Database query lacks error handling in RAG hot path"* on a data-access function that **correctly throws**. The author rebutted: error-handling for that call belongs at the caller (the explicit job of T1.8, the very next PR). The bot ignored stated task decomposition and posted CHANGES_REQUESTED on a design point.
- **Scope ignorance (P11).** #37 (ECS `Resource:"*"` deferred with rationale — entire pre-existing policy is `*`) and #39 (S3-fallback-coverage deferred per the task plan) both got carry-over nags despite explicit author-stated scope in the PR description.

## Change

### 1. Structural: context-aware test-coverage suppression (new `scope-awareness.ts`)

- `detectNoTestHarness(conventions)` — regex-set scan for documented declarations: *"no unit test suite"*, *"no test harness yet"*, *"tests are out of scope"*, *"no tests yet/currently"*, *"no co-located tests"*. Case-insensitive. Conservative by construction: requires an explicit declaration, NOT casual mentions of "tests" or absence of test files. Under-detection (keeps legacy nagging) is safe; over-detection (hides real gaps) is not.
- `suppressTestCoverageFindings(findings)` — replaces N \`category: 'test-coverage'\` findings with **one info-level aggregate note** carrying the count, a pointer to the conventions document, and a re-enablement hint. No-op when there are zero coverage findings (no "we suppressed nothing" notes).
- Wired into `runReviewPipeline` between orchestrator output and grounding. The rollup propagates through the existing `suppressedCount` math (no special accounting needed).

### 2. Prompt-only: layering & scope rules in `SHARED_PREAMBLE`

Single source of truth (every finding-emitting agent + the orchestrator inherits this preamble). Two rules added:

- **Layering & responsibility.** *"A library / data-access function that correctly THROWS on an error is NOT a bug for 'not handling' errors that belong to the caller. … Flag the actual gap (an UNHANDLED call site) instead, if one exists."* — directly targets the #38 mis-framing.
- **PR-description scope.** *"Respect the PR description's stated SCOPE. If the description says a concern is 'out of scope', 'deferred to TX/the next PR', 'tracked elsewhere', 'follow-up issue …', or 'intentionally not addressed' — and the diff does not introduce or worsen that concern — do NOT raise it as a new finding."* — directly targets #37/#39 carry-over nags.

(Prompt-only changes are not deterministically testable, but they're the cheap part of the win; the structural fix above is the regression-locked one.)

## Tests

- **8 new scope-awareness.test.ts cases**:
  - Canonical phrases the plan's example repos use → detected.
  - Case-insensitive.
  - Casual mentions of "tests" (e.g. *"Run \`pnpm test\`"*) → NOT detected (under-match direction is the safe one).
  - Empty / undefined / whitespace-only → false.
  - `suppressTestCoverageFindings` collapses N → 1 info, preserves non-coverage findings, handles single-finding case (1 → 1 note with singular copy), preserves the first finding's file path on the aggregate note (so it anchors meaningfully).
- `@mergewatch/core` **429 passed**; `core` / `server` / `lambda` typecheck clean; full \`pnpm run build\` passes.

## E2E-27 fixture card
Added per the runbook update protocol — deduped (a new behavior, not a duplicate of E2E-17 or E2E-23). Includes the **regression check**: remove the no-harness declaration in a follow-up commit → suppression goes away → per-function coverage findings restored. Confirms suppression is opt-in via the declaration, not permanent.

## Stack-aware notes

Branched off \`main\`. Does NOT stack on #152 (W7) or #153 (W8) — these touch different code paths. Trivial mergebook in \`e2e/RUNBOOK.md\` if landed after #152/#153 (each adds its own E2E table row + card; the E2E IDs are reserved separately — W7=E2E-25, W8=E2E-26, W11=E2E-27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)