### PR TITLE
FB-C + FB-D — inline-comment reactions + /mergewatch reject

### DIFF
--- a/docs/false-positive-feedback-plan.md
+++ b/docs/false-positive-feedback-plan.md
@@ -157,7 +157,7 @@ Ranked by dependency order (foundation first → capture → aggregation → sur
 
 ---
 
-### FB-C — Inline-comment 👎 reactions → disputes
+### FB-C — Inline-comment 👎 reactions → disputes  ✅ SHIPPED
 
 **Where the gap lives:** Top-comment reactions are already collected via `ReviewItem.reactions`. Inline-comment reactions are not. Yet reactions on an inline finding are arguably *more* signal-dense than top-level reactions — they're per-finding, attributed to the reviewer, and require zero typing.
 
@@ -172,7 +172,7 @@ The bot's inline-comment ID is already linked to a finding via `ReviewItem.findi
 
 ---
 
-### FB-D — `/mergewatch reject "<reason>"` slash command
+### FB-D — `/mergewatch reject "<reason>"` slash command  ✅ SHIPPED
 
 **Where the gap lives:** W3 triage prose is the cleanest signal we have — author writes a sentence explaining why a finding is wrong — but it requires the author to write prose and lives only on top-level comments. Inline threads have only `/resolve` (which is success-shaped, not FP-shaped). There's no quick "this finding is wrong" channel from an inline thread.
 
@@ -302,8 +302,8 @@ Compute cost is bounded by the largest installation's record count; rollups stay
 |---|---|---|---|---|---|
 | **FB-A** | FindingDispositionRecord storage + writers | Persist | S | — | ✅ SHIPPED |
 | **FB-B** | Quiet-drop derived counter | Persist | S | FB-A | ✅ SHIPPED |
-| **FB-C** | Inline-comment 👎 → disputes | Capture | M | FB-A | ★★★ |
-| **FB-D** | `/mergewatch reject` slash command | Capture | M | FB-A | ★★ |
+| **FB-C** | Inline-comment 👎 → disputes | Capture | M | FB-A | ✅ SHIPPED |
+| **FB-D** | `/mergewatch reject` slash command | Capture | M | FB-A | ✅ SHIPPED |
 | **FB-E** | Nightly InstallationFPInsight rollup | Aggregate | M | FB-A, FB-B | ★★★ |
 | **FB-F** | FP funnel chart | Surface | M | FB-E | ★★ |
 | **FB-G** | Dispute-rate-by-agent chart | Surface | M | FB-E | ★★ |

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -165,8 +165,8 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-36](#e2e-36-fp-g--linter-aware-style-agent) | Repos with detected linters (eslint / ruff / clippy / biome) get a stricter STYLE_REVIEWER_PROMPT that defers lint-equivalent findings (FP-G) | 2m | 60s | FP-G |
 | [E2E-37](#e2e-37-fb-a--findingdispositionrecord-storage--writers) | FindingDispositionRecord rows are written on every surfacing, W3 dispute, FP-F inline-resolve (FB-A) | 2m | 60s | FB-A |
 | [E2E-38](#e2e-38-fb-b--quiet-drop-derived-counter) | Quiet-drop (finding gone without code change) increments `silentDropCount` on the matching record (FB-B) | 2m | 60s | FB-B |
-| [E2E-39](#e2e-39-fb-c--inline-comment--reactions--disputes-target) | 👎 / 🤔 on a bot inline comment increments `disputeCount`; 👍 / ❤️ / 🚀 increments `agreementCount` (FB-C) — **TARGET** | 2m | 60s | FB-C |
-| [E2E-40](#e2e-40-fb-d--mergewatch-reject-slash-command-target) | `/mergewatch reject <category> [reason]` on an inline thread persists a categorised rejection + posts a confirming bot reply (FB-D) — **TARGET** | 3m | 90s | FB-D |
+| [E2E-39](#e2e-39-fb-c--inline-comment--reactions--disputes) | 👎 / 🤔 on a bot inline comment increments `disputeCount`; 👍 / ❤️ / 🚀 increments `agreementCount` (FB-C) | 2m | 60s | FB-C |
+| [E2E-40](#e2e-40-fb-d--mergewatch-reject-slash-command) | `/mergewatch reject <category> [reason]` on an inline thread persists a categorised rejection + posts a confirming bot reply (FB-D) | 3m | 90s | FB-D |
 | [E2E-41](#e2e-41-fb-e--nightly-installationfpinsight-rollup-target) | Nightly scheduled job produces InstallationFPInsight rollups for 7d / 30d / 90d windows per installation (FB-E) — **TARGET** | 3m | 90s | FB-E |
 | [E2E-42](#e2e-42-fb-f--dashboard-fp-funnel-chart-target) | Org dashboard renders the FP funnel: surfaced → carried → resolved → disputed → silently-dropped (FB-F) — **TARGET** | 2m | 60s | FB-F |
 | [E2E-43](#e2e-43-fb-g--dispute-rate-by-agent-line-chart-target) | Org dashboard renders dispute-rate over time with one line per agent category (FB-G) — **TARGET** | 2m | 60s | FB-G |
@@ -1542,9 +1542,9 @@ Branch: `fixture/38-quiet-drop`. A PR with a finding that the orchestrator's con
 
 ---
 
-### E2E-39: FB-C — inline-comment 👎 reactions → disputes — TARGET
+### E2E-39: FB-C — inline-comment 👎 reactions → disputes
 
-**Status:** **Not yet implemented.** See [`docs/false-positive-feedback-plan.md` → FB-C](./../docs/false-positive-feedback-plan.md#fb-c--inline-comment--reactions--disputes).
+**Status:** ✅ SHIPPED. See [`docs/false-positive-feedback-plan.md` → FB-C](./../docs/false-positive-feedback-plan.md#fb-c--inline-comment--reactions--disputes--shipped).
 
 **Behavior (intended, once FB-C ships):** reactions on the bot's inline finding comments are collected and mapped:
 
@@ -1580,9 +1580,9 @@ Branch: `fixture/39-inline-reactions`. A PR with at least one inline-comment-eli
 
 ---
 
-### E2E-40: FB-D — `/mergewatch reject` slash command — TARGET
+### E2E-40: FB-D — `/mergewatch reject` slash command
 
-**Status:** **Not yet implemented.** See [`docs/false-positive-feedback-plan.md` → FB-D](./../docs/false-positive-feedback-plan.md#fb-d--mergewatch-reject-slash-command).
+**Status:** ✅ SHIPPED. See [`docs/false-positive-feedback-plan.md` → FB-D](./../docs/false-positive-feedback-plan.md#fb-d--mergewatch-reject-slash-command--shipped).
 
 **Behavior (intended, once FB-D ships):** new inline-thread intent parser alongside `detectResolveIntent`. Recognises `/mergewatch reject <category> [optional reason]` where category is one of: `already-handled`, `out-of-scope`, `wrong-target`, `style-disagreement`, `other`. Increments `disputeCount` AND appends `{ category, text?, at }` to `rejectReasons[]` on the `FindingDispositionRecord`. Bot posts a confirming reply (`Got it — recording as <category>. This pattern won't be re-raised on similar code unless conditions change.`). Thread is NOT auto-resolved (different from `/resolve` — rejection is for *finding-level FP signal*, resolution is for *thread-level closure*).
 

--- a/packages/core/src/agents/inline-reply.test.ts
+++ b/packages/core/src/agents/inline-reply.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Octokit } from '@octokit/rest';
 import type { ILLMProvider } from '../llm/types.js';
-import { handleInlineReply, detectResolveIntent, MAX_BOT_REPLIES } from './inline-reply.js';
+import {
+  handleInlineReply,
+  detectResolveIntent,
+  parseRejectIntent,
+  REJECT_CATEGORIES,
+  MAX_BOT_REPLIES,
+} from './inline-reply.js';
 
 // ─── detectResolveIntent ────────────────────────────────────────────────────
 
@@ -47,6 +53,82 @@ describe('detectResolveIntent', () => {
     expect(detectResolveIntent('resolves the issue in the next PR')).toBe(false);
     expect(detectResolveIntent('I cannot resolve this right now')).toBe(false);
     expect(detectResolveIntent('the bug will resolve itself')).toBe(false);
+  });
+});
+
+// ─── parseRejectIntent (FB-D) ──────────────────────────────────────────────
+
+describe('parseRejectIntent (FB-D)', () => {
+  it('parses a known category with no free-text reason', () => {
+    expect(parseRejectIntent('/mergewatch reject already-handled')).toEqual({
+      category: 'already-handled',
+      text: undefined,
+      coerced: false,
+    });
+  });
+
+  it('parses a known category with a free-text reason', () => {
+    expect(parseRejectIntent('/mergewatch reject out-of-scope This is integration-only')).toEqual({
+      category: 'out-of-scope',
+      text: 'This is integration-only',
+      coerced: false,
+    });
+  });
+
+  it('recognises every locked category', () => {
+    for (const cat of REJECT_CATEGORIES) {
+      const r = parseRejectIntent(`/mergewatch reject ${cat}`);
+      expect(r?.category).toBe(cat);
+      expect(r?.coerced).toBe(false);
+    }
+  });
+
+  it('is case-insensitive on the `/mergewatch reject` prefix AND the category', () => {
+    expect(parseRejectIntent('/Mergewatch Reject ALREADY-HANDLED')).toMatchObject({
+      category: 'already-handled',
+      coerced: false,
+    });
+  });
+
+  it('silently coerces an unrecognised category to `other`, preserving the typo in the text', () => {
+    // Locked design: don't ask the user to re-type — preserve the signal.
+    expect(parseRejectIntent('/mergewatch reject typo-cat foo bar')).toEqual({
+      category: 'other',
+      text: 'typo-cat foo bar',
+      coerced: true,
+    });
+  });
+
+  it('coerces bare `/mergewatch reject` (no category at all) to `other` with no text', () => {
+    expect(parseRejectIntent('/mergewatch reject')).toEqual({
+      category: 'other',
+      text: undefined,
+      coerced: true,
+    });
+  });
+
+  it('returns null when the line shape does not match (no slash command)', () => {
+    expect(parseRejectIntent("here's how I'd reject this differently")).toBeNull();
+    expect(parseRejectIntent('this finding should be rejected')).toBeNull();
+    expect(parseRejectIntent('')).toBeNull();
+  });
+
+  it('matches when the command appears after other lines in a multi-line reply', () => {
+    const body = 'Thanks for the review.\n/mergewatch reject style-disagreement we use snake_case in python';
+    expect(parseRejectIntent(body)).toMatchObject({
+      category: 'style-disagreement',
+      text: 'we use snake_case in python',
+      coerced: false,
+    });
+  });
+
+  it('does not bleed into a following line (single-line scope)', () => {
+    const body = '/mergewatch reject already-handled\nbut on the next line, free text';
+    expect(parseRejectIntent(body)).toEqual({
+      category: 'already-handled',
+      text: undefined,
+      coerced: false,
+    });
   });
 });
 
@@ -357,5 +439,115 @@ describe('handleInlineReply', () => {
     );
     expect(result.action).toBe('replied');
     expect(result.resolvedFindingKeys).toBeUndefined();
+  });
+
+  // ─── FB-D — /mergewatch reject ───────────────────────────────────────────
+
+  it('FB-D — `/mergewatch reject <category>` returns action=rejected with category + match keys', async () => {
+    const inlineRoot = {
+      id: 100,
+      body: '<!-- mergewatch-inline -->\n**🔴 Missing try/catch around this call**\n\nWrap fetch().',
+      user: { login: 'mergewatch[bot]', type: 'Bot' as const },
+      created_at: '2026-04-01T00:00:00Z',
+      path: 'packages/server/src/worker.ts',
+    };
+    const { octokit, calls } = makeOctokitMock([
+      inlineRoot,
+      { id: 101, body: '/mergewatch reject already-handled We use a middleware', user: { login: 'santthosh', type: 'User' as const }, in_reply_to_id: 100, created_at: '2026-04-01T01:00:00Z' },
+    ]);
+    const llm = makeLLM('unused');
+    const result = await handleInlineReply(
+      { owner: 'o', repo: 'r', prNumber: 1, replyCommentId: 101 },
+      { octokit, llm, lightModelId: 'light' },
+    );
+    expect(result.action).toBe('rejected');
+    expect(result.rejectCategory).toBe('already-handled');
+    expect(result.rejectText).toBe('We use a middleware');
+    expect(result.rejectedFindingKeys).toEqual([
+      'packages/server/src/worker.ts::T::Missing try/catch around this call',
+    ]);
+    // Zero LLM cost on the fast path.
+    expect(llm.calls).toHaveLength(0);
+    // Bot posts a confirming reply with the category name.
+    expect(calls.createReplyForReviewComment).toHaveBeenCalled();
+    const replyArg = (calls.createReplyForReviewComment as any).mock.calls[0][0];
+    expect(replyArg.body).toContain('already-handled');
+    // Does NOT auto-resolve the thread (orthogonal verbs).
+    expect(calls.graphql).not.toHaveBeenCalled();
+  });
+
+  it('FB-D — bot reply explains the silent-other coercion when the user mistypes', async () => {
+    const inlineRoot = {
+      id: 100,
+      body: '<!-- mergewatch-inline -->\n**🔴 Some title**\n\nDesc.',
+      user: { login: 'mergewatch[bot]', type: 'Bot' as const },
+      created_at: '2026-04-01T00:00:00Z',
+      path: 'src/a.ts',
+    };
+    const { octokit, calls } = makeOctokitMock([
+      inlineRoot,
+      { id: 101, body: '/mergewatch reject typo-cat foo', user: { login: 'santthosh', type: 'User' as const }, in_reply_to_id: 100, created_at: '2026-04-01T01:00:00Z' },
+    ]);
+    const llm = makeLLM('unused');
+    const result = await handleInlineReply(
+      { owner: 'o', repo: 'r', prNumber: 1, replyCommentId: 101 },
+      { octokit, llm, lightModelId: 'light' },
+    );
+    expect(result.action).toBe('rejected');
+    expect(result.rejectCategory).toBe('other');
+    expect(result.rejectText).toBe('typo-cat foo');
+    const replyArg = (calls.createReplyForReviewComment as any).mock.calls[0][0];
+    expect(replyArg.body).toContain('other');
+    expect(replyArg.body).toMatch(/known reject category/i);
+  });
+
+  it('FB-D — resolve takes precedence when both `/resolve` and `/mergewatch reject` appear in the same reply', async () => {
+    // Document the locked precedence: explicit `/resolve` wins (the
+    // handler checks resolve intent BEFORE reject intent in the
+    // fast-path chain). Users wanting BOTH should reject first, then
+    // resolve separately.
+    const inlineRoot = {
+      id: 100,
+      body: '<!-- mergewatch-inline -->\n**🔴 Some title**\n\nDesc.',
+      user: { login: 'mergewatch[bot]', type: 'Bot' as const },
+      created_at: '2026-04-01T00:00:00Z',
+      path: 'src/a.ts',
+    };
+    const { octokit } = makeOctokitMock([
+      inlineRoot,
+      { id: 101, body: '/resolve\n/mergewatch reject already-handled', user: { login: 'santthosh', type: 'User' as const }, in_reply_to_id: 100, created_at: '2026-04-01T01:00:00Z' },
+    ]);
+    const llm = makeLLM('unused');
+    const result = await handleInlineReply(
+      { owner: 'o', repo: 'r', prNumber: 1, replyCommentId: 101 },
+      { octokit, llm, lightModelId: 'light' },
+    );
+    expect(result.action).toBe('resolved');
+    expect(result.rejectCategory).toBeUndefined();
+  });
+
+  it('FB-D — `/mergewatch reject` without a recoverable finding still posts a confirmation and returns the category (no keys)', async () => {
+    // Root has no `path` → keys can't be derived. The category + text
+    // still surface so the bot's confirmation reply is correct; the
+    // dispute-write path in the handler will be a no-op when keys is
+    // empty (recordDisputes guards on empty array).
+    const inlineRoot = {
+      id: 100,
+      body: '<!-- mergewatch-inline -->\n**🔴 Title**\n\nDesc.',
+      user: { login: 'mergewatch[bot]', type: 'Bot' as const },
+      created_at: '2026-04-01T00:00:00Z',
+    };
+    const { octokit } = makeOctokitMock([
+      inlineRoot,
+      { id: 101, body: '/mergewatch reject other', user: { login: 'santthosh', type: 'User' as const }, in_reply_to_id: 100, created_at: '2026-04-01T01:00:00Z' },
+    ]);
+    const llm = makeLLM('unused');
+    const result = await handleInlineReply(
+      { owner: 'o', repo: 'r', prNumber: 1, replyCommentId: 101 },
+      { octokit, llm, lightModelId: 'light' },
+    );
+    expect(result.action).toBe('rejected');
+    expect(result.rejectCategory).toBe('other');
+    expect(result.rejectedFindingKeys).toBeUndefined();
   });
 });

--- a/packages/core/src/agents/inline-reply.ts
+++ b/packages/core/src/agents/inline-reply.ts
@@ -74,6 +74,100 @@ export function detectResolveIntent(text: string): boolean {
   return false;
 }
 
+// ─── FB-D — /mergewatch reject ────────────────────────────────────────────
+
+/**
+ * Closed set of categories accepted by `/mergewatch reject`. Decisions
+ * locked in the FP-feedback plan (docs/false-positive-feedback-plan.md →
+ * FB-D, "Design decisions (locked)").
+ *
+ * Any unrecognised category coerces silently to `other`, with the original
+ * token preserved as the leading word of the free-text reason. Preserves
+ * the signal even when the reviewer mistypes — the dashboard surfaces
+ * these as `other`-category rejections for triage.
+ */
+export const REJECT_CATEGORIES = [
+  'already-handled',
+  'out-of-scope',
+  'wrong-target',
+  'style-disagreement',
+  'other',
+] as const;
+
+export type RejectCategory = typeof REJECT_CATEGORIES[number];
+
+const REJECT_CATEGORY_SET = new Set<RejectCategory>(REJECT_CATEGORIES);
+
+/**
+ * Structured result of parsing a `/mergewatch reject` line.
+ *   - `category` — one of REJECT_CATEGORIES; never undefined (coerces to 'other').
+ *   - `text`     — optional free-text reason (the rest of the line after the
+ *                  category, or the unrecognised token + rest when fallback fires).
+ *   - `coerced`  — true when the user typed something that wasn't a known
+ *                  category and we silently coerced to 'other'. Surfaces in
+ *                  the bot's confirming reply so the reviewer knows what
+ *                  was actually persisted.
+ */
+export interface RejectIntent {
+  category: RejectCategory;
+  text?: string;
+  coerced: boolean;
+}
+
+const REJECT_LINE_PATTERN = /(?:^|\s)\/mergewatch\s+reject\b(.*?)(?:\n|$)/i;
+
+/**
+ * Recognise `/mergewatch reject <category> [optional reason]` in a reply.
+ *
+ * Grammar (locked in PR #164):
+ *   /mergewatch reject already-handled
+ *   /mergewatch reject out-of-scope This is integration-only, not unit.
+ *   /mergewatch reject style-disagreement we use snake_case in this repo
+ *
+ * Match rules:
+ *   • Slash form required — must be `/mergewatch reject` exactly (case-
+ *     insensitive). Free-prose like "I'd reject this" does NOT match.
+ *   • Standalone line (or end-of-text). Won't fire on `/mergewatch reject`
+ *     mentioned in the middle of a sentence with other commands.
+ *   • Category is the next whitespace-delimited token. If it's not in
+ *     REJECT_CATEGORIES, we coerce to 'other' AND prepend the typo
+ *     token to the free-text reason (so the signal isn't lost).
+ *   • Everything after the category (on the same line) is the optional
+ *     free-text reason, trimmed.
+ *
+ * Returns `null` when the line shape doesn't match at all (don't fire).
+ */
+export function parseRejectIntent(text: string): RejectIntent | null {
+  if (!text) return null;
+  const match = text.match(REJECT_LINE_PATTERN);
+  if (!match) return null;
+
+  // match[1] is the suffix after `/mergewatch reject` on the SAME line
+  // (the line-anchor `(?:\n|$)` stops the lazy match). Could be empty,
+  // a category, or `<category> <text>`.
+  const suffix = (match[1] ?? '').trim();
+  if (!suffix) {
+    // Bare `/mergewatch reject` with no category — coerce to 'other',
+    // no text. Bot's confirming reply tells the user what happened.
+    return { category: 'other', text: undefined, coerced: true };
+  }
+
+  // First whitespace-delimited token = category candidate.
+  const firstWs = suffix.search(/\s/);
+  const catToken = firstWs === -1 ? suffix : suffix.slice(0, firstWs);
+  const rest = firstWs === -1 ? '' : suffix.slice(firstWs + 1).trim();
+
+  const candidate = catToken.toLowerCase() as RejectCategory;
+  if (REJECT_CATEGORY_SET.has(candidate)) {
+    return { category: candidate, text: rest || undefined, coerced: false };
+  }
+  // Silent-other coercion: preserve the unrecognised token in `text` so
+  // the signal isn't lost. Example: `/mergewatch reject typo-cat foo` →
+  // { category: 'other', text: 'typo-cat foo', coerced: true }.
+  const coercedText = (catToken + (rest ? ' ' + rest : '')).trim();
+  return { category: 'other', text: coercedText || undefined, coerced: true };
+}
+
 export interface InlineReplyContext {
   owner: string;
   repo: string;
@@ -92,11 +186,11 @@ export interface InlineReplyDeps {
 }
 
 export interface InlineReplyResult {
-  action: 'skipped' | 'replied' | 'resolved';
+  action: 'skipped' | 'replied' | 'resolved' | 'rejected';
   reason?: string;
   /** Populated when `action === 'replied'`. */
   recommendation?: 'resolve' | 'keep' | 'needs_info';
-  /** Populated when `action === 'replied'`. */
+  /** Populated when `action === 'replied'` or `'rejected'`. */
   botCommentId?: number;
   /**
    * FP-F — Stable identity keys for the finding the developer resolved.
@@ -109,6 +203,19 @@ export interface InlineReplyResult {
    * or the title couldn't be parsed (defensive — never crashes resolve).
    */
   resolvedFindingKeys?: string[];
+  /**
+   * FB-D — Stable identity keys for the finding the developer rejected
+   * via `/mergewatch reject`. Same key-derivation rules as
+   * `resolvedFindingKeys`. The handler increments `disputeCount` and
+   * appends to `rejectReasons[]` on each key's FindingDispositionRecord
+   * via `recordDisputes` + `appendRejectReason`. Empty/undefined if the
+   * keys couldn't be recovered (same fail-safe as resolve).
+   */
+  rejectedFindingKeys?: string[];
+  /** FB-D — categorical reason persisted alongside the rejection. */
+  rejectCategory?: RejectCategory;
+  /** FB-D — optional free-text reason persisted alongside the rejection. */
+  rejectText?: string;
   inputTokens: number;
   outputTokens: number;
   estimatedCostUsd: number | null;
@@ -265,6 +372,35 @@ export async function handleInlineReply(
         };
       }
       return { action: 'skipped', reason: 'could not locate review thread id', inputTokens: 0, outputTokens: 0, estimatedCostUsd: 0 };
+    }
+
+    // FB-D — `/mergewatch reject <category> [text]` fast path. Like
+    // resolve, this skips the LLM (deterministic parse). Unlike resolve,
+    // it does NOT auto-resolve the GitHub thread — rejection records the
+    // signal; closure stays a human decision.
+    const rejectIntent = parseRejectIntent(lastComment.body);
+    if (rejectIntent) {
+      const rejectedFindingKeys = deriveResolvedFindingKeys(root);
+      // Confirming reply: short, structured, mentions both the category
+      // we persisted AND (when coerced) the original token so the user
+      // can see what happened.
+      const confirmation = rejectIntent.coerced
+        ? `Got it — your reply didn't match a known reject category, so I'm recording this as \`other\`. Recognised categories: \`already-handled\`, \`out-of-scope\`, \`wrong-target\`, \`style-disagreement\`, \`other\`.`
+        : `Got it — recording as \`${rejectIntent.category}\`. This finding's pattern won't be re-raised on similar code unless conditions change.`;
+      const botCommentId = await replyToReviewComment(
+        deps.octokit, ctx.owner, ctx.repo, ctx.prNumber, root.id, confirmation,
+      );
+      return {
+        action: 'rejected',
+        reason: 'explicit /mergewatch reject',
+        botCommentId,
+        rejectedFindingKeys: rejectedFindingKeys.length > 0 ? rejectedFindingKeys : undefined,
+        rejectCategory: rejectIntent.category,
+        rejectText: rejectIntent.text,
+        inputTokens: 0,
+        outputTokens: 0,
+        estimatedCostUsd: 0,
+      };
     }
 
     // LLM reply path.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,9 +44,11 @@ export {
 export {
   handleInlineReply,
   detectResolveIntent,
+  parseRejectIntent,
+  REJECT_CATEGORIES,
   MAX_BOT_REPLIES,
 } from './agents/inline-reply.js';
-export type { InlineReplyContext, InlineReplyDeps, InlineReplyResult } from './agents/inline-reply.js';
+export type { InlineReplyContext, InlineReplyDeps, InlineReplyResult, RejectIntent, RejectCategory } from './agents/inline-reply.js';
 export type {
   AgentFinding,
   OrchestratedFinding,
@@ -139,12 +141,13 @@ export { detectNoTestHarness, suppressTestCoverageFindings } from './scope-aware
 export { clusterFindings, extractSignificantTokens, dedupeCrossAgentByLine } from './finding-clustering.js';
 export type { ClusterableFinding, ClusterOptions, TaggedClusterableFindings } from './finding-clustering.js';
 
-// ─── Disposition writers (FB-A / FB-B) ─────────────────────────────────────
+// ─── Disposition writers (FB-A / FB-B / FB-C) ─────────────────────────────
 export {
   recordFindingSurfacings,
   recordDisputes,
   detectQuietDrops,
   recordQuietDrops,
+  pollAndRecordInlineReactions,
 } from './insights/disposition-writer.js';
 
 // ─── Config ─────────────────────────────────────────────────────────────────

--- a/packages/core/src/insights/disposition-writer.test.ts
+++ b/packages/core/src/insights/disposition-writer.test.ts
@@ -4,9 +4,11 @@ import {
   recordDisputes,
   detectQuietDrops,
   recordQuietDrops,
+  pollAndRecordInlineReactions,
 } from './disposition-writer.js';
 import type { IFindingDispositionStore } from '../storage/types.js';
 import type { OrchestratedFinding, PreviousFinding } from '../agents/reviewer.js';
+import type { Octokit } from '@octokit/rest';
 
 // ─── Mock store ─────────────────────────────────────────────────────────────
 
@@ -249,5 +251,162 @@ describe('recordQuietDrops (FB-B)', () => {
     const store = makeMockStore();
     await recordQuietDrops(store, 42, 'org/repo', []);
     expect(store.calls.incrementSilentDrop).toHaveLength(0);
+  });
+});
+
+// ─── pollAndRecordInlineReactions (FB-C) ────────────────────────────────────
+
+interface MockReviewCommentInput {
+  id: number;
+  body: string;
+  path?: string;
+  user?: { type: string };
+  reactions?: Record<string, number>;
+}
+
+function makeReactionOctokit(comments: MockReviewCommentInput[]): Octokit {
+  return {
+    pulls: {
+      listReviewComments: vi.fn(async () => ({ data: comments })),
+    },
+  } as unknown as Octokit;
+}
+
+describe('pollAndRecordInlineReactions (FB-C)', () => {
+  const inlineBody = '<!-- mergewatch-inline -->\n**🔴 Missing try/catch around fetch**\n\nDesc.';
+  const expectedKey = 'src/worker.ts::T::Missing try/catch around fetch';
+
+  it('emits one incrementDispute per 👎 above the prior snapshot', async () => {
+    const store = makeMockStore();
+    const octokit = makeReactionOctokit([
+      { id: 100, body: inlineBody, path: 'src/worker.ts', user: { type: 'Bot' }, reactions: { '-1': 2 } },
+    ]);
+    // Prior snapshot had 0 thumbs-down → delta is +2 → two dispute increments.
+    const newSnapshot = await pollAndRecordInlineReactions(
+      octokit, 'o', 'r', 1,
+      /* prevSnapshot */ {},
+      store, 42, 'org/repo',
+    );
+    expect(store.calls.incrementDispute.filter((c) => c[2] === expectedKey)).toHaveLength(2);
+    expect(store.calls.incrementAgreement).toHaveLength(0);
+    expect(newSnapshot['100']['-1']).toBe(2);
+  });
+
+  it('emits one incrementAgreement per 👍 / ❤️ / 🚀 above the prior snapshot', async () => {
+    const store = makeMockStore();
+    const octokit = makeReactionOctokit([
+      { id: 100, body: inlineBody, path: 'src/worker.ts', user: { type: 'Bot' }, reactions: { '+1': 1, heart: 1, rocket: 2 } },
+    ]);
+    await pollAndRecordInlineReactions(octokit, 'o', 'r', 1, {}, store, 42, 'org/repo');
+    // 4 agreements (1+1+2), all on the same match key.
+    expect(store.calls.incrementAgreement.filter((c) => c[2] === expectedKey)).toHaveLength(4);
+    expect(store.calls.incrementDispute).toHaveLength(0);
+  });
+
+  it('ignores 👀 (eyes), 🎉 (hooray), 😄 (laugh) — non-FP-shaped reactions', async () => {
+    const store = makeMockStore();
+    const octokit = makeReactionOctokit([
+      { id: 100, body: inlineBody, path: 'src/worker.ts', user: { type: 'Bot' }, reactions: { eyes: 3, hooray: 2, laugh: 1 } },
+    ]);
+    await pollAndRecordInlineReactions(octokit, 'o', 'r', 1, {}, store, 42, 'org/repo');
+    expect(store.calls.incrementDispute).toHaveLength(0);
+    expect(store.calls.incrementAgreement).toHaveLength(0);
+  });
+
+  it('only writes the POSITIVE delta vs the prior snapshot (monotonic)', async () => {
+    const store = makeMockStore();
+    const octokit = makeReactionOctokit([
+      { id: 100, body: inlineBody, path: 'src/worker.ts', user: { type: 'Bot' }, reactions: { '-1': 3 } },
+    ]);
+    // Prior already counted 2 thumbs-down. Current is 3 → delta = +1.
+    await pollAndRecordInlineReactions(
+      octokit, 'o', 'r', 1,
+      { '100': { '-1': 2 } },
+      store, 42, 'org/repo',
+    );
+    expect(store.calls.incrementDispute.filter((c) => c[2] === expectedKey)).toHaveLength(1);
+  });
+
+  it('ignores reaction REMOVAL (current < prior — monotonic, never decrements)', async () => {
+    const store = makeMockStore();
+    const octokit = makeReactionOctokit([
+      { id: 100, body: inlineBody, path: 'src/worker.ts', user: { type: 'Bot' }, reactions: { '-1': 1 } },
+    ]);
+    // Prior counted 3, current is 1 → reviewer removed reactions. Monotonic
+    // counters never decrement; we just emit no new increments.
+    await pollAndRecordInlineReactions(
+      octokit, 'o', 'r', 1,
+      { '100': { '-1': 3 } },
+      store, 42, 'org/repo',
+    );
+    expect(store.calls.incrementDispute).toHaveLength(0);
+  });
+
+  it('skips comments that are NOT bot-authored', async () => {
+    const store = makeMockStore();
+    const octokit = makeReactionOctokit([
+      { id: 100, body: inlineBody, path: 'src/worker.ts', user: { type: 'User' }, reactions: { '-1': 5 } },
+    ]);
+    await pollAndRecordInlineReactions(octokit, 'o', 'r', 1, {}, store, 42, 'org/repo');
+    expect(store.calls.incrementDispute).toHaveLength(0);
+  });
+
+  it('skips comments missing the INLINE_BOT_COMMENT_MARKER (CopilotAI / dependabot threads)', async () => {
+    const store = makeMockStore();
+    // Bot-authored but lacks our marker — another reviewer bot.
+    const octokit = makeReactionOctokit([
+      { id: 100, body: '**🔴 Some title from another bot**', path: 'src/a.ts', user: { type: 'Bot' }, reactions: { '-1': 2 } },
+    ]);
+    await pollAndRecordInlineReactions(octokit, 'o', 'r', 1, {}, store, 42, 'org/repo');
+    expect(store.calls.incrementDispute).toHaveLength(0);
+  });
+
+  it('captures a snapshot row even when match keys cannot be derived (missing path)', async () => {
+    // Path is missing → can't derive match keys → no counter increments,
+    // but we STILL record the current counts so the next poll sees the
+    // snapshot baseline. (Ensures the system stays consistent if the
+    // comment gains a path later via some edit, etc.)
+    const store = makeMockStore();
+    const octokit = makeReactionOctokit([
+      { id: 100, body: inlineBody, user: { type: 'Bot' }, reactions: { '-1': 2 } },
+    ]);
+    const newSnapshot = await pollAndRecordInlineReactions(octokit, 'o', 'r', 1, {}, store, 42, 'org/repo');
+    expect(store.calls.incrementDispute).toHaveLength(0);
+    expect(newSnapshot['100']['-1']).toBe(2);
+  });
+
+  it('returns an empty snapshot + skips writes when store / installationId is unset', async () => {
+    const octokit = makeReactionOctokit([
+      { id: 100, body: inlineBody, path: 'src/worker.ts', user: { type: 'Bot' }, reactions: { '-1': 2 } },
+    ]);
+    const result = await pollAndRecordInlineReactions(octokit, 'o', 'r', 1, {}, undefined, 42, 'org/repo');
+    expect(result).toEqual({});
+  });
+
+  it('returns the new snapshot the caller persists on the latest review record', async () => {
+    const store = makeMockStore();
+    const octokit = makeReactionOctokit([
+      { id: 100, body: inlineBody, path: 'src/worker.ts', user: { type: 'Bot' }, reactions: { '-1': 2, '+1': 1, eyes: 5 } },
+      { id: 200, body: inlineBody, path: 'src/other.ts', user: { type: 'Bot' }, reactions: { heart: 3 } },
+    ]);
+    const newSnapshot = await pollAndRecordInlineReactions(octokit, 'o', 'r', 1, {}, store, 42, 'org/repo');
+    // 'eyes' is not in REACTION_TRACKED_TYPES → omitted from the snapshot too.
+    expect(newSnapshot['100']).toEqual({ '-1': 2, '+1': 1 });
+    expect(newSnapshot['200']).toEqual({ heart: 3 });
+  });
+
+  it('returns empty snapshot on listReviewComments failure (best-effort)', async () => {
+    const store = makeMockStore();
+    const octokit = {
+      pulls: {
+        listReviewComments: vi.fn(async () => { throw new Error('API down'); }),
+      },
+    } as unknown as Octokit;
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = await pollAndRecordInlineReactions(octokit, 'o', 'r', 1, {}, store, 42, 'org/repo');
+    expect(result).toEqual({});
+    expect(store.calls.incrementDispute).toHaveLength(0);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
   });
 });

--- a/packages/core/src/insights/disposition-writer.ts
+++ b/packages/core/src/insights/disposition-writer.ts
@@ -264,6 +264,16 @@ export async function pollAndRecordInlineReactions(
   }
 
   const inst = String(installationId);
+  // Collect every increment operation across all comments, all types, all
+  // deltas, all match-keys into a single Promise.allSettled batch. Three
+  // wins over the prior per-call sequential `await + catch + continue`:
+  //   1. Parallel I/O (cheap but real on large reaction-active PRs).
+  //   2. One greppable failure-summary log line per poll instead of N
+  //      individual warns scrolling past in CloudWatch.
+  //   3. Matches the same shape as the FB-D appendRejectReason batch in
+  //      both handlers (review-processor.ts + review-agent.ts) — one
+  //      pattern for "best-effort fan-out of analytics writes".
+  const incrementOps: Promise<void>[] = [];
   for (const c of comments) {
     // Restrict to MergeWatch inline findings: bot-authored AND carrying
     // the inline marker. Same guard the inline-reply path uses (so
@@ -299,19 +309,29 @@ export async function pollAndRecordInlineReactions(
       const increment = isDispute
         ? store.incrementDispute.bind(store)
         : store.incrementAgreement.bind(store);
-      // Apply the delta `delta` times, fanned out across both match keys.
-      // We don't batch because counter writes are individually idempotent
-      // at the wire level and the volumes are small (most PRs see <5
-      // reactions per inline comment).
+      // Queue up `delta` increments fanned out across the finding's match
+      // keys (typically 2: title + fingerprint). Counter writes are
+      // idempotent at the wire level so the parallel-batch shape is safe;
+      // the store layer's internal try/catch handles per-call failures.
       for (let i = 0; i < delta; i++) {
         for (const key of matchKeys) {
-          try {
-            await increment(inst, repoFullName, key);
-          } catch (err) {
-            console.warn('[fb-c] reaction increment failed for %s %s:', type, key, err);
-          }
+          incrementOps.push(increment(inst, repoFullName, key));
         }
       }
+    }
+  }
+
+  // Single batch + single failure-summary log line. Best-effort —
+  // counters never block the review and rejections still get the
+  // verified snapshot return value below.
+  if (incrementOps.length > 0) {
+    const settled = await Promise.allSettled(incrementOps);
+    const failed = settled.filter((r) => r.status === 'rejected').length;
+    if (failed > 0) {
+      console.warn(
+        '[fb-c] %d/%d reaction increment write(s) failed on %s',
+        failed, settled.length, repoFullName,
+      );
     }
   }
 

--- a/packages/core/src/insights/disposition-writer.ts
+++ b/packages/core/src/insights/disposition-writer.ts
@@ -17,6 +17,8 @@ import type { IFindingDispositionStore } from '../storage/types.js';
 import type { OrchestratedFinding, PreviousFinding } from '../agents/reviewer.js';
 import { findingMatchKeys, fingerprintFromCode } from '../review-delta.js';
 import { extractSignificantTokens } from '../finding-clustering.js';
+import { INLINE_BOT_COMMENT_MARKER, extractInlineCommentTitle } from '../github/client.js';
+import type { Octokit } from '@octokit/rest';
 
 /**
  * FB-A — record one surfacing per finding. Writes one upsertSurface call per
@@ -176,6 +178,144 @@ export async function recordQuietDrops(
       }
     }
   }
+}
+
+// ─── FB-C — inline-comment reactions → disputes / agreements ───────────────
+
+/**
+ * GitHub reaction content types we map onto FindingDispositionRecord counters.
+ *   - `-1` (👎) / `confused` (🤔)      → disputeCount
+ *   - `+1` (👍) / `heart` (❤️) / `rocket` (🚀) → agreementCount
+ *
+ * `eyes` (👀) is filtered out — the bot itself uses it as the "I'm
+ * looking at it" read-receipt on inline-reply threads, and a user 👀
+ * is ambiguous (interest, not agreement/disagreement).
+ *
+ * `laugh` (😄) and `hooray` (🎉) are also ignored; they're celebratory
+ * but don't cleanly express agreement with a *finding*.
+ */
+const REACTION_DISPUTE_TYPES = ['-1', 'confused'] as const;
+const REACTION_AGREEMENT_TYPES = ['+1', 'heart', 'rocket'] as const;
+const REACTION_TRACKED_TYPES = [...REACTION_DISPUTE_TYPES, ...REACTION_AGREEMENT_TYPES] as readonly string[];
+
+/** Per-reaction-type count summary as GitHub returns it in the listReviewComments payload. */
+type ReactionCounts = Record<string, number>;
+
+interface InlineCommentForReactionPoll {
+  id: number;
+  body: string;
+  path?: string;
+  reactions?: ReactionCounts | null;
+  /** GitHub user type: 'Bot' for the bot's own comments; we keep only those. */
+  userType?: string | null;
+}
+
+/**
+ * FB-C — poll reaction counts on every MergeWatch inline comment on a PR,
+ * compute the delta vs the prior snapshot, and emit dispute/agreement
+ * increments on the corresponding `FindingDispositionRecord`s.
+ *
+ * Why polling: GitHub does NOT emit a webhook event for reactions added
+ * to a review comment. The cheapest reliable capture is to fold a single
+ * `pulls.listReviewComments` call into the existing post-pipeline path —
+ * the summary `reactions` field on each comment already carries per-type
+ * counts, so no extra per-comment API calls are needed.
+ *
+ * Counters are monotonic — we never decrement on reaction removal. The
+ * snapshot prevents double-counting on subsequent polls: only positive
+ * deltas vs the prior snapshot turn into increments.
+ *
+ * Returns the new snapshot for the caller to persist on the latest review
+ * record. When no FindingDispositionStore is provided (back-compat path
+ * with the analytics layer not yet wired), returns an empty snapshot and
+ * skips the writes — same fail-safe shape as the other FB-A helpers.
+ */
+export async function pollAndRecordInlineReactions(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  prevSnapshot: Record<string, Record<string, number>> | undefined,
+  store: IFindingDispositionStore | undefined,
+  installationId: string | number | undefined,
+  repoFullName: string,
+): Promise<Record<string, Record<string, number>>> {
+  const newSnapshot: Record<string, Record<string, number>> = {};
+  if (!store || installationId == null) return newSnapshot;
+
+  // Single API call, listing every review comment on the PR. The summary
+  // `reactions` field on each comment gives per-type counts directly —
+  // no per-comment reaction-list call needed.
+  let comments: InlineCommentForReactionPoll[];
+  try {
+    const { data } = await octokit.pulls.listReviewComments({
+      owner, repo, pull_number: prNumber, per_page: 100,
+    });
+    comments = (data as Array<Record<string, unknown>>).map((c) => ({
+      id: Number(c.id),
+      body: String(c.body ?? ''),
+      path: typeof c.path === 'string' ? c.path : undefined,
+      reactions: (c.reactions as ReactionCounts | undefined) ?? null,
+      userType: (c.user as Record<string, unknown> | undefined)?.type as string | undefined,
+    }));
+  } catch (err) {
+    console.warn('[fb-c] failed to list review comments for %s/%s#%d:', owner, repo, prNumber, err);
+    return newSnapshot;
+  }
+
+  const inst = String(installationId);
+  for (const c of comments) {
+    // Restrict to MergeWatch inline findings: bot-authored AND carrying
+    // the inline marker. Same guard the inline-reply path uses (so
+    // CopilotAI / dependabot / human review comments don't sneak in).
+    if (c.userType !== 'Bot') continue;
+    if (!c.body.includes(INLINE_BOT_COMMENT_MARKER)) continue;
+    if (!c.reactions) continue;
+
+    // Capture current counts for the next-poll baseline regardless of
+    // whether we can derive match keys (the snapshot is keyed by
+    // commentId; key-derivation failure shouldn't drop us out of sync).
+    const currentForComment: Record<string, number> = {};
+    for (const type of REACTION_TRACKED_TYPES) {
+      const n = Number(c.reactions[type] ?? 0);
+      if (n > 0) currentForComment[type] = n;
+    }
+    newSnapshot[String(c.id)] = currentForComment;
+
+    // Recover the finding's stable identity keys. Same shape as
+    // FP-F's deriveResolvedFindingKeys (path + extracted title).
+    if (!c.path) continue;
+    const title = extractInlineCommentTitle(c.body);
+    if (!title) continue;
+    const matchKeys = findingMatchKeys({ file: c.path, line: 0, title });
+
+    const prior = prevSnapshot?.[String(c.id)] ?? {};
+    for (const type of REACTION_TRACKED_TYPES) {
+      const now = currentForComment[type] ?? 0;
+      const before = Number(prior[type] ?? 0);
+      const delta = now - before;
+      if (delta <= 0) continue; // monotonic: ignore removals
+      const isDispute = (REACTION_DISPUTE_TYPES as readonly string[]).includes(type);
+      const increment = isDispute
+        ? store.incrementDispute.bind(store)
+        : store.incrementAgreement.bind(store);
+      // Apply the delta `delta` times, fanned out across both match keys.
+      // We don't batch because counter writes are individually idempotent
+      // at the wire level and the volumes are small (most PRs see <5
+      // reactions per inline comment).
+      for (let i = 0; i < delta; i++) {
+        for (const key of matchKeys) {
+          try {
+            await increment(inst, repoFullName, key);
+          } catch (err) {
+            console.warn('[fb-c] reaction increment failed for %s %s:', type, key, err);
+          }
+        }
+      }
+    }
+  }
+
+  return newSnapshot;
 }
 
 // Re-exported so external callers don't need to dip into review-delta.js

--- a/packages/core/src/types/db.ts
+++ b/packages/core/src/types/db.ts
@@ -327,6 +327,24 @@ export interface ReviewItem {
   estimatedCostUsd?: number;
 
   /**
+   * FB-C — Last-observed reaction counts per inline bot comment on this PR,
+   * keyed by comment ID. Used to compute reaction deltas on the next
+   * review run (counters in `FindingDispositionRecord` are monotonic, so
+   * we need to know "what we've already counted" to avoid double-writing
+   * the same 👎 on every re-review).
+   *
+   * Inner map shape: each GitHub reaction content type ('+1', '-1',
+   * 'laugh', 'hooray', 'confused', 'heart', 'rocket', 'eyes') → count
+   * of non-bot reactions observed at the time of the last poll. Reactions
+   * added by `mergewatch[bot]` (the bot's own 👀 read-receipt etc.) are
+   * filtered out client-side and never enter this snapshot.
+   *
+   * Persisted on the LATEST complete review for the PR. Updated on every
+   * review run that polls reactions.
+   */
+  inlineReactionsSnapshot?: Record<string, Record<string, number>>;
+
+  /**
    * FP-F — Stable `findingMatchKeys` for findings the author resolved by
    * replying `/resolve` (or equivalent) on an inline review-comment thread.
    *

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -52,6 +52,7 @@ import {
   recordQuietDrops,
   pollAndRecordInlineReactions,
 } from '@mergewatch/core';
+import type { RejectCategory, FindingDispositionRecord } from '@mergewatch/core';
 import type {
   ReviewJobPayload,
   ReviewItem,
@@ -260,14 +261,27 @@ async function handleInlineReplyMode(
     ) {
       const inst = String(installationId);
       const at = new Date().toISOString();
-      const reason: { category: 'already-handled' | 'out-of-scope' | 'wrong-target' | 'style-disagreement' | 'other'; text?: string; at: string } = {
-        category: result.rejectCategory,
+      // Reuse the exported RejectCategory + FindingDispositionRecord shapes
+      // so the inline type can't drift if the categories are widened.
+      const reason: NonNullable<FindingDispositionRecord['rejectReasons']>[number] = {
+        category: result.rejectCategory as RejectCategory,
         ...(result.rejectText ? { text: result.rejectText } : {}),
         at,
       };
-      for (const key of result.rejectedFindingKeys) {
-        await dispositionStore.appendRejectReason(inst, repoFullName, key, reason)
-          .catch((err) => console.warn('[fb-d] appendRejectReason failed for %s:', key, err));
+      // Parallel + summary-logged. See server/review-processor.ts for
+      // the rationale (one log line for a batch of failures, not one per
+      // key — easier to grep, sufficient for the analytics-volume scale).
+      const settled = await Promise.allSettled(
+        result.rejectedFindingKeys.map((key) =>
+          dispositionStore.appendRejectReason(inst, repoFullName, key, reason),
+        ),
+      );
+      const failed = settled.filter((r) => r.status === 'rejected').length;
+      if (failed > 0) {
+        console.warn(
+          '[fb-d] %d/%d appendRejectReason write(s) failed for %s#%d (category=%s)',
+          failed, settled.length, repoFullName, prNumber, result.rejectCategory,
+        );
       }
       await recordDisputes(dispositionStore, installationId, repoFullName, result.rejectedFindingKeys);
       console.log(

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -50,6 +50,7 @@ import {
   recordDisputes,
   detectQuietDrops,
   recordQuietDrops,
+  pollAndRecordInlineReactions,
 } from '@mergewatch/core';
 import type {
   ReviewJobPayload,
@@ -246,6 +247,37 @@ async function handleInlineReplyMode(
       );
       // FB-A — every inline-resolve is also an explicit dispute for analytics.
       await recordDisputes(dispositionStore, installationId, repoFullName, result.resolvedFindingKeys);
+    }
+
+    // FB-D — `/mergewatch reject` persists a categorised rejection per
+    // match key. Mirrors the server handler.
+    if (
+      installationId != null &&
+      result.action === 'rejected' &&
+      result.rejectedFindingKeys &&
+      result.rejectedFindingKeys.length > 0 &&
+      result.rejectCategory
+    ) {
+      const inst = String(installationId);
+      const at = new Date().toISOString();
+      const reason: { category: 'already-handled' | 'out-of-scope' | 'wrong-target' | 'style-disagreement' | 'other'; text?: string; at: string } = {
+        category: result.rejectCategory,
+        ...(result.rejectText ? { text: result.rejectText } : {}),
+        at,
+      };
+      for (const key of result.rejectedFindingKeys) {
+        await dispositionStore.appendRejectReason(inst, repoFullName, key, reason)
+          .catch((err) => console.warn('[fb-d] appendRejectReason failed for %s:', key, err));
+      }
+      await recordDisputes(dispositionStore, installationId, repoFullName, result.rejectedFindingKeys);
+      console.log(
+        '[fb-d] recorded %d /mergewatch reject%s (category=%s) on %s#%d',
+        result.rejectedFindingKeys.length,
+        result.rejectedFindingKeys.length === 1 ? '' : 's',
+        result.rejectCategory,
+        repoFullName,
+        prNumber,
+      );
     }
 
     console.log(
@@ -659,7 +691,7 @@ export async function handler(
       delta = computeReviewDelta(result.findings, prevComplete.findings);
     }
 
-    // FB-A / FB-B — best-effort analytics writes. Mirrors the server
+    // FB-A / FB-B / FB-C — best-effort analytics writes. Mirrors the server
     // handler; see packages/server/src/review-processor.ts for the
     // rationale. All failures are caught + logged inside the helpers
     // and never block the review path.
@@ -672,6 +704,13 @@ export async function handler(
         await recordQuietDrops(dispositionStore, installationId, repoFullName, quietDrops);
       }
     }
+    const updatedReactionsSnapshot = await pollAndRecordInlineReactions(
+      octokit, owner, repo, prNumber,
+      prevComplete?.inlineReactionsSnapshot,
+      dispositionStore,
+      installationId,
+      repoFullName,
+    );
 
     const durationMs = Date.now() - new Date(reviewStartedAt).getTime();
 
@@ -818,6 +857,12 @@ export async function handler(
       inputTokens: result.inputTokens || undefined,
       outputTokens: result.outputTokens || undefined,
       estimatedCostUsd: result.estimatedCostUsd ?? undefined,
+      // FB-C — persist the new reaction snapshot for delta-vs-snapshot
+      // reconciliation on the next review run. See server/review-processor.ts
+      // for the rationale.
+      ...(Object.keys(updatedReactionsSnapshot).length > 0
+        ? { inlineReactionsSnapshot: updatedReactionsSnapshot }
+        : {}),
     });
 
     // ── Record billing (SaaS only) ────

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -13,6 +13,7 @@ import {
   handleInlineReply,
   fetchTriageComments, computeDisputedKeys, partitionDisputed,
   recordFindingSurfacings, recordDisputes, detectQuietDrops, recordQuietDrops,
+  pollAndRecordInlineReactions,
 } from '@mergewatch/core';
 import type { WebhookDeps } from './webhook-handler.js';
 
@@ -178,6 +179,39 @@ async function handleInlineReplyJob(
       // FB-A — every inline-resolve also counts as an explicit per-finding
       // dispute. Best-effort write; the helper logs+swallows on failure.
       await recordDisputes(deps.dispositionStore, installationId, repoFullName, result.resolvedFindingKeys);
+    }
+
+    // FB-D — `/mergewatch reject` persists a categorised rejection per
+    // match key. Mirrors the FP-F path but records `rejectReasons[]` +
+    // increments `disputeCount`. Best-effort.
+    if (
+      deps.dispositionStore &&
+      installationId != null &&
+      result.action === 'rejected' &&
+      result.rejectedFindingKeys &&
+      result.rejectedFindingKeys.length > 0 &&
+      result.rejectCategory
+    ) {
+      const inst = String(installationId);
+      const at = new Date().toISOString();
+      const reason: { category: 'already-handled' | 'out-of-scope' | 'wrong-target' | 'style-disagreement' | 'other'; text?: string; at: string } = {
+        category: result.rejectCategory,
+        ...(result.rejectText ? { text: result.rejectText } : {}),
+        at,
+      };
+      for (const key of result.rejectedFindingKeys) {
+        await deps.dispositionStore.appendRejectReason(inst, repoFullName, key, reason)
+          .catch((err) => console.warn('[fb-d] appendRejectReason failed for %s:', key, err));
+      }
+      await recordDisputes(deps.dispositionStore, installationId, repoFullName, result.rejectedFindingKeys);
+      console.log(
+        '[fb-d] recorded %d /mergewatch reject%s (category=%s) on %s#%d',
+        result.rejectedFindingKeys.length,
+        result.rejectedFindingKeys.length === 1 ? '' : 's',
+        result.rejectCategory,
+        repoFullName,
+        prNumber,
+      );
     }
 
     console.log(
@@ -547,19 +581,23 @@ export async function processReviewJob(
       delta = computeReviewDelta(result.findings, prevComplete.findings);
     }
 
-    // FB-A / FB-B — analytics writes. All best-effort; failures inside the
-    // helpers are caught + logged and never block the review path.
+    // FB-A / FB-B / FB-C — analytics writes. All best-effort; failures inside
+    // the helpers are caught + logged and never block the review path.
     //
-    //   surfacings        — one upsertSurface + (verified|unverified) per
+    //   surfacings (FB-A) — one upsertSurface + (verified|unverified) per
     //                       finding × match-key. Captures category, agent,
     //                       and W10 sigTokens for later clustering.
     //   quiet drops (FB-B) — findings that vanished without a code change at
     //                       the cited line → silentDropCount++. Strong
     //                       implicit FP signal.
+    //   reactions (FB-C)  — fold a single listReviewComments call into the
+    //                       post-pipeline path; delta vs the prior snapshot
+    //                       drives dispute/agreement counter increments.
+    //                       Returns the new snapshot for persistence below.
     //
-    // Both writes use the same nowIso anchor so a re-review of the same
-    // commit produces identical lastSeen timestamps on duplicate calls
-    // (rare but possible on retries).
+    // FB-A and FB-B share `nowIso` so a re-review of the same commit
+    // produces identical lastSeen timestamps on duplicate calls (rare but
+    // possible on retries).
     const nowIso = new Date().toISOString();
     await recordFindingSurfacings(deps.dispositionStore, installationId, repoFullName, result.findings, nowIso);
     if (prevComplete?.findings && prevComplete.findings.length > 0) {
@@ -569,6 +607,13 @@ export async function processReviewJob(
         await recordQuietDrops(deps.dispositionStore, installationId, repoFullName, quietDrops);
       }
     }
+    const updatedReactionsSnapshot = await pollAndRecordInlineReactions(
+      octokit, owner, repo, prNumber,
+      prevComplete?.inlineReactionsSnapshot,
+      deps.dispositionStore,
+      installationId,
+      repoFullName,
+    );
 
     // Compute cumulative cost across all reviews on this PR
     const prevCost = prevReviewsResult.reduce((sum, r) => sum + (r.estimatedCostUsd ?? 0), 0);
@@ -705,6 +750,14 @@ export async function processReviewJob(
       inputTokens: result.inputTokens || undefined,
       outputTokens: result.outputTokens || undefined,
       estimatedCostUsd: result.estimatedCostUsd ?? undefined,
+      // FB-C — persist the new reaction snapshot so the next review can
+      // compute deltas without re-counting already-observed reactions.
+      // Omit when empty so the field stays absent on freshly-reviewed
+      // PRs with no inline comments yet (back-compat with the typed
+      // ReviewItem shape).
+      ...(Object.keys(updatedReactionsSnapshot).length > 0
+        ? { inlineReactionsSnapshot: updatedReactionsSnapshot }
+        : {}),
     });
 
     // Create structured check run (matches Lambda pattern)

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -1,4 +1,4 @@
-import type { ReviewJobPayload, IInstallationStore, IReviewStore, IGitHubAuthProvider, ILLMProvider, FileFetchOptions, ReviewDelta, MergeWatchConfig } from '@mergewatch/core';
+import type { ReviewJobPayload, IInstallationStore, IReviewStore, IGitHubAuthProvider, ILLMProvider, FileFetchOptions, ReviewDelta, MergeWatchConfig, RejectCategory, FindingDispositionRecord } from '@mergewatch/core';
 import {
   getPRDiff, getPRContext, addPRReaction, removePRReaction, postReviewComment, updateReviewComment,
   findExistingBotComment, getCommentReactions, createCheckRun,
@@ -194,14 +194,30 @@ async function handleInlineReplyJob(
     ) {
       const inst = String(installationId);
       const at = new Date().toISOString();
-      const reason: { category: 'already-handled' | 'out-of-scope' | 'wrong-target' | 'style-disagreement' | 'other'; text?: string; at: string } = {
-        category: result.rejectCategory,
+      // Reuses the exported RejectCategory union from core so the inline
+      // shape can't drift if the categories are widened. The reason shape
+      // matches `FindingDispositionRecord['rejectReasons'][number]`.
+      const reason: NonNullable<FindingDispositionRecord['rejectReasons']>[number] = {
+        category: result.rejectCategory as RejectCategory,
         ...(result.rejectText ? { text: result.rejectText } : {}),
         at,
       };
-      for (const key of result.rejectedFindingKeys) {
-        await deps.dispositionStore.appendRejectReason(inst, repoFullName, key, reason)
-          .catch((err) => console.warn('[fb-d] appendRejectReason failed for %s:', key, err));
+      // Parallel + summary-logged: a per-key catch'd loop was sequential
+      // and emitted one warn per failure. Promise.allSettled lets the
+      // writes run in parallel and the failure count is emitted as a
+      // single line — easier to grep + sufficient for the current
+      // analytics-volume scale.
+      const settled = await Promise.allSettled(
+        result.rejectedFindingKeys.map((key) =>
+          deps.dispositionStore!.appendRejectReason(inst, repoFullName, key, reason),
+        ),
+      );
+      const failed = settled.filter((r) => r.status === 'rejected').length;
+      if (failed > 0) {
+        console.warn(
+          '[fb-d] %d/%d appendRejectReason write(s) failed for %s#%d (category=%s)',
+          failed, settled.length, repoFullName, prNumber, result.rejectCategory,
+        );
       }
       await recordDisputes(deps.dispositionStore, installationId, repoFullName, result.rejectedFindingKeys);
       console.log(

--- a/packages/storage-postgres/drizzle/0004_messy_next_avengers.sql
+++ b/packages/storage-postgres/drizzle/0004_messy_next_avengers.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "reviews" ADD COLUMN IF NOT EXISTS "inline_reactions_snapshot" jsonb DEFAULT '{}'::jsonb;

--- a/packages/storage-postgres/drizzle/meta/0004_snapshot.json
+++ b/packages/storage-postgres/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,643 @@
+{
+  "id": "33cc97e1-2471-4677-a1f3-d40b9995917c",
+  "prevId": "45d0ffbb-e0a4-42ba-be60-3017529666d3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_installation_idx": {
+          "name": "api_keys_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.finding_dispositions": {
+      "name": "finding_dispositions",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finding_match_key": {
+          "name": "finding_match_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_count": {
+          "name": "surface_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dispute_count": {
+          "name": "dispute_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verified_count": {
+          "name": "verified_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unverified_count": {
+          "name": "unverified_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "silent_drop_count": {
+          "name": "silent_drop_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "agreement_count": {
+          "name": "agreement_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_agent": {
+          "name": "top_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sig_tokens": {
+          "name": "sig_tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reject_reasons": {
+          "name": "reject_reasons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "finding_dispositions_installation_idx": {
+          "name": "finding_dispositions_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "finding_dispositions_installation_id_repo_full_name_finding_match_key_pk": {
+          "name": "finding_dispositions_installation_id_repo_full_name_finding_match_key_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name",
+            "finding_match_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installation_settings": {
+      "name": "installation_settings",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "severity_threshold": {
+          "name": "severity_threshold",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Low'"
+        },
+        "comment_types": {
+          "name": "comment_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"syntax\":true,\"logic\":true,\"style\":true}'::jsonb"
+        },
+        "max_comments": {
+          "name": "max_comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 25
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"prSummary\":true,\"confidenceScore\":true,\"issuesTable\":true,\"diagram\":true}'::jsonb"
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "comment_header": {
+          "name": "comment_header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installations": {
+      "name": "installations",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monitored": {
+          "name": "monitored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "installations_installation_id_repo_full_name_pk": {
+          "name": "installations_installation_id_repo_full_name_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_sessions": {
+      "name": "mcp_sessions",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_billed_at": {
+          "name": "first_billed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_billed_cents": {
+          "name": "max_billed_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iteration": {
+          "name": "iteration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number_commit_sha": {
+          "name": "pr_number_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_title": {
+          "name": "pr_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_author": {
+          "name": "pr_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_author_avatar": {
+          "name": "pr_author_avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_branch": {
+          "name": "head_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_severity": {
+          "name": "top_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_text": {
+          "name": "summary_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagram_text": {
+          "name": "diagram_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_score": {
+          "name": "merge_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_score_reason": {
+          "name": "merge_score_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "findings": {
+          "name": "findings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reactions": {
+          "name": "reactions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_used": {
+          "name": "settings_used",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_cost_usd": {
+          "name": "estimated_cost_usd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inline_resolved_keys": {
+          "name": "inline_resolved_keys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "inline_reactions_snapshot": {
+          "name": "inline_reactions_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "reviews_installation_idx": {
+          "name": "reviews_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_pr_idx": {
+          "name": "reviews_pr_idx",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "reviews_repo_full_name_pr_number_commit_sha_pk": {
+          "name": "reviews_repo_full_name_pr_number_commit_sha_pk",
+          "columns": [
+            "repo_full_name",
+            "pr_number_commit_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/storage-postgres/drizzle/meta/_journal.json
+++ b/packages/storage-postgres/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1779471084197,
       "tag": "0003_jittery_steel_serpent",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1779473116425,
+      "tag": "0004_messy_next_avengers",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/storage-postgres/src/review-store.ts
+++ b/packages/storage-postgres/src/review-store.ts
@@ -151,6 +151,10 @@ export class PostgresReviewStore implements IReviewStore {
       ...(Array.isArray(row.inlineResolvedKeys) && row.inlineResolvedKeys.length > 0
         ? { inlineResolvedKeys: row.inlineResolvedKeys as string[] }
         : {}),
+      ...(row.inlineReactionsSnapshot && typeof row.inlineReactionsSnapshot === 'object'
+        && Object.keys(row.inlineReactionsSnapshot as Record<string, unknown>).length > 0
+        ? { inlineReactionsSnapshot: row.inlineReactionsSnapshot as Record<string, Record<string, number>> }
+        : {}),
     }));
   }
 }

--- a/packages/storage-postgres/src/schema.ts
+++ b/packages/storage-postgres/src/schema.ts
@@ -55,6 +55,10 @@ export const reviews = pgTable('reviews', {
   // FP-F — keys for findings the author resolved on inline comment threads.
   // Union'd with the live W3 disputedKeys on subsequent reviews.
   inlineResolvedKeys: jsonb('inline_resolved_keys').default([]),
+  // FB-C — last-observed reaction counts per inline bot comment, keyed by
+  // commentId. Drives the reaction-delta → dispute/agreement increments
+  // on subsequent reviews.
+  inlineReactionsSnapshot: jsonb('inline_reactions_snapshot').default({}),
 }, (t) => ({
   pk: primaryKey({ columns: [t.repoFullName, t.prNumberCommitSha] }),
   installationIdx: index('reviews_installation_idx').on(t.installationId),


### PR DESCRIPTION
## Summary

**PR 2 of the FP-feedback plan** (#164). Captures explicit per-finding FP signal from GitHub-native channels:
- **Passive** — 👎 / 🤔 reactions on bot inline comments (no typing needed)
- **Active** — `/mergewatch reject <category>` slash command (categorical signal)

Both feed the `FindingDispositionRecord` counters laid down by FB-A. No new UI surface yet — that's PR 4+.

## FB-C — Inline-comment reactions → disputes / agreements

`packages/core/src/insights/disposition-writer.ts` + handlers

- New `pollAndRecordInlineReactions(octokit, …)`. Single `pulls.listReviewComments` call — the summary `reactions` field on each comment already carries per-type counts, so no per-comment reaction-list API call is needed.
- **Reaction mapping** (locked):

  | Reaction | Counter |
  |---|---|
  | 👎 `-1` | `disputeCount` |
  | 🤔 `confused` | `disputeCount` |
  | 👍 `+1` | `agreementCount` |
  | ❤️ `heart` | `agreementCount` |
  | 🚀 `rocket` | `agreementCount` |
  | 👀 / 🎉 / 😄 | ignored (read-receipt / ambiguous) |

- **Monotonic via snapshot**: only the positive delta vs the prior snapshot triggers increments. A reviewer who 👎 then *removes* the reaction can't make the dispute counter regress.
- **Filter to MergeWatch comments only**: bot-authored AND carrying `INLINE_BOT_COMMENT_MARKER`. CopilotAI / dependabot / human inline comments stay out.
- **Storage**: new `ReviewItem.inlineReactionsSnapshot` field (jsonb on Postgres via migration `0004_…`; DynamoDB is schemaless).
- **Wiring**: both handlers fold the poll into the existing post-pipeline analytics block as FB-A/B. New snapshot persists via `updateStatus`.
- **Best-effort**: a failed `listReviewComments` returns an empty snapshot and logs `[fb-c] failed to list review comments` — never blocks a review.

## FB-D — `/mergewatch reject` slash command

`packages/core/src/agents/inline-reply.ts` + handlers

- New `parseRejectIntent(text)` recogniser. Grammar (locked in PR #164):

  ```
  /mergewatch reject <category> [optional free-text]
  ```

- **Categories** (closed set): `already-handled`, `out-of-scope`, `wrong-target`, `style-disagreement`, `other`.
- **Silent-other coercion**: anything unrecognised coerces to `other` and preserves the typed token as the leading word of the free-text reason. Bare `/mergewatch reject` (no category) also coerces to `other` with no text. *Preserves the signal even when the reviewer mistypes.*
- `handleInlineReply` gained a new `'rejected'` action between resolve and the LLM-reply branch. Posts a confirming bot reply naming the recorded category (and explaining the coercion when it happened).
- **Does NOT auto-resolve** the GitHub thread — rejection records the signal; closure is a human decision. `/resolve` and `/reject` stay orthogonal verbs. (Precedence: `/resolve` wins when both intents appear in the same reply.)
- **`InlineReplyResult`** gained `rejectedFindingKeys`, `rejectCategory`, `rejectText`. Handlers translate these into:
  - `appendRejectReason` on each match key (categorical analytics)
  - `recordDisputes` on each match key (dispute count)

## Tests

| File | New cases | Coverage |
|------|-----------|---------|
| `core/src/agents/inline-reply.test.ts` | **13** | `parseRejectIntent` — every category, case-insensitive, mistyped coercion, bare verb, prose-form rejection, multi-line scope. `handleInlineReply` rejected-action — path with category + text, silent-other reply explainer, resolve-takes-precedence, no-keys fallback. |
| `core/src/insights/disposition-writer.test.ts` | **11** | `pollAndRecordInlineReactions` — each mapping branch, monotonic-via-delta, reaction-removal no-op, non-bot skip, missing marker skip, missing path → snapshot-only, empty store no-op, snapshot return shape, API failure → empty snapshot. |

Local validation:
- `core test` **556 / 556** (was 532 + 24 new)
- `core typecheck` clean
- `drizzle migrations:check` 🐶🔥
- `pnpm run build` 12/12
- `pnpm run typecheck` 20/20
- `pnpm run test:coverage` **20/20**

## Migration safety

- **Postgres 0004**: `ADD COLUMN IF NOT EXISTS` (per CLAUDE.md).
- **DynamoDB**: schemaless; new `inlineReactionsSnapshot` surfaces without DDL.
- **Old reviews** without the snapshot get treated as "everything is new" on first poll — first poll for an established PR may emit a burst of dispute/agreement increments (catch-up). Acceptable for v1; the counters are monotonic so over-counting is the only risk, not undercounting.

## E2E Regression

`e2e/RUNBOOK.md` — **E2E-39** + **E2E-40** flipped from TARGET to ✅ SHIPPED, per [[e2e-regression-spec-per-pr]].

## Plan doc

`docs/false-positive-feedback-plan.md` — FB-C + FB-D marked **✅ SHIPPED** in section headings and the priority table.

## Next

**PR 3** in the plan is **FB-E** (nightly `InstallationFPInsight` rollup) — unblocked once #166 merges. After that the dashboard charts (PR 4+) can finally read aggregated data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)