### PR TITLE
feat(review): W6 — single authoritative review comment (no duplicate verdict body)

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -154,6 +154,7 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-25](#e2e-25-w7-score-guardrail--unverified-only-criticals-dont-block) | A Critical the W2 pass couldn't confirm → score clamped to 3/COMMENT (not 2/REQUEST_CHANGES), check stays advisory | 2m | 60s | W7 |
 | [E2E-26](#e2e-26-w8-location-accuracy--snap-to-call-site-not-definition) | A call-site finding cited at a function definition line snaps to the actual call site (W8) | 2m | 60s | W8 |
 | [E2E-27](#e2e-27-w11-scope-awareness--test-coverage-suppression-when-the-repo-documents-no-harness) | Repo AGENTS.md declares "no test harness" → N "lacks coverage" findings collapse into one info note (W11) | 2m | 60s | W11 |
+| [E2E-28](#e2e-28-w6-single-authoritative-review-comment--no-duplicate-verdict-body) | One issue comment + one formal Review per run; the Review body is empty (APPROVE) or an HTML-comment stub (REQUEST_CHANGES / COMMENT) — no duplicate verdict text (W6) | 2m | 60s | W6 |
 
 ---
 
@@ -1137,6 +1138,40 @@ The test-coverage agent will naturally raise "lacks coverage" on each new public
 - ❌ Removing the declaration in a follow-up commit does NOT restore per-function findings (suppression became sticky)
 
 **Note**: `detectNoTestHarness` is deliberately conservative — it requires an explicit declaration ("No unit test suite", "tests are out of scope", "no test harness", etc.). A casual mention of "tests" anywhere in AGENTS.md does NOT trigger suppression. If the test-coverage agent is still nagging on a repo that genuinely has no harness, the fix is to add the declaration to AGENTS.md, not to widen the regex.
+
+---
+
+### E2E-28: W6 single authoritative review comment — no duplicate verdict body
+
+**Behavior**: each review run produces exactly **one** rendered content surface — the upserted summary comment (carrying `<!-- mergewatch-review -->`). The formal PR Review object still exists to carry the APPROVE / REQUEST_CHANGES / COMMENT event and the batched inline comments, but its rendered body is **empty** (APPROVE: body omitted; REQUEST_CHANGES / COMMENT: an HTML-comment-only stub that renders as nothing). No more "🔴 Critical issues found — see the full review in the summary comment above" duplication next to the actual review. Verified the P6 noise observed on voice-bot #31 (5 overlapping comments) and orca #37 / #38 (verdict stubs on top of the main comment).
+
+**Setup**
+
+Branch: `fixture/28-single-comment`. Two micro-fixtures, one per verdict tier:
+
+- **Clean PR** (APPROVE path). A trivial JSDoc-only diff in `src/utils.ts` — same shape as E2E-01.
+- **PR with a Critical** (REQUEST_CHANGES path). A small file with a textbook security issue (e.g. unauthenticated admin endpoint, à la E2E-18 step 1).
+
+Run the fixtures separately to exercise both branches of the body-handling logic.
+
+**Expected outcomes — both fixtures**
+
+- [ ] **One** issue comment authored by `mergewatch[bot]` on the PR conversation. Inspect via `gh pr view <n> --json comments -q '.comments | length'` → 1.
+- [ ] **One** formal PR Review authored by `mergewatch[bot]`. Inspect via `gh pr view <n> --json reviews -q '.reviews | length'` → 1 (post-`dismissStaleReviews`).
+- [ ] The formal Review's **rendered** body is empty:
+  - APPROVE fixture: `gh api repos/<owner>/<repo>/pulls/<n>/reviews | jq '.[-1].body'` → `null` (body field omitted).
+  - REQUEST_CHANGES / COMMENT fixture: `… | jq '.[-1].body'` → `"<!-- mergewatch-review -->"` (HTML-comment stub; GitHub's UI renders zero visible content).
+- [ ] In the GitHub UI, the Review timeline entry shows only the event label (*"mergewatch approved these changes"* / *"requested changes"* / *"left a comment"*) plus the inline-comment count — **no** verdict text body below the label.
+- [ ] The summary comment IS the verdict surface: contains the 1-5 score, mergeScoreReason, findings table, etc.
+- [ ] No standalone inline-comment Review events (the inline comments are bundled under the single formal Review).
+
+**Failure modes**
+- ❌ Two issue comments authored by `mergewatch[bot]` on the same PR run (the upsert path regressed — `findExistingBotComment` failed to find the marker)
+- ❌ Formal Review's rendered body contains *"Critical issues found"* / *"Review recommended"* — duplicate of summary comment verdict line (the W6 reviewBody-`=`-`''` change regressed)
+- ❌ APPROVE Review has a body field present at all (legacy: omit entirely for APPROVE)
+- ❌ Multiple formal Review objects on the same commit (`dismissStaleReviews` failed; should leave exactly one non-dismissed Review per run)
+
+**Note**: the HTML-comment stub `<!-- mergewatch-review -->` is the same marker used by the upserted issue comment. That's intentional — both surfaces share one identifier so future tooling can find them by a single grep.
 
 ---
 

--- a/packages/core/src/github/client.test.ts
+++ b/packages/core/src/github/client.test.ts
@@ -7,6 +7,7 @@ import {
   parseRepoConfigYaml,
   addPRReaction,
   removePRReaction,
+  submitPRReview,
 } from './client.js';
 import type { Octokit } from '@octokit/rest';
 
@@ -528,5 +529,73 @@ describe('removePRReaction', () => {
     await expect(removePRReaction(octokit, 'o', 'r', 42, 12345)).resolves.toBeUndefined();
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// submitPRReview — W6 single-authoritative-comment body handling
+// ---------------------------------------------------------------------------
+
+describe('submitPRReview body handling (W6)', () => {
+  // Mock just enough Octokit surface to capture the createReview payload.
+  function captureCall() {
+    const calls: Array<Record<string, unknown>> = [];
+    const octokit = {
+      pulls: { createReview: vi.fn(async (args: Record<string, unknown>) => { calls.push(args); return { data: {} }; }) },
+    } as unknown as Octokit;
+    return { octokit, calls };
+  }
+
+  it('APPROVE with empty body → body field omitted entirely', async () => {
+    const { octokit, calls } = captureCall();
+    await submitPRReview(octokit, 'o', 'r', 1, '', 'APPROVE');
+    expect(calls).toHaveLength(1);
+    expect('body' in calls[0]).toBe(false);
+    expect(calls[0].event).toBe('APPROVE');
+  });
+
+  it('REQUEST_CHANGES with empty body → HTML-comment stub (GitHub requires body for this event)', async () => {
+    const { octokit, calls } = captureCall();
+    await submitPRReview(octokit, 'o', 'r', 1, '', 'REQUEST_CHANGES');
+    expect(calls).toHaveLength(1);
+    expect(calls[0].body).toBe('<!-- mergewatch-review -->');
+    expect(calls[0].event).toBe('REQUEST_CHANGES');
+  });
+
+  it('COMMENT with empty body → HTML-comment stub (GitHub requires body for this event)', async () => {
+    const { octokit, calls } = captureCall();
+    await submitPRReview(octokit, 'o', 'r', 1, '', 'COMMENT');
+    expect(calls).toHaveLength(1);
+    expect(calls[0].body).toBe('<!-- mergewatch-review -->');
+    expect(calls[0].event).toBe('COMMENT');
+  });
+
+  it('caller-supplied non-empty body is passed through unchanged (forward-compat)', async () => {
+    const { octokit, calls } = captureCall();
+    const body = 'A future tier may want this verbatim.';
+    await submitPRReview(octokit, 'o', 'r', 1, body, 'COMMENT');
+    expect(calls[0].body).toBe(body);
+  });
+
+  it('whitespace-only body is treated as empty for every event', async () => {
+    const { octokit, calls } = captureCall();
+    await submitPRReview(octokit, 'o', 'r', 1, '   \n\t  ', 'APPROVE');
+    await submitPRReview(octokit, 'o', 'r', 1, '   ', 'REQUEST_CHANGES');
+    expect('body' in calls[0]).toBe(false);
+    expect(calls[1].body).toBe('<!-- mergewatch-review -->');
+  });
+
+  it('passes inline comments through unchanged, batched in one API call', async () => {
+    const { octokit, calls } = captureCall();
+    const inline = [{ path: 'a.ts', line: 10, side: 'RIGHT', body: 'finding' }];
+    await submitPRReview(octokit, 'o', 'r', 1, '', 'REQUEST_CHANGES', inline);
+    expect(calls).toHaveLength(1); // single createReview call
+    expect(calls[0].comments).toEqual(inline);
+  });
+
+  it('omits the `comments` field when no inline comments are passed', async () => {
+    const { octokit, calls } = captureCall();
+    await submitPRReview(octokit, 'o', 'r', 1, '', 'COMMENT');
+    expect('comments' in calls[0]).toBe(false);
   });
 });

--- a/packages/core/src/github/client.ts
+++ b/packages/core/src/github/client.ts
@@ -381,17 +381,38 @@ export async function submitPRReview(
   event: 'APPROVE' | 'REQUEST_CHANGES' | 'COMMENT',
   comments?: Array<{ path: string; line: number; side: string; body: string }>,
 ): Promise<void> {
-  // GitHub treats `body` as optional for APPROVE but required for
-  // REQUEST_CHANGES and COMMENT. When callers want a clean "approved these
-  // changes" timeline entry without a trailing comment block, they pass an
-  // empty body — omit the field entirely to keep the rendered Review
-  // body-less.
-  const omitBody = event === 'APPROVE' && (!body || body.trim().length === 0);
+  // W6 — single authoritative review comment. The paired upserted issue
+  // comment (carrying `BOT_COMMENT_MARKER`) is the canonical place for the
+  // verdict, findings, diagram, etc. The formal PR Review object only
+  // exists to carry (a) the APPROVE / REQUEST_CHANGES / COMMENT event and
+  // (b) the inline comments. Its body should add NO duplicate content.
+  //
+  // GitHub's API constraints differ by event:
+  //   - APPROVE        → body is optional. Omit the field entirely.
+  //   - REQUEST_CHANGES / COMMENT → body is REQUIRED. We pass an HTML-
+  //     comment-only stub (`<!-- mergewatch-review -->`); GitHub's markdown
+  //     renderer strips HTML comments, so the Review object renders with
+  //     no visible body text and the timeline shows only the event label
+  //     ("requested changes" / "left a comment") plus the inline comments.
+  //
+  // A caller may still pass real body text — we pass it through unchanged
+  // for forward-compatibility (e.g., a future tier that genuinely wants a
+  // verbatim Review body).
+  const trimmed = (body ?? '').trim();
+  let effectiveBody: string | undefined;
+  if (trimmed) {
+    effectiveBody = body;
+  } else if (event === 'APPROVE') {
+    effectiveBody = undefined;
+  } else {
+    effectiveBody = '<!-- mergewatch-review -->';
+  }
+
   await octokit.pulls.createReview({
     owner,
     repo,
     pull_number: prNumber,
-    ...(omitBody ? {} : { body }),
+    ...(effectiveBody === undefined ? {} : { body: effectiveBody }),
     event,
     ...(comments && comments.length > 0 ? { comments } : {}),
   });

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -652,20 +652,14 @@ export async function handler(
 
     // ── Step C: Surface verdict + inline findings ──────────────────────────
     // Branching policy:
-    //   APPROVE (score 4-5) → submit a Review with NO body so the timeline
-    //     shows a clean "approved these changes" event. Inline comments are
-    //     bundled under the Review.
-    //   REQUEST_CHANGES / COMMENT (score 1-3) → submit a Review with a
-    //     minimal one-line body pointing at the summary comment. GitHub
-    //     requires a body for these events; a single sentence is far less
-    //     noisy than the multi-section verdict block we had before #132
-    //     and consolidates inline comments into a SINGLE Review event
-    //     (rather than N×COMMENTED reviews from standalone inline comments).
-    const reviewBody = reviewEvent === 'APPROVE'
-      ? ''
-      : reviewEvent === 'REQUEST_CHANGES'
-        ? '🔴 Critical issues found — see the full review in the summary comment above.'
-        : '🟡 Review recommended — see the full review in the summary comment above.';
+    // W6 — single authoritative review comment. Pass an empty body for
+    // every event; submitPRReview handles the GitHub API constraint
+    // (APPROVE → body omitted; REQUEST_CHANGES / COMMENT → an HTML-
+    // comment-only stub that renders as nothing). The paired upserted
+    // summary comment is the sole place the verdict / findings / etc. live;
+    // the formal Review object now only carries the event label + the
+    // batched inline comments — no duplicate "Critical issues found" body.
+    const reviewBody = '';
     try {
       await dismissStaleReviews(octokit, owner, repo, prNumber);
       await submitPRReview(octokit, owner, repo, prNumber, reviewBody, reviewEvent, inlineComments);

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -522,21 +522,15 @@ export async function processReviewJob(
     const warningCount = result.findings.filter((f: any) => f.severity === 'warning').length;
     const infoCount = result.findings.filter((f: any) => f.severity === 'info').length;
 
-    // ── Step C: Surface verdict + inline findings ──────────────────────────
-    // Branching policy (mirrors Lambda):
-    //   APPROVE (score 4-5) → submit a Review with NO body so the timeline
-    //     shows a clean "approved these changes" event. Inline comments
-    //     bundle under the Review.
-    //   REQUEST_CHANGES / COMMENT (score 1-3) → submit a Review with a
-    //     minimal one-line body pointing at the summary comment. GitHub
-    //     requires a body for these events; a single sentence consolidates
-    //     all inline comments into a single Review event instead of N
-    //     separate COMMENTED reviews from standalone inline comments.
-    const reviewBody = reviewEvent === 'APPROVE'
-      ? ''
-      : reviewEvent === 'REQUEST_CHANGES'
-        ? '🔴 Critical issues found — see the full review in the summary comment above.'
-        : '🟡 Review recommended — see the full review in the summary comment above.';
+    // ── Step C: Surface verdict + inline findings (W6 — single authoritative comment) ──
+    // Pass an empty body for every event; submitPRReview handles the
+    // GitHub API constraint (APPROVE → body omitted; REQUEST_CHANGES /
+    // COMMENT → an HTML-comment-only stub that renders as nothing). The
+    // paired upserted summary comment is the sole place the verdict /
+    // findings / etc. live; the formal Review object now only carries the
+    // event label + the batched inline comments — no duplicate "Critical
+    // issues found" body.
+    const reviewBody = '';
     try {
       await dismissStaleReviews(octokit, owner, repo, prNumber);
       await submitPRReview(octokit, owner, repo, prNumber, reviewBody, reviewEvent, inlineComments);


### PR DESCRIPTION
## Problem — the duplicate-verdict noise (P6)

Every review run produced **two** content surfaces in the PR conversation:

1. **The summary issue comment** (full content — verdict, findings table, diagram, details). Upserted via the existing `<!-- mergewatch-review -->` marker.
2. **The formal PR Review object** carrying the APPROVE / REQUEST_CHANGES / COMMENT event + inline comments — with a redundant short body that restated the verdict: *"🔴 Critical issues found — see the full review in the summary comment above."* or *"🟡 Review recommended — …"*.

That second body is what the user sees twice in the timeline. The plan called it out on voice-bot #31 (5 overlapping bot comments), orca #37, and orca #38.

## Change

The formal PR Review still has to exist (it's the only carrier for the APPROVE/REQUEST_CHANGES/COMMENT event GitHub renders in the timeline, and the only place inline comments batch under a single Review event). What we can fix is its *body*.

GitHub's API says:
- **APPROVE** — body is optional.
- **REQUEST_CHANGES / COMMENT** — body is required.

`submitPRReview` now handles this constraint internally so callers don't need to think about it:

| Caller passes | Event | API receives |
|---|---|---|
| empty/whitespace | APPROVE | `body` field **omitted entirely** |
| empty/whitespace | REQUEST_CHANGES | `body: '<!-- mergewatch-review -->'` |
| empty/whitespace | COMMENT | `body: '<!-- mergewatch-review -->'` |
| non-empty | any | passed through unchanged (forward-compat) |

GitHub's markdown renderer strips HTML comments, so the rendered Review body shows **zero visible content** — the timeline entry surfaces only the event label (*"mergewatch approved these changes"* / *"requested changes"* / *"left a comment"*) plus the batched inline comments. The summary issue comment is the sole authoritative content surface.

Both handlers (`packages/server/src/review-processor.ts`, `packages/lambda/src/handlers/review-agent.ts`) now pass `''` for `reviewBody`; the legacy "🔴 / 🟡 …" stub strings are removed.

The HTML-comment stub doubles as the existing `BOT_COMMENT_MARKER` — same identifier on both surfaces, so future tooling can find them by a single grep.

## Tests

New `submitPRReview body handling (W6)` block in `client.test.ts` — mocks Octokit and asserts the captured `createReview` payload:

- APPROVE + empty body → `body` field absent.
- REQUEST_CHANGES + empty body → `body: '<!-- mergewatch-review -->'`.
- COMMENT + empty body → same stub.
- Caller-supplied non-empty body passes through unchanged.
- Whitespace-only body treated as empty for every event.
- Inline comments batched in one call; `comments` field omitted when none.

`@mergewatch/core` **450 passed** (443 + 7 new W6 tests); `core` / `server` / `lambda` typecheck clean; full `pnpm run build` passes.

## E2E-28 fixture card
Added per the runbook update protocol — deduped (distinct from E2E-11 which is about re-review *dismissal* across commits; this is about non-duplication *within a single run*). Covers both APPROVE and REQUEST_CHANGES paths, with `gh api` inspection commands to assert the captured API payload shape on a real PR.

## Stack-aware notes

Branched off `main` (which now has W7 + W8 + W11). Does NOT stack on any open PR. Trivial mergebook in `e2e/RUNBOOK.md` if any other PR lands first that also touches the E2E table — same pattern as the W7 / W8 / W11 conflicts; just keep both rows in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)