### PR TITLE
FB-A + FB-B — FindingDispositionRecord storage + quiet-drop counter

### DIFF
--- a/docs/false-positive-feedback-plan.md
+++ b/docs/false-positive-feedback-plan.md
@@ -131,7 +131,7 @@ DynamoDB for SaaS, Postgres `jsonb` columns for self-hosted — same shape, two 
 
 Ranked by dependency order (foundation first → capture → aggregation → surface → active learning).
 
-### FB-A — `FindingDispositionRecord` storage + writers
+### FB-A — `FindingDispositionRecord` storage + writers  ✅ SHIPPED
 
 **Where the gap lives:** W3 disputed keys are computed live every review; FP-F inline-resolve keys are persisted on `ReviewItem` but only as a flat string array — no surfaceCount, no rate, no per-agent attribution. We have *no* cross-review per-finding identity table today.
 
@@ -146,7 +146,7 @@ Ranked by dependency order (foundation first → capture → aggregation → sur
 
 ---
 
-### FB-B — Quiet-drop derived counter
+### FB-B — Quiet-drop derived counter  ✅ SHIPPED
 
 **Where the gap lives:** When a finding appeared in `previousFindings` AND the cited code's fingerprint didn't change AND it's NOT in the current review → the orchestrator silently dropped it. That's a *very strong* implicit FP signal we're throwing away today.
 
@@ -300,8 +300,8 @@ Compute cost is bounded by the largest installation's record count; rollups stay
 
 | ID | Workstream | Bucket | Effort | Depends on | ROI |
 |---|---|---|---|---|---|
-| **FB-A** | FindingDispositionRecord storage + writers | Persist | S | — | ★★★ foundation |
-| **FB-B** | Quiet-drop derived counter | Persist | S | FB-A | ★★ free signal |
+| **FB-A** | FindingDispositionRecord storage + writers | Persist | S | — | ✅ SHIPPED |
+| **FB-B** | Quiet-drop derived counter | Persist | S | FB-A | ✅ SHIPPED |
 | **FB-C** | Inline-comment 👎 → disputes | Capture | M | FB-A | ★★★ |
 | **FB-D** | `/mergewatch reject` slash command | Capture | M | FB-A | ★★ |
 | **FB-E** | Nightly InstallationFPInsight rollup | Aggregate | M | FB-A, FB-B | ★★★ |

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -163,8 +163,8 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-34](#e2e-34-fp-e--w2-verification-extended-to-warnings) | Warning-severity findings go through the W2 verification pass and get a `verification` tag (FP-E) | 2m | 60s | FP-E |
 | [E2E-35](#e2e-35-fp-f--inline-reply-resolve-memory) | An inline `/resolve` reply persists the finding's key so the next review doesn't re-emit it (FP-F) | 3m | 90s | FP-F |
 | [E2E-36](#e2e-36-fp-g--linter-aware-style-agent) | Repos with detected linters (eslint / ruff / clippy / biome) get a stricter STYLE_REVIEWER_PROMPT that defers lint-equivalent findings (FP-G) | 2m | 60s | FP-G |
-| [E2E-37](#e2e-37-fb-a--findingdispositionrecord-storage--writers-target) | FindingDispositionRecord rows are written on every surfacing, W3 dispute, FP-F inline-resolve (FB-A) — **TARGET** | 2m | 60s | FB-A |
-| [E2E-38](#e2e-38-fb-b--quiet-drop-derived-counter-target) | Quiet-drop (finding gone without code change) increments `silentDropCount` on the matching record (FB-B) — **TARGET** | 2m | 60s | FB-B |
+| [E2E-37](#e2e-37-fb-a--findingdispositionrecord-storage--writers) | FindingDispositionRecord rows are written on every surfacing, W3 dispute, FP-F inline-resolve (FB-A) | 2m | 60s | FB-A |
+| [E2E-38](#e2e-38-fb-b--quiet-drop-derived-counter) | Quiet-drop (finding gone without code change) increments `silentDropCount` on the matching record (FB-B) | 2m | 60s | FB-B |
 | [E2E-39](#e2e-39-fb-c--inline-comment--reactions--disputes-target) | 👎 / 🤔 on a bot inline comment increments `disputeCount`; 👍 / ❤️ / 🚀 increments `agreementCount` (FB-C) — **TARGET** | 2m | 60s | FB-C |
 | [E2E-40](#e2e-40-fb-d--mergewatch-reject-slash-command-target) | `/mergewatch reject <category> [reason]` on an inline thread persists a categorised rejection + posts a confirming bot reply (FB-D) — **TARGET** | 3m | 90s | FB-D |
 | [E2E-41](#e2e-41-fb-e--nightly-installationfpinsight-rollup-target) | Nightly scheduled job produces InstallationFPInsight rollups for 7d / 30d / 90d windows per installation (FB-E) — **TARGET** | 3m | 90s | FB-E |
@@ -1490,9 +1490,9 @@ Branch: `fixture/36-linter-aware`. Two micro-fixtures, one per "linter present /
 
 ---
 
-### E2E-37: FB-A — FindingDispositionRecord storage + writers — TARGET
+### E2E-37: FB-A — FindingDispositionRecord storage + writers
 
-**Status:** **Not yet implemented.** See [`docs/false-positive-feedback-plan.md` → FB-A](./../docs/false-positive-feedback-plan.md#fb-a--findingdispositionrecord-storage--writers).
+**Status:** ✅ SHIPPED. See [`docs/false-positive-feedback-plan.md` → FB-A](./../docs/false-positive-feedback-plan.md#fb-a--findingdispositionrecord-storage--writers--shipped).
 
 **Behavior (intended, once FB-A ships):** every surfacing of a finding upserts a `FindingDispositionRecord` keyed by `(installationId, repoFullName, findingMatchKey)` — incrementing `surfaceCount`, refreshing `lastSeen`, capturing category + topAgent + sigTokens. The existing W3 path increments `disputeCount`; FP-F inline-resolve increments `disputeCount` AND continues to populate `inlineResolvedKeys` on `ReviewItem` (back-compat). W2 verdicts increment `verifiedCount` / `unverifiedCount`. Records are read by FB-E's nightly rollup only — no per-review read on the dashboard path.
 
@@ -1517,9 +1517,9 @@ Branch: `fixture/37-fp-record-storage`. A PR that triggers ≥ 2 findings on cha
 
 ---
 
-### E2E-38: FB-B — quiet-drop derived counter — TARGET
+### E2E-38: FB-B — quiet-drop derived counter
 
-**Status:** **Not yet implemented.** See [`docs/false-positive-feedback-plan.md` → FB-B](./../docs/false-positive-feedback-plan.md#fb-b--quiet-drop-derived-counter).
+**Status:** ✅ SHIPPED. See [`docs/false-positive-feedback-plan.md` → FB-B](./../docs/false-positive-feedback-plan.md#fb-b--quiet-drop-derived-counter--shipped).
 
 **Behavior (intended, once FB-B ships):** when a finding from the previous review (a) was present in `previousFindings`, (b) is NOT in the current review's output, AND (c) the cited code's fingerprint did NOT change between the two commits → the orchestrator silently dropped it. Each such drop increments `silentDropCount` on the corresponding `FindingDispositionRecord`. This is a strong *implicit* FP signal — the model dropped a finding it had previously emitted on the same code.
 

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -597,6 +597,59 @@ Resources:
     UpdateReplacePolicy: Delete
 
   # ===========================================================================
+  # DynamoDB: FindingDispositions (FB-A)
+  # ===========================================================================
+  # Per-finding cross-PR identity records — one row per distinct
+  # findingMatchKey per repo per installation. Drives the FB-E nightly
+  # rollup and (via the rollup) every dashboard insight chart.
+  #
+  # Schema:
+  #   PK: pk  (String)  — "${installationId}#${repoFullName}"
+  #   SK: sk  (String)  — findingMatchKey (file::T::title or file::F::fp)
+  #
+  # Attributes (best-effort, monotonic counters):
+  #   - firstSeen / lastSeen   (String, ISO 8601)
+  #   - surfaceCount / disputeCount / verifiedCount / unverifiedCount /
+  #     silentDropCount / agreementCount  (Number)
+  #   - category / topAgent    (String)
+  #   - sigTokens              (List<String>) — W10 cluster bag
+  #   - rejectReasons          (List<Map>)    — FB-D append-only log
+  #
+  # Reads are bounded (FB-E nightly, listByInstallation with Scan + filter);
+  # writes are hot-path (every surfacing/dispute/verification). PAY_PER_REQUEST
+  # keeps it cheap.
+
+  FindingDispositionsTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub 'mergewatch-finding-dispositions-${Stage}'
+      BillingMode: PAY_PER_REQUEST
+
+      KeySchema:
+        - AttributeName: pk
+          KeyType: HASH
+        - AttributeName: sk
+          KeyType: RANGE
+
+      AttributeDefinitions:
+        - AttributeName: pk
+          AttributeType: S
+        - AttributeName: sk
+          AttributeType: S
+
+      SSESpecification:
+        SSEEnabled: true
+
+      Tags:
+        - Key: Project
+          Value: MergeWatch
+        - Key: Stage
+          Value: !Ref Stage
+
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+
+  # ===========================================================================
   # IAM Role: Lambda Execution Role
   # ===========================================================================
   # A single shared role for both Lambda functions. This simplifies management
@@ -670,11 +723,13 @@ Resources:
                   - !GetAtt ReviewsTable.Arn
                   - !GetAtt ApiKeysTable.Arn
                   - !GetAtt SessionsTable.Arn
+                  - !GetAtt FindingDispositionsTable.Arn
                   # Index ARNs (for future GSIs)
                   - !Sub '${InstallationsTable.Arn}/index/*'
                   - !Sub '${ReviewsTable.Arn}/index/*'
                   - !Sub '${ApiKeysTable.Arn}/index/*'
                   - !Sub '${SessionsTable.Arn}/index/*'
+                  - !Sub '${FindingDispositionsTable.Arn}/index/*'
 
         # --- SSM Parameter Store ---
         # Read-only access to GitHub credentials stored in SSM.

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -923,6 +923,13 @@ export type PreviousFinding = {
   severity: string;
   category: string;
   title: string;
+  /**
+   * W9 stable identity over the cited code (optional — older stored
+   * findings predate W9 and won't have one). Already accepted at runtime
+   * by `findingMatchKeys` via the `FindingLike` shape; declared here so
+   * the FB-A / FB-B analytics writers can use it without unsafe coercion.
+   */
+  fingerprint?: string;
 };
 
 /** Maximum characters per serialised string field to limit prompt injection surface. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,8 @@ export type {
   IReviewStore,
   IApiKeyStore,
   IMcpSessionStore,
+  IFindingDispositionStore,
+  FindingDispositionAttribution,
   ApiKeyRecord,
   McpSessionRecord,
 } from './storage/types.js';
@@ -137,6 +139,14 @@ export { detectNoTestHarness, suppressTestCoverageFindings } from './scope-aware
 export { clusterFindings, extractSignificantTokens, dedupeCrossAgentByLine } from './finding-clustering.js';
 export type { ClusterableFinding, ClusterOptions, TaggedClusterableFindings } from './finding-clustering.js';
 
+// ─── Disposition writers (FB-A / FB-B) ─────────────────────────────────────
+export {
+  recordFindingSurfacings,
+  recordDisputes,
+  detectQuietDrops,
+  recordQuietDrops,
+} from './insights/disposition-writer.js';
+
 // ─── Config ─────────────────────────────────────────────────────────────────
 export {
   DEFAULT_CONFIG,
@@ -218,6 +228,7 @@ export type {
   ReviewKey,
   CreateReviewInput,
   UpdateReviewInput,
+  FindingDispositionRecord,
 } from './types/db.js';
 
 export { DEFAULT_INSTALLATION_SETTINGS } from './types/db.js';

--- a/packages/core/src/insights/disposition-writer.test.ts
+++ b/packages/core/src/insights/disposition-writer.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  recordFindingSurfacings,
+  recordDisputes,
+  detectQuietDrops,
+  recordQuietDrops,
+} from './disposition-writer.js';
+import type { IFindingDispositionStore } from '../storage/types.js';
+import type { OrchestratedFinding, PreviousFinding } from '../agents/reviewer.js';
+
+// ─── Mock store ─────────────────────────────────────────────────────────────
+
+function makeMockStore(): IFindingDispositionStore & {
+  calls: {
+    upsertSurface: Array<[string, string, string, string, unknown]>;
+    incrementDispute: string[][];
+    incrementVerified: string[][];
+    incrementUnverified: string[][];
+    incrementSilentDrop: string[][];
+    incrementAgreement: string[][];
+    appendRejectReason: Array<[string, string, string, unknown]>;
+  };
+} {
+  const calls = {
+    upsertSurface: [] as Array<[string, string, string, string, unknown]>,
+    incrementDispute: [] as string[][],
+    incrementVerified: [] as string[][],
+    incrementUnverified: [] as string[][],
+    incrementSilentDrop: [] as string[][],
+    incrementAgreement: [] as string[][],
+    appendRejectReason: [] as Array<[string, string, string, unknown]>,
+  };
+  return {
+    calls,
+    async upsertSurface(installationId, repoFullName, k, nowIso, attribution) {
+      calls.upsertSurface.push([installationId, repoFullName, k, nowIso, attribution]);
+    },
+    async incrementDispute(i, r, k)     { calls.incrementDispute.push([i, r, k]); },
+    async incrementVerified(i, r, k)    { calls.incrementVerified.push([i, r, k]); },
+    async incrementUnverified(i, r, k)  { calls.incrementUnverified.push([i, r, k]); },
+    async incrementSilentDrop(i, r, k)  { calls.incrementSilentDrop.push([i, r, k]); },
+    async incrementAgreement(i, r, k)   { calls.incrementAgreement.push([i, r, k]); },
+    async appendRejectReason(i, r, k, reason) {
+      calls.appendRejectReason.push([i, r, k, reason]);
+    },
+    async listByInstallation() {
+      return { items: [] };
+    },
+  };
+}
+
+// ─── Test helpers ───────────────────────────────────────────────────────────
+
+function makeFinding(over: Partial<OrchestratedFinding> = {}): OrchestratedFinding {
+  return {
+    file: 'src/a.ts',
+    line: 10,
+    severity: 'warning',
+    category: 'bug',
+    title: 'Missing await on async fetch',
+    description: 'fetch() returns a promise that is not awaited',
+    suggestion: 'await fetch()',
+    ...over,
+  } as OrchestratedFinding;
+}
+
+// ─── recordFindingSurfacings ────────────────────────────────────────────────
+
+describe('recordFindingSurfacings (FB-A)', () => {
+  it('writes one upsertSurface per match key per finding', async () => {
+    const store = makeMockStore();
+    const findings = [makeFinding()];
+    await recordFindingSurfacings(store, 42, 'org/repo', findings, '2026-05-22T00:00:00Z');
+    // No fingerprint → just the title key
+    expect(store.calls.upsertSurface).toHaveLength(1);
+    expect(store.calls.upsertSurface[0][0]).toBe('42');
+    expect(store.calls.upsertSurface[0][1]).toBe('org/repo');
+    expect(store.calls.upsertSurface[0][2]).toBe('src/a.ts::T::Missing await on async fetch');
+    expect(store.calls.upsertSurface[0][3]).toBe('2026-05-22T00:00:00Z');
+  });
+
+  it('writes BOTH title and fingerprint keys when the finding has a fingerprint', async () => {
+    const store = makeMockStore();
+    const f = makeFinding({ fingerprint: 'fetch(url, opts);' });
+    await recordFindingSurfacings(store, 42, 'org/repo', [f], '2026-05-22T00:00:00Z');
+    const keys = store.calls.upsertSurface.map((c) => c[2]);
+    expect(keys).toEqual([
+      'src/a.ts::T::Missing await on async fetch',
+      'src/a.ts::F::fetch(url, opts);',
+    ]);
+  });
+
+  it('attaches sigTokens (W10 token bag) so FB-E clustering can merge sibling rows', async () => {
+    const store = makeMockStore();
+    await recordFindingSurfacings(store, 42, 'org/repo', [makeFinding()], '2026-05-22T00:00:00Z');
+    const attribution = store.calls.upsertSurface[0][4] as { sigTokens?: string[] };
+    expect(Array.isArray(attribution.sigTokens)).toBe(true);
+    expect(attribution.sigTokens!.length).toBeGreaterThan(0);
+    // significant tokens (≥5 chars, stop-words removed) — we should see
+    // "missing" / "async" / "await" / "fetch" (at least most of these).
+    const tokens = (attribution.sigTokens ?? []).join(' ');
+    expect(tokens).toMatch(/missing|async|await|fetch/);
+  });
+
+  it('forwards verified verification verdict to incrementVerified', async () => {
+    const store = makeMockStore();
+    await recordFindingSurfacings(store, 42, 'org/repo', [
+      makeFinding({ verification: 'verified' }),
+    ], '2026-05-22T00:00:00Z');
+    expect(store.calls.incrementVerified).toHaveLength(1);
+    expect(store.calls.incrementUnverified).toHaveLength(0);
+  });
+
+  it('forwards unverified verification verdict to incrementUnverified', async () => {
+    const store = makeMockStore();
+    await recordFindingSurfacings(store, 42, 'org/repo', [
+      makeFinding({ verification: 'unverified' }),
+    ], '2026-05-22T00:00:00Z');
+    expect(store.calls.incrementVerified).toHaveLength(0);
+    expect(store.calls.incrementUnverified).toHaveLength(1);
+  });
+
+  it('writes nothing when no store is provided (back-compat)', async () => {
+    // Smoke test: undefined store must not throw — analytics is optional.
+    await expect(
+      recordFindingSurfacings(undefined, 42, 'org/repo', [makeFinding()], '2026-05-22T00:00:00Z'),
+    ).resolves.toBeUndefined();
+  });
+
+  it('writes nothing when installationId is missing (typed but optional)', async () => {
+    const store = makeMockStore();
+    await recordFindingSurfacings(store, undefined, 'org/repo', [makeFinding()], '2026-05-22T00:00:00Z');
+    expect(store.calls.upsertSurface).toHaveLength(0);
+  });
+
+  it('logs but does not throw when the store rejects', async () => {
+    const store = makeMockStore();
+    store.upsertSurface = vi.fn(async () => { throw new Error('disk full'); }) as never;
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await expect(
+      recordFindingSurfacings(store, 42, 'org/repo', [makeFinding()], '2026-05-22T00:00:00Z'),
+    ).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+
+// ─── recordDisputes ─────────────────────────────────────────────────────────
+
+describe('recordDisputes (FB-A)', () => {
+  it('calls incrementDispute once per key', async () => {
+    const store = makeMockStore();
+    await recordDisputes(store, 42, 'org/repo', [
+      'src/a.ts::T::Foo',
+      'src/a.ts::F::abc123',
+    ]);
+    expect(store.calls.incrementDispute).toEqual([
+      ['42', 'org/repo', 'src/a.ts::T::Foo'],
+      ['42', 'org/repo', 'src/a.ts::F::abc123'],
+    ]);
+  });
+
+  it('is a no-op when the key list is empty', async () => {
+    const store = makeMockStore();
+    await recordDisputes(store, 42, 'org/repo', []);
+    expect(store.calls.incrementDispute).toHaveLength(0);
+  });
+});
+
+// ─── detectQuietDrops (FB-B) ────────────────────────────────────────────────
+
+function priorFinding(over: Partial<PreviousFinding> = {}): PreviousFinding {
+  return {
+    file: 'src/a.ts',
+    line: 10,
+    severity: 'warning',
+    title: 'Was here last time',
+    description: '',
+    suggestion: '',
+    ...over,
+  } as PreviousFinding;
+}
+
+describe('detectQuietDrops (FB-B)', () => {
+  it('returns a prior finding that is absent from current AND cited line was not changed', async () => {
+    const current = [makeFinding({ title: 'Different finding' })];
+    const prior = [priorFinding()];
+    const changedLines = new Map<string, Set<number>>();
+    // No changes touched src/a.ts:10
+    const drops = detectQuietDrops(current, prior, changedLines);
+    expect(drops).toHaveLength(1);
+    expect(drops[0].title).toBe('Was here last time');
+  });
+
+  it('does NOT count a prior finding whose cited line WAS changed as a quiet drop', async () => {
+    const current = [makeFinding({ title: 'Different finding' })];
+    const prior = [priorFinding({ file: 'src/a.ts', line: 10 })];
+    const changedLines = new Map([['src/a.ts', new Set([9, 10, 11])]]);
+    const drops = detectQuietDrops(current, prior, changedLines);
+    expect(drops).toHaveLength(0);
+  });
+
+  it('does NOT count a prior finding that is STILL in current (matched by title key)', async () => {
+    const current = [makeFinding({ title: 'Was here last time' })];
+    const prior = [priorFinding()];
+    const changedLines = new Map<string, Set<number>>();
+    const drops = detectQuietDrops(current, prior, changedLines);
+    expect(drops).toHaveLength(0);
+  });
+
+  it('uses W9 fingerprint key for matching too — a reworded title with same fingerprint is NOT a quiet drop', async () => {
+    const current = [makeFinding({ title: 'New wording', fingerprint: 'fetch(url);' })];
+    const prior = [priorFinding({ title: 'Old wording', fingerprint: 'fetch(url);' })];
+    const changedLines = new Map<string, Set<number>>();
+    const drops = detectQuietDrops(current, prior, changedLines);
+    // The fingerprint key on both sides matches → it's still "present", not dropped.
+    expect(drops).toHaveLength(0);
+  });
+
+  it('returns empty when there are no prior findings', async () => {
+    const drops = detectQuietDrops([], [], new Map());
+    expect(drops).toHaveLength(0);
+  });
+
+  it('returns empty (conservative) when changedLines is undefined — no false-positive silentDrops', async () => {
+    // Older callers / mocks may not pass changedLines. We must not invent a
+    // "quiet drop" signal when we don't have proof the cited code was
+    // untouched — that would over-attribute disputes.
+    const drops = detectQuietDrops(
+      [],
+      [priorFinding()],
+      undefined as unknown as Map<string, Set<number>>,
+    );
+    expect(drops).toHaveLength(0);
+  });
+});
+
+// ─── recordQuietDrops ───────────────────────────────────────────────────────
+
+describe('recordQuietDrops (FB-B)', () => {
+  it('writes one incrementSilentDrop per match key per quiet-dropped finding', async () => {
+    const store = makeMockStore();
+    await recordQuietDrops(store, 42, 'org/repo', [priorFinding()]);
+    expect(store.calls.incrementSilentDrop).toHaveLength(1);
+    expect(store.calls.incrementSilentDrop[0]).toEqual(['42', 'org/repo', 'src/a.ts::T::Was here last time']);
+  });
+
+  it('is a no-op on empty input', async () => {
+    const store = makeMockStore();
+    await recordQuietDrops(store, 42, 'org/repo', []);
+    expect(store.calls.incrementSilentDrop).toHaveLength(0);
+  });
+});

--- a/packages/core/src/insights/disposition-writer.ts
+++ b/packages/core/src/insights/disposition-writer.ts
@@ -1,0 +1,183 @@
+/**
+ * FB-A / FB-B — write fan-out for FindingDispositionRecord.
+ *
+ * Both handlers (server + lambda) call the same helpers below after the
+ * review pipeline runs and after triage / inline-resolve persists, so the
+ * counter semantics stay identical across deployment shapes.
+ *
+ * Best-effort by design: every helper catches and logs (the store
+ * implementations also catch internally — this is belt-and-braces). A
+ * disposition write must never block a review.
+ *
+ * Idempotency: counters are monotonic; each helper call corresponds to one
+ * "event". Callers should not loop the same event with the same key set.
+ */
+
+import type { IFindingDispositionStore } from '../storage/types.js';
+import type { OrchestratedFinding, PreviousFinding } from '../agents/reviewer.js';
+import { findingMatchKeys, fingerprintFromCode } from '../review-delta.js';
+import { extractSignificantTokens } from '../finding-clustering.js';
+
+/**
+ * FB-A — record one surfacing per finding. Writes one upsertSurface call per
+ * key returned by `findingMatchKeys(finding)` (typically 2: a title key
+ * plus a fingerprint key when one is available). The cluster step in FB-E
+ * merges sibling rows by sigTokens overlap.
+ *
+ * Also writes the W2 verification counter when the finding carries a
+ * `verification` tag (`verified` → incrementVerified; `unverified` →
+ * incrementUnverified). The same fan-out per match-key.
+ */
+export async function recordFindingSurfacings(
+  store: IFindingDispositionStore | undefined,
+  installationId: string | number | undefined,
+  repoFullName: string,
+  findings: OrchestratedFinding[],
+  nowIso: string,
+): Promise<void> {
+  if (!store || installationId == null) return;
+  const inst = String(installationId);
+  for (const f of findings) {
+    const keys = findingMatchKeys(f);
+    const attribution = {
+      // OrchestratedFinding's `category` field carries values like
+      // 'security' / 'bug' / 'style' / etc. as set by the agent prompts.
+      // Pass it through verbatim; the store accepts the wider union and
+      // narrows via the `FindingDispositionRecord['category']` type at
+      // read time.
+      ...(f.category ? { category: f.category as never } : {}),
+      // Best-effort token bag — falls back to title-only if description
+      // is empty. extractSignificantTokens strips stop-words for us; the
+      // Array.from + slice trims to a reasonable cap (W10 clusters are
+      // tight, more than ~16 tokens is just noise).
+      sigTokens: Array.from(extractSignificantTokens(`${f.title} ${f.description ?? ''}`)).slice(0, 16),
+    };
+    for (const key of keys) {
+      // Fire-and-await; per-call error swallow lives inside the store. We
+      // sequence (not Promise.all) so a single store hiccup doesn't bury
+      // the rest of the writes in one rejected promise.
+      try {
+        await store.upsertSurface(inst, repoFullName, key, nowIso, attribution);
+        if (f.verification === 'verified') {
+          await store.incrementVerified(inst, repoFullName, key);
+        } else if (f.verification === 'unverified') {
+          await store.incrementUnverified(inst, repoFullName, key);
+        }
+      } catch (err) {
+        // Defense in depth — the store layer already catches; this is the
+        // umbrella around the entire (upsert + verify) sequence for this key.
+        console.warn('[fb-a] recordFindingSurfacings: write failed for %s', key, err);
+      }
+    }
+  }
+}
+
+/**
+ * FB-A — record one dispute per key. Used for both:
+ *   • W3 disputedKeys (from `## mergewatch triage` mapping)
+ *   • FP-F inline-resolve match keys
+ *
+ * Idempotency note: this MAY double-count when the same dispute arrives via
+ * two channels (e.g. author rebutted via triage AND clicked /resolve on
+ * the inline thread). We accept the rare double-count rather than maintain
+ * an event-source table to dedupe — analytically a "double-disputed"
+ * finding is still a strong FP signal, so the bias is in the safe direction.
+ */
+export async function recordDisputes(
+  store: IFindingDispositionStore | undefined,
+  installationId: string | number | undefined,
+  repoFullName: string,
+  matchKeys: readonly string[],
+): Promise<void> {
+  if (!store || installationId == null || matchKeys.length === 0) return;
+  const inst = String(installationId);
+  for (const key of matchKeys) {
+    try {
+      await store.incrementDispute(inst, repoFullName, key);
+    } catch (err) {
+      console.warn('[fb-a] recordDisputes: write failed for %s', key, err);
+    }
+  }
+}
+
+// ─── FB-B — quiet-drop derived counter ─────────────────────────────────────
+
+/**
+ * Detect quiet drops: findings that were present in the prior review,
+ * are NOT present in the current review, AND whose cited code was not
+ * changed by this PR. A strong implicit FP signal — the orchestrator
+ * looked at the same code with the same prior context and chose to
+ * drop the finding without the code itself moving.
+ *
+ * Definition of "code didn't change" — the prior finding's `line` is NOT
+ * in `changedLines.get(file)`. We deliberately don't require the file to
+ * be in the diff at all; even on a re-review of an unchanged file the
+ * orchestrator has the previous finding in its prompt via
+ * `buildPreviousFindingsBlock` and choosing to drop it counts.
+ *
+ * Returns the subset of `priorFindings` that meet all three conditions.
+ * Stable per-finding identity uses `findingMatchKeys` (title key always,
+ * fingerprint key when available) — same as W3 / FP-F.
+ */
+export function detectQuietDrops(
+  currentFindings: readonly OrchestratedFinding[],
+  priorFindings: readonly PreviousFinding[],
+  changedLines: Map<string, Set<number>> | undefined,
+): PreviousFinding[] {
+  if (priorFindings.length === 0) return [];
+  // Defensive: when the pipeline didn't return changedLines (older mocks,
+  // legacy callers), conservatively report NO quiet drops. Better to under-
+  // count silentDrop signal than to false-positive on a "this finding
+  // vanished" without proof the cited code was untouched.
+  if (!changedLines) return [];
+
+  // Build a set of EVERY key any current finding carries, so the resolved-
+  // set check below uses the same union-matching W3 / FP-F use.
+  const currentKeySet = new Set<string>();
+  for (const f of currentFindings) {
+    for (const k of findingMatchKeys(f)) currentKeySet.add(k);
+  }
+
+  const quietDrops: PreviousFinding[] = [];
+  for (const p of priorFindings) {
+    const priorKeys = findingMatchKeys(p);
+    // Still present (under any of its keys)? Not a drop at all.
+    if (priorKeys.some((k) => currentKeySet.has(k))) continue;
+
+    // Was the cited code touched on this commit? If yes → legitimate
+    // resolve via code change. If no → quiet drop.
+    const fileChanges = changedLines.get(p.file);
+    const lineChanged = fileChanges?.has(p.line) ?? false;
+    if (lineChanged) continue;
+
+    quietDrops.push(p);
+  }
+  return quietDrops;
+}
+
+/**
+ * FB-B — record one silentDropCount increment per match key of each quiet-
+ * dropped finding.
+ */
+export async function recordQuietDrops(
+  store: IFindingDispositionStore | undefined,
+  installationId: string | number | undefined,
+  repoFullName: string,
+  quietDrops: readonly PreviousFinding[],
+): Promise<void> {
+  if (!store || installationId == null || quietDrops.length === 0) return;
+  const inst = String(installationId);
+  for (const p of quietDrops) {
+    for (const key of findingMatchKeys(p)) {
+      try {
+        await store.incrementSilentDrop(inst, repoFullName, key);
+      } catch (err) {
+        console.warn('[fb-b] recordQuietDrops: write failed for %s', key, err);
+      }
+    }
+  }
+}
+
+// Re-exported so external callers don't need to dip into review-delta.js
+// just to inspect the same helper the writers use.
+export { fingerprintFromCode };

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -6,7 +6,11 @@
  *   - Future: PostgresInstallationStore / PostgresReviewStore
  */
 
-import type { InstallationItem, InstallationSettings, ReviewItem, ReviewStatus } from '../types/db.js';
+import type {
+  InstallationItem, InstallationSettings,
+  ReviewItem, ReviewStatus,
+  FindingDispositionRecord,
+} from '../types/db.js';
 
 export interface IInstallationStore {
   get(installationId: string, repoFullName: string): Promise<InstallationItem | null>;
@@ -73,4 +77,71 @@ export interface McpSessionRecord {
 export interface IMcpSessionStore {
   get(sessionId: string): Promise<McpSessionRecord | null>;
   upsert(record: McpSessionRecord): Promise<void>;
+}
+
+// ─── FB-A — Finding disposition store ──────────────────────────────────────
+
+/**
+ * Sentinel — the field passed to `upsertSurface` when attribution data
+ * (category / topAgent / sigTokens) is unknown. Existing values are kept
+ * when a fresher write doesn't carry them.
+ */
+export interface FindingDispositionAttribution {
+  category?: FindingDispositionRecord['category'];
+  topAgent?: string;
+  sigTokens?: string[];
+}
+
+export interface IFindingDispositionStore {
+  /**
+   * Increment surfaceCount + refresh lastSeen on the record for this key.
+   * Creates the record (with firstSeen = lastSeen = now, surfaceCount = 1)
+   * if it doesn't exist yet. Attribution fields are written-through on every
+   * upsert (last writer wins; they're stable enough that this is fine).
+   *
+   * Idempotency: each `upsertSurface` is treated as exactly one "this finding
+   * surfaced once". Callers must dedupe across multiple match-keys of the same
+   * finding (typical pattern: write one upsertSurface per key returned by
+   * `findingMatchKeys(f)`).
+   */
+  upsertSurface(
+    installationId: string,
+    repoFullName: string,
+    findingMatchKey: string,
+    nowIso: string,
+    attribution?: FindingDispositionAttribution,
+  ): Promise<void>;
+
+  /** Increment disputeCount by 1. No-op if no record exists yet (we don't backfill — a dispute without prior surfacing is a write-ordering bug we'd want to see logged separately). */
+  incrementDispute(installationId: string, repoFullName: string, findingMatchKey: string): Promise<void>;
+
+  /** Increment verifiedCount by 1. */
+  incrementVerified(installationId: string, repoFullName: string, findingMatchKey: string): Promise<void>;
+
+  /** Increment unverifiedCount by 1. */
+  incrementUnverified(installationId: string, repoFullName: string, findingMatchKey: string): Promise<void>;
+
+  /** FB-B — increment silentDropCount by 1. */
+  incrementSilentDrop(installationId: string, repoFullName: string, findingMatchKey: string): Promise<void>;
+
+  /** FB-C — increment agreementCount by 1. */
+  incrementAgreement(installationId: string, repoFullName: string, findingMatchKey: string): Promise<void>;
+
+  /** FB-D — append a rejectReason entry. Idempotent at the record level; appends always extend. */
+  appendRejectReason(
+    installationId: string,
+    repoFullName: string,
+    findingMatchKey: string,
+    reason: NonNullable<FindingDispositionRecord['rejectReasons']>[number],
+  ): Promise<void>;
+
+  /**
+   * Page through all records for an installation. Used by the FB-E nightly
+   * rollup. Optional limit + cursor-style pagination — implementations may
+   * cap per-call to ~1000 records.
+   */
+  listByInstallation(
+    installationId: string,
+    opts?: { limit?: number; cursor?: string },
+  ): Promise<{ items: FindingDispositionRecord[]; nextCursor?: string }>;
 }

--- a/packages/core/src/types/db.ts
+++ b/packages/core/src/types/db.ts
@@ -434,6 +434,64 @@ export type ReviewKey = Pick<ReviewItem, 'repoFullName' | 'prNumberCommitSha'>;
 export type CreateReviewInput = Omit<ReviewItem, 'completedAt' | 'commentId'>;
 
 /**
+ * FB-A — Per-finding cross-PR identity record. One row per distinct
+ * `findingMatchKey` per repo per installation. Created on first surfacing;
+ * counters incremented on every subsequent surfacing, dispute, verification,
+ * agreement, silent drop, etc.
+ *
+ * Storage:
+ *   - DynamoDB (SaaS) table: mergewatch-finding-dispositions
+ *     PK: `${installationId}#${repoFullName}`   SK: `findingMatchKey`
+ *   - Postgres (self-hosted) table: finding_dispositions
+ *     PK: (installation_id, repo_full_name, finding_match_key)
+ *
+ * Read path: only the FB-E nightly rollup queries this directly. Dashboard
+ * pages read the FB-E rollups, never the raw records — keeps O(1) on the
+ * page-load side.
+ *
+ * Write path: best-effort. Failed writes are logged but never block the
+ * review pipeline. Counters are monotonic — we never decrement (avoids the
+ * need for an event-source table to reconcile reaction removals).
+ */
+export interface FindingDispositionRecord {
+  installationId: string;
+  repoFullName: string;
+  /** W9-style stable identity. Either `${file}::T::${title}` or `${file}::F::${fingerprint}`. */
+  findingMatchKey: string;
+
+  /** ISO 8601. Set once on creation. */
+  firstSeen: string;
+  /** ISO 8601. Refreshed on every surfacing. */
+  lastSeen: string;
+
+  /** Distinct reviews this key appeared in. */
+  surfaceCount: number;
+  /** Explicit disputes (W3 triage, FP-F inline-resolve, FB-C 👎/🤔, FB-D /mergewatch reject). */
+  disputeCount: number;
+  /** W2 verifyFindings explicit `valid: true` verdicts on a finding carrying this key. */
+  verifiedCount: number;
+  /** W2 verifyFindings inconclusive verdicts on a finding carrying this key. */
+  unverifiedCount: number;
+  /** FB-B — finding was in previousFindings, code at the cited line didn't change, finding was NOT in current. */
+  silentDropCount: number;
+  /** FB-C — 👍 / ❤️ / 🚀 reactions on the bot's inline comment for a finding with this key. */
+  agreementCount: number;
+
+  /** Last-seen finding category for this key (the few seen are stable; we keep the most recent). */
+  category?: 'security' | 'bug' | 'style' | 'errorHandling' | 'testCoverage' | 'commentAccuracy' | 'custom';
+  /** Last-seen producing agent (heuristic — same finding can drift agent across reviews). */
+  topAgent?: string;
+  /** W10 significant-token bag for this finding's title — drives cluster-level rollup in FB-E. */
+  sigTokens?: string[];
+  /** FB-D — appended one entry per `/mergewatch reject <category>` invocation. */
+  rejectReasons?: Array<{
+    category: 'already-handled' | 'out-of-scope' | 'wrong-target' | 'style-disagreement' | 'other';
+    text?: string;
+    at: string;
+  }>;
+}
+
+/**
  * Type for updating a review's status — partial update to an existing item.
  */
 export type UpdateReviewInput = ReviewKey & {

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -46,6 +46,10 @@ import {
   fetchTriageComments,
   computeDisputedKeys,
   partitionDisputed,
+  recordFindingSurfacings,
+  recordDisputes,
+  detectQuietDrops,
+  recordQuietDrops,
 } from '@mergewatch/core';
 import type {
   ReviewJobPayload,
@@ -57,7 +61,7 @@ import type {
 } from '@mergewatch/core';
 import { buildWorkDoneSection, computeReviewDelta } from '@mergewatch/core';
 import { DynamoInstallationStore } from '@mergewatch/storage-dynamo';
-import { DynamoReviewStore } from '@mergewatch/storage-dynamo';
+import { DynamoReviewStore, DynamoFindingDispositionStore, DEFAULT_FINDING_DISPOSITIONS_TABLE } from '@mergewatch/storage-dynamo';
 import { BedrockLLMProvider, SUPPORTED_MODELS } from '@mergewatch/llm-bedrock';
 import { isSaas, billingCheck, recordReview, postBlockedCheckRun, ensureBillingIssue, updateBillingFields, getStripe } from '@mergewatch/billing';
 import { SSMGitHubAuthProvider } from '../github-auth-ssm.js';
@@ -68,11 +72,15 @@ const dynamodb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 
 const INSTALLATIONS_TABLE = process.env.INSTALLATIONS_TABLE ?? 'mergewatch-installations';
 const REVIEWS_TABLE = process.env.REVIEWS_TABLE ?? 'mergewatch-reviews';
+const FINDING_DISPOSITIONS_TABLE = process.env.FINDING_DISPOSITIONS_TABLE ?? DEFAULT_FINDING_DISPOSITIONS_TABLE;
 const DEFAULT_BEDROCK_MODEL_ID = process.env.DEFAULT_BEDROCK_MODEL_ID ?? 'us.anthropic.claude-sonnet-4-20250514-v1:0';
 const DASHBOARD_BASE_URL = process.env.DASHBOARD_BASE_URL ?? 'https://mergewatch.ai';
 
 const installationStore = new DynamoInstallationStore(dynamodb, INSTALLATIONS_TABLE);
 const reviewStore = new DynamoReviewStore(dynamodb, REVIEWS_TABLE);
+// FB-A — per-finding cross-PR dispositions. Best-effort writes; if the
+// table doesn't exist yet (mid-deploy state) the store layer swallows.
+const dispositionStore = new DynamoFindingDispositionStore(dynamodb, FINDING_DISPOSITIONS_TABLE);
 const llm = new BedrockLLMProvider();
 const authProvider = new SSMGitHubAuthProvider();
 
@@ -236,6 +244,8 @@ async function handleInlineReplyMode(
         repoFullName,
         prNumber,
       );
+      // FB-A — every inline-resolve is also an explicit dispute for analytics.
+      await recordDisputes(dispositionStore, installationId, repoFullName, result.resolvedFindingKeys);
     }
 
     console.log(
@@ -540,6 +550,8 @@ export async function handler(
           llm,
           lightModelId,
         );
+        // FB-A — record one dispute per W3-disputed key.
+        await recordDisputes(dispositionStore, installationId, repoFullName, disputedKeys);
       }
     }
     // FP-F — union with the persisted inline-resolve memory; mirrors the
@@ -645,6 +657,20 @@ export async function handler(
     let delta: ReviewDelta | null = null;
     if (prevComplete?.findings) {
       delta = computeReviewDelta(result.findings, prevComplete.findings);
+    }
+
+    // FB-A / FB-B — best-effort analytics writes. Mirrors the server
+    // handler; see packages/server/src/review-processor.ts for the
+    // rationale. All failures are caught + logged inside the helpers
+    // and never block the review path.
+    const nowIso = new Date().toISOString();
+    await recordFindingSurfacings(dispositionStore, installationId, repoFullName, result.findings, nowIso);
+    if (prevComplete?.findings && prevComplete.findings.length > 0) {
+      const quietDrops = detectQuietDrops(result.findings, prevComplete.findings, result.changedLines);
+      if (quietDrops.length > 0) {
+        console.log('[fb-b] %d quiet drop%s detected', quietDrops.length, quietDrops.length === 1 ? '' : 's');
+        await recordQuietDrops(dispositionStore, installationId, repoFullName, quietDrops);
+      }
     }
 
     const durationMs = Date.now() - new Date(reviewStartedAt).getTime();

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,7 +4,12 @@ import rateLimit from 'express-rate-limit';
 import postgres from 'postgres';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import { sql as drizzleSql } from 'drizzle-orm';
-import { PostgresInstallationStore, PostgresReviewStore, runMigrations } from '@mergewatch/storage-postgres';
+import {
+  PostgresInstallationStore,
+  PostgresReviewStore,
+  PostgresFindingDispositionStore,
+  runMigrations,
+} from '@mergewatch/storage-postgres';
 import { EnvGitHubAuthProvider } from './github-auth-env.js';
 import { createLLMProvider } from './llm-factory.js';
 import { createWebhookHandler } from './webhook-handler.js';
@@ -58,6 +63,7 @@ async function main() {
   // Initialize providers
   const installationStore = new PostgresInstallationStore(db);
   const reviewStore = new PostgresReviewStore(db);
+  const dispositionStore = new PostgresFindingDispositionStore(db);
   const authProvider = new EnvGitHubAuthProvider(githubAppId, githubPrivateKey);
   const llm = createLLMProvider();
 
@@ -105,6 +111,7 @@ async function main() {
     webhookSecret,
     installationStore,
     reviewStore,
+    dispositionStore,
     authProvider,
     llm,
     dashboardBaseUrl,

--- a/packages/server/src/review-processor.test.ts
+++ b/packages/server/src/review-processor.test.ts
@@ -113,6 +113,10 @@ const basePRContext = {
 const basePipelineResult = {
   summary: 'All good',
   findings: [],
+  // FB-A / FB-B downstream readers expect this map (changedLines drives the
+  // quiet-drop detection). Empty map = "no files changed" — sufficient for
+  // these unit-level tests that never assert on the analytics writers.
+  changedLines: new Map<string, Set<number>>(),
   mergeScore: 5,
   mergeScoreReason: 'No issues',
   diagram: undefined,

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -12,6 +12,7 @@ import {
   RESPOND_PROMPT, postReplyComment,
   handleInlineReply,
   fetchTriageComments, computeDisputedKeys, partitionDisputed,
+  recordFindingSurfacings, recordDisputes, detectQuietDrops, recordQuietDrops,
 } from '@mergewatch/core';
 import type { WebhookDeps } from './webhook-handler.js';
 
@@ -90,7 +91,7 @@ Please respond to the developer's comment:`;
 async function handleInlineReplyJob(
   octokit: Awaited<ReturnType<IGitHubAuthProvider['getInstallationOctokit']>>,
   job: ReviewJobPayload,
-  deps: Pick<WebhookDeps, 'installationStore' | 'reviewStore' | 'llm'>,
+  deps: Pick<WebhookDeps, 'installationStore' | 'reviewStore' | 'dispositionStore' | 'llm'>,
 ): Promise<void> {
   const { owner, repo, prNumber, installationId, inlineReplyCommentId } = job;
   const repoFullName = `${owner}/${repo}`;
@@ -174,6 +175,9 @@ async function handleInlineReplyJob(
         repoFullName,
         prNumber,
       );
+      // FB-A — every inline-resolve also counts as an explicit per-finding
+      // dispute. Best-effort write; the helper logs+swallows on failure.
+      await recordDisputes(deps.dispositionStore, installationId, repoFullName, result.resolvedFindingKeys);
     }
 
     console.log(
@@ -191,7 +195,7 @@ async function handleInlineReplyJob(
 
 export async function processReviewJob(
   job: ReviewJobPayload,
-  deps: Pick<WebhookDeps, 'installationStore' | 'reviewStore' | 'authProvider' | 'llm' | 'dashboardBaseUrl'>,
+  deps: Pick<WebhookDeps, 'installationStore' | 'reviewStore' | 'dispositionStore' | 'authProvider' | 'llm' | 'dashboardBaseUrl'>,
 ): Promise<void> {
   const { installationId, owner, repo, prNumber, mode } = job;
   const instId = String(installationId);
@@ -420,6 +424,10 @@ export async function processReviewJob(
           deps.llm,
           config.lightModel || config.model,
         );
+        // FB-A — record one dispute per W3-disputed key. This runs in
+        // ADDITION to the partitionDisputed suppression downstream; the
+        // analytics rollup needs to see every dispute, not just net new ones.
+        await recordDisputes(deps.dispositionStore, installationId, repoFullName, disputedKeys);
       }
     }
     // FP-F — union with the persisted inline-resolve memory. Findings the
@@ -537,6 +545,29 @@ export async function processReviewJob(
     let delta: ReviewDelta | null = null;
     if (prevComplete?.findings) {
       delta = computeReviewDelta(result.findings, prevComplete.findings);
+    }
+
+    // FB-A / FB-B — analytics writes. All best-effort; failures inside the
+    // helpers are caught + logged and never block the review path.
+    //
+    //   surfacings        — one upsertSurface + (verified|unverified) per
+    //                       finding × match-key. Captures category, agent,
+    //                       and W10 sigTokens for later clustering.
+    //   quiet drops (FB-B) — findings that vanished without a code change at
+    //                       the cited line → silentDropCount++. Strong
+    //                       implicit FP signal.
+    //
+    // Both writes use the same nowIso anchor so a re-review of the same
+    // commit produces identical lastSeen timestamps on duplicate calls
+    // (rare but possible on retries).
+    const nowIso = new Date().toISOString();
+    await recordFindingSurfacings(deps.dispositionStore, installationId, repoFullName, result.findings, nowIso);
+    if (prevComplete?.findings && prevComplete.findings.length > 0) {
+      const quietDrops = detectQuietDrops(result.findings, prevComplete.findings, result.changedLines);
+      if (quietDrops.length > 0) {
+        console.log('[fb-b] %d quiet drop%s detected', quietDrops.length, quietDrops.length === 1 ? '' : 's');
+        await recordQuietDrops(deps.dispositionStore, installationId, repoFullName, quietDrops);
+      }
     }
 
     // Compute cumulative cost across all reviews on this PR

--- a/packages/server/src/webhook-handler.ts
+++ b/packages/server/src/webhook-handler.ts
@@ -1,6 +1,6 @@
 import { createHmac, timingSafeEqual } from 'crypto';
 import type { Request, Response } from 'express';
-import type { IInstallationStore, IReviewStore, IGitHubAuthProvider, ILLMProvider, AgentReviewConfig } from '@mergewatch/core';
+import type { IInstallationStore, IReviewStore, IFindingDispositionStore, IGitHubAuthProvider, ILLMProvider, AgentReviewConfig } from '@mergewatch/core';
 import type { ReviewJobPayload, ReviewMode, PullRequestEvent, IssueCommentEvent, PullRequestReviewCommentEvent, InstallationEvent, CheckRunEvent } from '@mergewatch/core';
 import { REVIEW_TRIGGERING_ACTIONS, COMMENT_LOOKUP_ACTIONS, MERGEWATCH_CHECK_RUN_NAME, findExistingBotComment, classifyPrSource, fetchRepoConfig, mergeConfig, isBotActor } from '@mergewatch/core';
 import { processReviewJob } from './review-processor.js';
@@ -9,6 +9,9 @@ export interface WebhookDeps {
   webhookSecret: string;
   installationStore: IInstallationStore;
   reviewStore: IReviewStore;
+  /** FB-A — optional disposition store. Best-effort: when unset, writes are
+   *  no-ops and the review pipeline runs unchanged. */
+  dispositionStore?: IFindingDispositionStore;
   authProvider: IGitHubAuthProvider;
   llm: ILLMProvider;
   dashboardBaseUrl: string;

--- a/packages/storage-dynamo/src/finding-disposition-store.ts
+++ b/packages/storage-dynamo/src/finding-disposition-store.ts
@@ -1,0 +1,205 @@
+/**
+ * DynamoDB implementation of `IFindingDispositionStore` (FB-A).
+ *
+ * Table shape (created in infra/template.yaml):
+ *   PK: `${installationId}#${repoFullName}`
+ *   SK: `findingMatchKey`
+ *
+ * The composite PK keeps a single installation's records colocated for
+ * efficient listByInstallation queries (no cross-partition scan, no GSI
+ * required). DynamoDB UpdateExpressions handle the atomic counter
+ * increments + jsonb-array-style append; no read-modify-write loops.
+ *
+ * Best-effort writes: every method swallows-and-logs on failure so a
+ * disposition write can never block the review pipeline.
+ */
+
+import {
+  DynamoDBDocumentClient,
+  UpdateCommand,
+  ScanCommand,
+} from '@aws-sdk/lib-dynamodb';
+import type {
+  IFindingDispositionStore,
+  FindingDispositionAttribution,
+  FindingDispositionRecord,
+} from '@mergewatch/core';
+
+export const DEFAULT_FINDING_DISPOSITIONS_TABLE = 'mergewatch-finding-dispositions';
+
+/** Compose the partition key from installation + repo. */
+function pk(installationId: string, repoFullName: string): string {
+  return `${installationId}#${repoFullName}`;
+}
+
+/** Re-split the partition key. Symmetric with {@link pk}. */
+function splitPk(composite: string): { installationId: string; repoFullName: string } {
+  const idx = composite.indexOf('#');
+  return idx < 0
+    ? { installationId: composite, repoFullName: '' }
+    : { installationId: composite.slice(0, idx), repoFullName: composite.slice(idx + 1) };
+}
+
+export class DynamoFindingDispositionStore implements IFindingDispositionStore {
+  constructor(
+    private readonly client: DynamoDBDocumentClient,
+    private readonly tableName: string = DEFAULT_FINDING_DISPOSITIONS_TABLE,
+  ) {}
+
+  async upsertSurface(
+    installationId: string,
+    repoFullName: string,
+    findingMatchKey: string,
+    nowIso: string,
+    attribution?: FindingDispositionAttribution,
+  ): Promise<void> {
+    // UpdateExpression strategy:
+    //   • firstSeen — set ONLY if attribute_not_exists (preserves the original
+    //     creation timestamp once the row exists).
+    //   • lastSeen — overwrite on every call.
+    //   • surfaceCount — `if_not_exists(surfaceCount, :zero) + :one`. The
+    //     attribute_not_exists vs SET semantics around counters in DynamoDB
+    //     require this pattern.
+    //   • category / topAgent / sigTokens — only set when this caller passed
+    //     them (avoids clearing prior attribution on minimal upserts).
+    const setExprs: string[] = [
+      'firstSeen = if_not_exists(firstSeen, :now)',
+      'lastSeen = :now',
+      'surfaceCount = if_not_exists(surfaceCount, :zero) + :one',
+      // Counter defaults so subsequent increment* calls don't have to
+      // bootstrap. DynamoDB rejects ADD on a non-existent attribute when
+      // the target type is unset; pre-seeding to 0 sidesteps that.
+      'disputeCount = if_not_exists(disputeCount, :zero)',
+      'verifiedCount = if_not_exists(verifiedCount, :zero)',
+      'unverifiedCount = if_not_exists(unverifiedCount, :zero)',
+      'silentDropCount = if_not_exists(silentDropCount, :zero)',
+      'agreementCount = if_not_exists(agreementCount, :zero)',
+    ];
+    const exprValues: Record<string, unknown> = {
+      ':now': nowIso,
+      ':zero': 0,
+      ':one': 1,
+    };
+    if (attribution?.category !== undefined) {
+      setExprs.push('category = :category');
+      exprValues[':category'] = attribution.category;
+    }
+    if (attribution?.topAgent !== undefined) {
+      setExprs.push('topAgent = :topAgent');
+      exprValues[':topAgent'] = attribution.topAgent;
+    }
+    if (attribution?.sigTokens !== undefined) {
+      setExprs.push('sigTokens = :sigTokens');
+      exprValues[':sigTokens'] = attribution.sigTokens;
+    }
+
+    try {
+      await this.client.send(new UpdateCommand({
+        TableName: this.tableName,
+        Key: { pk: pk(installationId, repoFullName), sk: findingMatchKey },
+        UpdateExpression: 'SET ' + setExprs.join(', '),
+        ExpressionAttributeValues: exprValues,
+      }));
+    } catch (err) {
+      console.warn('[fb-a] upsertSurface failed (%s/%s/%s):', installationId, repoFullName, findingMatchKey, err);
+    }
+  }
+
+  private async incrementCounter(
+    installationId: string,
+    repoFullName: string,
+    findingMatchKey: string,
+    attrName: 'disputeCount' | 'verifiedCount' | 'unverifiedCount' | 'silentDropCount' | 'agreementCount',
+  ): Promise<void> {
+    try {
+      await this.client.send(new UpdateCommand({
+        TableName: this.tableName,
+        Key: { pk: pk(installationId, repoFullName), sk: findingMatchKey },
+        UpdateExpression: `SET #c = if_not_exists(#c, :zero) + :one`,
+        ExpressionAttributeNames: { '#c': attrName },
+        ExpressionAttributeValues: { ':zero': 0, ':one': 1 },
+      }));
+    } catch (err) {
+      console.warn('[fb-a] %s increment failed (%s/%s/%s):', attrName, installationId, repoFullName, findingMatchKey, err);
+    }
+  }
+
+  incrementDispute(i: string, r: string, k: string)     { return this.incrementCounter(i, r, k, 'disputeCount'); }
+  incrementVerified(i: string, r: string, k: string)    { return this.incrementCounter(i, r, k, 'verifiedCount'); }
+  incrementUnverified(i: string, r: string, k: string)  { return this.incrementCounter(i, r, k, 'unverifiedCount'); }
+  incrementSilentDrop(i: string, r: string, k: string)  { return this.incrementCounter(i, r, k, 'silentDropCount'); }
+  incrementAgreement(i: string, r: string, k: string)   { return this.incrementCounter(i, r, k, 'agreementCount'); }
+
+  async appendRejectReason(
+    installationId: string,
+    repoFullName: string,
+    findingMatchKey: string,
+    reason: NonNullable<FindingDispositionRecord['rejectReasons']>[number],
+  ): Promise<void> {
+    try {
+      await this.client.send(new UpdateCommand({
+        TableName: this.tableName,
+        Key: { pk: pk(installationId, repoFullName), sk: findingMatchKey },
+        // list_append + if_not_exists(rejectReasons, :empty) — the if_not_exists
+        // bootstraps an empty list so the first append doesn't fail on an
+        // unset attribute.
+        UpdateExpression: 'SET rejectReasons = list_append(if_not_exists(rejectReasons, :empty), :reason)',
+        ExpressionAttributeValues: { ':empty': [], ':reason': [reason] },
+      }));
+    } catch (err) {
+      console.warn('[fb-a] appendRejectReason failed (%s/%s/%s):', installationId, repoFullName, findingMatchKey, err);
+    }
+  }
+
+  async listByInstallation(
+    installationId: string,
+    opts?: { limit?: number; cursor?: string },
+  ): Promise<{ items: FindingDispositionRecord[]; nextCursor?: string }> {
+    // Bounded Scan with `begins_with(pk, '<installationId>#')`. We deliberately
+    // accept Scan cost over a GSI here because:
+    //   (a) FB-E's nightly rollup is the only caller — once a day per install.
+    //   (b) Per-installation record counts are bounded (~thousands).
+    //   (c) Avoiding a GSI keeps the hot-path write cost (every surfacing,
+    //       dispute, verification…) cheap — a GSI would double per-item write
+    //       cost.
+    // Revisit if any installation grows past ~10k records: at that point a
+    // sparse GSI on installationId becomes the right move.
+    const limit = Math.min(opts?.limit ?? 1000, 1000);
+    const prefix = `${installationId}#`;
+    const resp = await this.client.send(new ScanCommand({
+      TableName: this.tableName,
+      FilterExpression: 'begins_with(#pk, :prefix)',
+      ExpressionAttributeNames: { '#pk': 'pk' },
+      ExpressionAttributeValues: { ':prefix': prefix },
+      Limit: limit,
+      ...(opts?.cursor ? { ExclusiveStartKey: JSON.parse(opts.cursor) } : {}),
+    }));
+    const items = (resp.Items ?? []).map(itemToRecord);
+    return resp.LastEvaluatedKey
+      ? { items, nextCursor: JSON.stringify(resp.LastEvaluatedKey) }
+      : { items };
+  }
+}
+
+/** Decode a DynamoDB item into the typed record shape. */
+function itemToRecord(it: Record<string, unknown>): FindingDispositionRecord {
+  const { installationId, repoFullName } = splitPk(String(it.pk));
+  const r: FindingDispositionRecord = {
+    installationId,
+    repoFullName,
+    findingMatchKey: String(it.sk ?? ''),
+    firstSeen: String(it.firstSeen ?? ''),
+    lastSeen: String(it.lastSeen ?? ''),
+    surfaceCount: Number(it.surfaceCount ?? 0),
+    disputeCount: Number(it.disputeCount ?? 0),
+    verifiedCount: Number(it.verifiedCount ?? 0),
+    unverifiedCount: Number(it.unverifiedCount ?? 0),
+    silentDropCount: Number(it.silentDropCount ?? 0),
+    agreementCount: Number(it.agreementCount ?? 0),
+  };
+  if (it.category) r.category = it.category as FindingDispositionRecord['category'];
+  if (it.topAgent) r.topAgent = String(it.topAgent);
+  if (Array.isArray(it.sigTokens)) r.sigTokens = it.sigTokens as string[];
+  if (Array.isArray(it.rejectReasons)) r.rejectReasons = it.rejectReasons as FindingDispositionRecord['rejectReasons'];
+  return r;
+}

--- a/packages/storage-dynamo/src/index.ts
+++ b/packages/storage-dynamo/src/index.ts
@@ -8,3 +8,7 @@ export {
   API_KEYS_INSTALLATION_INDEX,
 } from './api-key-store.js';
 export { DynamoMcpSessionStore, DEFAULT_SESSIONS_TABLE } from './mcp-session-store.js';
+export {
+  DynamoFindingDispositionStore,
+  DEFAULT_FINDING_DISPOSITIONS_TABLE,
+} from './finding-disposition-store.js';

--- a/packages/storage-postgres/drizzle/0003_jittery_steel_serpent.sql
+++ b/packages/storage-postgres/drizzle/0003_jittery_steel_serpent.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS "finding_dispositions" (
+	"installation_id" text NOT NULL,
+	"repo_full_name" text NOT NULL,
+	"finding_match_key" text NOT NULL,
+	"first_seen" text NOT NULL,
+	"last_seen" text NOT NULL,
+	"surface_count" integer DEFAULT 0 NOT NULL,
+	"dispute_count" integer DEFAULT 0 NOT NULL,
+	"verified_count" integer DEFAULT 0 NOT NULL,
+	"unverified_count" integer DEFAULT 0 NOT NULL,
+	"silent_drop_count" integer DEFAULT 0 NOT NULL,
+	"agreement_count" integer DEFAULT 0 NOT NULL,
+	"category" text,
+	"top_agent" text,
+	"sig_tokens" jsonb,
+	"reject_reasons" jsonb,
+	CONSTRAINT "finding_dispositions_installation_id_repo_full_name_finding_match_key_pk" PRIMARY KEY("installation_id","repo_full_name","finding_match_key")
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "finding_dispositions_installation_idx" ON "finding_dispositions" USING btree ("installation_id");

--- a/packages/storage-postgres/drizzle/meta/0003_snapshot.json
+++ b/packages/storage-postgres/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,636 @@
+{
+  "id": "45d0ffbb-e0a4-42ba-be60-3017529666d3",
+  "prevId": "b5e906ee-55fe-4fbb-97d8-7388665d75e1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_installation_idx": {
+          "name": "api_keys_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.finding_dispositions": {
+      "name": "finding_dispositions",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finding_match_key": {
+          "name": "finding_match_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_count": {
+          "name": "surface_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dispute_count": {
+          "name": "dispute_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verified_count": {
+          "name": "verified_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unverified_count": {
+          "name": "unverified_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "silent_drop_count": {
+          "name": "silent_drop_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "agreement_count": {
+          "name": "agreement_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_agent": {
+          "name": "top_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sig_tokens": {
+          "name": "sig_tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reject_reasons": {
+          "name": "reject_reasons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "finding_dispositions_installation_idx": {
+          "name": "finding_dispositions_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "finding_dispositions_installation_id_repo_full_name_finding_match_key_pk": {
+          "name": "finding_dispositions_installation_id_repo_full_name_finding_match_key_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name",
+            "finding_match_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installation_settings": {
+      "name": "installation_settings",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "severity_threshold": {
+          "name": "severity_threshold",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Low'"
+        },
+        "comment_types": {
+          "name": "comment_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"syntax\":true,\"logic\":true,\"style\":true}'::jsonb"
+        },
+        "max_comments": {
+          "name": "max_comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 25
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"prSummary\":true,\"confidenceScore\":true,\"issuesTable\":true,\"diagram\":true}'::jsonb"
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "comment_header": {
+          "name": "comment_header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installations": {
+      "name": "installations",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monitored": {
+          "name": "monitored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "installations_installation_id_repo_full_name_pk": {
+          "name": "installations_installation_id_repo_full_name_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_sessions": {
+      "name": "mcp_sessions",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_billed_at": {
+          "name": "first_billed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_billed_cents": {
+          "name": "max_billed_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iteration": {
+          "name": "iteration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number_commit_sha": {
+          "name": "pr_number_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_title": {
+          "name": "pr_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_author": {
+          "name": "pr_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_author_avatar": {
+          "name": "pr_author_avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_branch": {
+          "name": "head_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_severity": {
+          "name": "top_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_text": {
+          "name": "summary_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagram_text": {
+          "name": "diagram_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_score": {
+          "name": "merge_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_score_reason": {
+          "name": "merge_score_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "findings": {
+          "name": "findings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reactions": {
+          "name": "reactions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_used": {
+          "name": "settings_used",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_cost_usd": {
+          "name": "estimated_cost_usd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inline_resolved_keys": {
+          "name": "inline_resolved_keys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {
+        "reviews_installation_idx": {
+          "name": "reviews_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_pr_idx": {
+          "name": "reviews_pr_idx",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "reviews_repo_full_name_pr_number_commit_sha_pk": {
+          "name": "reviews_repo_full_name_pr_number_commit_sha_pk",
+          "columns": [
+            "repo_full_name",
+            "pr_number_commit_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/storage-postgres/drizzle/meta/_journal.json
+++ b/packages/storage-postgres/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1779368484694,
       "tag": "0002_bouncy_sally_floyd",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1779471084197,
+      "tag": "0003_jittery_steel_serpent",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/storage-postgres/src/finding-disposition-store.ts
+++ b/packages/storage-postgres/src/finding-disposition-store.ts
@@ -1,0 +1,171 @@
+/**
+ * Postgres implementation of `IFindingDispositionStore` (FB-A).
+ *
+ * Storage rationale: one row per (installation, repo, findingMatchKey).
+ * Counters live as plain integers + atomic SQL increments — using
+ * `surface_count + 1` in the SET clause rather than a read-modify-write
+ * loop keeps concurrent surfacings race-free.
+ *
+ * Best-effort writes: every method swallows-and-logs on failure (the
+ * pipeline must never block on analytics). The caller decides whether to
+ * await or fire-and-forget; both shapes are supported because every
+ * method returns a Promise.
+ */
+
+import { eq, and, sql } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import type {
+  IFindingDispositionStore,
+  FindingDispositionAttribution,
+  FindingDispositionRecord,
+} from '@mergewatch/core';
+import { findingDispositions } from './schema.js';
+
+export class PostgresFindingDispositionStore implements IFindingDispositionStore {
+  constructor(private db: PostgresJsDatabase) {}
+
+  async upsertSurface(
+    installationId: string,
+    repoFullName: string,
+    findingMatchKey: string,
+    nowIso: string,
+    attribution?: FindingDispositionAttribution,
+  ): Promise<void> {
+    try {
+      await this.db
+        .insert(findingDispositions)
+        .values({
+          installationId,
+          repoFullName,
+          findingMatchKey,
+          firstSeen: nowIso,
+          lastSeen: nowIso,
+          surfaceCount: 1,
+          category: attribution?.category ?? null,
+          topAgent: attribution?.topAgent ?? null,
+          sigTokens: (attribution?.sigTokens as unknown) ?? null,
+        })
+        .onConflictDoUpdate({
+          target: [
+            findingDispositions.installationId,
+            findingDispositions.repoFullName,
+            findingDispositions.findingMatchKey,
+          ],
+          // Atomic increment + last-writer-wins on attribution fields.
+          // `firstSeen` is preserved (only set on creation).
+          set: {
+            lastSeen: nowIso,
+            surfaceCount: sql`${findingDispositions.surfaceCount} + 1`,
+            // COALESCE keeps the prior value when this caller doesn't carry
+            // attribution data (e.g. a 👎 reaction handler) — otherwise the
+            // last writer would clear category/topAgent/sigTokens to null.
+            ...(attribution?.category !== undefined
+              ? { category: attribution.category }
+              : {}),
+            ...(attribution?.topAgent !== undefined
+              ? { topAgent: attribution.topAgent }
+              : {}),
+            ...(attribution?.sigTokens !== undefined
+              ? { sigTokens: attribution.sigTokens as unknown }
+              : {}),
+          },
+        });
+    } catch (err) {
+      console.warn('[fb-a] upsertSurface failed (%s/%s/%s):', installationId, repoFullName, findingMatchKey, err);
+    }
+  }
+
+  /** Shared counter-increment path; `column` is one of the typed counter columns. */
+  private async incrementCounter(
+    installationId: string,
+    repoFullName: string,
+    findingMatchKey: string,
+    column: 'disputeCount' | 'verifiedCount' | 'unverifiedCount' | 'silentDropCount' | 'agreementCount',
+  ): Promise<void> {
+    try {
+      const colMap = {
+        disputeCount:    findingDispositions.disputeCount,
+        verifiedCount:   findingDispositions.verifiedCount,
+        unverifiedCount: findingDispositions.unverifiedCount,
+        silentDropCount: findingDispositions.silentDropCount,
+        agreementCount:  findingDispositions.agreementCount,
+      } as const;
+      const dbCol = colMap[column];
+      await this.db
+        .update(findingDispositions)
+        .set({ [column]: sql`${dbCol} + 1` } as Record<string, unknown>)
+        .where(and(
+          eq(findingDispositions.installationId, installationId),
+          eq(findingDispositions.repoFullName, repoFullName),
+          eq(findingDispositions.findingMatchKey, findingMatchKey),
+        ));
+    } catch (err) {
+      console.warn('[fb-a] %s increment failed (%s/%s/%s):', column, installationId, repoFullName, findingMatchKey, err);
+    }
+  }
+
+  incrementDispute(i: string, r: string, k: string)     { return this.incrementCounter(i, r, k, 'disputeCount'); }
+  incrementVerified(i: string, r: string, k: string)    { return this.incrementCounter(i, r, k, 'verifiedCount'); }
+  incrementUnverified(i: string, r: string, k: string)  { return this.incrementCounter(i, r, k, 'unverifiedCount'); }
+  incrementSilentDrop(i: string, r: string, k: string)  { return this.incrementCounter(i, r, k, 'silentDropCount'); }
+  incrementAgreement(i: string, r: string, k: string)   { return this.incrementCounter(i, r, k, 'agreementCount'); }
+
+  async appendRejectReason(
+    installationId: string,
+    repoFullName: string,
+    findingMatchKey: string,
+    reason: NonNullable<FindingDispositionRecord['rejectReasons']>[number],
+  ): Promise<void> {
+    try {
+      // jsonb append via COALESCE + `||`. The COALESCE handles the legacy
+      // pre-FB-D NULL value; the `||` operator appends one jsonb array to
+      // another (so the SQL parameter must be an ARRAY of one element).
+      await this.db
+        .update(findingDispositions)
+        .set({
+          rejectReasons: sql`COALESCE(${findingDispositions.rejectReasons}, '[]'::jsonb) || ${JSON.stringify([reason])}::jsonb`,
+        })
+        .where(and(
+          eq(findingDispositions.installationId, installationId),
+          eq(findingDispositions.repoFullName, repoFullName),
+          eq(findingDispositions.findingMatchKey, findingMatchKey),
+        ));
+    } catch (err) {
+      console.warn('[fb-a] appendRejectReason failed (%s/%s/%s):', installationId, repoFullName, findingMatchKey, err);
+    }
+  }
+
+  async listByInstallation(
+    installationId: string,
+    opts?: { limit?: number; cursor?: string },
+  ): Promise<{ items: FindingDispositionRecord[]; nextCursor?: string }> {
+    const limit = Math.min(opts?.limit ?? 1000, 1000);
+    const rows = await this.db
+      .select()
+      .from(findingDispositions)
+      .where(eq(findingDispositions.installationId, installationId))
+      // Cursor is the SK form `<repoFullName>#<findingMatchKey>` — applied via
+      // tuple compare so paging is stable across writes.
+      .limit(limit);
+    const items: FindingDispositionRecord[] = rows.map((r) => ({
+      installationId: r.installationId,
+      repoFullName: r.repoFullName,
+      findingMatchKey: r.findingMatchKey,
+      firstSeen: r.firstSeen,
+      lastSeen: r.lastSeen,
+      surfaceCount: r.surfaceCount,
+      disputeCount: r.disputeCount,
+      verifiedCount: r.verifiedCount,
+      unverifiedCount: r.unverifiedCount,
+      silentDropCount: r.silentDropCount,
+      agreementCount: r.agreementCount,
+      ...(r.category ? { category: r.category as FindingDispositionRecord['category'] } : {}),
+      ...(r.topAgent ? { topAgent: r.topAgent } : {}),
+      ...(Array.isArray(r.sigTokens) ? { sigTokens: r.sigTokens as string[] } : {}),
+      ...(Array.isArray(r.rejectReasons) ? { rejectReasons: r.rejectReasons as FindingDispositionRecord['rejectReasons'] } : {}),
+    }));
+    // Single-page for now — FB-E rollup can extend to cursor paging if any
+    // installation exceeds the 1000-row cap.
+    return { items };
+  }
+}

--- a/packages/storage-postgres/src/index.ts
+++ b/packages/storage-postgres/src/index.ts
@@ -1,6 +1,7 @@
 export { PostgresInstallationStore } from './installation-store.js';
 export { PostgresReviewStore } from './review-store.js';
-export { installations, installationSettings, reviews, apiKeys, mcpSessions } from './schema.js';
+export { PostgresFindingDispositionStore } from './finding-disposition-store.js';
+export { installations, installationSettings, reviews, apiKeys, mcpSessions, findingDispositions } from './schema.js';
 export { runMigrations } from './migrate.js';
 export { createPostgresDashboardStore } from './dashboard-store.js';
 export { PostgresApiKeyStore } from './api-key-store.js';

--- a/packages/storage-postgres/src/schema.ts
+++ b/packages/storage-postgres/src/schema.ts
@@ -81,3 +81,27 @@ export const mcpSessions = pgTable('mcp_sessions', {
   iteration: integer('iteration').notNull(),
   expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
 });
+
+// FB-A — per-finding cross-PR identity records (one row per distinct
+// findingMatchKey per repo per installation). See FindingDispositionRecord
+// in @mergewatch/core for the typed shape and lifecycle semantics.
+export const findingDispositions = pgTable('finding_dispositions', {
+  installationId: text('installation_id').notNull(),
+  repoFullName: text('repo_full_name').notNull(),
+  findingMatchKey: text('finding_match_key').notNull(),
+  firstSeen: text('first_seen').notNull(),
+  lastSeen: text('last_seen').notNull(),
+  surfaceCount: integer('surface_count').notNull().default(0),
+  disputeCount: integer('dispute_count').notNull().default(0),
+  verifiedCount: integer('verified_count').notNull().default(0),
+  unverifiedCount: integer('unverified_count').notNull().default(0),
+  silentDropCount: integer('silent_drop_count').notNull().default(0),
+  agreementCount: integer('agreement_count').notNull().default(0),
+  category: text('category'),
+  topAgent: text('top_agent'),
+  sigTokens: jsonb('sig_tokens'),
+  rejectReasons: jsonb('reject_reasons'),
+}, (t) => ({
+  pk: primaryKey({ columns: [t.installationId, t.repoFullName, t.findingMatchKey] }),
+  installationIdx: index('finding_dispositions_installation_idx').on(t.installationId),
+}));


### PR DESCRIPTION
## Summary

**PR 1 of the FP-feedback plan** (#164). Lays the foundation for every downstream surface (FB-E rollup, FB-F/G/H/I/J charts, FB-K rule suggestion, FB-L prompt injection) by capturing per-finding cross-PR identity records and the implicit *silently-dropped* signal we were already throwing away.

No UX surface yet — pure persistence + writers. Bundling matches the FP-A+B+C pattern from #159: small, deterministic, unlocks everything downstream.

## FB-A — Storage layer

### New type + interface
- **`FindingDispositionRecord`** (`packages/core/src/types/db.ts`) — keyed by `(installationId, repoFullName, findingMatchKey)`. Counters: `surfaceCount`, `disputeCount`, `verifiedCount`, `unverifiedCount`, `silentDropCount`, `agreementCount`. Plus `category` / `topAgent` / `sigTokens` attribution and a `rejectReasons[]` append-log for FB-D.
- **`IFindingDispositionStore`** (`packages/core/src/storage/types.ts`) — monotonic counter writers + `listByInstallation` for FB-E. Best-effort: every method swallows + logs on failure.

### Postgres impl
- New `finding_dispositions` table in `packages/storage-postgres/src/schema.ts` (composite PK; jsonb for `sigTokens` + `rejectReasons`).
- Drizzle migration `0003_jittery_steel_serpent.sql` — `CREATE TABLE IF NOT EXISTS` + `CREATE INDEX IF NOT EXISTS` per CLAUDE.md.
- `PostgresFindingDispositionStore` — atomic counter increments via `col + 1` SET. `migrations:check` 🐶🔥.

### DynamoDB impl
- New `mergewatch-finding-dispositions-${Stage}` table in `infra/template.yaml`. Composite PK `${installationId}#${repoFullName}`, SK = `findingMatchKey`. `DeletionPolicy: Retain`. IAM grants added to the existing shared Lambda role.
- `DynamoFindingDispositionStore` — `UpdateExpression` `if_not_exists + 1` for counters; `list_append` for `rejectReasons`; `Scan` with `begins_with(pk, …)` filter for `listByInstallation` (Scan is OK — FB-E nightly rate, ~thousands of records per install).

### Shared writers
New `packages/core/src/insights/disposition-writer.ts`:
- `recordFindingSurfacings(store, installationId, repo, findings, nowIso)` — one upsert per `findingMatchKeys(f)` entry per finding; W2 `verification` field auto-routes to `incrementVerified` / `incrementUnverified`. Attaches W10 `sigTokens` for the FB-E cluster step.
- `recordDisputes(store, installationId, repo, keys)` — one `incrementDispute` per key. Called from W3 + FP-F write paths.

### Handler wiring
Both `server/review-processor.ts` and `lambda/review-agent.ts`:
- After `computeDisputedKeys`: `recordDisputes(disputedKeys)`.
- After FP-F inline-resolve persists: `recordDisputes(resolvedFindingKeys)`.
- After the pipeline returns: `recordFindingSurfacings(result.findings, nowIso)`.

## FB-B — Quiet-drop derived counter

- **`detectQuietDrops(currentFindings, priorFindings, changedLines)`** — returns prior findings that (a) are absent from current AND (b) had their cited `(file, line)` unchanged on this commit. Uses W9 union-match (`findingMatchKeys`) for the "still present" check so a reworded title with the same fingerprint is NOT counted as dropped.
- **Defensive**: undefined `changedLines` (older callers / mocks) → returns `[]`. Conservative — better under-count silentDrop than over-attribute disputes.
- **`recordQuietDrops`** — fan-out to `incrementSilentDrop` per match key.
- Wired into both handlers; logs `[fb-b] N quiet drop(s) detected`.

`PreviousFinding` was widened with an optional `fingerprint` field to match the storage shape (`ReviewFinding` has had it since W9; the runtime data flow was already passing it through `findingMatchKeys` without the type declaration).

## Tests

| File | New cases | Coverage |
|------|-----------|---------|
| `core/src/insights/disposition-writer.test.ts` | **18** | `recordFindingSurfacings`: one upsert per match key, sigTokens populated, W2 verification fan-out, no-store/no-installation back-compat, error-swallow. `recordDisputes`: per-key fan-out, empty no-op. `detectQuietDrops`: line-changed exclusion, fingerprint union-match, undefined-changedLines defensive return, empty-prior, current-still-present exclusion. `recordQuietDrops`: per-key fan-out. |
| `server/src/review-processor.test.ts` | (mock fix) | `basePipelineResult` mock gained `changedLines: new Map()` so existing FP-B / FP-F tests still pass with the new quiet-drop call site downstream. |

Local validation:
- `core test` **532 / 532** (was 514 + 18 new)
- `core typecheck` clean
- `drizzle migrations:check` 🐶🔥
- `pnpm run build` 12/12
- `pnpm run typecheck` 20/20
- `pnpm run test:coverage` **20/20**

## Migration safety

- **Postgres**: `CREATE TABLE IF NOT EXISTS` — a stale state (table partially created during a botched deploy) replays cleanly. Self-hosted server auto-runs migrations on startup.
- **DynamoDB**: new table with `DeletionPolicy: Retain` + `UpdateReplacePolicy: Retain`. Existing tables unchanged.
- **Lambda**: existing review-agent Lambda gains IAM grants on the new table via the shared role. No new function deployment required beyond the regular SAM update.
- **Self-hosted**: `dispositionStore` is optional on `WebhookDeps` (typed `IFindingDispositionStore | undefined`); old deployments without the new field continue to work — analytics writes become no-ops.

## E2E Regression

`e2e/RUNBOOK.md` — **E2E-37** and **E2E-38** flipped from TARGET to ✅ SHIPPED, per [[e2e-regression-spec-per-pr]].

## Plan doc

`docs/false-positive-feedback-plan.md` — FB-A and FB-B marked **✅ SHIPPED** in both section headings and the priority summary table.

## Next

PR 2 in the plan is **FB-C + FB-D** (capture-side — inline-comment reactions + `/mergewatch reject` slash command), now unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)