### PR TITLE
FP-A + FP-B + FP-C — confidence floor + previousFindings pre-filter + cross-agent dedup

### DIFF
--- a/docs/false-positive-reduction-plan.md
+++ b/docs/false-positive-reduction-plan.md
@@ -23,7 +23,7 @@ No new failure patterns. Every concrete bad review we've seen is covered by W1�
 
 Ranked by ROI: deterministic + low cost + high blast radius first.
 
-### FP-A — Hard confidence-floor filter  ★★★
+### FP-A — Hard confidence-floor filter  ✅ SHIPPED
 
 **Where the gap lives:** `packages/core/src/agents/prompts.ts:481` (rule #5 of `ORCHESTRATOR_PROMPT`):
 > *"Drop any finding with confidence below 75."*
@@ -52,7 +52,7 @@ if (lowConfidence.length > 0) {
 
 ---
 
-### FP-B — Pre-filter `previousFindings` by `disputedKeys`  ★★★
+### FP-B — Pre-filter `previousFindings` by `disputedKeys`  ✅ SHIPPED
 
 **Where the gap lives:** both handlers (`packages/server/src/review-processor.ts:425`, `packages/lambda/src/handlers/review-agent.ts:545`) pass `previousFindings: prevComplete?.findings` **raw** to `runReviewPipeline`. The orchestrator prompt then includes those prior findings via `buildPreviousFindingsBlock` (`reviewer.ts:798`) and explicitly tells the model to *"carry forward if still present."*
 
@@ -65,7 +65,7 @@ W3's `partitionDisputed` runs **after** the orchestrator. So the orchestrator ha
 
 ---
 
-### FP-C — Pre-orchestrator same-file-same-line dedup  ★★
+### FP-C — Pre-orchestrator same-file-same-line dedup  ✅ SHIPPED
 
 **Where the gap lives:** the orchestrator is the ONLY cross-agent dedup point, and it's an LLM. Two agents flagging exactly `file:42` with overlapping titles relies on the model to merge them. W10's `clusterFindings` catches some post-hoc clustering on a wider region, but trivial same-file-same-line duplicates should be killed *before* the orchestrator sees them — saves prompt tokens AND eliminates a class of cross-agent doubles the model misses.
 
@@ -143,9 +143,9 @@ Pass the detected set into a new `LINTER_AWARE_DIRECTIVE` placeholder injected i
 
 | ID | Opportunity | Cost | Code blast radius | ROI |
 |---|---|---|---|---|
-| **FP-A** | Hard confidence-floor filter | tiny | one filter call | ★★★ |
-| **FP-B** | Pre-filter `previousFindings` by disputedKeys | tiny | two handlers, ~10 lines | ★★★ |
-| **FP-C** | Pre-orchestrator same-file-same-line dedup | small | reuses W10's helper | ★★ |
+| **FP-A** | Hard confidence-floor filter | tiny | one filter call | ✅ SHIPPED |
+| **FP-B** | Pre-filter `previousFindings` by disputedKeys | tiny | two handlers, ~10 lines | ✅ SHIPPED |
+| **FP-C** | Pre-orchestrator same-file-same-line dedup | small | reuses W10's helper | ✅ SHIPPED |
 | **FP-D** | Diagram path validation | small | `parseDiagramResponse` post-process | ★★ |
 | **FP-E** | Extend W2 verification to warnings | LLM-cost +$0.02–0.03/review | one severity-skip line | ★ |
 | **FP-F** | Inline-reply resolve memory → disputedKeys | medium | new storage field + handler wiring | ★ |

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -156,9 +156,9 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-27](#e2e-27-w11-scope-awareness--test-coverage-suppression-when-the-repo-documents-no-harness) | Repo AGENTS.md declares "no test harness" → N "lacks coverage" findings collapse into one info note (W11) | 2m | 60s | W11 |
 | [E2E-28](#e2e-28-w6-single-authoritative-review-comment--no-duplicate-verdict-body) | One issue comment + one formal Review per run; the Review body is empty (APPROVE) or an HTML-comment stub (REQUEST_CHANGES / COMMENT) — no duplicate verdict text (W6) | 2m | 60s | W6 |
 | [E2E-29](#e2e-29-w10-finding-consolidation--fragments-on-the-same-region-merge) | N fragmented findings on the same code region (same file, line-span ≤ 50, ≥ 1 shared significant token) collapse into one merged finding with the strongest severity + a "Related concerns" list (W10) | 2m | 60s | W10 |
-| [E2E-30](#e2e-30-fp-a--hard-confidence-floor-filter-target) | Findings with `confidence < 75` deterministically dropped post-orchestrator (FP-A) — **TARGET** | 1m | 60s | FP-A |
-| [E2E-31](#e2e-31-fp-b--pre-filter-previousfindings-by-disputedkeys-target) | Prior findings whose key is in `disputedKeys` are excluded from the orchestrator's input, not just suppressed downstream (FP-B) — **TARGET** | 2m | 60s | FP-B |
-| [E2E-32](#e2e-32-fp-c--pre-orchestrator-cross-agent-dedup-target) | Same-file-same-line cross-agent doubles merge before the orchestrator sees them (FP-C) — **TARGET** | 1m | 60s | FP-C |
+| [E2E-30](#e2e-30-fp-a--hard-confidence-floor-filter) | Findings with `confidence < 75` deterministically dropped post-orchestrator (FP-A) | 1m | 60s | FP-A |
+| [E2E-31](#e2e-31-fp-b--pre-filter-previousfindings-by-disputedkeys) | Prior findings whose key is in `disputedKeys` are excluded from the orchestrator's input, not just suppressed downstream (FP-B) | 2m | 60s | FP-B |
+| [E2E-32](#e2e-32-fp-c--pre-orchestrator-cross-agent-dedup) | Same-file-same-line cross-agent doubles merge before the orchestrator sees them (FP-C) | 1m | 60s | FP-C |
 | [E2E-33](#e2e-33-fp-d--diagram-path-validation-target) | Diagram citing a file NOT in the PR's changed-files set is dropped entirely (FP-D) — **TARGET** | 1m | 60s | FP-D |
 | [E2E-34](#e2e-34-fp-e--w2-verification-extended-to-warnings-target) | Warning-severity findings go through the W2 verification pass and get a `verification` tag (FP-E) — **TARGET** | 2m | 60s | FP-E |
 | [E2E-35](#e2e-35-fp-f--inline-reply-resolve-memory-target) | An inline `/resolve` reply persists the finding's key so the next review doesn't re-emit it (FP-F) — **TARGET** | 3m | 90s | FP-F |
@@ -1236,9 +1236,9 @@ The bait: bug / security / style / error-handling agents each have a distinct an
 
 ---
 
-### E2E-30: FP-A — hard confidence-floor filter — TARGET
+### E2E-30: FP-A — hard confidence-floor filter
 
-**Status:** **Not yet implemented.** See [`docs/false-positive-reduction-plan.md` → FP-A](./../docs/false-positive-reduction-plan.md#fp-a--hard-confidence-floor-filter--).
+**Status:** ✅ **SHIPPED.** Implemented as a deterministic post-orchestrator filter at the top of `runReviewPipeline`. Constant `CONFIDENCE_FLOOR = 75` near the other pipeline constants in `packages/core/src/agents/reviewer.ts`. See [`docs/false-positive-reduction-plan.md` → FP-A](./../docs/false-positive-reduction-plan.md#fp-a--hard-confidence-floor-filter--).
 
 **Behavior (intended, once FP-A ships):** the orchestrator's prompt rule #5 (*"Drop any finding with confidence below 75"*) is enforced **deterministically** in code. Any finding whose `confidence < 75` is dropped post-orchestrator regardless of what the model returns. Findings with no `confidence` field default to 100 (no suppression).
 
@@ -1271,9 +1271,9 @@ To force the suppression deterministically in a self-hosted run, inject `{ ...fi
 
 ---
 
-### E2E-31: FP-B — pre-filter previousFindings by disputedKeys — TARGET
+### E2E-31: FP-B — pre-filter previousFindings by disputedKeys
 
-**Status:** **Not yet implemented.** See [`docs/false-positive-reduction-plan.md` → FP-B](./../docs/false-positive-reduction-plan.md#fp-b--pre-filter-previousfindings-by-disputedkeys--).
+**Status:** ✅ **SHIPPED.** Both handlers (`packages/server/src/review-processor.ts`, `packages/lambda/src/handlers/review-agent.ts`) now compute `disputedKeys` before constructing the `runReviewPipeline` options, then use `partitionDisputed(prevComplete.findings, disputedKeys).kept` as the `previousFindings` arg. Regression-locked by two integration tests in `review-processor.test.ts`. See [`docs/false-positive-reduction-plan.md` → FP-B](./../docs/false-positive-reduction-plan.md#fp-b--pre-filter-previousfindings-by-disputedkeys--).
 
 **Behavior (intended, once FP-B ships):** prior findings whose stable identity key is in `disputedKeys` (the W3 author-rebutted set computed from `## mergewatch triage` comments) are **excluded from the orchestrator's `previousFindings` block entirely**. Today they're passed through and the orchestrator prompt encourages it to "carry forward" them; W3's suppression then runs downstream. After FP-B, the orchestrator never sees them — saves prompt tokens and eliminates the small set of re-emissions that slip past W3's stable-key match because the model reframed the finding.
 
@@ -1297,9 +1297,9 @@ Branch: `fixture/31-prev-disputed-prefilter`. Two-commit sequence:
 
 ---
 
-### E2E-32: FP-C — pre-orchestrator cross-agent dedup — TARGET
+### E2E-32: FP-C — pre-orchestrator cross-agent dedup
 
-**Status:** **Not yet implemented.** See [`docs/false-positive-reduction-plan.md` → FP-C](./../docs/false-positive-reduction-plan.md#fp-c--pre-orchestrator-same-file-same-line-dedup--).
+**Status:** ✅ **SHIPPED.** `dedupeCrossAgentByLine` in `packages/core/src/finding-clustering.ts` is invoked on the per-agent `taggedFindings` immediately before `runOrchestratorAgent`. Reuses W10's `extractSignificantTokens` for the title-overlap gate. Regression-locked by 6 unit tests covering the strict exact-line match, the multi-agent 3-way merge, the same-line-no-token-overlap case (no merge), the different-line case (no merge), the empty-categories preservation, and the same-line-shared-token merge. See [`docs/false-positive-reduction-plan.md` → FP-C](./../docs/false-positive-reduction-plan.md#fp-c--pre-orchestrator-same-file-same-line-dedup--).
 
 **Behavior (intended, once FP-C ships):** when two or more agents flag the same `(file, line)` with overlapping titles, the duplicates are merged **before** the orchestrator's LLM call. Reuses W10's `extractSignificantTokens` for title-similarity. Strongest severity wins; absorbed siblings recorded.
 

--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -1131,6 +1131,67 @@ describe('runReviewPipeline', () => {
     expect(typeof result.outputTokens).toBe('number');
   });
 
+  // ─── FP-A: hard confidence-floor filter ──────────────────────────────────
+
+  it('FP-A — drops findings with confidence < 75 deterministically post-orchestrator', async () => {
+    // Trigger the orchestrator by feeding the security agent one finding —
+    // an all-empty agent input short-circuits the orchestrator and bypasses
+    // its mock response entirely (see "skips LLM for empty input" test).
+    const securityFinding = validFindingsJson([{ file: 'foo.ts', line: 3, severity: 'warning', title: 'trigger', confidence: 90 }]);
+    const summary = JSON.stringify({ summary: 'Refactor.' });
+    const diagram = '%% overview\nflowchart TD\n  A-->B';
+    // Orchestrator returns 3 findings: confidence 90 (kept), 75 (boundary kept),
+    // 50 (dropped by FP-A). The model didn't honor its own rule #5 — FP-A does.
+    const orchestrator = JSON.stringify({
+      findings: [
+        { file: 'foo.ts', line: 3, severity: 'warning', confidence: 90, category: 'security', title: 'Confident issue',  description: '', suggestion: '' },
+        { file: 'foo.ts', line: 3, severity: 'warning', confidence: 75, category: 'bug',      title: 'Boundary issue',   description: '', suggestion: '' },
+        { file: 'foo.ts', line: 3, severity: 'warning', confidence: 50, category: 'style',    title: 'Speculative issue', description: '', suggestion: '' },
+      ],
+      mergeScore: 3, mergeScoreReason: 'Has warnings.',
+    });
+    const llm = createMockLLM([
+      securityFinding, JSON.stringify({ findings: [] }), JSON.stringify({ findings: [] }),
+      JSON.stringify({ findings: [] }), JSON.stringify({ findings: [] }), JSON.stringify({ findings: [] }),
+      summary, diagram, orchestrator,
+    ]);
+    const result = await runReviewPipeline(
+      { diff: sampleDiff, context: sampleContext, modelId: 'heavy', lightModelId: 'light', maxFindings: 25, enabledAgents: allAgentsEnabled },
+      { llm },
+    );
+
+    // Both the 90 and the 75 survive (the filter is `< 75`, not `<= 75`).
+    // The speculative 50 is dropped.
+    const titles = result.findings.map((f) => f.title);
+    expect(titles).toContain('Confident issue');
+    expect(titles).toContain('Boundary issue');
+    expect(titles).not.toContain('Speculative issue');
+  });
+
+  it('FP-A — findings with NO `confidence` field default to 100 and are kept (back-compat)', async () => {
+    const securityFinding = validFindingsJson([{ file: 'foo.ts', line: 3, severity: 'warning', title: 'trigger', confidence: 90 }]);
+    const summary = JSON.stringify({ summary: 'Refactor.' });
+    const diagram = '%% overview\nflowchart TD\n  A-->B';
+    const orchestrator = JSON.stringify({
+      findings: [
+        // No `confidence` field — must default to 100 and be kept.
+        { file: 'foo.ts', line: 3, severity: 'warning', category: 'bug', title: 'Legacy untagged', description: '', suggestion: '' },
+      ],
+      mergeScore: 3, mergeScoreReason: 'Has warnings.',
+    });
+    const llm = createMockLLM([
+      securityFinding, JSON.stringify({ findings: [] }), JSON.stringify({ findings: [] }),
+      JSON.stringify({ findings: [] }), JSON.stringify({ findings: [] }), JSON.stringify({ findings: [] }),
+      summary, diagram, orchestrator,
+    ]);
+    const result = await runReviewPipeline(
+      { diff: sampleDiff, context: sampleContext, modelId: 'heavy', lightModelId: 'light', maxFindings: 25, enabledAgents: allAgentsEnabled },
+      { llm },
+    );
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].title).toBe('Legacy untagged');
+  });
+
 });
 
 // ─── agentAuthored flag (AGENT_MODE_SUFFIX injection) ───────────────

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -39,7 +39,7 @@ import type { ReviewDelta } from '../review-delta.js';
 import { computeReviewDelta, fingerprintFromCode } from '../review-delta.js';
 import { partitionDisputed } from '../triage.js';
 import { detectNoTestHarness, suppressTestCoverageFindings } from '../scope-awareness.js';
-import { clusterFindings } from '../finding-clustering.js';
+import { clusterFindings, dedupeCrossAgentByLine } from '../finding-clustering.js';
 import { FILE_REQUEST_INSTRUCTION, invokeWithFileFetching } from '../context/agentic-fetcher.js';
 import type { FileFetchOptions } from '../context/agentic-fetcher.js';
 import { fetchFileContents } from '../context/file-fetcher.js';
@@ -105,6 +105,17 @@ export interface ReviewContext {
  * that still keeps end-to-end latency within typical targets.
  */
 const AGENT_CONCURRENCY = 3;
+
+/**
+ * FP-A — Hard confidence-floor for findings emitted by the orchestrator. The
+ * agent prompts ask the model to self-report `confidence: 1-100` and the
+ * orchestrator's own prompt (rule #5) instructs it to drop anything below
+ * this threshold. The model doesn't always honor that rule, so the pipeline
+ * enforces it deterministically post-orchestrator. Findings with no
+ * `confidence` field default to 100 (kept) so pre-FP-A stored records and
+ * agents that don't emit confidence aren't accidentally suppressed.
+ */
+const CONFIDENCE_FLOOR = 75;
 
 /**
  * Run task factories with a bounded concurrency. Results are returned in the
@@ -1640,11 +1651,30 @@ export async function runReviewPipeline(
     ...customTagged,
   ];
 
-  // Count total raw findings before orchestration
+  // Count total raw findings before orchestration. Captured before FP-C
+  // merges cross-agent doubles so the downstream `suppressedCount` math
+  // (totalRawFindings − filteredFindings.length) accurately reflects the
+  // dedup work, alongside W10's same-region clustering + W11's coverage
+  // suppression.
   const totalRawFindings = taggedFindings.reduce((sum, t) => sum + (t.findings?.length ?? 0), 0);
 
+  // FP-C — pre-orchestrator same-`(file, line)` cross-agent dedup. Merges
+  // exact-line doubles BEFORE the orchestrator's LLM call sees them so the
+  // prompt is shorter AND we don't rely on the model to spot identical-
+  // location duplicates. Wider line-region clustering is W10's job and runs
+  // POST-orchestrator on the final finding set.
+  const fpCResult = dedupeCrossAgentByLine(taggedFindings);
+  if (fpCResult.dedupedCount > 0) {
+    console.warn(
+      '[fp-c] merged %d cross-agent finding%s at the same (file, line)',
+      fpCResult.dedupedCount,
+      fpCResult.dedupedCount === 1 ? '' : 's',
+    );
+  }
+  const dedupedTaggedFindings = fpCResult.taggedFindings as TaggedFindings[];
+
   const orchestratorResult = await runOrchestratorAgent(
-    taggedFindings,
+    dedupedTaggedFindings,
     lightModelId,
     maxFindings,
     llm,
@@ -1652,6 +1682,28 @@ export async function runReviewPipeline(
     conventions,
     agentAuthored,
   );
+
+  // FP-A — Hard confidence-floor filter.
+  // The orchestrator's prompt (rule #5) tells the model to drop findings with
+  // confidence < 75, but nothing in code enforces it. This deterministic post-
+  // orchestrator filter catches the entire class of "model didn't honor its
+  // own confidence rule" false positives. Findings with NO `confidence` field
+  // default to 100 (no surprise suppression of legacy findings).
+  {
+    const before = orchestratorResult.findings.length;
+    orchestratorResult.findings = orchestratorResult.findings.filter(
+      (f) => (f.confidence ?? 100) >= CONFIDENCE_FLOOR,
+    );
+    const dropped = before - orchestratorResult.findings.length;
+    if (dropped > 0) {
+      console.warn(
+        '[confidence-floor] dropped %d finding%s with confidence < %d',
+        dropped,
+        dropped === 1 ? '' : 's',
+        CONFIDENCE_FLOOR,
+      );
+    }
+  }
 
   // W11 — scope/architecture awareness: when the repo's conventions
   // document explicitly declares no test harness, collapse the per-

--- a/packages/core/src/finding-clustering.test.ts
+++ b/packages/core/src/finding-clustering.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   clusterFindings,
   extractSignificantTokens,
+  dedupeCrossAgentByLine,
   type ClusterableFinding,
 } from './finding-clustering.js';
 
@@ -162,5 +163,98 @@ describe('clusterFindings', () => {
     expect(out[0].line).toBe(82);
     expect(out[0].description).toMatch(/Untrusted JSON/);
     expect(out[0].description).toMatch(/SQL injection/);
+  });
+});
+
+// ─── FP-C: pre-orchestrator cross-agent dedup ───────────────────────────────
+
+describe('dedupeCrossAgentByLine', () => {
+  function cf(partial: Partial<ClusterableFinding> & { line: number; title: string }): ClusterableFinding {
+    return { file: 'src/x.ts', severity: 'warning', description: '', ...partial };
+  }
+
+  it('returns inputs unchanged when there are < 2 findings total', () => {
+    const tagged = [
+      { category: 'security', findings: [cf({ line: 1, title: 'Single' })] },
+      { category: 'bug', findings: [] },
+    ];
+    const r = dedupeCrossAgentByLine(tagged);
+    expect(r.dedupedCount).toBe(0);
+    expect(r.taggedFindings).toEqual(tagged);
+  });
+
+  it('merges same-(file, line) findings across agents when they share a significant token', () => {
+    // Two agents flag the same `exec()` line — same file, same line, shared
+    // "command" token. Should merge into one finding under the primary's
+    // category (strongest severity wins; ties → earliest-encountered).
+    const tagged = [
+      { category: 'security', findings: [cf({ line: 10, severity: 'critical', title: 'Command injection via user input' })] },
+      { category: 'bug',      findings: [cf({ line: 10, severity: 'warning',  title: 'Command argument not escaped' })] },
+    ];
+    const r = dedupeCrossAgentByLine(tagged);
+    expect(r.dedupedCount).toBe(1);
+    const sec = r.taggedFindings.find((t) => t.category === 'security')!;
+    expect(sec.findings).toHaveLength(1);
+    expect(sec.findings![0].severity).toBe('critical'); // strongest severity wins
+    expect(sec.findings![0].title).toMatch(/and 1 related cross-agent concern/);
+    expect(sec.findings![0].description).toMatch(/\(bug\) Command argument not escaped/);
+    const bug = r.taggedFindings.find((t) => t.category === 'bug')!;
+    expect(bug.findings).toHaveLength(0); // absorbed into security
+  });
+
+  it('does NOT merge same-(file, line) findings when titles share no significant tokens', () => {
+    // Two distinct concerns that happen to land on the same line — no overlap.
+    const tagged = [
+      { category: 'security', findings: [cf({ line: 10, title: 'Command injection in exec call' })] },
+      { category: 'style',    findings: [cf({ line: 10, title: 'Magic constant should be extracted' })] },
+    ];
+    const r = dedupeCrossAgentByLine(tagged);
+    expect(r.dedupedCount).toBe(0);
+    // Each finding stays in its original category bucket.
+    expect(r.taggedFindings.find((t) => t.category === 'security')!.findings).toHaveLength(1);
+    expect(r.taggedFindings.find((t) => t.category === 'style')!.findings).toHaveLength(1);
+  });
+
+  it('does NOT merge findings on DIFFERENT lines (FP-C is strict exact-line; W10 handles wider regions)', () => {
+    // Adjacent lines (11 vs 12) sharing a token — W10 might cluster these
+    // post-orchestrator, but FP-C must not because they're not exact-line.
+    const tagged = [
+      { category: 'security', findings: [cf({ line: 11, title: 'Validation missing on payload' })] },
+      { category: 'bug',      findings: [cf({ line: 12, title: 'Validation missing on payload' })] },
+    ];
+    const r = dedupeCrossAgentByLine(tagged);
+    expect(r.dedupedCount).toBe(0);
+  });
+
+  it('preserves the per-category bucket structure (empty categories stay present)', () => {
+    // Even when a category is empty (no findings), it must still appear in
+    // the output so the orchestrator's per-category prompt isn't reshuffled.
+    const tagged = [
+      { category: 'security', findings: [cf({ line: 1, title: 'A' })] },
+      { category: 'bug', findings: [] },
+      { category: 'style', findings: [] },
+    ];
+    const r = dedupeCrossAgentByLine(tagged);
+    expect(r.taggedFindings.map((t) => t.category)).toEqual(['security', 'bug', 'style']);
+    expect(r.taggedFindings[1].findings).toEqual([]);
+    expect(r.taggedFindings[2].findings).toEqual([]);
+  });
+
+  it('merges 3+ same-(file, line) cross-agent findings into one (PR #38-style concentration)', () => {
+    // Three agents independently flag the same line. All share "validation"
+    // → merge into one under the strongest-severity primary.
+    const tagged = [
+      { category: 'security',       findings: [cf({ line: 42, severity: 'warning',  title: 'Input validation missing' })] },
+      { category: 'bug',            findings: [cf({ line: 42, severity: 'critical', title: 'Payload validation skipped — possible crash' })] },
+      { category: 'error-handling', findings: [cf({ line: 42, severity: 'warning',  title: 'Validation throws not handled' })] },
+    ];
+    const r = dedupeCrossAgentByLine(tagged);
+    expect(r.dedupedCount).toBe(2);
+    const bug = r.taggedFindings.find((t) => t.category === 'bug')!;
+    expect(bug.findings).toHaveLength(1);
+    expect(bug.findings![0].severity).toBe('critical');
+    expect(bug.findings![0].title).toMatch(/and 2 related cross-agent concerns/);
+    expect(bug.findings![0].description).toMatch(/\(security\)/);
+    expect(bug.findings![0].description).toMatch(/\(error-handling\)/);
   });
 });

--- a/packages/core/src/finding-clustering.ts
+++ b/packages/core/src/finding-clustering.ts
@@ -215,3 +215,128 @@ export function clusterFindings<T extends ClusterableFinding>(
 
   return { findings: result, clusteredCount };
 }
+
+/**
+ * FP-C — pre-orchestrator cross-agent dedup.
+ *
+ * Distinct from `clusterFindings` (W10) above: W10 runs POST-orchestrator
+ * over a wider line region. FP-C runs PRE-orchestrator and only merges
+ * EXACT-`(file, line)` matches across agents — the case where two or more
+ * agents independently flagged the same single line for related concerns.
+ * The orchestrator is supposed to dedup these (its prompt rule #1), but as
+ * an LLM it's not deterministic; doing the obvious exact-line merges in
+ * code saves prompt tokens AND catches what the model misses.
+ *
+ * Merge gate: same `(file, line)` AND ≥1 shared significant token in the
+ * combined title+description text of any pair within the group (uses
+ * `extractSignificantTokens`, same as W10). The token guard prevents
+ * merging two genuinely-distinct concerns that happen to land on the same
+ * line (e.g. a security finding and a comment-accuracy nit on the same `eval`
+ * call have no overlapping significant tokens).
+ *
+ * Output shape: preserves the input's `TaggedFindings[]` structure so the
+ * orchestrator still sees per-category buckets. Merged findings sit in the
+ * primary's category; absorbed siblings are listed in the description with
+ * their original category attribution, so the orchestrator (and any reader
+ * of the persisted finding) can audit the merge.
+ */
+export interface TaggedClusterableFindings<T extends ClusterableFinding> {
+  category: string;
+  findings?: T[];
+}
+
+export function dedupeCrossAgentByLine<T extends ClusterableFinding>(
+  taggedFindings: ReadonlyArray<TaggedClusterableFindings<T>>,
+): { taggedFindings: TaggedClusterableFindings<T>[]; dedupedCount: number } {
+  // Flatten with category + original-order attribution.
+  interface Entry { category: string; finding: T; order: number }
+  const all: Entry[] = [];
+  let order = 0;
+  for (const t of taggedFindings) {
+    for (const f of (t.findings ?? [])) {
+      all.push({ category: t.category, finding: f, order: order++ });
+    }
+  }
+  if (all.length < 2) {
+    return { taggedFindings: taggedFindings.map((t) => ({ ...t, findings: [...(t.findings ?? [])] })), dedupedCount: 0 };
+  }
+
+  // Group by exact `file::line`.
+  const groups = new Map<string, Entry[]>();
+  for (const e of all) {
+    const k = `${e.finding.file}::${e.finding.line}`;
+    const g = groups.get(k) ?? [];
+    g.push(e);
+    groups.set(k, g);
+  }
+
+  const surviving: Entry[] = [];
+  let dedupedCount = 0;
+
+  for (const g of groups.values()) {
+    if (g.length === 1) {
+      surviving.push(g[0]);
+      continue;
+    }
+    // Pre-extract token sets for the overlap check.
+    const tokens = g.map((e) =>
+      extractSignificantTokens(`${e.finding.title} ${e.finding.description}`),
+    );
+    let anyOverlap = false;
+    outer: for (let i = 0; i < g.length; i++) {
+      for (let j = i + 1; j < g.length; j++) {
+        for (const t of tokens[i]) {
+          if (tokens[j].has(t)) { anyOverlap = true; break outer; }
+        }
+      }
+    }
+    if (!anyOverlap) {
+      // Same line, different concerns — pass through unmerged.
+      surviving.push(...g);
+      continue;
+    }
+    // Merge. Strongest severity wins; ties go to earliest-encountered.
+    const sorted = [...g].sort((a, b) => {
+      const dRank = SEVERITY_RANK[b.finding.severity] - SEVERITY_RANK[a.finding.severity];
+      return dRank !== 0 ? dRank : a.order - b.order;
+    });
+    const primary = sorted[0];
+    const others = sorted.slice(1);
+    const relatedList = others
+      .map((o) => `- (${o.category}) ${o.finding.title}`)
+      .join('\n');
+    const mergedFinding: T = {
+      ...primary.finding,
+      title: `${primary.finding.title} — and ${others.length} related cross-agent concern${others.length === 1 ? '' : 's'}`,
+      description: `${primary.finding.description}\n\n**Related cross-agent concerns merged into this finding (FP-C):**\n${relatedList}`,
+    };
+    surviving.push({ category: primary.category, finding: mergedFinding, order: primary.order });
+    dedupedCount += others.length;
+  }
+
+  // Re-bucket by category in the ORIGINAL category order — agents that
+  // ended up empty stay present (with `findings: []`) so the orchestrator's
+  // per-category prompt sections aren't reshuffled by our merging.
+  const byCategory = new Map<string, T[]>();
+  for (const e of surviving) {
+    const arr = byCategory.get(e.category) ?? [];
+    arr.push(e.finding);
+    byCategory.set(e.category, arr);
+  }
+  // Preserve order WITHIN each category (sort by original `order`).
+  for (const arr of byCategory.values()) {
+    arr.sort((a, b) => {
+      const ea = surviving.find((s) => s.finding === a)!;
+      const eb = surviving.find((s) => s.finding === b)!;
+      return ea.order - eb.order;
+    });
+  }
+
+  return {
+    taggedFindings: taggedFindings.map((t) => ({
+      category: t.category,
+      findings: byCategory.get(t.category) ?? [],
+    })),
+    dedupedCount,
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -129,9 +129,9 @@ export type { TriagePriorFinding } from './triage.js';
 // ─── Scope/architecture awareness (W11) ─────────────────────────────────────
 export { detectNoTestHarness, suppressTestCoverageFindings } from './scope-awareness.js';
 
-// ─── Finding consolidation (W10) ────────────────────────────────────────────
-export { clusterFindings, extractSignificantTokens } from './finding-clustering.js';
-export type { ClusterableFinding, ClusterOptions } from './finding-clustering.js';
+// ─── Finding consolidation (W10) + cross-agent dedup (FP-C) ────────────────
+export { clusterFindings, extractSignificantTokens, dedupeCrossAgentByLine } from './finding-clustering.js';
+export type { ClusterableFinding, ClusterOptions, TaggedClusterableFindings } from './finding-clustering.js';
 
 // ─── Config ─────────────────────────────────────────────────────────────────
 export {

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -43,6 +43,7 @@ import {
   handleInlineReply,
   fetchTriageComments,
   computeDisputedKeys,
+  partitionDisputed,
 } from '@mergewatch/core';
 import type {
   ReviewJobPayload,
@@ -514,6 +515,24 @@ export async function handler(
       }
     }
 
+    // FP-B — pre-filter `previousFindings` by `disputedKeys`. Mirrors the
+    // server handler; see review-processor.ts for the rationale (orchestrator
+    // input shouldn't carry findings the author already dispositioned).
+    const priorForOrchestrator = prevComplete?.findings && disputedKeys.length > 0
+      ? partitionDisputed(prevComplete.findings, disputedKeys).kept
+      : prevComplete?.findings;
+    if (
+      prevComplete?.findings &&
+      priorForOrchestrator &&
+      priorForOrchestrator.length < prevComplete.findings.length
+    ) {
+      console.warn(
+        '[fp-b] excluded %d disputed prior finding%s from the orchestrator input',
+        prevComplete.findings.length - priorForOrchestrator.length,
+        prevComplete.findings.length - priorForOrchestrator.length === 1 ? '' : 's',
+      );
+    }
+
     // Load repo conventions (AGENTS.md / CONVENTIONS.md or the `conventions:` path)
     const conventionsResult = await fetchConventions(octokit, owner, repo, headSha, runtimeConfig.conventions);
     if (conventionsResult) {
@@ -542,7 +561,7 @@ export async function handler(
       tone: runtimeConfig.ux.tone,
       customPricing: runtimeConfig.pricing,
       previousDiagram,
-      previousFindings: prevComplete?.findings,
+      previousFindings: priorForOrchestrator,
       disputedKeys,
       conventions: conventionsResult?.content,
       agentAuthored: event.source === 'agent',

--- a/packages/server/src/review-processor.test.ts
+++ b/packages/server/src/review-processor.test.ts
@@ -43,6 +43,10 @@ vi.mock('@mergewatch/core', async (importOriginal) => {
       outputTokens: 100,
       estimatedCostUsd: 0.002,
     }),
+    // Triage-mapping path (W3 / FP-B). Default to "no triage" so existing
+    // tests aren't affected; the FP-B test overrides these per-call.
+    fetchTriageComments: vi.fn().mockResolvedValue([]),
+    computeDisputedKeys: vi.fn().mockResolvedValue([]),
   };
 });
 
@@ -50,6 +54,7 @@ import {
   getPRContext, getPRDiff, createCheckRun, shouldSkipPR, shouldSkipByRules,
   runReviewPipeline, postReplyComment, fetchRepoConfig, handleInlineReply,
   addPRReaction, removePRReaction, submitPRReview, mergeScoreToReviewEvent,
+  fetchTriageComments, computeDisputedKeys,
 } from '@mergewatch/core';
 import { processReviewJob } from './review-processor.js';
 
@@ -728,5 +733,76 @@ describe('processReviewJob — agent-authored wiring', () => {
 
     const pipelineOptions = (runReviewPipeline as any).mock.calls[0][0];
     expect(pipelineOptions.agentAuthored).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FP-B — pre-filter previousFindings by disputedKeys
+// ---------------------------------------------------------------------------
+
+describe('processReviewJob — FP-B previousFindings pre-filter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getPRContext as any).mockResolvedValue(basePRContext);
+    (getPRDiff as any).mockResolvedValue('diff content');
+    (shouldSkipPR as any).mockReturnValue(null);
+    (shouldSkipByRules as any).mockReturnValue(null);
+    (runReviewPipeline as any).mockResolvedValue(basePipelineResult);
+    (fetchRepoConfig as any).mockResolvedValue(null);
+    (addPRReaction as any).mockResolvedValue(12345);
+    // Reset the triage mocks back to the "no-triage" defaults — `vi.clearAllMocks`
+    // resets call history but PRESERVES per-test `mockResolvedValue` overrides,
+    // so without these resets a non-empty disputedKeys set leaks into the next
+    // test.
+    (fetchTriageComments as any).mockResolvedValue([]);
+    (computeDisputedKeys as any).mockResolvedValue([]);
+  });
+
+  it('excludes disputed prior findings from the orchestrator input (no orchestrator re-emission of rebutted concerns)', async () => {
+    // Prior review had two findings. The author rebutted ONE via a triage
+    // comment; the W3 mapping resolved its stable key. FP-B should drop
+    // that finding from the `previousFindings` array passed to the pipeline.
+    const priorFindings = [
+      { file: 'a.ts', line: 10, severity: 'critical', category: 'security', title: 'Rebutted concern', description: '', suggestion: '' },
+      { file: 'b.ts', line: 20, severity: 'warning',  category: 'bug',      title: 'Still valid',      description: '', suggestion: '' },
+    ];
+    // The W3 stable key for the "no fingerprint" path is `file::T::title`
+    // (see `findingMatchKeys` in review-delta.ts).
+    const disputedKey = 'a.ts::T::Rebutted concern';
+
+    const deps = makeDeps();
+    (deps.reviewStore.queryByPR as any).mockResolvedValue([
+      { status: 'complete', prNumberCommitSha: '42#OLD_SHA', findings: priorFindings },
+    ]);
+    (fetchTriageComments as any).mockResolvedValue(['## mergewatch triage\n\nrebutting first finding...']);
+    (computeDisputedKeys as any).mockResolvedValue([disputedKey]);
+
+    await processReviewJob(makeJob({ headSha: 'NEW_SHA' }), deps);
+
+    const opts = (runReviewPipeline as any).mock.calls[0][0];
+    expect(opts.previousFindings).toEqual([
+      { file: 'b.ts', line: 20, severity: 'warning', category: 'bug', title: 'Still valid', description: '', suggestion: '' },
+    ]);
+    // disputedKeys is ALSO still passed through (W3 downstream suppression
+    // remains a defense-in-depth layer for current findings the orchestrator
+    // might still emit despite FP-B).
+    expect(opts.disputedKeys).toEqual([disputedKey]);
+  });
+
+  it('passes prior findings unchanged when there are no disputed keys (no triage on this PR)', async () => {
+    const priorFindings = [
+      { file: 'a.ts', line: 10, severity: 'critical', category: 'security', title: 'Real concern', description: '', suggestion: '' },
+    ];
+    const deps = makeDeps();
+    (deps.reviewStore.queryByPR as any).mockResolvedValue([
+      { status: 'complete', prNumberCommitSha: '42#OLD_SHA', findings: priorFindings },
+    ]);
+    // Default mocks above: fetchTriageComments → []; computeDisputedKeys → [].
+
+    await processReviewJob(makeJob({ headSha: 'NEW_SHA' }), deps);
+
+    const opts = (runReviewPipeline as any).mock.calls[0][0];
+    expect(opts.previousFindings).toEqual(priorFindings);
+    expect(opts.disputedKeys).toEqual([]);
   });
 });

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -11,7 +11,7 @@ import {
   buildWorkDoneSection, computeReviewDelta,
   RESPOND_PROMPT, postReplyComment,
   handleInlineReply,
-  fetchTriageComments, computeDisputedKeys,
+  fetchTriageComments, computeDisputedKeys, partitionDisputed,
 } from '@mergewatch/core';
 import type { WebhookDeps } from './webhook-handler.js';
 
@@ -391,6 +391,28 @@ export async function processReviewJob(
       }
     }
 
+    // FP-B — pre-filter `previousFindings` by `disputedKeys`. Without this,
+    // the orchestrator's prompt (which includes prior findings via
+    // `buildPreviousFindingsBlock` and tells the model to "carry forward if
+    // still present") gets handed findings the author already dispositioned
+    // — encouraging it to re-emit them in slightly-different framings that
+    // W3's stable-key match downstream can miss. Pre-filtering at the
+    // orchestrator's INPUT side closes the loop and saves prompt tokens.
+    const priorForOrchestrator = prevComplete?.findings && disputedKeys.length > 0
+      ? partitionDisputed(prevComplete.findings, disputedKeys).kept
+      : prevComplete?.findings;
+    if (
+      prevComplete?.findings &&
+      priorForOrchestrator &&
+      priorForOrchestrator.length < prevComplete.findings.length
+    ) {
+      console.warn(
+        '[fp-b] excluded %d disputed prior finding%s from the orchestrator input',
+        prevComplete.findings.length - priorForOrchestrator.length,
+        prevComplete.findings.length - priorForOrchestrator.length === 1 ? '' : 's',
+      );
+    }
+
     // Load repo conventions (AGENTS.md / CONVENTIONS.md or the `conventions:` path)
     const conventionsResult = await fetchConventions(octokit, owner, repo, ref, config.conventions);
     if (conventionsResult) {
@@ -422,7 +444,7 @@ export async function processReviewJob(
         tone: config.ux.tone,
         customPricing: config.pricing,
         previousDiagram,
-        previousFindings: prevComplete?.findings,
+        previousFindings: priorForOrchestrator,
         disputedKeys,
         conventions: conventionsResult?.content,
         agentAuthored: job.source === 'agent',


### PR DESCRIPTION
## Summary

Three deterministic, structural false-positive reductions at the orchestrator boundary — straight from the FP-reduction plan introduced in #158. Each closes a distinct gap that the existing W1–W11 workstreams cannot catch on their own.

## Changes

### FP-A — Hard confidence-floor filter
`packages/core/src/agents/reviewer.ts`

`ORCHESTRATOR_PROMPT` rule #5 says "Drop any finding with confidence below 75" but nothing enforced it. Now a deterministic post-orchestrator filter drops any finding whose `confidence < 75`.

- New `CONFIDENCE_FLOOR = 75` constant alongside the other pipeline constants.
- Findings with **no** `confidence` field default to `100` (kept) — no surprise suppression of legacy / pre-FP-A records or of agents that don't emit confidence.
- Telemetry: `[confidence-floor] dropped N finding(s)`.

### FP-B — Pre-filter `previousFindings` by `disputedKeys`
`packages/server/src/review-processor.ts`, `packages/lambda/src/handlers/review-agent.ts`

Both handlers used to pass `prevComplete?.findings` raw to `runReviewPipeline`. The orchestrator prompt then included those via `buildPreviousFindingsBlock` with "carry forward if still present" guidance — even findings the author had already dispositioned via `## mergewatch triage`. W3's suppression ran downstream, so the orchestrator was *encouraged* to re-emit them, occasionally in slightly-different framings that W3's stable-key match missed.

Now both handlers compute `disputedKeys` first and pass `partitionDisputed(prevComplete.findings, disputedKeys).kept` as `previousFindings`. This closes the W3 loop on the orchestrator's **input** side. Telemetry: `[fp-b] excluded N disputed prior finding(s)`. Also saves prompt tokens.

### FP-C — Pre-orchestrator cross-agent dedup
`packages/core/src/finding-clustering.ts` + `reviewer.ts` wiring

The orchestrator is the only cross-agent dedup point in the pipeline and it's an LLM — exact-`(file, line)` doubles from different agents rely on the model to merge them. W10's `clusterFindings` catches wider-region clusters **post**-orchestrator; FP-C handles the strict exact-line case **pre**-orchestrator.

- New `dedupeCrossAgentByLine` reuses W10's `extractSignificantTokens` for the title-overlap gate (≥1 shared significant token across title+description) so two genuinely-distinct concerns on the same line never merge.
- Merge: strongest severity wins, ties → earliest-encountered. Absorbed siblings listed in the description with their original category attribution (audit trail).
- Per-category bucket structure preserved so the orchestrator's prompt isn't reshuffled.
- Telemetry: `[fp-c] merged N cross-agent finding(s)`.

## Tests

- **+2 FP-A** in `reviewer.test.ts` — boundary at 75 (kept), 90 (kept), 50 (dropped); no-confidence defaults to 100 (kept).
- **+6 FP-C** in `finding-clustering.test.ts` — <2 findings no-op; same-line + shared token merges; same-line + no overlap doesn't merge; different-line never merges (strict FP-C vs broader W10); empty-categories preserved; 3-way merge picks strongest severity.
- **+2 FP-B** in `review-processor.test.ts` — disputed prior finding excluded; no-triage path is unchanged.

Local validation:
- `core typecheck` clean
- `core test` 471 + 8 new = **all green**
- `pnpm run build` 12/12
- `server`/`lambda` typecheck clean
- `pnpm run test:coverage` **20/20 tasks successful**

## E2E Regression

`e2e/RUNBOOK.md` — **E2E-30 / E2E-31 / E2E-32** flipped from `TARGET / Not yet implemented` (added in #158) to **✅ SHIPPED** regression guards, per [[e2e-regression-spec-per-pr]].

## Plan doc

`docs/false-positive-reduction-plan.md` — FP-A / FP-B / FP-C marked **✅ SHIPPED** in both the per-item sections and the priority summary table. FP-D / FP-E / FP-F / FP-G remain pending (tracked as separate tasks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)