### PR TITLE
FB-E — nightly InstallationFPInsight rollup (FP-feedback PR 3)

### DIFF
--- a/docs/false-positive-feedback-plan.md
+++ b/docs/false-positive-feedback-plan.md
@@ -198,7 +198,7 @@ The bot posts a confirming reply (`Got it — recording as <category>. This patt
 
 ---
 
-### FB-E — Nightly `InstallationFPInsight` rollup
+### FB-E — Nightly `InstallationFPInsight` rollup  ✅ SHIPPED
 
 **Where the gap lives:** Reading per-finding records on every dashboard pageload is O(N) on installation size. We want the dashboard to be O(1).
 
@@ -304,7 +304,7 @@ Compute cost is bounded by the largest installation's record count; rollups stay
 | **FB-B** | Quiet-drop derived counter | Persist | S | FB-A | ✅ SHIPPED |
 | **FB-C** | Inline-comment 👎 → disputes | Capture | M | FB-A | ✅ SHIPPED |
 | **FB-D** | `/mergewatch reject` slash command | Capture | M | FB-A | ✅ SHIPPED |
-| **FB-E** | Nightly InstallationFPInsight rollup | Aggregate | M | FB-A, FB-B | ★★★ |
+| **FB-E** | Nightly InstallationFPInsight rollup | Aggregate | M | FB-A, FB-B | ✅ SHIPPED |
 | **FB-F** | FP funnel chart | Surface | M | FB-E | ★★ |
 | **FB-G** | Dispute-rate-by-agent chart | Surface | M | FB-E | ★★ |
 | **FB-H** | Top recurring themes table | Surface | M | FB-E | ★★★ |

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -167,7 +167,7 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-38](#e2e-38-fb-b--quiet-drop-derived-counter) | Quiet-drop (finding gone without code change) increments `silentDropCount` on the matching record (FB-B) | 2m | 60s | FB-B |
 | [E2E-39](#e2e-39-fb-c--inline-comment--reactions--disputes) | 👎 / 🤔 on a bot inline comment increments `disputeCount`; 👍 / ❤️ / 🚀 increments `agreementCount` (FB-C) | 2m | 60s | FB-C |
 | [E2E-40](#e2e-40-fb-d--mergewatch-reject-slash-command) | `/mergewatch reject <category> [reason]` on an inline thread persists a categorised rejection + posts a confirming bot reply (FB-D) | 3m | 90s | FB-D |
-| [E2E-41](#e2e-41-fb-e--nightly-installationfpinsight-rollup-target) | Nightly scheduled job produces InstallationFPInsight rollups for 7d / 30d / 90d windows per installation (FB-E) — **TARGET** | 3m | 90s | FB-E |
+| [E2E-41](#e2e-41-fb-e--nightly-installationfpinsight-rollup) | Nightly scheduled job produces InstallationFPInsight rollups for 7d / 30d / 90d windows per installation (FB-E) | 3m | 90s | FB-E |
 | [E2E-42](#e2e-42-fb-f--dashboard-fp-funnel-chart-target) | Org dashboard renders the FP funnel: surfaced → carried → resolved → disputed → silently-dropped (FB-F) — **TARGET** | 2m | 60s | FB-F |
 | [E2E-43](#e2e-43-fb-g--dispute-rate-by-agent-line-chart-target) | Org dashboard renders dispute-rate over time with one line per agent category (FB-G) — **TARGET** | 2m | 60s | FB-G |
 | [E2E-44](#e2e-44-fb-h--top-recurring-fp-themes-table-target) | Org dashboard renders a sortable table of the top-10 disputed clusters with drill-through (FB-H) — **TARGET** | 2m | 60s | FB-H |
@@ -1609,9 +1609,9 @@ Branch: `fixture/40-mergewatch-reject`. PR with an inline finding:
 
 ---
 
-### E2E-41: FB-E — Nightly InstallationFPInsight rollup — TARGET
+### E2E-41: FB-E — Nightly InstallationFPInsight rollup
 
-**Status:** **Not yet implemented.** See [`docs/false-positive-feedback-plan.md` → FB-E](./../docs/false-positive-feedback-plan.md#fb-e--nightly-installationfpinsight-rollup).
+**Status:** ✅ SHIPPED. See [`docs/false-positive-feedback-plan.md` → FB-E](./../docs/false-positive-feedback-plan.md#fb-e--nightly-installationfpinsight-rollup--shipped).
 
 **Behavior (intended, once FB-E ships):** scheduled task (EventBridge → Lambda for SaaS; node-cron for self-hosted) runs nightly per installation. For each window (7d / 30d / 90d), aggregates `FindingDispositionRecord` rows into a single `InstallationFPInsight` row carrying: `totalFindingsSurfaced`, `disputeRate`, `perCategory`, `topClusters[]` (via W10 token clustering), `perRepo`. Stored in a new `mergewatch-installation-fp-insights` table. All dashboard charts read exclusively from these rollups.
 

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -369,6 +369,60 @@ Resources:
           - handlers/mcp.ts
 
   # ===========================================================================
+  # Lambda: Insights Rollup (FB-E)
+  # ===========================================================================
+  # Scheduled nightly to aggregate FindingDispositionRecord rows into
+  # InstallationFPInsight rollups (7d / 30d / 90d windows per installation).
+  # Powers the dashboard FB-F..FB-J charts.
+  #
+  # Cron: 03:00 UTC daily (`cron(0 3 * * ? *)`). Chosen for low traffic
+  # collision with EU/US business hours. Idempotent — re-running the same
+  # window-end overwrites with identical numbers.
+
+  InsightsRollupFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub 'mergewatch-insights-rollup-${Stage}'
+      Description: Nightly FP insight rollup (FB-E) — aggregates disposition records into per-installation rolling-window insights
+
+      CodeUri: ../packages/lambda/src/
+      Handler: handlers/insights-rollup.handler
+
+      # Light workload — Scan + filter + aggregate. 512MB is plenty;
+      # bumping memory mainly for CPU headroom on the clustering step.
+      MemorySize: 512
+
+      # Bounded by the largest installation's record count (low-thousands
+      # at scale). 5 min ceiling matches the SAM template's Globals.
+      Timeout: 300
+
+      Role: !GetAtt LambdaExecutionRole.Arn
+
+      Environment:
+        Variables:
+          STAGE: !Ref Stage
+          INSTALLATIONS_TABLE: !Ref InstallationsTable
+          FINDING_DISPOSITIONS_TABLE: !Ref FindingDispositionsTable
+          FP_INSIGHTS_TABLE: !Ref FpInsightsTable
+
+      # EventBridge schedule trigger — 03:00 UTC daily.
+      Events:
+        NightlyRollup:
+          Type: Schedule
+          Properties:
+            Schedule: cron(0 3 * * ? *)
+            Description: Nightly insight rollup at 03:00 UTC
+
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Target: es2022
+        Sourcemap: true
+        EntryPoints:
+          - handlers/insights-rollup.ts
+
+  # ===========================================================================
   # DynamoDB Table: Installations
   # ===========================================================================
   # Tracks GitHub App installations and per-repo configuration.
@@ -650,6 +704,56 @@ Resources:
     UpdateReplacePolicy: Retain
 
   # ===========================================================================
+  # DynamoDB: InstallationFPInsights (FB-E)
+  # ===========================================================================
+  # Per-installation rolling-window FP insight rollups. Three rows per
+  # installation (7d / 30d / 90d), replaced idempotently by the nightly
+  # InsightsRollupFunction. Reads power the dashboard FB-F..FB-J charts.
+  #
+  # Schema:
+  #   PK: installationId (String)
+  #   SK: window         (String — '7d' | '30d' | '90d')
+  #
+  # Attributes (set on every nightly run):
+  #   - windowStart / windowEnd / generatedAt (String, ISO 8601)
+  #   - totalFindingsSurfaced / totalDisputes / totalSilentDrops /
+  #     totalAgreements (Number)
+  #   - disputeRate (String — same precision discipline as estimated_cost_usd)
+  #   - perCategory / perRepo / topClusters (Map / List)
+  #
+  # Idempotent writes via PutCommand → no ConditionExpression needed.
+
+  FpInsightsTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub 'mergewatch-installation-fp-insights-${Stage}'
+      BillingMode: PAY_PER_REQUEST
+
+      KeySchema:
+        - AttributeName: installationId
+          KeyType: HASH
+        - AttributeName: window
+          KeyType: RANGE
+
+      AttributeDefinitions:
+        - AttributeName: installationId
+          AttributeType: S
+        - AttributeName: window
+          AttributeType: S
+
+      SSESpecification:
+        SSEEnabled: true
+
+      Tags:
+        - Key: Project
+          Value: MergeWatch
+        - Key: Stage
+          Value: !Ref Stage
+
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+
+  # ===========================================================================
   # IAM Role: Lambda Execution Role
   # ===========================================================================
   # A single shared role for both Lambda functions. This simplifies management
@@ -724,12 +828,14 @@ Resources:
                   - !GetAtt ApiKeysTable.Arn
                   - !GetAtt SessionsTable.Arn
                   - !GetAtt FindingDispositionsTable.Arn
+                  - !GetAtt FpInsightsTable.Arn
                   # Index ARNs (for future GSIs)
                   - !Sub '${InstallationsTable.Arn}/index/*'
                   - !Sub '${ReviewsTable.Arn}/index/*'
                   - !Sub '${ApiKeysTable.Arn}/index/*'
                   - !Sub '${SessionsTable.Arn}/index/*'
                   - !Sub '${FindingDispositionsTable.Arn}/index/*'
+                  - !Sub '${FpInsightsTable.Arn}/index/*'
 
         # --- SSM Parameter Store ---
         # Read-only access to GitHub credentials stored in SSM.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,7 @@ export type {
   IApiKeyStore,
   IMcpSessionStore,
   IFindingDispositionStore,
+  IFPInsightStore,
   FindingDispositionAttribution,
   ApiKeyRecord,
   McpSessionRecord,
@@ -150,6 +151,11 @@ export {
   pollAndRecordInlineReactions,
 } from './insights/disposition-writer.js';
 
+// ─── Insight rollup (FB-E) ─────────────────────────────────────────────────
+export { buildInsightFromDispositions, WINDOW_LENGTH_MS } from './insights/rollup.js';
+export { runInsightRollup } from './insights/run-rollup.js';
+export type { RollupStores, RollupRunResult } from './insights/run-rollup.js';
+
 // ─── Config ─────────────────────────────────────────────────────────────────
 export {
   DEFAULT_CONFIG,
@@ -232,6 +238,7 @@ export type {
   CreateReviewInput,
   UpdateReviewInput,
   FindingDispositionRecord,
+  InstallationFPInsight,
 } from './types/db.js';
 
 export { DEFAULT_INSTALLATION_SETTINGS } from './types/db.js';

--- a/packages/core/src/insights/rollup.test.ts
+++ b/packages/core/src/insights/rollup.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from 'vitest';
+import { buildInsightFromDispositions, WINDOW_LENGTH_MS } from './rollup.js';
+import type { FindingDispositionRecord } from '../types/db.js';
+
+// ─── Test fixtures ──────────────────────────────────────────────────────────
+
+const WINDOW_END = '2026-05-22T00:00:00.000Z';
+const WINDOW_END_MS = new Date(WINDOW_END).getTime();
+
+function isoOffset(daysBack: number): string {
+  return new Date(WINDOW_END_MS - daysBack * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function record(over: Partial<FindingDispositionRecord> = {}): FindingDispositionRecord {
+  return {
+    installationId: '42',
+    repoFullName: 'org/repo',
+    findingMatchKey: 'src/a.ts::T::Missing await on fetch',
+    firstSeen: isoOffset(5),
+    lastSeen: isoOffset(1),
+    surfaceCount: 1,
+    disputeCount: 0,
+    verifiedCount: 0,
+    unverifiedCount: 0,
+    silentDropCount: 0,
+    agreementCount: 0,
+    category: 'bug',
+    topAgent: 'bug',
+    sigTokens: ['missing', 'await', 'fetch'],
+    ...over,
+  };
+}
+
+// ─── Window filtering ───────────────────────────────────────────────────────
+
+describe('buildInsightFromDispositions — window filtering', () => {
+  it('includes only records whose lastSeen falls inside the window', () => {
+    const records = [
+      record({ lastSeen: isoOffset(1), surfaceCount: 5 }),
+      record({ lastSeen: isoOffset(10), surfaceCount: 3 }),
+      record({ lastSeen: isoOffset(45), surfaceCount: 7 }),
+    ];
+    const r7  = buildInsightFromDispositions('42', '7d',  WINDOW_END, records);
+    const r30 = buildInsightFromDispositions('42', '30d', WINDOW_END, records);
+    const r90 = buildInsightFromDispositions('42', '90d', WINDOW_END, records);
+    expect(r7.totalFindingsSurfaced).toBe(5);          // only the 1-day-old
+    expect(r30.totalFindingsSurfaced).toBe(5 + 3);     // 1d + 10d
+    expect(r90.totalFindingsSurfaced).toBe(5 + 3 + 7); // all three
+  });
+
+  it('sets windowStart correctly relative to windowEnd for each window', () => {
+    const r7 = buildInsightFromDispositions('42', '7d', WINDOW_END, []);
+    expect(new Date(r7.windowEnd).getTime() - new Date(r7.windowStart).getTime()).toBe(WINDOW_LENGTH_MS['7d']);
+  });
+
+  it('returns zero counters with no records', () => {
+    const r = buildInsightFromDispositions('42', '7d', WINDOW_END, []);
+    expect(r.totalFindingsSurfaced).toBe(0);
+    expect(r.totalDisputes).toBe(0);
+    expect(r.disputeRate).toBe(0);
+    expect(r.topClusters).toEqual([]);
+    expect(r.perCategory).toEqual({});
+    expect(r.perRepo).toEqual({});
+  });
+});
+
+// ─── Global counters ───────────────────────────────────────────────────────
+
+describe('buildInsightFromDispositions — global counters', () => {
+  it('sums every counter across in-window records', () => {
+    const records = [
+      record({ surfaceCount: 10, disputeCount: 3, silentDropCount: 1, agreementCount: 2 }),
+      record({ surfaceCount: 4,  disputeCount: 1, silentDropCount: 2, agreementCount: 1 }),
+    ];
+    const r = buildInsightFromDispositions('42', '7d', WINDOW_END, records);
+    expect(r.totalFindingsSurfaced).toBe(14);
+    expect(r.totalDisputes).toBe(4);
+    expect(r.totalSilentDrops).toBe(3);
+    expect(r.totalAgreements).toBe(3);
+    expect(r.disputeRate).toBeCloseTo(4 / 14);
+  });
+
+  it('disputeRate is 0 when no surfacings (avoids divide-by-zero)', () => {
+    const r = buildInsightFromDispositions('42', '7d', WINDOW_END, []);
+    expect(r.disputeRate).toBe(0);
+  });
+});
+
+// ─── Per-category / per-repo buckets ───────────────────────────────────────
+
+describe('buildInsightFromDispositions — buckets', () => {
+  it('buckets by category and computes per-category rate', () => {
+    const records = [
+      record({ category: 'security', surfaceCount: 10, disputeCount: 1 }),
+      record({ category: 'style',    surfaceCount: 20, disputeCount: 16 }),
+      record({ category: 'security', surfaceCount: 5,  disputeCount: 0  }),
+    ];
+    const r = buildInsightFromDispositions('42', '7d', WINDOW_END, records);
+    expect(r.perCategory).toEqual({
+      security: { surfaced: 15, disputed: 1,  rate: 1  / 15 },
+      style:    { surfaced: 20, disputed: 16, rate: 16 / 20 },
+    });
+  });
+
+  it('lumps records without a category under "uncategorized"', () => {
+    const records = [
+      record({ category: undefined, surfaceCount: 4, disputeCount: 2 }),
+    ];
+    const r = buildInsightFromDispositions('42', '7d', WINDOW_END, records);
+    expect(r.perCategory).toEqual({
+      uncategorized: { surfaced: 4, disputed: 2, rate: 0.5 },
+    });
+  });
+
+  it('buckets by repoFullName independently of category', () => {
+    const records = [
+      record({ repoFullName: 'org/api', surfaceCount: 6, disputeCount: 3 }),
+      record({ repoFullName: 'org/web', surfaceCount: 4, disputeCount: 0 }),
+    ];
+    const r = buildInsightFromDispositions('42', '7d', WINDOW_END, records);
+    expect(r.perRepo['org/api'].rate).toBeCloseTo(0.5);
+    expect(r.perRepo['org/web'].rate).toBe(0);
+  });
+});
+
+// ─── Clusters ───────────────────────────────────────────────────────────────
+
+describe('buildInsightFromDispositions — clusters', () => {
+  it('clusters records that share at least one sigToken', () => {
+    const records = [
+      record({ findingMatchKey: 'src/a.ts::T::Missing await on fetch',  sigTokens: ['missing', 'await', 'fetch'],   surfaceCount: 5, disputeCount: 4 }),
+      record({ findingMatchKey: 'src/b.ts::T::Async fetch not awaited', sigTokens: ['async',   'fetch', 'awaited'], surfaceCount: 3, disputeCount: 2 }),
+      // Different cluster — no shared tokens with the above.
+      record({ findingMatchKey: 'src/c.ts::T::Magic number 42',        sigTokens: ['magic',  'number'],            surfaceCount: 2, disputeCount: 0 }),
+    ];
+    const r = buildInsightFromDispositions('42', '7d', WINDOW_END, records);
+    // Two distinct clusters.
+    expect(r.topClusters).toHaveLength(2);
+    // The fetch cluster sums both members.
+    const fetchCluster = r.topClusters.find((c) => c.sigTokens.includes('fetch'))!;
+    expect(fetchCluster.surfaceCount).toBe(8);
+    expect(fetchCluster.disputeCount).toBe(6);
+    expect(fetchCluster.rate).toBeCloseTo(6 / 8);
+  });
+
+  it('picks the highest-surfacing member\'s title as the cluster representative', () => {
+    const records = [
+      record({ findingMatchKey: 'src/a.ts::T::Tiny issue',   sigTokens: ['shared'], surfaceCount: 1 }),
+      record({ findingMatchKey: 'src/b.ts::T::Main concern', sigTokens: ['shared'], surfaceCount: 20 }),
+    ];
+    const r = buildInsightFromDispositions('42', '7d', WINDOW_END, records);
+    expect(r.topClusters[0].representativeTitle).toBe('Main concern');
+  });
+
+  it('falls back to the file path when the match key is fingerprint-form (no title)', () => {
+    const records = [
+      record({ findingMatchKey: 'src/a.ts::F::const x = await fn();', sigTokens: ['some', 'token'], surfaceCount: 5 }),
+    ];
+    const r = buildInsightFromDispositions('42', '7d', WINDOW_END, records);
+    expect(r.topClusters[0].representativeTitle).toBe('src/a.ts');
+  });
+
+  it('skips records with no sigTokens — they don\'t cluster but still count in totals', () => {
+    const records = [
+      record({ sigTokens: undefined, surfaceCount: 7, disputeCount: 2 }),
+      record({ sigTokens: ['shared'], surfaceCount: 3, disputeCount: 1 }),
+    ];
+    const r = buildInsightFromDispositions('42', '7d', WINDOW_END, records);
+    expect(r.totalFindingsSurfaced).toBe(10);    // both contribute to totals
+    expect(r.topClusters).toHaveLength(1);       // only the one with sigTokens clusters
+    expect(r.topClusters[0].surfaceCount).toBe(3);
+  });
+
+  it('sorts top clusters by disputeRate × surfaceCount desc (leverage)', () => {
+    // High rate but low volume vs lower rate but higher volume.
+    const records = [
+      record({ findingMatchKey: 'a::T::Rare gem',       sigTokens: ['rare'],   surfaceCount: 2,  disputeCount: 2  }), // rate=1.0  leverage=2
+      record({ findingMatchKey: 'b::T::Bigger problem', sigTokens: ['common'], surfaceCount: 30, disputeCount: 12 }), // rate=0.4  leverage=12
+    ];
+    const r = buildInsightFromDispositions('42', '7d', WINDOW_END, records);
+    expect(r.topClusters[0].representativeTitle).toBe('Bigger problem');
+  });
+
+  it('caps topClusters at the configured limit (default 10)', () => {
+    // Build 15 distinct clusters by giving each a unique sigToken.
+    const records = Array.from({ length: 15 }, (_, i) => record({
+      findingMatchKey: `src/${i}.ts::T::Cluster ${i}`,
+      sigTokens: [`uniqueToken${i}`],
+      surfaceCount: 1,
+      disputeCount: 1,
+    }));
+    const r = buildInsightFromDispositions('42', '7d', WINDOW_END, records);
+    expect(r.topClusters).toHaveLength(10);
+  });
+});
+
+// ─── Window metadata ────────────────────────────────────────────────────────
+
+describe('buildInsightFromDispositions — metadata', () => {
+  it('echoes installationId and window verbatim', () => {
+    const r = buildInsightFromDispositions('inst-42', '30d', WINDOW_END, []);
+    expect(r.installationId).toBe('inst-42');
+    expect(r.window).toBe('30d');
+  });
+
+  it('sets generatedAt = windowEnd (the rollup is anchored to the window upper bound)', () => {
+    const r = buildInsightFromDispositions('42', '7d', WINDOW_END, []);
+    expect(r.generatedAt).toBe(r.windowEnd);
+    expect(r.windowEnd).toBe(WINDOW_END);
+  });
+});

--- a/packages/core/src/insights/rollup.ts
+++ b/packages/core/src/insights/rollup.ts
@@ -1,0 +1,222 @@
+/**
+ * FB-E — aggregate FindingDispositionRecord rows into an
+ * `InstallationFPInsight` rollup per rolling window.
+ *
+ * Pure function: takes already-fetched records + a window length, returns
+ * the typed insight. Doesn't touch storage, doesn't touch time directly
+ * (window bounds are passed in as ISO strings). Testable without any
+ * mocking beyond seed data.
+ */
+
+import type { FindingDispositionRecord, InstallationFPInsight } from '../types/db.js';
+
+/** Rolling window definitions: ISO 8601 duration → milliseconds. */
+export const WINDOW_LENGTH_MS: Record<InstallationFPInsight['window'], number> = {
+  '7d':  7  * 24 * 60 * 60 * 1000,
+  '30d': 30 * 24 * 60 * 60 * 1000,
+  '90d': 90 * 24 * 60 * 60 * 1000,
+};
+
+/** Cap on `topClusters[]` per insight. Keeps rollups small and the
+ *  dashboard render snappy; FB-H surfaces top-10 anyway. */
+const TOP_CLUSTERS_LIMIT = 10;
+
+/**
+ * Compute one rolling-window insight from a set of disposition records.
+ *
+ *   1. Filter records to those whose `lastSeen` falls inside the window.
+ *   2. Sum the global counters.
+ *   3. Bucket by `category` and by `repoFullName`.
+ *   4. Cluster by shared significant tokens (union-find on sigToken
+ *      overlap) and pick top-N by `surfaceCount × disputeRate`.
+ *
+ * Defensive defaults — rates are 0 when surfaceCount is 0; missing
+ * sigTokens skip the cluster step but still feed the totals.
+ */
+export function buildInsightFromDispositions(
+  installationId: string,
+  window: InstallationFPInsight['window'],
+  windowEndIso: string,
+  records: readonly FindingDispositionRecord[],
+): InstallationFPInsight {
+  const windowEndMs = new Date(windowEndIso).getTime();
+  const windowStartMs = windowEndMs - WINDOW_LENGTH_MS[window];
+  const windowStartIso = new Date(windowStartMs).toISOString();
+
+  // Filter to "active in window" — lastSeen inside [windowStart, windowEnd].
+  // We deliberately use lastSeen (most-recent surfacing) rather than
+  // firstSeen so a long-running finding contributes to its currently-
+  // active window rather than its first-discovered one.
+  const inWindow = records.filter((r) => {
+    const t = new Date(r.lastSeen).getTime();
+    return t >= windowStartMs && t <= windowEndMs;
+  });
+
+  // Global counters.
+  let totalFindingsSurfaced = 0;
+  let totalDisputes = 0;
+  let totalSilentDrops = 0;
+  let totalAgreements = 0;
+  for (const r of inWindow) {
+    totalFindingsSurfaced += r.surfaceCount;
+    totalDisputes        += r.disputeCount;
+    totalSilentDrops     += r.silentDropCount;
+    totalAgreements      += r.agreementCount;
+  }
+  const disputeRate = totalFindingsSurfaced > 0 ? totalDisputes / totalFindingsSurfaced : 0;
+
+  // Per-category and per-repo buckets.
+  const perCategory: Record<string, { surfaced: number; disputed: number; rate: number }> = {};
+  const perRepo:     Record<string, { surfaced: number; disputed: number; rate: number }> = {};
+  for (const r of inWindow) {
+    const cat = r.category ?? 'uncategorized';
+    if (!perCategory[cat]) perCategory[cat] = { surfaced: 0, disputed: 0, rate: 0 };
+    perCategory[cat].surfaced += r.surfaceCount;
+    perCategory[cat].disputed += r.disputeCount;
+
+    if (!perRepo[r.repoFullName]) perRepo[r.repoFullName] = { surfaced: 0, disputed: 0, rate: 0 };
+    perRepo[r.repoFullName].surfaced += r.surfaceCount;
+    perRepo[r.repoFullName].disputed += r.disputeCount;
+  }
+  for (const bucket of Object.values(perCategory)) {
+    bucket.rate = bucket.surfaced > 0 ? bucket.disputed / bucket.surfaced : 0;
+  }
+  for (const bucket of Object.values(perRepo)) {
+    bucket.rate = bucket.surfaced > 0 ? bucket.disputed / bucket.surfaced : 0;
+  }
+
+  // Top clusters — group records by shared sigToken overlap.
+  const topClusters = clusterRecordsBySigTokens(inWindow).slice(0, TOP_CLUSTERS_LIMIT);
+
+  return {
+    installationId,
+    window,
+    windowStart: windowStartIso,
+    windowEnd: windowEndIso,
+    generatedAt: windowEndIso,
+    totalFindingsSurfaced,
+    totalDisputes,
+    disputeRate,
+    totalSilentDrops,
+    totalAgreements,
+    perCategory,
+    perRepo,
+    topClusters,
+  };
+}
+
+// ─── Internal: clustering ────────────────────────────────────────────────────
+
+interface ClusterMember {
+  rec: FindingDispositionRecord;
+  tokens: Set<string>;
+}
+
+interface RawCluster {
+  members: ClusterMember[];
+}
+
+/**
+ * Group disposition records into clusters of "the same finding shape".
+ * Two records are in the same cluster when their sigToken bags share at
+ * least one token (Jaccard > 0 over significant tokens). Implemented as a
+ * disjoint-set union-find over the records list.
+ *
+ * Records without sigTokens are skipped entirely — they don't participate
+ * in clusters (no signal to group on) but they DO still contribute to
+ * the global + per-category + per-repo totals above.
+ *
+ * Output is sorted by `disputeRate × surfaceCount` desc so the dashboard
+ * top-N renders the highest-leverage items first.
+ */
+function clusterRecordsBySigTokens(
+  records: readonly FindingDispositionRecord[],
+): InstallationFPInsight['topClusters'] {
+  const members: ClusterMember[] = [];
+  for (const r of records) {
+    if (!r.sigTokens || r.sigTokens.length === 0) continue;
+    members.push({ rec: r, tokens: new Set(r.sigTokens) });
+  }
+  if (members.length === 0) return [];
+
+  // Union-find by shared significant token. We pre-index records by
+  // each token they carry — when two records share a token they're
+  // unioned. O(N · K) where K is the avg sigTokens-per-record cap (16).
+  const parent: number[] = members.map((_, i) => i);
+  const find = (i: number): number => {
+    while (parent[i] !== i) {
+      parent[i] = parent[parent[i]]; // path compression
+      i = parent[i];
+    }
+    return i;
+  };
+  const union = (a: number, b: number) => {
+    const ra = find(a), rb = find(b);
+    if (ra !== rb) parent[ra] = rb;
+  };
+
+  const tokenIndex = new Map<string, number[]>();
+  for (let i = 0; i < members.length; i++) {
+    for (const t of members[i].tokens) {
+      if (!tokenIndex.has(t)) tokenIndex.set(t, []);
+      tokenIndex.get(t)!.push(i);
+    }
+  }
+  for (const idxs of tokenIndex.values()) {
+    for (let j = 1; j < idxs.length; j++) {
+      union(idxs[0], idxs[j]);
+    }
+  }
+
+  // Group by root.
+  const byRoot = new Map<number, RawCluster>();
+  for (let i = 0; i < members.length; i++) {
+    const root = find(i);
+    if (!byRoot.has(root)) byRoot.set(root, { members: [] });
+    byRoot.get(root)!.members.push(members[i]);
+  }
+
+  // Synthesize the public cluster shape: representative title (the
+  // highest-surfacing member's title — extracted from the match key) +
+  // union of sigTokens + summed counts.
+  const clusters: InstallationFPInsight['topClusters'] = [];
+  for (const c of byRoot.values()) {
+    let surfaceCount = 0;
+    let disputeCount = 0;
+    const tokens = new Set<string>();
+    let topMember = c.members[0];
+    for (const m of c.members) {
+      surfaceCount += m.rec.surfaceCount;
+      disputeCount += m.rec.disputeCount;
+      for (const t of m.tokens) tokens.add(t);
+      if (m.rec.surfaceCount > topMember.rec.surfaceCount) topMember = m;
+    }
+    clusters.push({
+      sigTokens: Array.from(tokens).sort(),
+      representativeTitle: extractTitleFromMatchKey(topMember.rec.findingMatchKey),
+      surfaceCount,
+      disputeCount,
+      rate: surfaceCount > 0 ? disputeCount / surfaceCount : 0,
+    });
+  }
+
+  // Sort by leverage: disputeRate × surfaceCount.
+  clusters.sort((a, b) => (b.rate * b.surfaceCount) - (a.rate * a.surfaceCount));
+  return clusters;
+}
+
+/**
+ * Pull a human-readable title out of a `file::T::<title>` match key.
+ * For `file::F::<fingerprint>` keys we don't have a title, so fall back
+ * to the file path — better than an opaque fingerprint hash on the dashboard.
+ */
+function extractTitleFromMatchKey(key: string): string {
+  // Format is `<file>::T::<title>` or `<file>::F::<fingerprint>`.
+  const titleSep = '::T::';
+  const fpSep    = '::F::';
+  const tIdx = key.indexOf(titleSep);
+  if (tIdx >= 0) return key.slice(tIdx + titleSep.length);
+  const fIdx = key.indexOf(fpSep);
+  if (fIdx >= 0) return key.slice(0, fIdx); // fall back to file path
+  return key;
+}

--- a/packages/core/src/insights/run-rollup.test.ts
+++ b/packages/core/src/insights/run-rollup.test.ts
@@ -105,14 +105,52 @@ describe('runInsightRollup (FB-E orchestrator)', () => {
     expect(result.rowsWritten).toBe(6); // 2 OK × 3 windows
   });
 
-  it('returns empty result when listInstallationIds fails (rollup aborts cleanly)', async () => {
+  it('re-throws when listInstallationIds fails so callers see operator-visible failure', async () => {
+    // Earlier behaviour returned an empty result, which made a catastrophic
+    // enumeration failure look identical to "no installations to process".
+    // Now we re-throw so the Lambda invocation fails (→ CloudWatch alarm)
+    // and the self-hosted cron's outer try/catch logs + skips the cycle.
     const stores = makeStores({ installationsThrow: true });
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const result = await runInsightRollup(stores, WINDOW_END);
-    expect(result.installationsProcessed).toBe(0);
-    expect(result.rowsWritten).toBe(0);
+    await expect(runInsightRollup(stores, WINDOW_END)).rejects.toThrow('list fail');
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
+  });
+
+  it('follows cursor pagination across multiple pages of disposition records', async () => {
+    // FB-E previously stopped after the first 1000-row page — a silent
+    // truncation hazard for installations with high finding volume. Now
+    // we loop until nextCursor is unset.
+    const calls: Array<{ id: string; cursor?: string }> = [];
+    const stores: RollupStores & { upserts: InstallationFPInsight[] } = {
+      upserts: [],
+      installationStore: { listInstallationIds: async () => ['42'] },
+      dispositionStore: {
+        listByInstallation: async (id, opts) => {
+          calls.push({ id, cursor: opts?.cursor });
+          if (!opts?.cursor) {
+            return { items: [record({ surfaceCount: 1 })], nextCursor: 'page-2' };
+          }
+          if (opts.cursor === 'page-2') {
+            return { items: [record({ surfaceCount: 2 })], nextCursor: 'page-3' };
+          }
+          // Final page: no nextCursor.
+          return { items: [record({ surfaceCount: 4 })] };
+        },
+      },
+      fpInsightStore: {
+        upsert: async (i) => { (stores.upserts as InstallationFPInsight[]).push(i); },
+      },
+    };
+    const result = await runInsightRollup(stores, WINDOW_END);
+    expect(calls).toEqual([
+      { id: '42', cursor: undefined },
+      { id: '42', cursor: 'page-2' },
+      { id: '42', cursor: 'page-3' },
+    ]);
+    // All three records (1+2+4=7) summed into each window's surface count.
+    expect(stores.upserts[0].totalFindingsSurfaced).toBe(7);
+    expect(result.installationsProcessed).toBe(1);
   });
 
   it('counts installations as failed when ANY of the three window upserts fails', async () => {

--- a/packages/core/src/insights/run-rollup.test.ts
+++ b/packages/core/src/insights/run-rollup.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi } from 'vitest';
+import { runInsightRollup, type RollupStores } from './run-rollup.js';
+import type { FindingDispositionRecord, InstallationFPInsight } from '../types/db.js';
+
+const WINDOW_END = '2026-05-22T00:00:00.000Z';
+
+function record(over: Partial<FindingDispositionRecord> = {}): FindingDispositionRecord {
+  return {
+    installationId: '42',
+    repoFullName: 'org/repo',
+    findingMatchKey: 'src/a.ts::T::X',
+    firstSeen: '2026-05-21T00:00:00.000Z',
+    lastSeen: '2026-05-21T00:00:00.000Z', // 1 day before window end → in 7d
+    surfaceCount: 1,
+    disputeCount: 0,
+    verifiedCount: 0,
+    unverifiedCount: 0,
+    silentDropCount: 0,
+    agreementCount: 0,
+    ...over,
+  };
+}
+
+function makeStores(opts: {
+  installationIds?: string[];
+  recordsByInstallation?: Record<string, FindingDispositionRecord[]>;
+  installationsThrow?: boolean;
+  dispositionThrowsFor?: string;
+  upsertThrowsFor?: string;
+}): RollupStores & { upserts: InstallationFPInsight[] } {
+  const upserts: InstallationFPInsight[] = [];
+  return {
+    upserts,
+    installationStore: {
+      listInstallationIds: vi.fn(async () => {
+        if (opts.installationsThrow) throw new Error('list fail');
+        return opts.installationIds ?? [];
+      }),
+    },
+    dispositionStore: {
+      listByInstallation: vi.fn(async (id: string) => {
+        if (opts.dispositionThrowsFor === id) throw new Error('disp fail');
+        return { items: opts.recordsByInstallation?.[id] ?? [] };
+      }),
+    },
+    fpInsightStore: {
+      upsert: vi.fn(async (insight: InstallationFPInsight) => {
+        if (opts.upsertThrowsFor === insight.installationId) throw new Error('upsert fail');
+        upserts.push(insight);
+      }),
+    },
+  };
+}
+
+describe('runInsightRollup (FB-E orchestrator)', () => {
+  it('writes 3 rows (7d / 30d / 90d) per installation', async () => {
+    const stores = makeStores({
+      installationIds: ['42', '99'],
+      recordsByInstallation: {
+        '42': [record({ installationId: '42', surfaceCount: 5 })],
+        '99': [record({ installationId: '99', surfaceCount: 3 })],
+      },
+    });
+    const result = await runInsightRollup(stores, WINDOW_END);
+    expect(result.installationsProcessed).toBe(2);
+    expect(result.rowsWritten).toBe(6); // 2 installations × 3 windows
+    expect(result.installationsFailed).toEqual([]);
+    expect(stores.upserts.map((u) => u.window).sort()).toEqual(['30d', '30d', '7d', '7d', '90d', '90d']);
+  });
+
+  it('uses the provided windowEndIso as the anchor for all windows', async () => {
+    const stores = makeStores({
+      installationIds: ['42'],
+      recordsByInstallation: { '42': [] },
+    });
+    await runInsightRollup(stores, WINDOW_END);
+    for (const upsert of stores.upserts) {
+      expect(upsert.windowEnd).toBe(WINDOW_END);
+      expect(upsert.generatedAt).toBe(WINDOW_END);
+    }
+  });
+
+  it('defaults windowEnd to now when not provided', async () => {
+    const stores = makeStores({ installationIds: ['42'], recordsByInstallation: { '42': [] } });
+    const before = Date.now();
+    await runInsightRollup(stores);
+    const after = Date.now();
+    const insightTs = new Date(stores.upserts[0].windowEnd).getTime();
+    expect(insightTs).toBeGreaterThanOrEqual(before);
+    expect(insightTs).toBeLessThanOrEqual(after);
+  });
+
+  it('isolates per-installation failure — one broken install doesn\'t halt the rest', async () => {
+    const stores = makeStores({
+      installationIds: ['ok-1', 'broken', 'ok-2'],
+      recordsByInstallation: {
+        'ok-1': [record({ installationId: 'ok-1' })],
+        'ok-2': [record({ installationId: 'ok-2' })],
+      },
+      dispositionThrowsFor: 'broken',
+    });
+    const result = await runInsightRollup(stores, WINDOW_END);
+    expect(result.installationsProcessed).toBe(2);
+    expect(result.installationsFailed).toEqual(['broken']);
+    expect(result.rowsWritten).toBe(6); // 2 OK × 3 windows
+  });
+
+  it('returns empty result when listInstallationIds fails (rollup aborts cleanly)', async () => {
+    const stores = makeStores({ installationsThrow: true });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = await runInsightRollup(stores, WINDOW_END);
+    expect(result.installationsProcessed).toBe(0);
+    expect(result.rowsWritten).toBe(0);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('counts installations as failed when ANY of the three window upserts fails', async () => {
+    // Tighter contract: if any upsert in the per-install loop throws,
+    // the whole install is marked failed (not "2/3 windows succeeded").
+    const stores = makeStores({
+      installationIds: ['42'],
+      recordsByInstallation: { '42': [record({ installationId: '42' })] },
+      upsertThrowsFor: '42',
+    });
+    const result = await runInsightRollup(stores, WINDOW_END);
+    expect(result.installationsProcessed).toBe(0);
+    expect(result.installationsFailed).toEqual(['42']);
+  });
+
+  it('writes 3 zero rows for an installation with no records (still has an insight to read)', async () => {
+    const stores = makeStores({
+      installationIds: ['fresh-install'],
+      recordsByInstallation: { 'fresh-install': [] },
+    });
+    await runInsightRollup(stores, WINDOW_END);
+    expect(stores.upserts).toHaveLength(3);
+    for (const upsert of stores.upserts) {
+      expect(upsert.totalFindingsSurfaced).toBe(0);
+      expect(upsert.disputeRate).toBe(0);
+    }
+  });
+
+  it('reports elapsedMs', async () => {
+    const stores = makeStores({ installationIds: ['42'], recordsByInstallation: { '42': [] } });
+    const result = await runInsightRollup(stores, WINDOW_END);
+    expect(typeof result.elapsedMs).toBe('number');
+    expect(result.elapsedMs).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/packages/core/src/insights/run-rollup.ts
+++ b/packages/core/src/insights/run-rollup.ts
@@ -14,7 +14,7 @@ import type {
   IFPInsightStore,
   IInstallationStore,
 } from '../storage/types.js';
-import type { InstallationFPInsight } from '../types/db.js';
+import type { FindingDispositionRecord, InstallationFPInsight } from '../types/db.js';
 import { buildInsightFromDispositions } from './rollup.js';
 
 const WINDOWS: InstallationFPInsight['window'][] = ['7d', '30d', '90d'];
@@ -57,19 +57,33 @@ export async function runInsightRollup(
   let installationsProcessed = 0;
   let rowsWritten = 0;
 
-  const installationIds = await stores.installationStore.listInstallationIds().catch((err) => {
+  // Re-throw on catastrophic enumeration failure so the operator sees it:
+  //   • Lambda → throws → invocation marked failed → CloudWatch alarm.
+  //   • Self-hosted cron → outer try/catch in `runOnce` swallows + logs.
+  // The PRIOR behaviour returned [] which made a complete failure look
+  // identical to "no installations to process" — invisible to ops.
+  let installationIds: string[];
+  try {
+    installationIds = await stores.installationStore.listInstallationIds();
+  } catch (err) {
     console.warn('[fb-e] listInstallationIds failed; rollup aborted:', err);
-    return [] as string[];
-  });
+    throw err;
+  }
 
   for (const installationId of installationIds) {
     try {
-      // Page through records — listByInstallation returns up to 1000 per
-      // call. For the typical installation that's a single page; for
-      // outliers we'd want to extend the loop to follow nextCursor. Here
-      // we take the first page (the rollup is best-effort + bounded by
-      // the store's cap; pagination support belongs in a follow-up).
-      const { items: records } = await stores.dispositionStore.listByInstallation(installationId, { limit: 1000 });
+      // Page through every disposition record for this installation. Earlier
+      // versions stopped after the first 1000-row page — fine for typical
+      // installations but a silent truncation hazard for the long tail.
+      // Cursor pagination keeps us correct across any record volume; each
+      // page is bounded by the store's `limit` so memory stays predictable.
+      const records: FindingDispositionRecord[] = [];
+      let cursor: string | undefined;
+      do {
+        const page = await stores.dispositionStore.listByInstallation(installationId, { limit: 1000, cursor });
+        records.push(...page.items);
+        cursor = page.nextCursor;
+      } while (cursor);
 
       for (const window of WINDOWS) {
         const insight = buildInsightFromDispositions(installationId, window, windowEndIso, records);

--- a/packages/core/src/insights/run-rollup.ts
+++ b/packages/core/src/insights/run-rollup.ts
@@ -1,0 +1,93 @@
+/**
+ * FB-E — orchestrator for the nightly insight rollup. Pure(-ish) function
+ * that runs the rollup across every installation; called by:
+ *   - the EventBridge → Lambda handler on SaaS
+ *   - the node-cron job in the self-hosted Express server
+ *
+ * Single shared entry point keeps the behaviour identical across deploy
+ * shapes — and the function is testable by injecting mock stores
+ * (no AWS / node-cron / Express coupling).
+ */
+
+import type {
+  IFindingDispositionStore,
+  IFPInsightStore,
+  IInstallationStore,
+} from '../storage/types.js';
+import type { InstallationFPInsight } from '../types/db.js';
+import { buildInsightFromDispositions } from './rollup.js';
+
+const WINDOWS: InstallationFPInsight['window'][] = ['7d', '30d', '90d'];
+
+export interface RollupStores {
+  installationStore: Pick<IInstallationStore, 'listInstallationIds'>;
+  dispositionStore: Pick<IFindingDispositionStore, 'listByInstallation'>;
+  fpInsightStore: Pick<IFPInsightStore, 'upsert'>;
+}
+
+export interface RollupRunResult {
+  installationsProcessed: number;
+  rowsWritten: number;
+  installationsFailed: string[];
+  elapsedMs: number;
+  windowEnd: string;
+}
+
+/**
+ * Run the nightly rollup. For each installation:
+ *   1. List its FindingDispositionRecord rows.
+ *   2. Build a 7d / 30d / 90d insight from them.
+ *   3. Upsert each insight row.
+ *
+ * Per-installation failure is isolated: a single broken installation
+ * doesn't take down the whole job; the failing installation IDs are
+ * returned for follow-up.
+ *
+ * Idempotent — re-running the same window-end overwrites the rows with
+ * identical numbers (the rollup is a pure function of the disposition
+ * records + windowEnd).
+ */
+export async function runInsightRollup(
+  stores: RollupStores,
+  /** ISO 8601 — anchor the windows to this timestamp. Defaults to `now`. */
+  windowEndIso: string = new Date().toISOString(),
+): Promise<RollupRunResult> {
+  const startMs = Date.now();
+  const installationsFailed: string[] = [];
+  let installationsProcessed = 0;
+  let rowsWritten = 0;
+
+  const installationIds = await stores.installationStore.listInstallationIds().catch((err) => {
+    console.warn('[fb-e] listInstallationIds failed; rollup aborted:', err);
+    return [] as string[];
+  });
+
+  for (const installationId of installationIds) {
+    try {
+      // Page through records — listByInstallation returns up to 1000 per
+      // call. For the typical installation that's a single page; for
+      // outliers we'd want to extend the loop to follow nextCursor. Here
+      // we take the first page (the rollup is best-effort + bounded by
+      // the store's cap; pagination support belongs in a follow-up).
+      const { items: records } = await stores.dispositionStore.listByInstallation(installationId, { limit: 1000 });
+
+      for (const window of WINDOWS) {
+        const insight = buildInsightFromDispositions(installationId, window, windowEndIso, records);
+        await stores.fpInsightStore.upsert(insight);
+        rowsWritten++;
+      }
+      installationsProcessed++;
+    } catch (err) {
+      console.warn('[fb-e] rollup failed for installation %s:', installationId, err);
+      installationsFailed.push(installationId);
+    }
+  }
+
+  return {
+    installationsProcessed,
+    rowsWritten,
+    installationsFailed,
+    elapsedMs: Date.now() - startMs,
+    windowEnd: windowEndIso,
+  };
+}

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -10,12 +10,21 @@ import type {
   InstallationItem, InstallationSettings,
   ReviewItem, ReviewStatus,
   FindingDispositionRecord,
+  InstallationFPInsight,
 } from '../types/db.js';
 
 export interface IInstallationStore {
   get(installationId: string, repoFullName: string): Promise<InstallationItem | null>;
   getSettings(installationId: string): Promise<InstallationSettings>;
   upsert(item: InstallationItem): Promise<void>;
+  /**
+   * FB-E — enumerate every distinct installation ID known to the store.
+   * Used by the nightly insight rollup to fan out across all
+   * installations. Returns an empty array when the underlying store is
+   * empty. No pagination — installation counts are bounded (low
+   * hundreds even at scale).
+   */
+  listInstallationIds(): Promise<string[]>;
 }
 
 export interface IReviewStore {
@@ -144,4 +153,24 @@ export interface IFindingDispositionStore {
     installationId: string,
     opts?: { limit?: number; cursor?: string },
   ): Promise<{ items: FindingDispositionRecord[]; nextCursor?: string }>;
+}
+
+// ─── FB-E — InstallationFPInsight rollup store ─────────────────────────────
+
+/**
+ * Persists the per-installation rolling-window FP insight rollups computed
+ * by the nightly job. Reads back to power the dashboard charts (FB-F..FB-J).
+ *
+ * Idempotent writes — `upsert` replaces the existing row for a given
+ * (installationId, window) tuple.
+ */
+export interface IFPInsightStore {
+  upsert(insight: InstallationFPInsight): Promise<void>;
+  get(installationId: string, window: InstallationFPInsight['window']): Promise<InstallationFPInsight | null>;
+  /**
+   * Read the full set of rolling-window rows for one installation —
+   * dashboard charts typically render all three windows side-by-side.
+   * Returns the rows in `window` order ('7d', '30d', '90d').
+   */
+  listByInstallation(installationId: string): Promise<InstallationFPInsight[]>;
 }

--- a/packages/core/src/types/db.ts
+++ b/packages/core/src/types/db.ts
@@ -510,6 +510,65 @@ export interface FindingDispositionRecord {
 }
 
 /**
+ * FB-E — Per-installation FP insight rollup. Produced nightly by aggregating
+ * `FindingDispositionRecord` rows over a rolling window (7d / 30d / 90d).
+ *
+ * Storage:
+ *   - DynamoDB (SaaS) table: mergewatch-installation-fp-insights
+ *     PK: `installationId`   SK: `window`   (e.g. PK=42, SK="30d")
+ *   - Postgres (self-hosted) table: installation_fp_insights
+ *     PK: (installation_id, window)
+ *
+ * Read path: dashboard charts (FB-F..FB-J) read these rows; never the raw
+ * `FindingDispositionRecord` table. Keeps page-load O(1).
+ *
+ * Write path: a scheduled job (EventBridge → Lambda for SaaS; node-cron
+ * in the Express server for self-hosted) replaces the three rolling-window
+ * rows for each installation once per night. Idempotent — re-running the
+ * same night overwrites with identical numbers.
+ */
+export interface InstallationFPInsight {
+  installationId: string;
+  /** Rolling window the row aggregates over. */
+  window: '7d' | '30d' | '90d';
+  /** ISO 8601 — the lower bound of the window (now - window length). */
+  windowStart: string;
+  /** ISO 8601 — the upper bound (rollup timestamp). */
+  windowEnd: string;
+  /** ISO 8601 — when this row was last computed; same as windowEnd for fresh rollups. */
+  generatedAt: string;
+
+  /** Sum of surfaceCount across every disposition record whose lastSeen falls inside the window. */
+  totalFindingsSurfaced: number;
+  /** Sum of disputeCount across the same set. */
+  totalDisputes: number;
+  /** disputeCount / surfaceCount across the window. 0 when totalFindingsSurfaced is 0. */
+  disputeRate: number;
+  /** Sum of silentDropCount — the implicit FP signal. */
+  totalSilentDrops: number;
+  /** Sum of agreementCount — the implicit TP signal. */
+  totalAgreements: number;
+
+  /** Bucketed by `FindingDispositionRecord.category` (security / bug / style / …). */
+  perCategory: Record<string, { surfaced: number; disputed: number; rate: number }>;
+  /** Bucketed by `FindingDispositionRecord.repoFullName`. */
+  perRepo: Record<string, { surfaced: number; disputed: number; rate: number }>;
+
+  /**
+   * Top-N clusters by `disputeRate × surfaceCount`. Clusters are built via
+   * union-find on shared significant tokens (same W10 token bag the
+   * orchestrator's FB-A writer captures on each surfacing).
+   */
+  topClusters: Array<{
+    sigTokens: string[];
+    representativeTitle: string;
+    surfaceCount: number;
+    disputeCount: number;
+    rate: number;
+  }>;
+}
+
+/**
  * Type for updating a review's status — partial update to an existing item.
  */
 export type UpdateReviewInput = ReviewKey & {

--- a/packages/lambda/src/handlers/insights-rollup.ts
+++ b/packages/lambda/src/handlers/insights-rollup.ts
@@ -1,12 +1,24 @@
 /**
  * FB-E — scheduled Lambda that runs the nightly insight rollup across
- * every installation. Triggered by an EventBridge rule (see
- * infra/template.yaml `InsightsRollupScheduleRule`). Runs unattended;
- * the only observability is CloudWatch logs.
+ * every installation. Triggered by an EventBridge schedule attached to
+ * the `InsightsRollupFunction` itself (see `Events.NightlyRollup` in
+ * `infra/template.yaml`). Runs unattended; the only observability is
+ * CloudWatch logs + the Lambda invocation status (200 / 207 / failed).
  *
  * Re-uses the shared `runInsightRollup` orchestrator from
  * `@mergewatch/core`. This handler is intentionally thin — it wires
  * stores, runs the rollup, logs the result, returns. No business logic.
+ *
+ * Error semantics:
+ *   • Per-installation failures isolated by the orchestrator → 207
+ *     Multi-Status return; CloudWatch can alarm on non-200.
+ *   • CATASTROPHIC enumeration failure (listInstallationIds) → the
+ *     orchestrator re-throws by design (see PR #169 review thread). We
+ *     intentionally do NOT wrap that in try/catch here: a thrown
+ *     exception fails the Lambda invocation, which is the strongest
+ *     possible signal to CloudWatch / on-call. Adding a catch here
+ *     would re-introduce the visibility gap MW's own round-1 review
+ *     asked us to fix.
  */
 
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';

--- a/packages/lambda/src/handlers/insights-rollup.ts
+++ b/packages/lambda/src/handlers/insights-rollup.ts
@@ -1,0 +1,60 @@
+/**
+ * FB-E — scheduled Lambda that runs the nightly insight rollup across
+ * every installation. Triggered by an EventBridge rule (see
+ * infra/template.yaml `InsightsRollupScheduleRule`). Runs unattended;
+ * the only observability is CloudWatch logs.
+ *
+ * Re-uses the shared `runInsightRollup` orchestrator from
+ * `@mergewatch/core`. This handler is intentionally thin — it wires
+ * stores, runs the rollup, logs the result, returns. No business logic.
+ */
+
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { runInsightRollup } from '@mergewatch/core';
+import {
+  DynamoInstallationStore,
+  DynamoFindingDispositionStore,
+  DynamoFPInsightStore,
+  DEFAULT_FINDING_DISPOSITIONS_TABLE,
+  DEFAULT_FP_INSIGHTS_TABLE,
+} from '@mergewatch/storage-dynamo';
+
+const dynamodb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+const INSTALLATIONS_TABLE = process.env.INSTALLATIONS_TABLE ?? 'mergewatch-installations';
+const FINDING_DISPOSITIONS_TABLE = process.env.FINDING_DISPOSITIONS_TABLE ?? DEFAULT_FINDING_DISPOSITIONS_TABLE;
+const FP_INSIGHTS_TABLE = process.env.FP_INSIGHTS_TABLE ?? DEFAULT_FP_INSIGHTS_TABLE;
+
+const installationStore = new DynamoInstallationStore(dynamodb, INSTALLATIONS_TABLE);
+const dispositionStore = new DynamoFindingDispositionStore(dynamodb, FINDING_DISPOSITIONS_TABLE);
+const fpInsightStore = new DynamoFPInsightStore(dynamodb, FP_INSIGHTS_TABLE);
+
+export async function handler(): Promise<{ statusCode: number; body: string }> {
+  console.log('[fb-e] insights rollup starting');
+  const result = await runInsightRollup({
+    installationStore,
+    dispositionStore,
+    fpInsightStore,
+  });
+  console.log(
+    '[fb-e] rollup complete — processed=%d, rows=%d, failed=[%s], elapsed=%dms, windowEnd=%s',
+    result.installationsProcessed,
+    result.rowsWritten,
+    result.installationsFailed.join(', '),
+    result.elapsedMs,
+    result.windowEnd,
+  );
+  if (result.installationsFailed.length > 0) {
+    // Soft-fail: return non-200 so EventBridge / CloudWatch can alarm
+    // on the metric, but don't throw — partial success is preserved.
+    return {
+      statusCode: 207,
+      body: JSON.stringify(result),
+    };
+  }
+  return {
+    statusCode: 200,
+    body: JSON.stringify(result),
+  };
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -8,11 +8,13 @@ import {
   PostgresInstallationStore,
   PostgresReviewStore,
   PostgresFindingDispositionStore,
+  PostgresFPInsightStore,
   runMigrations,
 } from '@mergewatch/storage-postgres';
 import { EnvGitHubAuthProvider } from './github-auth-env.js';
 import { createLLMProvider } from './llm-factory.js';
 import { createWebhookHandler } from './webhook-handler.js';
+import { startInsightsCron } from './insights-cron.js';
 
 function requireEnv(name: string): string {
   const value = process.env[name];
@@ -64,8 +66,15 @@ async function main() {
   const installationStore = new PostgresInstallationStore(db);
   const reviewStore = new PostgresReviewStore(db);
   const dispositionStore = new PostgresFindingDispositionStore(db);
+  const fpInsightStore = new PostgresFPInsightStore(db);
   const authProvider = new EnvGitHubAuthProvider(githubAppId, githubPrivateKey);
   const llm = createLLMProvider();
+
+  // FB-E — start the nightly insights rollup scheduler. Runs at startup
+  // (60s after init to let migrations complete) and every 24h after.
+  // Errors are caught + logged inside; the cron handle is kept for
+  // future graceful-shutdown support.
+  startInsightsCron({ installationStore, dispositionStore, fpInsightStore });
 
   // Express app
   const app = express();

--- a/packages/server/src/insights-cron.ts
+++ b/packages/server/src/insights-cron.ts
@@ -1,0 +1,80 @@
+/**
+ * FB-E — self-hosted insight rollup scheduler.
+ *
+ * Lightweight `setInterval`-based runner rather than a real cron library:
+ * the job is once-a-day, idempotent, and we don't need precise wall-clock
+ * timing. The first run fires `STARTUP_DELAY_MS` after server startup (to
+ * avoid colliding with DB-migration work); subsequent runs at 24h
+ * intervals from there. Operators who want precise 03:00 UTC scheduling
+ * can run the server as a Docker job triggered by an external cron.
+ */
+
+import { runInsightRollup } from '@mergewatch/core';
+import type {
+  IFindingDispositionStore,
+  IFPInsightStore,
+  IInstallationStore,
+} from '@mergewatch/core';
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+/** Wait 60s after startup before the first run so migrations / warm-up
+ *  paths complete first. */
+const STARTUP_DELAY_MS = 60 * 1000;
+
+export interface InsightsCronStores {
+  installationStore: IInstallationStore;
+  dispositionStore: IFindingDispositionStore;
+  fpInsightStore: IFPInsightStore;
+}
+
+export interface InsightsCronHandle {
+  /** Stop the scheduler. Used by tests + graceful shutdown. */
+  stop(): void;
+}
+
+/**
+ * Start the self-hosted insights rollup scheduler. Returns a handle so
+ * tests + graceful-shutdown paths can stop it. Runs the rollup once at
+ * startup (delayed by STARTUP_DELAY_MS) and then every 24 hours.
+ *
+ * Errors inside the rollup are caught by `runInsightRollup` and surfaced
+ * via the per-installation failure list — this scheduler also wraps the
+ * outer call in try/catch so a catastrophic error in the orchestrator
+ * (e.g. store crash) doesn't take down the Node process.
+ */
+export function startInsightsCron(stores: InsightsCronStores): InsightsCronHandle {
+  let stopped = false;
+  let intervalHandle: ReturnType<typeof setInterval> | undefined;
+
+  const runOnce = async () => {
+    if (stopped) return;
+    try {
+      console.log('[fb-e cron] starting nightly insights rollup');
+      const result = await runInsightRollup(stores);
+      console.log(
+        '[fb-e cron] rollup complete — processed=%d, rows=%d, failed=[%s], elapsed=%dms',
+        result.installationsProcessed,
+        result.rowsWritten,
+        result.installationsFailed.join(', '),
+        result.elapsedMs,
+      );
+    } catch (err) {
+      console.warn('[fb-e cron] rollup threw — skipping this cycle:', err);
+    }
+  };
+
+  // First-run delay so migrations have a chance to finish.
+  const firstRunTimer = setTimeout(() => {
+    if (stopped) return;
+    void runOnce();
+    intervalHandle = setInterval(() => void runOnce(), ONE_DAY_MS);
+  }, STARTUP_DELAY_MS);
+
+  return {
+    stop() {
+      stopped = true;
+      clearTimeout(firstRunTimer);
+      if (intervalHandle) clearInterval(intervalHandle);
+    },
+  };
+}

--- a/packages/storage-dynamo/src/fp-insight-store.ts
+++ b/packages/storage-dynamo/src/fp-insight-store.ts
@@ -1,0 +1,94 @@
+/**
+ * DynamoDB implementation of `IFPInsightStore` (FB-E).
+ *
+ * Table shape (created in infra/template.yaml):
+ *   PK: installationId   (String)
+ *   SK: window           (String — '7d' | '30d' | '90d')
+ *
+ * Three rows per installation, replaced idempotently by the nightly
+ * rollup. Reads are page-load critical (dashboard FB-F..FB-J) — a single
+ * Query against the PK returns all three windows in one round trip.
+ */
+
+import {
+  DynamoDBDocumentClient,
+  PutCommand,
+  GetCommand,
+  QueryCommand,
+} from '@aws-sdk/lib-dynamodb';
+import type { IFPInsightStore, InstallationFPInsight } from '@mergewatch/core';
+
+export const DEFAULT_FP_INSIGHTS_TABLE = 'mergewatch-installation-fp-insights';
+
+const WINDOW_ORDER: Record<InstallationFPInsight['window'], number> = {
+  '7d': 0, '30d': 1, '90d': 2,
+};
+
+export class DynamoFPInsightStore implements IFPInsightStore {
+  constructor(
+    private readonly client: DynamoDBDocumentClient,
+    private readonly tableName: string = DEFAULT_FP_INSIGHTS_TABLE,
+  ) {}
+
+  async upsert(insight: InstallationFPInsight): Promise<void> {
+    // Put replaces the entire row on every nightly run — idempotent by
+    // design. No UpdateExpression needed since we own every attribute.
+    await this.client.send(new PutCommand({
+      TableName: this.tableName,
+      Item: {
+        installationId: insight.installationId,
+        window: insight.window,
+        windowStart: insight.windowStart,
+        windowEnd: insight.windowEnd,
+        generatedAt: insight.generatedAt,
+        totalFindingsSurfaced: insight.totalFindingsSurfaced,
+        totalDisputes: insight.totalDisputes,
+        // Stored as string for parity with the postgres shape (avoids
+        // float-precision drift across re-reads); coerced back in get/list.
+        disputeRate: String(insight.disputeRate),
+        totalSilentDrops: insight.totalSilentDrops,
+        totalAgreements: insight.totalAgreements,
+        perCategory: insight.perCategory,
+        perRepo: insight.perRepo,
+        topClusters: insight.topClusters,
+      },
+    }));
+  }
+
+  async get(installationId: string, window: InstallationFPInsight['window']): Promise<InstallationFPInsight | null> {
+    const resp = await this.client.send(new GetCommand({
+      TableName: this.tableName,
+      Key: { installationId, window },
+    }));
+    return resp.Item ? itemToInsight(resp.Item) : null;
+  }
+
+  async listByInstallation(installationId: string): Promise<InstallationFPInsight[]> {
+    const resp = await this.client.send(new QueryCommand({
+      TableName: this.tableName,
+      KeyConditionExpression: 'installationId = :id',
+      ExpressionAttributeValues: { ':id': installationId },
+    }));
+    const items = (resp.Items ?? []).map(itemToInsight);
+    items.sort((a, b) => WINDOW_ORDER[a.window] - WINDOW_ORDER[b.window]);
+    return items;
+  }
+}
+
+function itemToInsight(it: Record<string, unknown>): InstallationFPInsight {
+  return {
+    installationId: String(it.installationId ?? ''),
+    window: it.window as InstallationFPInsight['window'],
+    windowStart: String(it.windowStart ?? ''),
+    windowEnd: String(it.windowEnd ?? ''),
+    generatedAt: String(it.generatedAt ?? ''),
+    totalFindingsSurfaced: Number(it.totalFindingsSurfaced ?? 0),
+    totalDisputes: Number(it.totalDisputes ?? 0),
+    disputeRate: Number(it.disputeRate ?? 0),
+    totalSilentDrops: Number(it.totalSilentDrops ?? 0),
+    totalAgreements: Number(it.totalAgreements ?? 0),
+    perCategory: (it.perCategory as InstallationFPInsight['perCategory']) ?? {},
+    perRepo: (it.perRepo as InstallationFPInsight['perRepo']) ?? {},
+    topClusters: (it.topClusters as InstallationFPInsight['topClusters']) ?? [],
+  };
+}

--- a/packages/storage-dynamo/src/index.ts
+++ b/packages/storage-dynamo/src/index.ts
@@ -12,3 +12,7 @@ export {
   DynamoFindingDispositionStore,
   DEFAULT_FINDING_DISPOSITIONS_TABLE,
 } from './finding-disposition-store.js';
+export {
+  DynamoFPInsightStore,
+  DEFAULT_FP_INSIGHTS_TABLE,
+} from './fp-insight-store.js';

--- a/packages/storage-dynamo/src/installation-store.ts
+++ b/packages/storage-dynamo/src/installation-store.ts
@@ -5,7 +5,7 @@
  * and loadInstallationSettings functions.
  */
 
-import { DynamoDBDocumentClient, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { DynamoDBDocumentClient, GetCommand, PutCommand, ScanCommand } from '@aws-sdk/lib-dynamodb';
 import type { IInstallationStore } from '@mergewatch/core';
 import type { InstallationItem, InstallationSettings } from '@mergewatch/core';
 import { DEFAULT_INSTALLATION_SETTINGS as DEFAULTS } from '@mergewatch/core';
@@ -61,5 +61,27 @@ export class DynamoInstallationStore implements IInstallationStore {
         Item: item,
       }),
     );
+  }
+
+  async listInstallationIds(): Promise<string[]> {
+    // ProjectionExpression keeps only the PK so the Scan is as cheap as
+    // possible. Page until LastEvaluatedKey is absent. Installation
+    // counts are bounded (low hundreds at scale) — a Scan beats a GSI
+    // for read cost on a once-a-day rollup workload.
+    const ids = new Set<string>();
+    let cursor: Record<string, unknown> | undefined;
+    do {
+      const resp = await this.client.send(new ScanCommand({
+        TableName: this.tableName,
+        ProjectionExpression: 'installationId',
+        ...(cursor ? { ExclusiveStartKey: cursor } : {}),
+      }));
+      for (const it of resp.Items ?? []) {
+        const id = it.installationId;
+        if (typeof id === 'string' || typeof id === 'number') ids.add(String(id));
+      }
+      cursor = resp.LastEvaluatedKey as Record<string, unknown> | undefined;
+    } while (cursor);
+    return Array.from(ids);
   }
 }

--- a/packages/storage-postgres/drizzle/0005_acoustic_puma.sql
+++ b/packages/storage-postgres/drizzle/0005_acoustic_puma.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS "installation_fp_insights" (
+	"installation_id" text NOT NULL,
+	"window" text NOT NULL,
+	"window_start" text NOT NULL,
+	"window_end" text NOT NULL,
+	"generated_at" text NOT NULL,
+	"total_findings_surfaced" integer DEFAULT 0 NOT NULL,
+	"total_disputes" integer DEFAULT 0 NOT NULL,
+	"dispute_rate" text DEFAULT '0' NOT NULL,
+	"total_silent_drops" integer DEFAULT 0 NOT NULL,
+	"total_agreements" integer DEFAULT 0 NOT NULL,
+	"per_category" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"per_repo" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"top_clusters" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	CONSTRAINT "installation_fp_insights_installation_id_window_pk" PRIMARY KEY("installation_id","window")
+);

--- a/packages/storage-postgres/drizzle/meta/0005_snapshot.json
+++ b/packages/storage-postgres/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,750 @@
+{
+  "id": "56239fbe-9c96-4d8d-aaee-6268b27f644b",
+  "prevId": "33cc97e1-2471-4677-a1f3-d40b9995917c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_installation_idx": {
+          "name": "api_keys_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.finding_dispositions": {
+      "name": "finding_dispositions",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finding_match_key": {
+          "name": "finding_match_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_count": {
+          "name": "surface_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dispute_count": {
+          "name": "dispute_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verified_count": {
+          "name": "verified_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unverified_count": {
+          "name": "unverified_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "silent_drop_count": {
+          "name": "silent_drop_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "agreement_count": {
+          "name": "agreement_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_agent": {
+          "name": "top_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sig_tokens": {
+          "name": "sig_tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reject_reasons": {
+          "name": "reject_reasons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "finding_dispositions_installation_idx": {
+          "name": "finding_dispositions_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "finding_dispositions_installation_id_repo_full_name_finding_match_key_pk": {
+          "name": "finding_dispositions_installation_id_repo_full_name_finding_match_key_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name",
+            "finding_match_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installation_fp_insights": {
+      "name": "installation_fp_insights",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window": {
+          "name": "window",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_end": {
+          "name": "window_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_findings_surfaced": {
+          "name": "total_findings_surfaced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_disputes": {
+          "name": "total_disputes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dispute_rate": {
+          "name": "dispute_rate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_silent_drops": {
+          "name": "total_silent_drops",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_agreements": {
+          "name": "total_agreements",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "per_category": {
+          "name": "per_category",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "per_repo": {
+          "name": "per_repo",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "top_clusters": {
+          "name": "top_clusters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "installation_fp_insights_installation_id_window_pk": {
+          "name": "installation_fp_insights_installation_id_window_pk",
+          "columns": [
+            "installation_id",
+            "window"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installation_settings": {
+      "name": "installation_settings",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "severity_threshold": {
+          "name": "severity_threshold",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Low'"
+        },
+        "comment_types": {
+          "name": "comment_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"syntax\":true,\"logic\":true,\"style\":true}'::jsonb"
+        },
+        "max_comments": {
+          "name": "max_comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 25
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"prSummary\":true,\"confidenceScore\":true,\"issuesTable\":true,\"diagram\":true}'::jsonb"
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "comment_header": {
+          "name": "comment_header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installations": {
+      "name": "installations",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monitored": {
+          "name": "monitored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "installations_installation_id_repo_full_name_pk": {
+          "name": "installations_installation_id_repo_full_name_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_sessions": {
+      "name": "mcp_sessions",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_billed_at": {
+          "name": "first_billed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_billed_cents": {
+          "name": "max_billed_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iteration": {
+          "name": "iteration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number_commit_sha": {
+          "name": "pr_number_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_title": {
+          "name": "pr_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_author": {
+          "name": "pr_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_author_avatar": {
+          "name": "pr_author_avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_branch": {
+          "name": "head_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_severity": {
+          "name": "top_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_text": {
+          "name": "summary_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagram_text": {
+          "name": "diagram_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_score": {
+          "name": "merge_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_score_reason": {
+          "name": "merge_score_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "findings": {
+          "name": "findings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reactions": {
+          "name": "reactions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_used": {
+          "name": "settings_used",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_cost_usd": {
+          "name": "estimated_cost_usd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inline_resolved_keys": {
+          "name": "inline_resolved_keys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "inline_reactions_snapshot": {
+          "name": "inline_reactions_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "reviews_installation_idx": {
+          "name": "reviews_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_pr_idx": {
+          "name": "reviews_pr_idx",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "reviews_repo_full_name_pr_number_commit_sha_pk": {
+          "name": "reviews_repo_full_name_pr_number_commit_sha_pk",
+          "columns": [
+            "repo_full_name",
+            "pr_number_commit_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/storage-postgres/drizzle/meta/_journal.json
+++ b/packages/storage-postgres/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1779473116425,
       "tag": "0004_messy_next_avengers",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1779481196813,
+      "tag": "0005_acoustic_puma",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/storage-postgres/src/fp-insight-store.ts
+++ b/packages/storage-postgres/src/fp-insight-store.ts
@@ -1,0 +1,101 @@
+/**
+ * Postgres implementation of `IFPInsightStore` (FB-E).
+ *
+ * Three rows per installation (one per rolling window), replaced
+ * idempotently by the nightly rollup job. Reads are page-load critical —
+ * the dashboard routes call `listByInstallation(installationId)` once
+ * per render to power FB-F..FB-J charts.
+ *
+ * `disputeRate` is stored as text (same reason `reviews.estimated_cost_usd`
+ * is) to avoid float-precision drift across pg float8 ↔ js number when
+ * the dashboard compares window-over-window.
+ */
+
+import { eq, and } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import type { IFPInsightStore, InstallationFPInsight } from '@mergewatch/core';
+import { installationFpInsights } from './schema.js';
+
+const WINDOW_ORDER: Record<InstallationFPInsight['window'], number> = {
+  '7d': 0, '30d': 1, '90d': 2,
+};
+
+export class PostgresFPInsightStore implements IFPInsightStore {
+  constructor(private db: PostgresJsDatabase) {}
+
+  async upsert(insight: InstallationFPInsight): Promise<void> {
+    await this.db
+      .insert(installationFpInsights)
+      .values({
+        installationId: insight.installationId,
+        window: insight.window,
+        windowStart: insight.windowStart,
+        windowEnd: insight.windowEnd,
+        generatedAt: insight.generatedAt,
+        totalFindingsSurfaced: insight.totalFindingsSurfaced,
+        totalDisputes: insight.totalDisputes,
+        disputeRate: String(insight.disputeRate),
+        totalSilentDrops: insight.totalSilentDrops,
+        totalAgreements: insight.totalAgreements,
+        perCategory: insight.perCategory as unknown,
+        perRepo: insight.perRepo as unknown,
+        topClusters: insight.topClusters as unknown,
+      })
+      .onConflictDoUpdate({
+        target: [installationFpInsights.installationId, installationFpInsights.window],
+        set: {
+          windowStart: insight.windowStart,
+          windowEnd: insight.windowEnd,
+          generatedAt: insight.generatedAt,
+          totalFindingsSurfaced: insight.totalFindingsSurfaced,
+          totalDisputes: insight.totalDisputes,
+          disputeRate: String(insight.disputeRate),
+          totalSilentDrops: insight.totalSilentDrops,
+          totalAgreements: insight.totalAgreements,
+          perCategory: insight.perCategory as unknown,
+          perRepo: insight.perRepo as unknown,
+          topClusters: insight.topClusters as unknown,
+        },
+      });
+  }
+
+  async get(installationId: string, window: InstallationFPInsight['window']): Promise<InstallationFPInsight | null> {
+    const rows = await this.db
+      .select()
+      .from(installationFpInsights)
+      .where(and(
+        eq(installationFpInsights.installationId, installationId),
+        eq(installationFpInsights.window, window),
+      ));
+    if (rows.length === 0) return null;
+    return rowToInsight(rows[0]);
+  }
+
+  async listByInstallation(installationId: string): Promise<InstallationFPInsight[]> {
+    const rows = await this.db
+      .select()
+      .from(installationFpInsights)
+      .where(eq(installationFpInsights.installationId, installationId));
+    return rows
+      .map(rowToInsight)
+      .sort((a, b) => WINDOW_ORDER[a.window] - WINDOW_ORDER[b.window]);
+  }
+}
+
+function rowToInsight(row: Record<string, unknown>): InstallationFPInsight {
+  return {
+    installationId: row.installationId as string,
+    window: row.window as InstallationFPInsight['window'],
+    windowStart: row.windowStart as string,
+    windowEnd: row.windowEnd as string,
+    generatedAt: row.generatedAt as string,
+    totalFindingsSurfaced: Number(row.totalFindingsSurfaced ?? 0),
+    totalDisputes: Number(row.totalDisputes ?? 0),
+    disputeRate: Number(row.disputeRate ?? 0),
+    totalSilentDrops: Number(row.totalSilentDrops ?? 0),
+    totalAgreements: Number(row.totalAgreements ?? 0),
+    perCategory: (row.perCategory as InstallationFPInsight['perCategory']) ?? {},
+    perRepo: (row.perRepo as InstallationFPInsight['perRepo']) ?? {},
+    topClusters: (row.topClusters as InstallationFPInsight['topClusters']) ?? [],
+  };
+}

--- a/packages/storage-postgres/src/index.ts
+++ b/packages/storage-postgres/src/index.ts
@@ -1,7 +1,11 @@
 export { PostgresInstallationStore } from './installation-store.js';
 export { PostgresReviewStore } from './review-store.js';
 export { PostgresFindingDispositionStore } from './finding-disposition-store.js';
-export { installations, installationSettings, reviews, apiKeys, mcpSessions, findingDispositions } from './schema.js';
+export { PostgresFPInsightStore } from './fp-insight-store.js';
+export {
+  installations, installationSettings, reviews, apiKeys, mcpSessions,
+  findingDispositions, installationFpInsights,
+} from './schema.js';
 export { runMigrations } from './migrate.js';
 export { createPostgresDashboardStore } from './dashboard-store.js';
 export { PostgresApiKeyStore } from './api-key-store.js';

--- a/packages/storage-postgres/src/installation-store.ts
+++ b/packages/storage-postgres/src/installation-store.ts
@@ -67,4 +67,15 @@ export class PostgresInstallationStore implements IInstallationStore {
         },
       });
   }
+
+  async listInstallationIds(): Promise<string[]> {
+    // Composite PK includes (installation_id, repo_full_name) so the same
+    // installation appears N times — one per monitored repo. DISTINCT
+    // gives us each installation once. Bounded result set (we're well
+    // under the 1k row limit even at SaaS scale).
+    const rows = await this.db
+      .selectDistinct({ installationId: installations.installationId })
+      .from(installations);
+    return rows.map((r) => r.installationId);
+  }
 }

--- a/packages/storage-postgres/src/schema.ts
+++ b/packages/storage-postgres/src/schema.ts
@@ -86,6 +86,29 @@ export const mcpSessions = pgTable('mcp_sessions', {
   expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
 });
 
+// FB-E — per-installation rolling-window FP insight rollups. Computed
+// nightly by the scheduled job; read by dashboard charts. See
+// InstallationFPInsight in @mergewatch/core for the typed shape.
+export const installationFpInsights = pgTable('installation_fp_insights', {
+  installationId: text('installation_id').notNull(),
+  // '7d' | '30d' | '90d' — typed at the application layer.
+  window: text('window').notNull(),
+  windowStart: text('window_start').notNull(),
+  windowEnd: text('window_end').notNull(),
+  generatedAt: text('generated_at').notNull(),
+  totalFindingsSurfaced: integer('total_findings_surfaced').notNull().default(0),
+  totalDisputes: integer('total_disputes').notNull().default(0),
+  // Stored as text to avoid float-precision drift across pg float8 ↔ js number.
+  disputeRate: text('dispute_rate').notNull().default('0'),
+  totalSilentDrops: integer('total_silent_drops').notNull().default(0),
+  totalAgreements: integer('total_agreements').notNull().default(0),
+  perCategory: jsonb('per_category').notNull().default({}),
+  perRepo: jsonb('per_repo').notNull().default({}),
+  topClusters: jsonb('top_clusters').notNull().default([]),
+}, (t) => ({
+  pk: primaryKey({ columns: [t.installationId, t.window] }),
+}));
+
 // FB-A — per-finding cross-PR identity records (one row per distinct
 // findingMatchKey per repo per installation). See FindingDispositionRecord
 // in @mergewatch/core for the typed shape and lifecycle semantics.


### PR DESCRIPTION
## Summary

**PR 3 of the FP-feedback plan** (#164). Aggregates the per-finding `FindingDispositionRecord` rows (FB-A) into per-installation **rolling-window rollups** (7d / 30d / 90d) that the dashboard charts (PR 4+: FB-F..FB-J) will read. Closes the **persist → aggregate** arc.

No UI surface yet — pure batch job. Once this merges, the dashboard work is unblocked.

## Storage layer

- New `InstallationFPInsight` type (`packages/core/src/types/db.ts`):
  - `totalFindingsSurfaced / totalDisputes / disputeRate`
  - `totalSilentDrops / totalAgreements`
  - `perCategory: Record<string, { surfaced, disputed, rate }>` — for FB-G
  - `perRepo: Record<string, { surfaced, disputed, rate }>` — for FB-J
  - `topClusters: Array<{ sigTokens, representativeTitle, surfaceCount, disputeCount, rate }>` — for FB-H
- New `IFPInsightStore` interface — `upsert / get / listByInstallation`.
- New `IInstallationStore.listInstallationIds()` — rollup needs to fan out across every installation.
- **Postgres**: new `installation_fp_insights` table + migration `0005_acoustic_puma.sql` (`CREATE TABLE IF NOT EXISTS`).
- **DynamoDB**: new `mergewatch-installation-fp-insights-${Stage}` table in `infra/template.yaml`. Composite PK `(installationId, window)` so one `Query` returns all three windows. `DeletionPolicy: Retain`.
- `disputeRate` stored as text in both backends — same precision discipline as `reviews.estimated_cost_usd`, avoids float drift across re-reads.

## Aggregation algorithm

New pure function `buildInsightFromDispositions(installationId, window, windowEndIso, records)`:

1. Filter records by `lastSeen ∈ [windowEnd - windowLength, windowEnd]`.
2. Sum global counters; bucket by `category` + `repoFullName`.
3. **Cluster** via union-find on shared `sigTokens` (≥1 token overlap unions records). Reuses the W10 token bag captured on every surfacing by FB-A.
4. Representative title = highest-surfacing member's title parsed from `findingMatchKey`. Falls back to file path for fingerprint-form keys.
5. Sort `topClusters` by `disputeRate × surfaceCount` (leverage); cap at 10.

Pure function — no storage / time / I/O coupling. Fully unit-testable.

## Orchestrator (shared across deploy shapes)

New `runInsightRollup(stores, windowEndIso?)` in `packages/core/src/insights/run-rollup.ts`:

- For each installation: `listByInstallation` → `buildInsight` × 3 windows → `upsert`.
- **Per-installation failure isolated** — a broken install doesn't halt the rest; returns `installationsFailed[]` for follow-up.
- Catastrophic `listInstallationIds` failure aborts cleanly with logged warning.
- Same entry point for SaaS Lambda + self-hosted cron → identical semantics across deploy shapes.

## SaaS: scheduled Lambda

- New `packages/lambda/src/handlers/insights-rollup.ts` — thin store-wiring + `runInsightRollup` + structured log.
- New `InsightsRollupFunction` in `infra/template.yaml`. EventBridge `Schedule` trigger: `cron(0 3 * * ? *)` (03:00 UTC daily). 512 MB, 5-min timeout. Re-uses the shared `LambdaExecutionRole` (with the new table's ARN added to the IAM policy).
- Returns 207 (Multi-Status) when ≥1 installation failed so CloudWatch can alarm on non-200; never throws.

## Self-hosted: lightweight cron

New `packages/server/src/insights-cron.ts`:

- `setTimeout(60s, …) → setInterval(24h, …)`. First run 60s after server startup (avoids colliding with DB migrations); subsequent runs daily.
- Errors caught + logged; can never take down the Node process.
- Wired into `packages/server/src/index.ts` after store init.

## Tests

| File | New cases | Coverage |
|------|-----------|---------|
| `core/src/insights/rollup.test.ts` | **16** | Window filtering (7d/30d/90d boundaries), global counter sums, divide-by-zero protection, per-category + per-repo bucketing, uncategorized fallback, clustering (shared-token union, representative-title selection, fingerprint-form fallback, no-sigTokens skip, leverage sort, 10-cluster cap), metadata echo. |
| `core/src/insights/run-rollup.test.ts` | **8** | 3 rows × N installations, default `windowEnd = now`, per-install failure isolation, `listInstallationIds` abort, upsert-failure marking install as failed, zero-record install still gets 3 zero rows, `elapsedMs` reported. |

Local validation:
- `core test` **580 / 580** (was 556 + 24 new)
- `core typecheck` clean
- `drizzle migrations:check` 🐶🔥
- `pnpm run build` 12/12
- `pnpm run typecheck` 20/20
- `pnpm run test:coverage` **20/20**

## Migration safety

- **Postgres 0005**: `CREATE TABLE IF NOT EXISTS` (per CLAUDE.md).
- **DynamoDB**: new table with `DeletionPolicy: Retain` + `UpdateReplacePolicy: Retain`.
- **Lambda**: gains IAM grants on the new table via the existing shared role; SAM deploy provisions the new `InsightsRollupFunction` + EventBridge rule + table together.
- **Self-hosted**: cron starts automatically; first run 60s after server startup. No new env vars required.

## E2E Regression

`e2e/RUNBOOK.md` — **E2E-41** flipped from `TARGET / Not yet implemented` to **✅ SHIPPED**, per [[e2e-regression-spec-per-pr]].

## Plan doc

`docs/false-positive-feedback-plan.md` — FB-E marked **✅ SHIPPED** in section heading and priority table.

## Next

**PR 4** in the plan is **FB-F + FB-G + FB-I** (first three dashboard charts: FP funnel + dispute-rate-by-agent + severity-shopping detector). Now that the rollup table is live, dashboard pages can be O(1) — they just read `listByInstallation` once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)