### PR TITLE
docs: false-positive-feedback plan (FB-A..FB-L) + e2e TARGET cards

### DIFF
--- a/docs/false-positive-feedback-plan.md
+++ b/docs/false-positive-feedback-plan.md
@@ -184,7 +184,14 @@ The bot's inline-comment ID is already linked to a finding via `ReviewItem.findi
 /mergewatch reject style-disagreement we use snake_case for python here
 ```
 
-Categories: `already-handled`, `out-of-scope`, `wrong-target`, `style-disagreement`, `other`. Free-text after the category is optional and persisted as `text`. The bot posts a confirming reply (`Got it — recording as <category>. This pattern won't be re-raised on similar code unless conditions change.`) and increments `disputeCount` + appends to `rejectReasons[]`.
+**Design decisions (locked):**
+
+- **Prefix form:** exactly `/mergewatch reject <category> [text]`. Slash-prefixed for discoverability via autocomplete-aware GitHub clients; full `mergewatch` (not `/mw`) to avoid collisions with other CI bots that may install a `/mw` prefix.
+- **Auto-resolve behaviour:** rejection does **NOT** auto-resolve the GitHub thread. Rejection is a *signal*; closure is a *human decision*. Reviewers can still type `/resolve` separately if they want both. Keeps `/resolve` and `/reject` as orthogonal verbs.
+- **Categories:** closed set — `already-handled`, `out-of-scope`, `wrong-target`, `style-disagreement`, `other`. Free-text after the category is optional and persisted as `text`.
+- **Unrecognised category fallback:** silently coerce to `other`, with the original token preserved as the leading word of `text`. Example: `/mergewatch reject typo-cat foo` persists as `{ category: 'other', text: 'typo-cat foo' }`. Preserves the signal even when the reviewer types something unexpected; the dashboard surfaces these as `other`-category rejections for triage.
+
+The bot posts a confirming reply (`Got it — recording as <category>. This pattern won't be re-raised on similar code unless conditions change.`) and increments `disputeCount` + appends to `rejectReasons[]`.
 
 **Code targets:** `packages/core/src/agents/inline-reply.ts` (new parser + handler branch), `packages/core/src/agents/prompts.ts` (confirmation reply template), `packages/server/src/review-processor.ts` + `packages/lambda/src/handlers/review-agent.ts` (write through).
 **E2E target:** [E2E-40](./../e2e/RUNBOOK.md#e2e-40-fb-d--mergewatch-reject-slash-command-target).

--- a/docs/false-positive-feedback-plan.md
+++ b/docs/false-positive-feedback-plan.md
@@ -1,0 +1,349 @@
+# False-Positive Feedback Plan
+
+**Status:** Forward-looking. Sister to [`false-positive-reduction-plan.md`](./false-positive-reduction-plan.md).
+**Purpose:** Close the *feedback loop* on false positives. FP-A..FP-G reduced FPs structurally by closing gaps inside the pipeline — they were prophylactic, evidence-free. This plan does the opposite: capture explicit feedback from real reviewers, aggregate it per installation, surface recurring themes, and (optionally) feed the strongest signals back into the prompts.
+
+---
+
+## How this differs from `false-positive-reduction-plan.md`
+
+- The FP plan was **inside-out**: walk the code, find prompt-only rules with no enforcement, close gaps prophylactically. Workstreams FP-A..FP-G all ship without ever observing a specific bad review — they harden the pipeline against classes of failure the code paths admit.
+- This plan is **outside-in**: capture what real reviewers actually disagree with, persist the disagreement, surface it, and let the org act on it. Every workstream here begins as data collection; the prompt-level interventions (FB-L) are gated behind explicit configuration and remain advisory by default.
+- Workstreams here are numbered **FB-A through FB-L** to avoid collision with the W1–W12 (review-quality) and FP-A..FP-G (false-positive-reduction) namespaces.
+
+---
+
+## What we already have but aren't fully using
+
+Before adding new capture, take stock of the signal that's already in the system:
+
+| Signal | Where it lives today | What we do with it |
+|---|---|---|
+| W3 triage prose (`## mergewatch triage`) | computed live → `disputedKeys` | drives suppression, not analytics |
+| FP-F inline-resolve keys | persisted on `ReviewItem.inlineResolvedKeys` | drives suppression, not analytics |
+| W2 verification verdicts | `verification: 'verified' \| 'unverified'` per finding | input to W7 score clamp; not aggregated |
+| Top-comment reactions | `ReviewItem.reactions` | collected but largely unused — 👎 is FP-shaped |
+| Dashboard thumbs | `ReviewItem.feedback` ('up' \| 'down') | review-level only, not finding-level |
+| W9 fingerprints + match keys | `findingMatchKeys` (always emits a title key, plus a fingerprint key when available) | stable cross-PR identity for free |
+| W10 cluster siblings | `clusterFindings` + `extractSignificantTokens` | already groups related concerns; same machinery clusters disputes |
+
+**Take-away:** ~70% of the signal already exists. The gap is **persistence + aggregation + surface**.
+
+---
+
+## Direction (locked in)
+
+Three architectural choices shape the rest of the plan:
+
+1. **Capture is GitHub-native first.** Inline-comment reactions, `/mergewatch reject` slash command, W3 triage prose, FP-F inline-resolve. Dashboard thumbs are a bonus surface, not the primary signal source.
+2. **Storage is a dedicated table**, not denormalized onto `ReviewItem`. `mergewatch-finding-dispositions` (PK: `installationId`, SK: `<repoFullName>#<findingMatchKey>`) keeps `ReviewItem` lean and makes org-wide queries feasible without scans.
+3. **Active learning stays surface-only.** Charts, suggestions, opt-in prompt injection — no auto-suppression. Humans stay in the loop.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ Capture (GitHub-native)                                         │
+│  • Inline-comment 👎 / 🤔 reactions                              │
+│  • /mergewatch reject "<reason>" slash command                  │
+│  • W3 triage prose (already wired)                              │
+│  • FP-F inline-resolve (already wired)                          │
+└──────────────────┬──────────────────────────────────────────────┘
+                   ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ Persist (new table)                                             │
+│  mergewatch-finding-dispositions                                │
+│  PK: installationId   SK: <repoFullName>#<findingMatchKey>      │
+└──────────────────┬──────────────────────────────────────────────┘
+                   ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ Aggregate (nightly rollup)                                      │
+│  mergewatch-installation-fp-insights                            │
+└──────────────────┬──────────────────────────────────────────────┘
+                   ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ Surface (dashboard only — no auto-action)                       │
+│  • FP funnel chart                                              │
+│  • Dispute-rate-by-agent chart                                  │
+│  • Top recurring FP themes                                      │
+│  • "Suggest .mergewatch.yml rule" CTA                           │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Storage shapes
+
+### `mergewatch-finding-dispositions`
+
+Per-finding-identity record. Created on first surfacing; updated on every subsequent surfacing, dispute, and verification.
+
+```ts
+interface FindingDispositionRecord {
+  installationId: number;          // PK
+  repoFullName: string;            // SK prefix
+  findingMatchKey: string;         // SK suffix (file::T::title OR file::F::fingerprint)
+  firstSeen: string;               // ISO; set once
+  lastSeen: string;                // ISO; updated on each surfacing
+  surfaceCount: number;            // # of distinct reviews this match key appeared in
+  disputeCount: number;            // # of explicit disputes
+  verifiedCount: number;           // # of times W2 said valid:true
+  unverifiedCount: number;         // # of times W2 returned unverified
+  silentDropCount: number;         // FB-B — # of times surfaced previously but dropped without code change
+  agreementCount: number;          // 👍 / ❤️ / 🚀 reactions on the inline comment
+  category?: 'security' | 'bug' | 'style' | 'errorHandling' | 'testCoverage' | 'commentAccuracy' | 'custom';
+  topAgent?: string;
+  sigTokens?: string[];            // reused W10 token bag — drives cluster rollup
+  rejectReasons?: Array<{          // FB-D — categorical reasons from /mergewatch reject
+    category: 'already-handled' | 'out-of-scope' | 'wrong-target' | 'style-disagreement' | 'other';
+    text?: string;                 // optional free-text
+    at: string;                    // ISO
+  }>;
+}
+```
+
+### `mergewatch-installation-fp-insights`
+
+Periodic rollup; one row per installation per window (7d / 30d / 90d).
+
+```ts
+interface InstallationFPInsight {
+  installationId: number;           // PK
+  window: '7d' | '30d' | '90d';     // SK prefix
+  windowStart: string; windowEnd: string;
+  totalFindingsSurfaced: number;
+  disputeRate: number;              // disputeCount / surfaceCount
+  perCategory: Record<string, { surfaced: number; disputed: number; rate: number }>;
+  topClusters: Array<{
+    sigTokens: string[];
+    representativeTitle: string;
+    surfaceCount: number;
+    disputeCount: number;
+    rate: number;
+  }>;
+  perRepo: Record<string, { surfaced: number; disputed: number; rate: number }>;  // FB-J
+}
+```
+
+DynamoDB for SaaS, Postgres `jsonb` columns for self-hosted — same shape, two backends, written behind the existing `IReviewStore`-style interface.
+
+---
+
+## Opportunities
+
+Ranked by dependency order (foundation first → capture → aggregation → surface → active learning).
+
+### FB-A — `FindingDispositionRecord` storage + writers
+
+**Where the gap lives:** W3 disputed keys are computed live every review; FP-F inline-resolve keys are persisted on `ReviewItem` but only as a flat string array — no surfaceCount, no rate, no per-agent attribution. We have *no* cross-review per-finding identity table today.
+
+**The fix:**
+- New `mergewatch-finding-dispositions` table (DynamoDB SaaS / Postgres self-hosted). Schema as above.
+- New `IFindingDispositionStore` interface in `@mergewatch/core` with `upsert(rec)`, `incrementCounter(...)`, `getByInstallation(installationId, limit?)`.
+- Wire writers into the existing W3 path (when `computeDisputedKeys` produces a key, increment `disputeCount`) and FP-F path (when inline-resolve persists, ditto). One write per signal — keep it cheap.
+- Surfacing increment: when `runReviewPipeline` finalises a finding into the review, upsert the record's `surfaceCount`.
+
+**Code targets:** `packages/core/src/storage/types.ts` (new interface), `packages/core/src/types/db.ts` (`FindingDispositionRecord` type), `packages/storage-dynamo/src/finding-disposition-store.ts` (new), `packages/storage-postgres/src/finding-disposition-store.ts` + Drizzle migration (new), `packages/server/src/review-processor.ts` + `packages/lambda/src/handlers/review-agent.ts` (wire writes).
+**E2E target:** [E2E-37](./../e2e/RUNBOOK.md#e2e-37-fb-a--findingdispositionrecord-storage--writers-target).
+
+---
+
+### FB-B — Quiet-drop derived counter
+
+**Where the gap lives:** When a finding appeared in `previousFindings` AND the cited code's fingerprint didn't change AND it's NOT in the current review → the orchestrator silently dropped it. That's a *very strong* implicit FP signal we're throwing away today.
+
+**The fix:** `computeReviewDelta` already produces the resolved-list. Cross-reference with the changedLines set + fingerprint stability check. For each "resolved without code change" finding, increment `silentDropCount` on its `FindingDispositionRecord`. No new agent, no new API call — pure derived signal.
+
+**Code targets:** `packages/core/src/agents/reviewer.ts` (compute the quiet-drop set after the orchestrator), handlers (write through to the store).
+**E2E target:** [E2E-38](./../e2e/RUNBOOK.md#e2e-38-fb-b--quiet-drop-derived-counter-target).
+
+---
+
+### FB-C — Inline-comment 👎 reactions → disputes
+
+**Where the gap lives:** Top-comment reactions are already collected via `ReviewItem.reactions`. Inline-comment reactions are not. Yet reactions on an inline finding are arguably *more* signal-dense than top-level reactions — they're per-finding, attributed to the reviewer, and require zero typing.
+
+**The fix:** Two parts:
+1. **Webhook**: subscribe to `pull_request_review_comment.created` reaction events (or add a periodic reaction-poll path for installations that don't enable the granular hook).
+2. **Mapping**: 👎 / 🤔 increment `disputeCount`; 👍 / ❤️ / 🚀 increment `agreementCount`. Removing a reaction is a no-op (we don't decrement — partly to keep the signal monotonic, partly because we'd otherwise need an event-source-table to reconcile).
+
+The bot's inline-comment ID is already linked to a finding via `ReviewItem.findings[].inlineCommentId` (or recoverable from the comment body's `**🔴 <title>**` + path, same as FP-F).
+
+**Code targets:** `packages/lambda/src/handlers/webhook.ts` + `packages/server/src/webhook-handler.ts` (new event), `packages/core/src/github/client.ts` (reaction-mapping helper), handlers (write through).
+**E2E target:** [E2E-39](./../e2e/RUNBOOK.md#e2e-39-fb-c--inline-comment--reactions--disputes-target).
+
+---
+
+### FB-D — `/mergewatch reject "<reason>"` slash command
+
+**Where the gap lives:** W3 triage prose is the cleanest signal we have — author writes a sentence explaining why a finding is wrong — but it requires the author to write prose and lives only on top-level comments. Inline threads have only `/resolve` (which is success-shaped, not FP-shaped). There's no quick "this finding is wrong" channel from an inline thread.
+
+**The fix:** New intent parser alongside `detectResolveIntent`. Recognises:
+
+```
+/mergewatch reject already-handled
+/mergewatch reject out-of-scope This is in the integration suite, not unit tests.
+/mergewatch reject style-disagreement we use snake_case for python here
+```
+
+Categories: `already-handled`, `out-of-scope`, `wrong-target`, `style-disagreement`, `other`. Free-text after the category is optional and persisted as `text`. The bot posts a confirming reply (`Got it — recording as <category>. This pattern won't be re-raised on similar code unless conditions change.`) and increments `disputeCount` + appends to `rejectReasons[]`.
+
+**Code targets:** `packages/core/src/agents/inline-reply.ts` (new parser + handler branch), `packages/core/src/agents/prompts.ts` (confirmation reply template), `packages/server/src/review-processor.ts` + `packages/lambda/src/handlers/review-agent.ts` (write through).
+**E2E target:** [E2E-40](./../e2e/RUNBOOK.md#e2e-40-fb-d--mergewatch-reject-slash-command-target).
+
+---
+
+### FB-E — Nightly `InstallationFPInsight` rollup
+
+**Where the gap lives:** Reading per-finding records on every dashboard pageload is O(N) on installation size. We want the dashboard to be O(1).
+
+**The fix:** Scheduled task (EventBridge → Lambda for SaaS; node-cron job in the Express server for self-hosted) runs nightly per installation. Aggregates `FindingDispositionRecord` rows into `InstallationFPInsight` rows for the 7d / 30d / 90d windows. Cluster step reuses W10's `extractSignificantTokens` + a simple union-find on shared tokens; representative title = highest-surfaceCount member.
+
+Compute cost is bounded by the largest installation's record count; rollups stay small (~tens of KB per installation per window).
+
+**Code targets:** `packages/core/src/insights/rollup.ts` (new — algorithm), `packages/lambda/src/handlers/insights-rollup.ts` (new — scheduled handler), `packages/server/src/insights-cron.ts` (new — self-hosted), `infra/template.yaml` (EventBridge rule).
+**E2E target:** [E2E-41](./../e2e/RUNBOOK.md#e2e-41-fb-e--nightly-installationfpinsight-rollup-target).
+
+---
+
+### FB-F — Dashboard FP funnel chart
+
+**Where the gap lives:** The dashboard surfaces individual reviews but nothing about FP *health* of the org.
+
+**The fix:** Stacked bar (or Sankey) at the top of an org dashboard view: `surfaced → carried → resolved → disputed → silently-dropped`. Single chart that answers "is the review noise increasing or decreasing for us?" Reads exclusively from the FB-E rollup. Recharts component.
+
+**Code targets:** `packages/dashboard/components/charts/FPFunnel.tsx` (new), `packages/dashboard/app/[installation]/insights/page.tsx` (new route), `packages/dashboard/app/api/insights/route.ts` (new API).
+**E2E target:** [E2E-42](./../e2e/RUNBOOK.md#e2e-42-fb-f--dashboard-fp-funnel-chart-target).
+
+---
+
+### FB-G — Dispute-rate-by-agent line chart
+
+**Where the gap lives:** Per-agent FP rates differ wildly across orgs (a Python-heavy shop disputes most TS-style nits; a Rails shop disputes most type-assertion warnings). No way to see which agent is the noisiest for *this* org.
+
+**The fix:** Time-series line chart, one line per agent category (`security`, `bug`, `style`, `errorHandling`, `testCoverage`, `commentAccuracy`, `custom`). X-axis: day buckets over 30/90 days. Y-axis: disputeRate. Reads from `InstallationFPInsight.perCategory`.
+
+**Code targets:** `packages/dashboard/components/charts/DisputeByAgent.tsx` (new), same route as FB-F.
+**E2E target:** [E2E-43](./../e2e/RUNBOOK.md#e2e-43-fb-g--dispute-rate-by-agent-line-chart-target).
+
+---
+
+### FB-H — Top recurring FP themes table
+
+**Where the gap lives:** Aggregate metrics show *that* the org disputes findings; they don't show *what* the org disputes. Without that, no acting on the data.
+
+**The fix:** Sortable table on the same dashboard route: rank `InstallationFPInsight.topClusters` by `disputeRate × surfaceCount`. Columns: representative title, sigTokens (as chips), surfaceCount, disputeCount, rate, last-seen, "View findings" drill-through. This is the actionable surface — every other chart contextualises this one.
+
+**Code targets:** `packages/dashboard/components/charts/TopFPThemes.tsx` (new), drill-through to a filtered `/reviews?match-key=…` view.
+**E2E target:** [E2E-44](./../e2e/RUNBOOK.md#e2e-44-fb-h--top-recurring-fp-themes-table-target).
+
+---
+
+### FB-I — Severity-shopping detector chart
+
+**Where the gap lives:** FP-E extended verification to warnings to close the severity-shopping loophole — the orchestrator might still downgrade Critical → Warning to dodge attention. We need a way to see whether warnings dispute-rate stays disproportionately high relative to criticals over time.
+
+**The fix:** Overlay two lines (warnings dispute-rate vs criticals dispute-rate) on a single chart. Add an annotation when `warningsRate > criticalsRate * 1.5` over a ≥2-week window — surfaces a potential regression of the FP-E intent.
+
+**Code targets:** `packages/dashboard/components/charts/SeverityShoppingDetector.tsx` (new).
+**E2E target:** [E2E-45](./../e2e/RUNBOOK.md#e2e-45-fb-i--severity-shopping-detector-chart-target).
+
+---
+
+### FB-J — Per-repo FP heatmap (org-wide)
+
+**Where the gap lives:** Organisations with dozens of repos need to know *which* repos are noisy. A single aggregate disputeRate hides this.
+
+**The fix:** Grid heatmap, rows = repos, cols = day/week buckets, cell colour = disputeRate. Reads `InstallationFPInsight.perRepo`. Sorted by total disputes desc; collapsed beyond row 20 with a "show all" link.
+
+**Code targets:** `packages/dashboard/components/charts/RepoFPHeatmap.tsx` (new).
+**E2E target:** [E2E-46](./../e2e/RUNBOOK.md#e2e-46-fb-j--per-repo-fp-heatmap-target).
+
+---
+
+### FB-K — Suggest `.mergewatch.yml` rule CTA
+
+**Where the gap lives:** Even with the themes table (FB-H), translating "we keep disputing X" into a working `.mergewatch.yml` rule still requires manual YAML drafting.
+
+**The fix:** On any cluster row with `disputeRate > 80%` AND `surfaceCount ≥ 5`, show a "Suggest ignore rule" CTA. Pre-generates a YAML snippet using the cluster's sigTokens as title-pattern keywords + the per-finding categories. One-click copy. The user pastes into their `.mergewatch.yml`; no auto-write to the repo (preserves human control).
+
+**Code targets:** `packages/dashboard/components/IgnoreRuleSuggestion.tsx` (new), `packages/core/src/insights/suggest-ignore.ts` (new — YAML synthesis helper, also exported for the MCP path).
+**E2E target:** [E2E-47](./../e2e/RUNBOOK.md#e2e-47-fb-k--suggest-mergewatchyml-rule-cta-target).
+
+---
+
+### FB-L — `{{KNOWN_FP_PATTERNS}}` prompt injection (opt-in)
+
+**Where the gap lives:** The strongest closed-loop signal — top disputed clusters — never makes it back into the review pipeline. Every review starts fresh.
+
+**The fix:** New placeholder `{{KNOWN_FP_PATTERNS}}` on every finding-producing agent prompt. At review time, fetch the org's top-K (default 5) disputed clusters from the latest `InstallationFPInsight` rollup and render:
+
+> *"In this organization the following finding patterns have been explicitly disputed by reviewers multiple times: [list with representative titles and sigTokens]. Report findings matching these patterns only if you have **strong** evidence — describe the evidence explicitly in the description."*
+
+**Critical guardrails**:
+- **Off by default.** Per-org config flag in `.mergewatch.yml`: `feedback: { learnFromDisputes: true }`. Opt-in.
+- **Soft guidance, not suppression.** The model is asked for stronger evidence, not silenced. A real defect that matches the pattern should still surface (with explicit reasoning).
+- **Rate-limited.** Only patterns with `surfaceCount ≥ 5` and `disputeRate ≥ 75%` qualify. Sub-threshold clusters don't leak into prompts.
+- **Logged.** Every review using the directive logs `[fb-l] injected N known-FP patterns` so the effect is auditable.
+
+**Code targets:** `packages/core/src/agents/prompts.ts` (new placeholder + `buildKnownFPPatternsDirective` builder), `packages/core/src/agents/reviewer.ts` (substitute on every finding agent), handlers (fetch + inject the latest insight), `packages/core/src/config/defaults.ts` (new feature flag).
+**E2E target:** [E2E-48](./../e2e/RUNBOOK.md#e2e-48-fb-l--known_fp_patterns-prompt-injection-target).
+
+---
+
+## Priority order
+
+| ID | Workstream | Bucket | Effort | Depends on | ROI |
+|---|---|---|---|---|---|
+| **FB-A** | FindingDispositionRecord storage + writers | Persist | S | — | ★★★ foundation |
+| **FB-B** | Quiet-drop derived counter | Persist | S | FB-A | ★★ free signal |
+| **FB-C** | Inline-comment 👎 → disputes | Capture | M | FB-A | ★★★ |
+| **FB-D** | `/mergewatch reject` slash command | Capture | M | FB-A | ★★ |
+| **FB-E** | Nightly InstallationFPInsight rollup | Aggregate | M | FB-A, FB-B | ★★★ |
+| **FB-F** | FP funnel chart | Surface | M | FB-E | ★★ |
+| **FB-G** | Dispute-rate-by-agent chart | Surface | M | FB-E | ★★ |
+| **FB-H** | Top recurring themes table | Surface | M | FB-E | ★★★ |
+| **FB-I** | Severity-shopping detector | Surface | S | FB-G | ★ |
+| **FB-J** | Per-repo FP heatmap | Surface | M | FB-E | ★★ |
+| **FB-K** | Suggest `.mergewatch.yml` rule CTA | Surface | M | FB-H | ★★ |
+| **FB-L** | `{{KNOWN_FP_PATTERNS}}` prompt injection | Learn | L | FB-E, FB-H | ★★★ (opt-in) |
+
+**Recommended bundling:**
+
+- **PR 1 — Foundation** — FB-A + FB-B. Tiny, deterministic, no UX surface yet. Same shape as the FP-A+B+C bundle.
+- **PR 2 — Capture** — FB-C + FB-D. Both are webhook-driven and share parsing helpers.
+- **PR 3 — Aggregation** — FB-E. Standalone scheduled job.
+- **PR 4 — Charts** — FB-F + FB-G + FB-I (the three line/bar charts on the same dashboard route). Pull `recharts` as a dep.
+- **PR 5 — Themes + heatmap** — FB-H + FB-J + FB-K (the actionable surface). All read the same rollup.
+- **PR 6 — Active learning** — FB-L (opt-in prompt injection). Heaviest lift, biggest risk surface, last.
+
+---
+
+## Privacy & cost notes
+
+- **Per-installation scoping is non-negotiable.** Disposition records carry `installationId` as the PK; no query path crosses installations.
+- **Anonymized cross-org insights** (a hypothetical "across MergeWatch users, these are the most-disputed patterns globally") are deliberately **out of scope** here. They'd require opt-in + privacy review + a separate aggregation pipeline. Worth revisiting later if the per-org signal proves useful.
+- **DynamoDB cost** is bounded: one record per distinct `findingMatchKey` per repo; even noisy installations land in the low-thousands range. TTL is **not** applied — recurring-FP signal is most valuable over long windows.
+- **Postgres cost** equivalent: the same table with a `(installation_id, repo_full_name, finding_match_key)` composite PK.
+
+---
+
+## Cross-references
+
+- [`docs/review-quality-plan.md`](./review-quality-plan.md) — original evidence-derived plan (W1–W12, P1–P13).
+- [`docs/false-positive-reduction-plan.md`](./false-positive-reduction-plan.md) — gap-driven prophylactic plan (FP-A..FP-G). All shipped.
+- [`e2e/RUNBOOK.md`](./../e2e/RUNBOOK.md) — fixture cards. Each FB-X opportunity has a corresponding **TARGET** card (E2E-37..E2E-48) added with this doc and inverted to a passing regression guard once the work lands.
+
+---
+
+## Update protocol
+
+When a new feedback channel or surface is identified:
+
+1. Add it as **FB-M** (next letter) to the Opportunities section.
+2. Add a matching **TARGET** card to `e2e/RUNBOOK.md` (next E2E-NN).
+3. Re-rank Priority order.
+
+When an opportunity is implemented:
+
+1. Update the opportunity's heading to **✅ SHIPPED (PR #NN)**.
+2. Flip the E2E card from TARGET to a passing fixture (or add the regression-check step).
+3. If the data the new surface exposes reveals a fresh structural FP class, log it as a new workstream in `false-positive-reduction-plan.md` and cross-reference back here.

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -163,6 +163,18 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-34](#e2e-34-fp-e--w2-verification-extended-to-warnings) | Warning-severity findings go through the W2 verification pass and get a `verification` tag (FP-E) | 2m | 60s | FP-E |
 | [E2E-35](#e2e-35-fp-f--inline-reply-resolve-memory) | An inline `/resolve` reply persists the finding's key so the next review doesn't re-emit it (FP-F) | 3m | 90s | FP-F |
 | [E2E-36](#e2e-36-fp-g--linter-aware-style-agent) | Repos with detected linters (eslint / ruff / clippy / biome) get a stricter STYLE_REVIEWER_PROMPT that defers lint-equivalent findings (FP-G) | 2m | 60s | FP-G |
+| [E2E-37](#e2e-37-fb-a--findingdispositionrecord-storage--writers-target) | FindingDispositionRecord rows are written on every surfacing, W3 dispute, FP-F inline-resolve (FB-A) — **TARGET** | 2m | 60s | FB-A |
+| [E2E-38](#e2e-38-fb-b--quiet-drop-derived-counter-target) | Quiet-drop (finding gone without code change) increments `silentDropCount` on the matching record (FB-B) — **TARGET** | 2m | 60s | FB-B |
+| [E2E-39](#e2e-39-fb-c--inline-comment--reactions--disputes-target) | 👎 / 🤔 on a bot inline comment increments `disputeCount`; 👍 / ❤️ / 🚀 increments `agreementCount` (FB-C) — **TARGET** | 2m | 60s | FB-C |
+| [E2E-40](#e2e-40-fb-d--mergewatch-reject-slash-command-target) | `/mergewatch reject <category> [reason]` on an inline thread persists a categorised rejection + posts a confirming bot reply (FB-D) — **TARGET** | 3m | 90s | FB-D |
+| [E2E-41](#e2e-41-fb-e--nightly-installationfpinsight-rollup-target) | Nightly scheduled job produces InstallationFPInsight rollups for 7d / 30d / 90d windows per installation (FB-E) — **TARGET** | 3m | 90s | FB-E |
+| [E2E-42](#e2e-42-fb-f--dashboard-fp-funnel-chart-target) | Org dashboard renders the FP funnel: surfaced → carried → resolved → disputed → silently-dropped (FB-F) — **TARGET** | 2m | 60s | FB-F |
+| [E2E-43](#e2e-43-fb-g--dispute-rate-by-agent-line-chart-target) | Org dashboard renders dispute-rate over time with one line per agent category (FB-G) — **TARGET** | 2m | 60s | FB-G |
+| [E2E-44](#e2e-44-fb-h--top-recurring-fp-themes-table-target) | Org dashboard renders a sortable table of the top-10 disputed clusters with drill-through (FB-H) — **TARGET** | 2m | 60s | FB-H |
+| [E2E-45](#e2e-45-fb-i--severity-shopping-detector-chart-target) | Warnings dispute-rate vs criticals dispute-rate over time, with annotation when warnings exceed criticals × 1.5 for ≥ 2 weeks (FB-I) — **TARGET** | 2m | 60s | FB-I |
+| [E2E-46](#e2e-46-fb-j--per-repo-fp-heatmap-target) | Org dashboard renders a per-repo × time heatmap of dispute rate (FB-J) — **TARGET** | 2m | 60s | FB-J |
+| [E2E-47](#e2e-47-fb-k--suggest-mergewatchyml-rule-cta-target) | Cluster with `disputeRate > 80%` & `surfaceCount ≥ 5` gets a one-click `.mergewatch.yml` snippet suggestion (FB-K) — **TARGET** | 2m | 60s | FB-K |
+| [E2E-48](#e2e-48-fb-l--known_fp_patterns-prompt-injection-target) | Opt-in `feedback.learnFromDisputes` injects top-K disputed clusters as soft guidance into every finding agent's prompt (FB-L) — **TARGET** | 3m | 90s | FB-L |
 
 ---
 
@@ -1475,6 +1487,323 @@ Branch: `fixture/36-linter-aware`. Two micro-fixtures, one per "linter present /
 - ❌ Code-smell findings (god functions, nesting) are also suppressed (over-defer — only lint-equivalent should defer)
 - ❌ Detection false-positive: a `.eslintrc.json` in a `node_modules/` subdirectory triggers the directive (the scan must be repo-root only — confirmed by reading `path: ''` from the root only, not recursive)
 - ❌ A `pyproject.toml` without `[tool.ruff]` triggers `ruff` (regex must require the explicit table header)
+
+---
+
+### E2E-37: FB-A — FindingDispositionRecord storage + writers — TARGET
+
+**Status:** **Not yet implemented.** See [`docs/false-positive-feedback-plan.md` → FB-A](./../docs/false-positive-feedback-plan.md#fb-a--findingdispositionrecord-storage--writers).
+
+**Behavior (intended, once FB-A ships):** every surfacing of a finding upserts a `FindingDispositionRecord` keyed by `(installationId, repoFullName, findingMatchKey)` — incrementing `surfaceCount`, refreshing `lastSeen`, capturing category + topAgent + sigTokens. The existing W3 path increments `disputeCount`; FP-F inline-resolve increments `disputeCount` AND continues to populate `inlineResolvedKeys` on `ReviewItem` (back-compat). W2 verdicts increment `verifiedCount` / `unverifiedCount`. Records are read by FB-E's nightly rollup only — no per-review read on the dashboard path.
+
+**Setup**
+
+Branch: `fixture/37-fp-record-storage`. A PR that triggers ≥ 2 findings on changed code, then a follow-up commit with no code changes:
+1. Submit PR → confirm two `FindingDispositionRecord` rows exist, each with `surfaceCount = 1`, no disputes.
+2. Author posts a `## mergewatch triage` reply rebutting one finding → re-review → confirm the rebutted row's `disputeCount = 1`.
+3. Push a no-op commit → re-review → confirm both rows now have `surfaceCount = 2` (the rebutted one was suppressed pre-orchestrator via FP-B but its surfacing on review #1 still counts).
+
+**Expected outcomes**
+
+- [ ] One row per distinct `findingMatchKey` per repo, never duplicates across reviews
+- [ ] `firstSeen` set once on creation; `lastSeen` refreshed on every surfacing
+- [ ] `disputeCount` increments on every W3 dispute AND every FP-F inline-resolve hitting that key
+- [ ] `verifiedCount` / `unverifiedCount` increment on every W2 pass that produces the corresponding verdict for that key
+- [ ] **Regression check**: `ReviewItem.inlineResolvedKeys` continues to work exactly as before — FB-A is additive
+
+**Failure modes**
+- ❌ Two records get created for the same finding because `findingMatchKey` was computed inconsistently across writers
+- ❌ A failed write blocks the review pipeline (writes must be best-effort / async)
+
+---
+
+### E2E-38: FB-B — quiet-drop derived counter — TARGET
+
+**Status:** **Not yet implemented.** See [`docs/false-positive-feedback-plan.md` → FB-B](./../docs/false-positive-feedback-plan.md#fb-b--quiet-drop-derived-counter).
+
+**Behavior (intended, once FB-B ships):** when a finding from the previous review (a) was present in `previousFindings`, (b) is NOT in the current review's output, AND (c) the cited code's fingerprint did NOT change between the two commits → the orchestrator silently dropped it. Each such drop increments `silentDropCount` on the corresponding `FindingDispositionRecord`. This is a strong *implicit* FP signal — the model dropped a finding it had previously emitted on the same code.
+
+**Setup**
+
+Branch: `fixture/38-quiet-drop`. A PR with a finding that the orchestrator's confidence wavers on:
+1. Review #1 surfaces finding X. Confirm `silentDropCount = 0`.
+2. Push a small change to an unrelated file (no change to the cited code). Re-review.
+3. If review #2 omits X → confirm `silentDropCount = 1` on X's record. If review #2 keeps X → no-op (regression check).
+
+**Expected outcomes**
+
+- [ ] `silentDropCount` only increments when the cited code's fingerprint is byte-identical across commits
+- [ ] An edit to the cited code that legitimately resolves the finding does NOT increment `silentDropCount`
+- [ ] Quiet drops feed into the FB-E rollup's "carried → resolved" arc, not the "disputed" arc — separately countable
+
+**Failure modes**
+- ❌ A finding resurfaces under a slightly different title and the prior version gets counted as "silently dropped" (W9 fingerprint must drive the match, not the title alone)
+- ❌ A finding the author actively addressed via code (legitimate resolve) increments `silentDropCount` (the code-change check is missing or wrong)
+
+---
+
+### E2E-39: FB-C — inline-comment 👎 reactions → disputes — TARGET
+
+**Status:** **Not yet implemented.** See [`docs/false-positive-feedback-plan.md` → FB-C](./../docs/false-positive-feedback-plan.md#fb-c--inline-comment--reactions--disputes).
+
+**Behavior (intended, once FB-C ships):** reactions on the bot's inline finding comments are collected and mapped:
+
+| Reaction | Counter |
+|---|---|
+| 👎 (`-1`) | `disputeCount` |
+| 🤔 (`confused`) | `disputeCount` |
+| 👍 (`+1`) | `agreementCount` |
+| ❤️ (`heart`) | `agreementCount` |
+| 🚀 (`rocket`) | `agreementCount` |
+
+Reaction *removal* is a no-op (signal stays monotonic). Anonymous: we count, we don't store reactor identity.
+
+**Setup**
+
+Branch: `fixture/39-inline-reactions`. A PR with at least one inline-comment-eligible finding:
+1. Confirm `FindingDispositionRecord` row exists post-review with `disputeCount = 0`, `agreementCount = 0`.
+2. Add 👎 to the inline bot comment → confirm `disputeCount = 1`.
+3. Add 🚀 → confirm `agreementCount = 1`.
+4. Remove the 👎 → confirm `disputeCount` stays at 1 (monotonic).
+
+**Expected outcomes**
+
+- [ ] 👎 / 🤔 ↔ `disputeCount` mapping fires per-reaction
+- [ ] 👍 / ❤️ / 🚀 ↔ `agreementCount` mapping fires per-reaction
+- [ ] Reactions on the TOP-level bot comment continue to populate `ReviewItem.reactions` separately (back-compat)
+- [ ] Reactions added by `mergewatch[bot]` itself are ignored (no self-counting)
+
+**Failure modes**
+- ❌ Reaction removal decrements the counter (must be monotonic)
+- ❌ Reactions on a CopilotAI / dependabot inline comment get attributed to a MergeWatch finding (must filter by `INLINE_BOT_COMMENT_MARKER`)
+- ❌ Bot's own reactions count (loop)
+
+---
+
+### E2E-40: FB-D — `/mergewatch reject` slash command — TARGET
+
+**Status:** **Not yet implemented.** See [`docs/false-positive-feedback-plan.md` → FB-D](./../docs/false-positive-feedback-plan.md#fb-d--mergewatch-reject-slash-command).
+
+**Behavior (intended, once FB-D ships):** new inline-thread intent parser alongside `detectResolveIntent`. Recognises `/mergewatch reject <category> [optional reason]` where category is one of: `already-handled`, `out-of-scope`, `wrong-target`, `style-disagreement`, `other`. Increments `disputeCount` AND appends `{ category, text?, at }` to `rejectReasons[]` on the `FindingDispositionRecord`. Bot posts a confirming reply (`Got it — recording as <category>. This pattern won't be re-raised on similar code unless conditions change.`). Thread is NOT auto-resolved (different from `/resolve` — rejection is for *finding-level FP signal*, resolution is for *thread-level closure*).
+
+**Setup**
+
+Branch: `fixture/40-mergewatch-reject`. PR with an inline finding:
+1. Reply `/mergewatch reject style-disagreement we use snake_case for python here` on the thread.
+2. Confirm the `FindingDispositionRecord` has `disputeCount = 1` and `rejectReasons[0] = { category: 'style-disagreement', text: 'we use snake_case for python here', at: <iso> }`.
+3. Confirm the bot posts a structured confirmation reply.
+4. Confirm the thread is NOT auto-resolved on GitHub.
+
+**Expected outcomes**
+
+- [ ] Recognised categories: `already-handled`, `out-of-scope`, `wrong-target`, `style-disagreement`, `other`
+- [ ] Unrecognised category (`/mergewatch reject typo-here`) → bot reply asks for a valid category, no record write
+- [ ] Multiple `/mergewatch reject` replies on the same thread append to `rejectReasons[]` (don't overwrite)
+- [ ] Top-level `## mergewatch triage` continues to function (FB-D is an inline-thread addition, not a replacement)
+
+**Failure modes**
+- ❌ `/mergewatch reject` is matched in prose ("here's how I'd reject this differently") — pattern must be standalone-line or slash-command form
+- ❌ The thread is auto-resolved (signal collected; closure is human-driven)
+
+---
+
+### E2E-41: FB-E — Nightly InstallationFPInsight rollup — TARGET
+
+**Status:** **Not yet implemented.** See [`docs/false-positive-feedback-plan.md` → FB-E](./../docs/false-positive-feedback-plan.md#fb-e--nightly-installationfpinsight-rollup).
+
+**Behavior (intended, once FB-E ships):** scheduled task (EventBridge → Lambda for SaaS; node-cron for self-hosted) runs nightly per installation. For each window (7d / 30d / 90d), aggregates `FindingDispositionRecord` rows into a single `InstallationFPInsight` row carrying: `totalFindingsSurfaced`, `disputeRate`, `perCategory`, `topClusters[]` (via W10 token clustering), `perRepo`. Stored in a new `mergewatch-installation-fp-insights` table. All dashboard charts read exclusively from these rollups.
+
+**Setup**
+
+Branch: `fixture/41-nightly-rollup`. Pre-seed an installation with ~20 `FindingDispositionRecord` rows spanning 3 repos, 2 categories, ~30% dispute rate. Trigger the rollup manually:
+1. SaaS: `aws lambda invoke --function-name mergewatch-insights-rollup-prod`.
+2. Self-hosted: `POST /api/insights/rollup` (admin endpoint).
+
+**Expected outcomes**
+
+- [ ] Three rollup rows per installation per night (`7d`, `30d`, `90d` windows)
+- [ ] `topClusters[]` is populated via `extractSignificantTokens` + union-find on shared tokens, sorted by `surfaceCount × disputeRate`
+- [ ] `perRepo[repoFullName]` populated for every repo with ≥ 1 surfacing in the window
+- [ ] Job is idempotent — re-running the same night doesn't double-count
+- [ ] Job completes within 60s for the largest expected installation
+
+**Failure modes**
+- ❌ Rollup reads or writes the wrong installation's records (cross-install contamination)
+- ❌ A repo deleted mid-window crashes the rollup
+- ❌ Cluster sigToken extraction differs from W10's — analytics should reuse the same helper, not a parallel one
+
+---
+
+### E2E-42: FB-F — Dashboard FP funnel chart — TARGET
+
+**Status:** **Not yet implemented.** See [`docs/false-positive-feedback-plan.md` → FB-F](./../docs/false-positive-feedback-plan.md#fb-f--dashboard-fp-funnel-chart).
+
+**Behavior (intended, once FB-F ships):** new `/dashboard/[installation]/insights` route. The funnel is the page's hero chart: stacked bar (or Sankey) showing `surfaced → carried → resolved → disputed → silently-dropped`. Window selector (7d / 30d / 90d). Reads exclusively from `InstallationFPInsight`; no per-finding queries on the page-load path.
+
+**Setup**
+
+Branch: `fixture/42-funnel-chart`. Seed an installation with the same data as E2E-41. Navigate to `/dashboard/<installation>/insights`:
+1. Confirm the funnel renders with the right counts at each stage.
+2. Switch window selector → numbers update.
+3. Page lighthouse score ≥ 90 (no per-finding scan on read).
+
+**Expected outcomes**
+
+- [ ] Each bar segment shows count + percentage on hover
+- [ ] Disputed segment is visually distinct (warm color)
+- [ ] Silently-dropped segment uses a neutral / muted color (signal, not failure)
+- [ ] Page reads only the rollup row, not per-finding records
+
+**Failure modes**
+- ❌ Page does an O(N) scan of `FindingDispositionRecord` on every render
+- ❌ Funnel widths visually misrepresent the proportions (chart misconfigured)
+
+---
+
+### E2E-43: FB-G — Dispute-rate-by-agent line chart — TARGET
+
+**Status:** **Not yet implemented.** See [`docs/false-positive-feedback-plan.md` → FB-G](./../docs/false-positive-feedback-plan.md#fb-g--dispute-rate-by-agent-line-chart).
+
+**Behavior (intended, once FB-G ships):** time-series line chart on the same `/insights` route, one line per agent category (`security`, `bug`, `style`, `errorHandling`, `testCoverage`, `commentAccuracy`, `custom`). X-axis: day buckets over 30d / 90d. Y-axis: disputeRate. Hover shows per-day surfacings + disputes.
+
+**Setup**
+
+Branch: `fixture/43-dispute-by-agent`. Pre-seeded data with a mix of disputed categories across 30 days. Render the chart.
+
+**Expected outcomes**
+
+- [ ] One line per active agent category — categories with zero surfacings are omitted (not zero-rendered)
+- [ ] Legend is interactive (click to toggle)
+- [ ] Date range follows the window selector (shared with FB-F)
+- [ ] When `disputeRate` is undefined for a bucket (no surfacings), the line shows a gap, not a fake zero
+
+**Failure modes**
+- ❌ A line drops to zero on a "no data" day, suggesting an improvement that didn't actually happen
+- ❌ Agent categories the org has disabled still render as zero-lines (UX clutter)
+
+---
+
+### E2E-44: FB-H — Top recurring FP themes table — TARGET
+
+**Status:** **Not yet implemented.** See [`docs/false-positive-feedback-plan.md` → FB-H](./../docs/false-positive-feedback-plan.md#fb-h--top-recurring-fp-themes-table).
+
+**Behavior (intended, once FB-H ships):** sortable table on the `/insights` route. Reads `InstallationFPInsight.topClusters` (top 10 by default). Columns: representative title, sigTokens (as chips), surfaceCount, disputeCount, disputeRate, lastSeen, "View findings" drill-through (links to `/reviews?match-key=<sample>`). This is the actionable surface — everything else contextualises this view.
+
+**Setup**
+
+Branch: `fixture/44-themes-table`. Pre-seed with three recognisable clusters (e.g. ~10 "missing await on async X" findings, ~7 "type assertion without runtime validation", ~5 "consider memoization"). Render the table.
+
+**Expected outcomes**
+
+- [ ] Three distinct cluster rows (no over-merging, no under-merging)
+- [ ] sigTokens chips include the cluster's distinguishing tokens (e.g. `await`, `async` for the missing-await cluster)
+- [ ] Sort by every column works; default sort is `disputeRate × surfaceCount` desc
+- [ ] Drill-through opens a filtered reviews view with the matching findings
+
+**Failure modes**
+- ❌ Clusters merge across categories ("missing await" and "missing semicolon" both have generic stop-tokens that overlap)
+- ❌ A cluster's representative title is the longest member rather than the highest-surfacing one
+- ❌ Drill-through 404s because the filtered reviews query isn't wired
+
+---
+
+### E2E-45: FB-I — Severity-shopping detector chart — TARGET
+
+**Status:** **Not yet implemented.** See [`docs/false-positive-feedback-plan.md` → FB-I](./../docs/false-positive-feedback-plan.md#fb-i--severity-shopping-detector-chart).
+
+**Behavior (intended, once FB-I ships):** dual-line chart overlaying warnings dispute-rate and criticals dispute-rate over time. When `warningsRate > criticalsRate × 1.5` over a ≥ 2-week window, an annotation surfaces ("Warnings disputed disproportionately — possible severity-shopping regression"). FP-E ships verification on both severities; this chart confirms whether that intervention sticks long-term.
+
+**Setup**
+
+Branch: `fixture/45-severity-shopping`. Pre-seed with a 4-week pattern where warnings dispute-rate is 2× the criticals rate for the last 2 weeks. Render.
+
+**Expected outcomes**
+
+- [ ] Two distinct lines (warnings & criticals)
+- [ ] Annotation appears for the ≥ 2-week period meeting the threshold
+- [ ] Annotation does NOT appear for short / noisy spikes
+
+**Failure modes**
+- ❌ Annotation triggers on a single-day spike (smoothing window must be ≥ 2 weeks)
+- ❌ The detector reports severity-shopping when there are very few criticals — small-N criticalsRate is noisy; require a minimum criticals surfacings count before evaluating
+
+---
+
+### E2E-46: FB-J — Per-repo FP heatmap — TARGET
+
+**Status:** **Not yet implemented.** See [`docs/false-positive-feedback-plan.md` → FB-J](./../docs/false-positive-feedback-plan.md#fb-j--per-repo-fp-heatmap-org-wide).
+
+**Behavior (intended, once FB-J ships):** grid heatmap on the `/insights` route. Rows = repos (top 20 by surfacings, expandable). Columns = day or week buckets. Cell colour = disputeRate (cool → warm). Reads `InstallationFPInsight.perRepo` cross-rollup-window.
+
+**Setup**
+
+Branch: `fixture/46-repo-heatmap`. Pre-seed 5 repos with distinct dispute patterns (one consistently noisy, one consistently clean, three mixed).
+
+**Expected outcomes**
+
+- [ ] Noisy repo's row is visually distinct (warm cells across many days)
+- [ ] Empty cells (no surfacings that bucket) are rendered as neutral, not warm
+- [ ] Sort by total disputes desc by default
+- [ ] Repo names link through to the per-repo reviews view
+
+**Failure modes**
+- ❌ A repo with very few surfacings looks "noisy" because the single dispute hits 100% disputeRate (require minimum surfacings before colour-coding, fall back to neutral)
+- ❌ A repo deleted from the org keeps showing up (clean stale repos out of the rollup)
+
+---
+
+### E2E-47: FB-K — Suggest `.mergewatch.yml` rule CTA — TARGET
+
+**Status:** **Not yet implemented.** See [`docs/false-positive-feedback-plan.md` → FB-K](./../docs/false-positive-feedback-plan.md#fb-k--suggest-mergewatchyml-rule-cta).
+
+**Behavior (intended, once FB-K ships):** on any row in the FB-H themes table with `disputeRate > 80%` AND `surfaceCount ≥ 5`, a "Suggest ignore rule" CTA appears. Clicking expands an inline pane showing a pre-generated `.mergewatch.yml` snippet built from the cluster's sigTokens + categories. One-click copy. No auto-write to the repo — user pastes manually.
+
+**Setup**
+
+Branch: `fixture/47-suggest-rule`. Pre-seed a high-dispute-rate cluster (90% disputeRate, 10 surfacings). Render the themes table.
+
+**Expected outcomes**
+
+- [ ] CTA appears only when both thresholds are met
+- [ ] Snippet uses the cluster's sigTokens as title-pattern keywords
+- [ ] Snippet is valid `.mergewatch.yml` (parses; doesn't break loading)
+- [ ] One-click copy to clipboard
+- [ ] No request to write to the repo is initiated
+
+**Failure modes**
+- ❌ Snippet escapes special characters incorrectly and the YAML doesn't parse
+- ❌ Threshold check uses surfaceCount alone (single highly-disputed finding gets a suggestion — too aggressive)
+- ❌ CTA auto-writes to the repo without user confirmation
+
+---
+
+### E2E-48: FB-L — `{{KNOWN_FP_PATTERNS}}` prompt injection — TARGET
+
+**Status:** **Not yet implemented.** See [`docs/false-positive-feedback-plan.md` → FB-L](./../docs/false-positive-feedback-plan.md#fb-l--known_fp_patterns-prompt-injection-opt-in).
+
+**Behavior (intended, once FB-L ships):** new placeholder `{{KNOWN_FP_PATTERNS}}` on every finding-producing agent prompt. **Off by default.** When the org has `feedback: { learnFromDisputes: true }` in `.mergewatch.yml`, the handler fetches the latest `InstallationFPInsight`, picks top-K clusters with `surfaceCount ≥ 5` AND `disputeRate ≥ 75%`, and renders them into a directive:
+
+> *"In this organization the following finding patterns have been explicitly disputed by reviewers multiple times: [list with representative titles + sigTokens]. Report findings matching these patterns only if you have **strong** evidence — describe the evidence explicitly in the description."*
+
+Soft guidance, not suppression. Log: `[fb-l] injected N known-FP patterns`.
+
+**Setup**
+
+Branch: `fixture/48-known-fp-injection`. Set `feedback: { learnFromDisputes: true }` in the repo's `.mergewatch.yml`. Pre-seed one cluster meeting the threshold. Open a PR that has a finding matching that cluster's sigTokens. Re-review.
+
+**Expected outcomes**
+
+- [ ] Agent log shows `[fb-l] injected 1 known-FP pattern`
+- [ ] The matching finding either (a) is omitted, or (b) appears with an *explicit evidence sentence* in its description (model honoured the "strong evidence" instruction)
+- [ ] With `learnFromDisputes: false` (default), no log line, no directive, prompt is byte-identical to the FP-G shape
+- [ ] Sub-threshold clusters (`surfaceCount = 3` or `disputeRate = 50%`) DO NOT leak into the prompt
+- [ ] **Regression check**: an entirely new defect that happens to match a known-FP cluster but has a clear, explicit failure case still surfaces
+
+**Failure modes**
+- ❌ Hard suppression: the model omits the finding without the evidence-sentence escape hatch
+- ❌ Sub-threshold cluster leaks (threshold check must happen at directive-build time, not at write-time)
+- ❌ Directive injection happens on the orchestrator's prompt rather than the per-agent prompts (loses the layered defense — orchestrator already has its own filters)
+- ❌ With `learnFromDisputes` unset, the prompt diverges from the FP-G baseline byte-for-byte (must be exact back-compat)
 
 ---
 

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -1597,13 +1597,15 @@ Branch: `fixture/40-mergewatch-reject`. PR with an inline finding:
 **Expected outcomes**
 
 - [ ] Recognised categories: `already-handled`, `out-of-scope`, `wrong-target`, `style-disagreement`, `other`
-- [ ] Unrecognised category (`/mergewatch reject typo-here`) → bot reply asks for a valid category, no record write
+- [ ] Unrecognised category (`/mergewatch reject typo-here foo`) → silently coerced to `{ category: 'other', text: 'typo-here foo' }`; bot's confirming reply says "recording as `other`". No request for re-entry (preserve the signal).
 - [ ] Multiple `/mergewatch reject` replies on the same thread append to `rejectReasons[]` (don't overwrite)
 - [ ] Top-level `## mergewatch triage` continues to function (FB-D is an inline-thread addition, not a replacement)
+- [ ] The GitHub thread is NOT auto-resolved by `/reject` — `/resolve` and `/reject` are orthogonal verbs
 
 **Failure modes**
 - ❌ `/mergewatch reject` is matched in prose ("here's how I'd reject this differently") — pattern must be standalone-line or slash-command form
 - ❌ The thread is auto-resolved (signal collected; closure is human-driven)
+- ❌ Unrecognised category writes nothing (must coerce to `other` and preserve the original token in `text`)
 
 ---
 


### PR DESCRIPTION
## Summary

Sister doc to [`docs/false-positive-reduction-plan.md`](./../blob/main/docs/false-positive-reduction-plan.md). Where FP-A..FP-G closed FPs structurally from *inside* the pipeline, this plan closes the *feedback loop* from the outside — capture explicit reviewer feedback, persist it cross-PR, surface trends, and (opt-in) feed the strongest signals back into the prompts.

Pure docs PR. No runtime change. Stage for the implementation bundles.

## Direction (locked in)

1. **Capture is GitHub-native first** — inline-comment 👎 reactions, `/mergewatch reject` slash command, plus the already-shipped W3 triage prose and FP-F inline-resolve. Dashboard thumbs are a bonus, not the primary signal source.
2. **Storage is a dedicated table** (`mergewatch-finding-dispositions`) keyed by `(installationId, repoFullName, findingMatchKey)`. Keeps `ReviewItem` lean; makes org-wide queries feasible without scans.
3. **Active learning stays surface-only** — charts, suggestions, opt-in prompt injection. No auto-suppression.

```
Capture (GitHub-native)
  ↓
Persist (mergewatch-finding-dispositions)
  ↓
Aggregate (nightly InstallationFPInsight rollup)
  ↓
Surface (dashboard charts + tables, opt-in prompt injection)
```

## Twelve workstreams

| ID | Workstream | Bucket | Effort | Depends on |
|---|---|---|---|---|
| **FB-A** | FindingDispositionRecord storage + writers | Persist | S | — |
| **FB-B** | Quiet-drop derived counter | Persist | S | FB-A |
| **FB-C** | Inline-comment 👎 / 👍 → disputes | Capture | M | FB-A |
| **FB-D** | `/mergewatch reject` slash command | Capture | M | FB-A |
| **FB-E** | Nightly InstallationFPInsight rollup | Aggregate | M | FB-A, FB-B |
| **FB-F** | Dashboard FP funnel chart | Surface | M | FB-E |
| **FB-G** | Dispute-rate-by-agent line chart | Surface | M | FB-E |
| **FB-H** | Top recurring FP themes table | Surface | M | FB-E |
| **FB-I** | Severity-shopping detector chart | Surface | S | FB-G |
| **FB-J** | Per-repo FP heatmap | Surface | M | FB-E |
| **FB-K** | Suggest `.mergewatch.yml` rule CTA | Surface | M | FB-H |
| **FB-L** | `{{KNOWN_FP_PATTERNS}}` prompt injection (opt-in) | Learn | L | FB-E, FB-H |

## Recommended bundling

Mirrors the FP-A+B+C pattern from #159:

- **PR 1** — FB-A + FB-B (foundation, deterministic, no UX)
- **PR 2** — FB-C + FB-D (capture-side, shared webhook plumbing)
- **PR 3** — FB-E (aggregation, standalone scheduled job)
- **PR 4** — FB-F + FB-G + FB-I (three line/bar charts, one dashboard route)
- **PR 5** — FB-H + FB-J + FB-K (actionable surface)
- **PR 6** — FB-L (active learning, opt-in, last)

## What's in this PR

- **`docs/false-positive-feedback-plan.md`** (NEW, 349 lines) — full plan with storage shapes (TypeScript interfaces for `FindingDispositionRecord` + `InstallationFPInsight`), capture→persist→aggregate→surface diagram, per-workstream opportunity sections (gap / fix / code targets / E2E target), priority table, privacy & cost notes, and standing update protocol.
- **`e2e/RUNBOOK.md`** (+329 lines):
  - Summary table gains 12 new rows for E2E-37..E2E-48 (all marked TARGET, per [[e2e-regression-spec-per-pr]]).
  - Twelve full TARGET fixture cards appended at the end of the card list, each with Status / Behavior (intended) / Setup / Expected outcomes / Failure modes — same shape as the existing TARGET cards introduced in #158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)