### PR TITLE
feat(review): W10 — finding consolidation (cluster fragmented findings on the same region)

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -155,6 +155,7 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-26](#e2e-26-w8-location-accuracy--snap-to-call-site-not-definition) | A call-site finding cited at a function definition line snaps to the actual call site (W8) | 2m | 60s | W8 |
 | [E2E-27](#e2e-27-w11-scope-awareness--test-coverage-suppression-when-the-repo-documents-no-harness) | Repo AGENTS.md declares "no test harness" → N "lacks coverage" findings collapse into one info note (W11) | 2m | 60s | W11 |
 | [E2E-28](#e2e-28-w6-single-authoritative-review-comment--no-duplicate-verdict-body) | One issue comment + one formal Review per run; the Review body is empty (APPROVE) or an HTML-comment stub (REQUEST_CHANGES / COMMENT) — no duplicate verdict text (W6) | 2m | 60s | W6 |
+| [E2E-29](#e2e-29-w10-finding-consolidation--fragments-on-the-same-region-merge) | N fragmented findings on the same code region (same file, line-span ≤ 50, ≥ 1 shared significant token) collapse into one merged finding with the strongest severity + a "Related concerns" list (W10) | 2m | 60s | W10 |
 
 ---
 
@@ -1172,6 +1173,59 @@ Run the fixtures separately to exercise both branches of the body-handling logic
 - ❌ Multiple formal Review objects on the same commit (`dismissStaleReviews` failed; should leave exactly one non-dismissed Review per run)
 
 **Note**: the HTML-comment stub `<!-- mergewatch-review -->` is the same marker used by the upserted issue comment. That's intentional — both surfaces share one identifier so future tooling can find them by a single grep.
+
+---
+
+### E2E-29: W10 finding consolidation — fragments on the same region merge
+
+**Behavior**: when the multi-agent pipeline emits multiple findings about the same underlying concern in the same code region — same file, line-span ≤ 50, ≥ 1 shared "significant" token across title + description — `clusterFindings` collapses them into **one** finding carrying the strongest severity, the earliest cited line, and a *"Related concerns clustered into this finding"* list of the absorbed siblings. The reader sees one row in "Requires your attention" where they would have seen N.
+
+Canonical reproduction: voice-bot PR #37 raised three findings about a single "validate the parsed S3 chunk file" concern — `seed.ts:82` (type assertion without runtime validation), `seed.ts:130` (untrusted JSON parsing without validation), `seed.ts:150` (SQL injection risk in dynamic construction). All three share *validation / structure / chunk* tokens; transitively they cluster (`:82↔:130` is 48 lines, `:130↔:150` is 20 lines, both within span 50).
+
+**Setup**
+
+Branch: `fixture/29-cluster`. Add a file that reliably draws multiple agents' attention to overlapping concerns in one region:
+
+```ts
+// src/seed.ts — designed to draw fragmented findings from multiple agents.
+type ChunkFileEntry = { text: string; embedding: number[]; metadata: unknown };
+
+export async function loadAndIndex(s3Key: string): Promise<void> {
+  // 1) Untrusted JSON — the json-parse / data-validation angle.
+  const raw = await s3.getObject(s3Key);
+  const json = JSON.parse(raw.Body.toString());
+
+  // 2) Type assertion without validation — the type-safety angle, same blob.
+  const chunks = json as ChunkFileEntry[];
+
+  // 3) Dynamic VALUES construction — the security angle, near the same code.
+  const values = chunks.map((c, i) => `(${i}, $${i + 1})`).join(', ');
+  await db.query(`INSERT INTO chunks VALUES ${values}`);
+}
+
+declare const s3: { getObject(key: string): Promise<{ Body: { toString(): string } }> };
+declare const db: { query(sql: string): Promise<unknown> };
+```
+
+The bait: bug / security / style / error-handling agents each have a distinct angle on the same root cause ("validate the parsed chunk file structure"), so the orchestrator output is expected to surface 2-3 findings in a tight line window.
+
+**Expected outcomes**
+
+- [ ] The rendered "Requires your attention" table shows **one** row referencing the parsed-chunk-file region, NOT 2-3 separate rows about validation / type assertion / untrusted JSON
+- [ ] The merged finding's title ends with *"… — and N related concern(s)"*
+- [ ] The merged finding's body contains a *"Related concerns clustered into this finding (W10):"* block listing each absorbed sibling with its original `file:line`, severity, and title
+- [ ] The merged finding's severity = the **strongest** severity in the cluster (critical > warning > info)
+- [ ] Agent log includes `[clustering] merged N related finding(s) into existing clusters`
+- [ ] `Suppressed N` in the Review details collapsible reflects the cluster reduction (N includes the absorbed count)
+- [ ] **Over-cluster regression check**: if the diff contains two genuinely-distinct concerns on the same file but in **different code regions** (e.g. one at line 20, one at line 300), they should NOT merge — verify both rows still appear
+
+**Failure modes**
+- ❌ All N findings still appear separately in the table (clustering didn't fire — probable cause: no shared significant token after stop-word filtering; check `extractSignificantTokens` on the actual titles)
+- ❌ Two findings on the same file in **different code regions** got merged into one (over-cluster — `maxLineSpan` may have been widened too far, or the token-overlap heuristic accepted a coincidental match)
+- ❌ The merged finding's severity is NOT the strongest in the cluster (severity-rank tie-break bug)
+- ❌ The merged finding's body lost the audit trail (the "Related concerns" list is missing or truncated)
+
+**Note**: `clusterFindings` is deliberately conservative. If you observe under-clustering in production (related findings should have merged but didn't), widen the heuristic via the `ClusterOptions` knobs (`maxLineSpan`, `minTokenOverlap`) rather than removing the cluster-size cap. Over-clustering would hide distinct issues under one heading — much worse than the noise it eliminates.
 
 ---
 

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -39,6 +39,7 @@ import type { ReviewDelta } from '../review-delta.js';
 import { computeReviewDelta, fingerprintFromCode } from '../review-delta.js';
 import { partitionDisputed } from '../triage.js';
 import { detectNoTestHarness, suppressTestCoverageFindings } from '../scope-awareness.js';
+import { clusterFindings } from '../finding-clustering.js';
 import { FILE_REQUEST_INSTRUCTION, invokeWithFileFetching } from '../context/agentic-fetcher.js';
 import type { FileFetchOptions } from '../context/agentic-fetcher.js';
 import { fetchFileContents } from '../context/file-fetcher.js';
@@ -1670,6 +1671,28 @@ export async function runReviewPipeline(
         suppressedCount === 1 ? '' : 's',
       );
       orchestratorResult.findings = collapsed;
+    }
+  }
+
+  // W10 — finding consolidation: cluster fragmented findings about the
+  // same code region (same file, lines within ±maxLineSpan, ≥1 shared
+  // significant token across title+description) into one finding with
+  // the strongest severity. Canonical case is voice-bot PR #37 where one
+  // "validate parsed S3 chunk file structure" concern was emitted as
+  // three separate findings at lines 82 / 130 / 150. Conservative defaults
+  // and a cluster-size cap keep over-clustering risk low. The absorbed
+  // count rolls into the downstream suppressedCount math.
+  {
+    const { findings: clustered, clusteredCount } = clusterFindings(
+      orchestratorResult.findings,
+    );
+    if (clusteredCount > 0) {
+      console.warn(
+        '[clustering] merged %d related finding%s into existing clusters',
+        clusteredCount,
+        clusteredCount === 1 ? '' : 's',
+      );
+      orchestratorResult.findings = clustered;
     }
   }
 

--- a/packages/core/src/finding-clustering.test.ts
+++ b/packages/core/src/finding-clustering.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest';
+import {
+  clusterFindings,
+  extractSignificantTokens,
+  type ClusterableFinding,
+} from './finding-clustering.js';
+
+function f(
+  partial: Partial<ClusterableFinding> & { line: number; title: string },
+): ClusterableFinding {
+  return {
+    file: 'src/x.ts',
+    severity: 'warning',
+    description: '',
+    ...partial,
+  };
+}
+
+describe('extractSignificantTokens', () => {
+  it('keeps lowercased alphanumeric tokens ≥ 5 chars', () => {
+    const tokens = extractSignificantTokens('Missing input validation on the boundary');
+    expect(tokens.has('validation')).toBe(true);
+    expect(tokens.has('boundary')).toBe(true);
+    // "input" is 5 chars — kept.
+    expect(tokens.has('input')).toBe(true);
+    // 4-char tokens are dropped (too generic).
+    expect(tokens.has('the')).toBe(false);
+    expect(tokens.has('on')).toBe(false);
+  });
+
+  it('drops generic finding-prose words', () => {
+    const tokens = extractSignificantTokens('Potential issue: missing risk concern');
+    // All four (potential / issue / missing / concern) are stop-listed.
+    expect(tokens.size).toBe(0);
+  });
+
+  it('returns an empty set for blank input', () => {
+    expect(extractSignificantTokens('').size).toBe(0);
+    expect(extractSignificantTokens('  !@#$ ').size).toBe(0);
+  });
+});
+
+describe('clusterFindings', () => {
+  it('returns inputs unchanged when there are < 2 findings', () => {
+    const single = [f({ line: 1, title: 'Single finding about validation' })];
+    expect(clusterFindings(single)).toEqual({ findings: single, clusteredCount: 0 });
+    expect(clusterFindings([])).toEqual({ findings: [], clusteredCount: 0 });
+  });
+
+  it('merges two findings when same file + close lines + shared significant token', () => {
+    const findings = [
+      f({ line: 10, title: 'Input validation missing on user payload' }),
+      f({ line: 12, title: 'Payload validation needs schema check' }),
+    ];
+    const { findings: out, clusteredCount } = clusterFindings(findings);
+    expect(clusteredCount).toBe(1);
+    expect(out).toHaveLength(1);
+    expect(out[0].title).toMatch(/and 1 related concern/);
+    expect(out[0].description).toMatch(/Related concerns clustered into this finding/);
+    expect(out[0].description).toMatch(/Payload validation/);
+  });
+
+  it('does NOT merge findings on DIFFERENT files even with identical titles', () => {
+    const findings = [
+      f({ file: 'a.ts', line: 10, title: 'Input validation missing' }),
+      f({ file: 'b.ts', line: 10, title: 'Input validation missing' }),
+    ];
+    const { clusteredCount, findings: out } = clusterFindings(findings);
+    expect(clusteredCount).toBe(0);
+    expect(out).toHaveLength(2);
+  });
+
+  it('does NOT merge findings on same file but lines too far apart (> maxLineSpan)', () => {
+    const findings = [
+      f({ line: 10,  title: 'Input validation missing on payload' }),
+      f({ line: 200, title: 'Input validation missing on payload' }),
+    ];
+    const { clusteredCount, findings: out } = clusterFindings(findings, { maxLineSpan: 50 });
+    expect(clusteredCount).toBe(0);
+    expect(out).toHaveLength(2);
+  });
+
+  it('does NOT merge findings on same file + close lines but NO significant token overlap', () => {
+    const findings = [
+      f({ line: 10, title: 'SQL injection in dynamic query' }),
+      f({ line: 12, title: 'Memory leak in event handler closure' }),
+    ];
+    const { clusteredCount } = clusterFindings(findings);
+    expect(clusteredCount).toBe(0);
+  });
+
+  it('clusters TRANSITIVELY (A↔B↔C with no direct A↔C edge still merges all three)', () => {
+    // A↔B share "validation"; B↔C share "structure"; A and C share nothing.
+    // Union-find should still group them all.
+    const findings = [
+      f({ line: 10, title: 'Input validation missing',
+          description: 'The payload validation step is skipped.' }),
+      f({ line: 14, title: 'Schema validation needs structure check',
+          description: 'The structure of the parsed payload is not validated.' }),
+      f({ line: 18, title: 'Object structure passed unchecked',
+          description: 'The object structure may contain unexpected fields.' }),
+    ];
+    const { clusteredCount, findings: out } = clusterFindings(findings);
+    expect(clusteredCount).toBe(2);
+    expect(out).toHaveLength(1);
+  });
+
+  it('strongest severity wins the merged finding', () => {
+    const findings = [
+      f({ line: 10, severity: 'info',     title: 'Untrusted JSON parsing' }),
+      f({ line: 12, severity: 'critical', title: 'Untrusted JSON sink runs SQL' }),
+      f({ line: 14, severity: 'warning',  title: 'Untrusted JSON path' }),
+    ];
+    const { findings: out } = clusterFindings(findings);
+    expect(out).toHaveLength(1);
+    expect(out[0].severity).toBe('critical');
+    // Within the same severity bucket, lowest line wins; here the only
+    // critical is line 12 so that's the primary.
+    expect(out[0].title).toMatch(/^Untrusted JSON sink runs SQL/);
+  });
+
+  it('respects the cluster-size cap — too-large clusters are NOT merged', () => {
+    // Six findings sharing "validation" within a tight line window. Cap is 5
+    // by default — the cluster is rejected and all six pass through unmerged.
+    const findings = Array.from({ length: 6 }, (_, i) =>
+      f({ line: 10 + i, title: `Validation issue ${i + 1} on payload structure` }),
+    );
+    const { findings: out, clusteredCount } = clusterFindings(findings);
+    expect(clusteredCount).toBe(0);
+    expect(out).toHaveLength(6);
+  });
+
+  it('caller can tune the heuristic via options', () => {
+    // With a stricter line-span, the same findings no longer cluster.
+    const findings = [
+      f({ line: 10, title: 'Validation missing on payload' }),
+      f({ line: 25, title: 'Validation missing on payload' }),
+    ];
+    expect(clusterFindings(findings, { maxLineSpan: 50 }).clusteredCount).toBe(1);
+    expect(clusterFindings(findings, { maxLineSpan: 10 }).clusteredCount).toBe(0);
+  });
+
+  it('reproduces the #37 fragmentation: 3 angles on "validate parsed S3 chunk file" merge into one', () => {
+    // Real findings (paraphrased from voice-bot PR #37):
+    const findings = [
+      f({ line: 82,  severity: 'warning', title: 'Type assertion without runtime validation',
+          description: 'The function casts chunks to ChunkFileEntry[] without validating the structure of individual chunk objects. Malformed chunk objects could lead to runtime errors.' }),
+      f({ line: 130, severity: 'info', title: 'Untrusted JSON parsing from S3 without validation',
+          description: 'JSON is parsed from S3 at line 130 without schema validation. Malformed or malicious JSON could cause parsing errors or unexpected data structures.' }),
+      f({ line: 150, severity: 'warning', title: 'SQL injection risk in dynamic VALUES clause construction',
+          description: 'The code dynamically constructs a SQL VALUES clause by concatenating strings. While parameters are used correctly, the structure could be exploited if input validation is missing.' }),
+    ];
+    const { findings: out, clusteredCount } = clusterFindings(findings);
+    // 82→130 line span = 48 (within 50), 130→150 = 20, so transitive cluster
+    // forms even though 82↔150 directly is 68 lines apart. All three share
+    // significant tokens ("validation", "structure", "chunk", "parsing").
+    expect(out).toHaveLength(1);
+    expect(clusteredCount).toBe(2);
+    // Highest severity in the cluster is warning, line 82 wins (lowest line
+    // among warnings is 82).
+    expect(out[0].severity).toBe('warning');
+    expect(out[0].line).toBe(82);
+    expect(out[0].description).toMatch(/Untrusted JSON/);
+    expect(out[0].description).toMatch(/SQL injection/);
+  });
+});

--- a/packages/core/src/finding-clustering.ts
+++ b/packages/core/src/finding-clustering.ts
@@ -1,0 +1,217 @@
+/**
+ * W10 — finding consolidation.
+ *
+ * The multi-agent pipeline can emit several findings about ONE underlying
+ * concern from different angles. Canonical example: voice-bot PR #37
+ * surfaced (a) "SQL injection risk in dynamic VALUES clause" at line 150,
+ * (b) "Type assertion without runtime validation" at line 82, and (c)
+ * "Untrusted JSON parsing from S3 without validation" at line 130 — three
+ * separate findings, one root cause ("validate the parsed S3 chunk file
+ * structure"). The reader sees three rows in the "Requires your attention"
+ * table where they should see one.
+ *
+ * This module clusters such fragments into a single finding carrying the
+ * strongest severity and a "Related concerns clustered into this finding"
+ * block listing the absorbed siblings. The user still has full audit
+ * (every framing is preserved in the merged finding's body); they just
+ * don't have to triage each angle separately.
+ *
+ * Conservative direction: over-clustering would hide distinct issues
+ * under one heading, which is worse than the noise it eliminates. The
+ * defaults below require (a) the SAME file, (b) lines within a bounded
+ * range, AND (c) at least one shared "significant" token across the
+ * combined title+description text. Clusters bigger than the cap are
+ * rejected as likely false positives — preferred output for a 6-finding
+ * "cluster" is six separate findings, not one suspicious super-finding.
+ */
+
+/** Minimal shape of a finding this module consumes. */
+export interface ClusterableFinding {
+  file: string;
+  line: number;
+  severity: 'critical' | 'warning' | 'info';
+  title: string;
+  description: string;
+}
+
+const SEVERITY_RANK: Record<ClusterableFinding['severity'], number> = {
+  critical: 3,
+  warning: 2,
+  info: 1,
+};
+
+/**
+ * Stop words + generic finding-prose words that carry no semantic weight
+ * for clustering. A finding title using only these is essentially
+ * unconstrained and would over-cluster against anything else.
+ */
+const W10_STOP_WORDS = new Set<string>([
+  // Common English stop words.
+  'about', 'after', 'again', 'against', 'because', 'before', 'being', 'below',
+  'between', 'could', 'might', 'should', 'their', 'there', 'these', 'those',
+  'where', 'which', 'while', 'with', 'within', 'without',
+  // Generic finding-prose vocabulary that says nothing specific.
+  'issue', 'issues', 'potential', 'concern', 'concerns', 'missing', 'lacking',
+  'lacks', 'lacks', 'risk', 'risks', 'consider', 'consideration', 'recommend',
+  'recommendation', 'recommended', 'suggest', 'suggested', 'suggestion',
+  'review', 'reviewed', 'finding', 'findings', 'problem', 'problems',
+  'function', 'method', 'value', 'values', 'variable', 'variables', 'class',
+  'object', 'objects', 'argument', 'arguments', 'parameter', 'parameters',
+  'change', 'changes', 'changed', 'check', 'checked', 'checks',
+]);
+
+/**
+ * Extract the "significant" tokens from a string: lowercase alphanumeric
+ * words ≥ 5 chars, minus the stop-word list. Length-5 is a deliberate
+ * floor — shorter tokens ("test", "code", "type") are too generic for
+ * Jaccard-style overlap to mean anything.
+ */
+export function extractSignificantTokens(text: string): Set<string> {
+  const tokens = text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .split(' ')
+    .filter((t) => t.length >= 5 && !W10_STOP_WORDS.has(t));
+  return new Set(tokens);
+}
+
+function sharedTokenCount(a: Set<string>, b: Set<string>): number {
+  let count = 0;
+  for (const t of a) if (b.has(t)) count++;
+  return count;
+}
+
+export interface ClusterOptions {
+  /**
+   * Maximum line distance (inclusive) at which two findings on the same
+   * file may cluster. Lines further apart than this are treated as
+   * structurally distinct code regions — never merged even if their
+   * titles look related. Default 50.
+   */
+  maxLineSpan?: number;
+  /**
+   * Minimum number of shared significant tokens for two findings to be
+   * considered the same underlying concern. Default 1 — enough to catch
+   * "validation"-themed siblings (#37) without merging arbitrary pairs.
+   */
+  minTokenOverlap?: number;
+  /**
+   * Reject clusters whose member count exceeds this cap. A 6-way cluster
+   * is more likely a false positive (the heuristic over-grouped) than a
+   * real "one concern, six angles" case. Default 5.
+   */
+  maxClusterSize?: number;
+}
+
+function clusterPair(
+  a: ClusterableFinding,
+  b: ClusterableFinding,
+  tokensA: Set<string>,
+  tokensB: Set<string>,
+  opts: Required<ClusterOptions>,
+): boolean {
+  if (a.file !== b.file) return false;
+  if (Math.abs(a.line - b.line) > opts.maxLineSpan) return false;
+  return sharedTokenCount(tokensA, tokensB) >= opts.minTokenOverlap;
+}
+
+/**
+ * Cluster fragmented findings about the same code region into one finding
+ * per cluster. Pure function — no I/O, no LLM. Conservative by design:
+ *   - requires same file AND bounded line distance AND ≥1 shared token,
+ *   - uses transitive union-find so A↔B↔C (with no direct A↔C edge)
+ *     still groups into one cluster,
+ *   - rejects clusters larger than `maxClusterSize` as likely false
+ *     positives (preserving original findings unchanged).
+ *
+ * Returns the post-cluster finding set plus the count of findings
+ * "absorbed" into other clusters (so the pipeline can roll it into
+ * `suppressedCount` for the rendered "Suppressed N" line).
+ */
+export function clusterFindings<T extends ClusterableFinding>(
+  findings: T[],
+  options: ClusterOptions = {},
+): { findings: T[]; clusteredCount: number } {
+  const opts: Required<ClusterOptions> = {
+    maxLineSpan: options.maxLineSpan ?? 50,
+    minTokenOverlap: options.minTokenOverlap ?? 1,
+    maxClusterSize: options.maxClusterSize ?? 5,
+  };
+
+  if (findings.length < 2) return { findings, clusteredCount: 0 };
+
+  // Pre-extract token sets — repeated tokenization is by far the hot path.
+  const tokenSets = findings.map((f) =>
+    extractSignificantTokens(`${f.title} ${f.description}`),
+  );
+
+  // Union-find / DSU over finding indices.
+  const parent = findings.map((_, i) => i);
+  const find = (x: number): number => {
+    if (parent[x] === x) return x;
+    parent[x] = find(parent[x]);
+    return parent[x];
+  };
+  const union = (a: number, b: number): void => {
+    const ra = find(a);
+    const rb = find(b);
+    if (ra !== rb) parent[ra] = rb;
+  };
+
+  // O(n²) over findings — n is small (post-orchestrator findings is
+  // typically <30; the orchestrator caps at maxFindings ≤ 25).
+  for (let i = 0; i < findings.length; i++) {
+    for (let j = i + 1; j < findings.length; j++) {
+      if (clusterPair(findings[i], findings[j], tokenSets[i], tokenSets[j], opts)) {
+        union(i, j);
+      }
+    }
+  }
+
+  // Bucket by root.
+  const buckets = new Map<number, number[]>();
+  for (let i = 0; i < findings.length; i++) {
+    const r = find(i);
+    const arr = buckets.get(r) ?? [];
+    arr.push(i);
+    buckets.set(r, arr);
+  }
+
+  const result: T[] = [];
+  let clusteredCount = 0;
+
+  for (const indices of buckets.values()) {
+    if (indices.length === 1) {
+      result.push(findings[indices[0]]);
+      continue;
+    }
+    // Cap: a too-large cluster is more likely heuristic over-reach than a
+    // real one-concern-many-angles case. Output the members verbatim.
+    if (indices.length > opts.maxClusterSize) {
+      for (const i of indices) result.push(findings[i]);
+      continue;
+    }
+    // Merge. Strongest severity becomes the primary; within the same
+    // severity, lower line wins (the earliest-cited member anchors the
+    // merged finding).
+    const members = indices.map((i) => findings[i]);
+    members.sort((a, b) => {
+      const dRank = SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity];
+      return dRank !== 0 ? dRank : a.line - b.line;
+    });
+    const primary = members[0];
+    const others = members.slice(1);
+    const relatedList = others
+      .map((o) => `- \`${o.file}:${o.line}\` (${o.severity}) — ${o.title}`)
+      .join('\n');
+    const merged: T = {
+      ...primary,
+      title: `${primary.title} — and ${others.length} related concern${others.length === 1 ? '' : 's'}`,
+      description: `${primary.description}\n\n**Related concerns clustered into this finding (W10):**\n${relatedList}`,
+    };
+    result.push(merged);
+    clusteredCount += others.length;
+  }
+
+  return { findings: result, clusteredCount };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -129,6 +129,10 @@ export type { TriagePriorFinding } from './triage.js';
 // ─── Scope/architecture awareness (W11) ─────────────────────────────────────
 export { detectNoTestHarness, suppressTestCoverageFindings } from './scope-awareness.js';
 
+// ─── Finding consolidation (W10) ────────────────────────────────────────────
+export { clusterFindings, extractSignificantTokens } from './finding-clustering.js';
+export type { ClusterableFinding, ClusterOptions } from './finding-clustering.js';
+
 // ─── Config ─────────────────────────────────────────────────────────────────
 export {
   DEFAULT_CONFIG,

--- a/packages/server/src/review-processor.test.ts
+++ b/packages/server/src/review-processor.test.ts
@@ -395,7 +395,12 @@ describe('processReviewJob — check runs', () => {
       );
     });
 
-    it('submits REQUEST_CHANGES with a non-empty body for low scores (critical findings)', async () => {
+    it('submits REQUEST_CHANGES with an empty body — W6 (wrapper handles the API stub)', async () => {
+      // Post-W6: the handler passes empty body for every event; submitPRReview
+      // substitutes the HTML-comment stub `<!-- mergewatch-review -->` for
+      // REQUEST_CHANGES / COMMENT to satisfy GitHub's required-body constraint
+      // while rendering as zero visible content. See client.test.ts's W6
+      // suite for the stub-substitution coverage.
       (mergeScoreToReviewEvent as any).mockReturnValue('REQUEST_CHANGES');
       (runReviewPipeline as any).mockResolvedValue({
         ...basePipelineResult,
@@ -410,13 +415,10 @@ describe('processReviewJob — check runs', () => {
       const call = (submitPRReview as any).mock.calls[0];
       const [, , , , body, event] = call;
       expect(event).toBe('REQUEST_CHANGES');
-      expect(body).toBeTruthy();
-      expect(body.length).toBeGreaterThan(0);
-      // GitHub requires a body for REQUEST_CHANGES; we point at the summary.
-      expect(body.toLowerCase()).toContain('summary comment');
+      expect(body).toBe('');
     });
 
-    it('submits COMMENT with a non-empty body for middle scores', async () => {
+    it('submits COMMENT with an empty body — W6 (wrapper handles the API stub)', async () => {
       (mergeScoreToReviewEvent as any).mockReturnValue('COMMENT');
       const deps = makeDeps();
       await processReviewJob(makeJob(), deps);
@@ -424,37 +426,14 @@ describe('processReviewJob — check runs', () => {
       const call = (submitPRReview as any).mock.calls[0];
       const [, , , , body, event] = call;
       expect(event).toBe('COMMENT');
-      expect(body).toBeTruthy();
-      expect(body.length).toBeGreaterThan(0);
+      expect(body).toBe('');
     });
 
-    it('uses a critical-flavored body for REQUEST_CHANGES vs review-recommended for COMMENT', async () => {
-      // First run: REQUEST_CHANGES
-      (mergeScoreToReviewEvent as any).mockReturnValue('REQUEST_CHANGES');
-      const deps1 = makeDeps();
-      await processReviewJob(makeJob(), deps1);
-      const requestBody = (submitPRReview as any).mock.calls[0][4];
-
-      vi.clearAllMocks();
-      (getPRContext as any).mockResolvedValue(basePRContext);
-      (getPRDiff as any).mockResolvedValue('diff content');
-      (shouldSkipPR as any).mockReturnValue(null);
-      (shouldSkipByRules as any).mockReturnValue(null);
-      (runReviewPipeline as any).mockResolvedValue(basePipelineResult);
-      (fetchRepoConfig as any).mockResolvedValue(null);
-      (addPRReaction as any).mockResolvedValue(12345);
-
-      // Second run: COMMENT
-      (mergeScoreToReviewEvent as any).mockReturnValue('COMMENT');
-      const deps2 = makeDeps();
-      await processReviewJob(makeJob(), deps2);
-      const commentBody = (submitPRReview as any).mock.calls[0][4];
-
-      expect(requestBody).not.toBe(commentBody);
-      // Critical findings are flagged in red; "review recommended" is yellow.
-      expect(requestBody).toContain('🔴');
-      expect(commentBody).toContain('🟡');
-    });
+    // Removed: "uses a critical-flavored body for REQUEST_CHANGES vs
+    // review-recommended for COMMENT". W6 (PR #155) is exactly this: the
+    // handler no longer emits flavored verdict bodies — the upserted summary
+    // issue comment is the single authoritative content surface. The old
+    // distinction is the bug that W6 eliminated.
   });
 });
 


### PR DESCRIPTION
## Problem — the P10 fragmentation pattern

Voice-bot PR #37 surfaced one "validate the parsed S3 chunk file structure" concern as **three separate findings**:

- `seed.ts:82` (warning) — "Type assertion without runtime validation"
- `seed.ts:130` (info) — "Untrusted JSON parsing from S3 without validation"
- `seed.ts:150` (warning) — "SQL injection risk in dynamic VALUES clause construction"

Each agent (bug / security / style) caught a real angle, but the reader sees three rows in "Requires your attention" where they should see one. The three are about the same root cause; the user has to triage each separately and realize they collapse into a single fix ("add `assertEmbedding()` + `parseChunkFile()` schema validation").

## Change

New `packages/core/src/finding-clustering.ts`:

- `extractSignificantTokens(text)` — lowercased alphanumeric tokens **≥ 5 chars** minus stop words and generic finding-prose vocabulary (*"issue"*, *"potential"*, *"concern"*, *"missing"*, *"function"*, *"value"*, *"check"*, …). The 5-char floor is deliberate — shorter tokens are too generic for Jaccard-style overlap to mean anything.
- `clusterFindings(findings, opts)` — pure function, **union-find** on (same file, `|line distance| ≤ maxLineSpan`, `≥ minTokenOverlap` shared significant tokens). Transitive clustering: A↔B↔C still groups into one cluster even if no direct A↔C edge exists. The #37 lines `82 ↔ 130` is 48 lines, `130 ↔ 150` is 20 — they daisy-chain into one cluster under the default `maxLineSpan = 50`, even though direct `82 ↔ 150 = 68` exceeds the cap.

**Conservative defaults** (`maxLineSpan: 50, minTokenOverlap: 1, maxClusterSize: 5`):
- A 6-way cluster is more likely heuristic over-reach than a real one-concern-many-angles case → members pass through unmerged.
- Over-clustering would hide distinct issues under one heading — worse than the noise it eliminates.

**Merge shape**:
- Strongest severity wins (critical > warning > info). Within the same severity, lowest line wins.
- Merged title: `${primary.title} — and N related concern(s)`.
- Merged body: original primary description + a `**Related concerns clustered into this finding (W10):**` block listing each absorbed sibling with its original `file:line (severity) — title`. Full audit trail; nothing lost.

Wired into `runReviewPipeline` after the W11 test-coverage suppression and before grounding. The absorbed count propagates through the existing `suppressedCount` math (no special accounting).

## Tests

13 new cases in `finding-clustering.test.ts`:

| Case | Outcome |
|---|---|
| Single finding / empty input | no-op |
| Same file + close lines + shared token | merge |
| Different files (identical titles) | no merge |
| Same file + far-apart lines (> `maxLineSpan`) | no merge |
| Same file + close lines + zero token overlap | no merge |
| Transitive A↔B↔C (no direct A↔C) | all three merge |
| Strongest severity wins; lowest line within bucket | locked in |
| Cluster-size cap (6-way) | passes through unmerged |
| Caller-tunable via `ClusterOptions` | both directions |
| **PR #37 reproduction** | 3 angles → 1 merged finding, severity `warning`, line `82` |

`@mergewatch/core` **463 passed** (450 + 13 new); `core` / `server` / `lambda` typecheck clean; full `pnpm run build` passes.

## E2E-29 fixture card
Added per the runbook update protocol — deduped (a new behavior, no overlap with E2E-11 / E2E-23 / E2E-28 which all touch other "comment plumbing" concerns). Includes the **over-cluster regression check**: two genuinely-distinct concerns on the same file but different regions (line 20 + line 300) must NOT merge.

## Not in scope (follow-ups)

- **LLM-based consolidation**: more flexible than the deterministic token-overlap heuristic but adds an LLM call + stochasticity. If we observe systemic under-clustering on real PRs (related findings that the heuristic misses because they share no length-5+ token), an LLM consolidation pass is the next step. The current heuristic is the safe v1 baseline.
- **Cluster across re-reviews** (a stable cluster-key persisted in the store like the W9 fingerprint). Not needed yet — clustering is per-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)