### PR TITLE
FP-L — propagate W2 verification tag to rendering surfaces (closes #175)

### DIFF
--- a/docs/false-positive-reduction-plan.md
+++ b/docs/false-positive-reduction-plan.md
@@ -205,6 +205,23 @@ Both layers compose: Layer 1 reduces the rate at which orchestrator-emitted find
 **Code targets (final):** `packages/core/src/agents/prompts.ts` (FINDING_VERIFICATION_PROMPT — new INVALID condition; `buildVerifierPriorContext` lists prior suggestions), `packages/core/src/agents/reviewer.ts` (PreviousFinding widened with optional `suggestion`).
 **E2E target:** [E2E-51](./../e2e/RUNBOOK.md#e2e-51-fp-j--verifier-honours-prior-recommendations).
 
+### FP-L — Propagate W2 verification to rendering surfaces  ✅ SHIPPED
+
+**Where the gap lived:** on PR #172 round-2, W2 tagged a critical as `verification: 'unverified'` and W7 correctly clamped the merge score to 3 (advisory) — but **three other rendering surfaces still shouted "🔴 CRITICAL"**: the inline review comment at the cited line, the "Requires your attention" action-items table at the top of the review comment, and the "🔴 Critical (N)" detailed section in the middle. The reviewer experience was schizophrenic: the formal verdict said *"Downgraded to advisory — the PR is not blocked on unverified concerns"* while three of the five visual surfaces (and the most-disruptive one — the inline comment that fires a GitHub notification) looked blocking.
+
+Root cause: W7's score-clamp checks `verification: 'unverified'` and adjusts the merge score. But `buildInlineComments` filtered on `severity === 'critical'` only, `formatReviewComment`'s `actionFindings` filtered on `severity === 'critical' || severity === 'warning'` only, and the Critical section dumped everything from `grouped.get('critical')`. When W2 added the verification tag, the rendering layer was never wired to the same signal. Filed as [#175](https://github.com/santthosh/mergewatch.ai/issues/175).
+
+**The fix (three layers, all pure-rendering):**
+
+- **Layer 1** — `buildInlineComments` filter rejects findings with `verification === 'unverified'`. The finding still appears in the top-level review body (under Layer 3's new sub-section) — it just doesn't get the most-disruptive surface (inline 🔴 + GitHub notification + red diff marker).
+- **Layer 2** — `formatReviewComment`'s `actionFindings` filter excludes unverified criticals from the "Requires your attention" table. The table now matches the W7-clamped score (an advisory PR doesn't claim to require attention on the formal blocking surface).
+- **Layer 3** — the `### 🔴 Critical (N)` header is split. Verified criticals keep the existing header; unverified criticals get a separate `### ⚠️ Unverified concerns (M)` sub-section with the advisory subtitle *"The verifier couldn't confirm these against the source. Review carefully; the PR is not blocked on them."* The sub-section is omitted entirely when there are no unverified criticals — no empty headers on the clean path.
+
+Back-compat: a finding with `verification` absent is treated as a pre-W2 record and renders normally in all three surfaces (no behaviour change for callers that don't run W2).
+
+**Code targets (final):** `packages/core/src/github/client.ts` (`InlineCommentCandidate.verification?` + filter), `packages/core/src/comment-formatter.ts` (`Finding.verification?` + action-table filter + split Critical section).
+**E2E target:** [E2E-52](./../e2e/RUNBOOK.md#e2e-52-fp-l--propagate-w2-verification-to-rendering-surfaces).
+
 ---
 
 ## Priority order
@@ -221,8 +238,9 @@ Both layers compose: Layer 1 reduces the rate at which orchestrator-emitted find
 | **FP-H** | Anti-anchoring on prior findings (L1 + L2) | small | prompt extension + verifier ctx | ✅ SHIPPED |
 | **FP-I** | Verify suggestion-already-implemented (L1 + L2) | small | verifier prompt + structural helper | ✅ SHIPPED |
 | **FP-J** | Verifier honours prior recommendations | small (L2 only) | verifier prompt extension | ✅ SHIPPED (L2); L1+L3 pending FB-A data |
+| **FP-L** | Propagate W2 verification tag to rendering surfaces | small | inline filter + comment-formatter split | ✅ SHIPPED |
 
-**Recommended sequencing:** **FP-A + FP-B + FP-C** as one PR (shipped — #159) — all three are tiny, deterministic, target the orchestrator boundary, and stack cleanly. Then FP-D as a separate Mermaid-focused PR (shipped — #160). Then FP-E / FP-F / FP-G as individual polish PRs (shipped — #161 / #162 / #163). **FP-H + FP-I + FP-J Layer 2** as a single follow-up bundle (this PR) — all three touch the same verifier prompt + reviewer surface, so bundling them is cheaper than three sequential PRs.
+**Recommended sequencing:** **FP-A + FP-B + FP-C** as one PR (shipped — #159) — all three are tiny, deterministic, target the orchestrator boundary, and stack cleanly. Then FP-D as a separate Mermaid-focused PR (shipped — #160). Then FP-E / FP-F / FP-G as individual polish PRs (shipped — #161 / #162 / #163). **FP-H + FP-I + FP-J Layer 2** as a single follow-up bundle (#171). **FP-L** as a standalone PR (this PR) — pure rendering change, no prompt churn, isolated blast radius; tying it in with FP-K (verifier-extension) would have mixed prompt-and-render concerns in one diff.
 
 ---
 

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -178,6 +178,7 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-49](#e2e-49-fp-h--anti-anchoring-on-prior-findings) | Re-review on a fix commit does NOT produce findings that pattern-match against the prior round's framing (FP-H L1 + L2) | 3m | 90s | FP-H |
 | [E2E-50](#e2e-50-fp-i--verify-suggestion-already-implemented) | A finding whose `suggestion` is byte-equivalent to existing code at the cited line is dropped by the verifier (FP-I L1 + L2) | 1m | 60s | FP-I |
 | [E2E-51](#e2e-51-fp-j--verifier-honours-prior-recommendations) | Re-review on a fix commit does NOT critique the application of a prior recommendation (FP-J L2 — Layer 1 + 3 pending FB-A data) | 2m | 60s | FP-J |
+| [E2E-52](#e2e-52-fp-l--propagate-w2-verification-to-rendering-surfaces) | An unverified critical drops off the inline / action-table surfaces and lands in a dedicated "Unverified concerns" sub-section (FP-L) | 2m | 60s | FP-L |
 
 ---
 
@@ -1899,6 +1900,37 @@ Branch: `fixture/51-no-self-contradiction`. Two-commit sequence:
 **Failure modes**
 - ❌ Genuine new defects on code that happens to be near a prior fix get incorrectly dropped as "contradicting prior advice"
 - ❌ Prior recommendations are passed in raw verbatim, allowing prompt-injection via crafted prior suggestion text (sanitisation must already cover this — same `sanitizePreviousFindingString` path used by `buildPreviousFindingsBlock`)
+
+---
+
+### E2E-52: FP-L — propagate W2 verification to rendering surfaces
+
+**Status:** ✅ SHIPPED. See [`docs/false-positive-reduction-plan.md` → FP-L](./../docs/false-positive-reduction-plan.md#fp-l--propagate-w2-verification-to-rendering-surfaces) and [`packages/core/src/comment-formatter.ts`](./../packages/core/src/comment-formatter.ts) / [`packages/core/src/github/client.ts`](./../packages/core/src/github/client.ts).
+
+**Behavior:** W2 already tags critical findings with `verification: 'unverified'` when the verifier can't confirm the defect against the source file, and W7 clamps the merge score to ≥ 3 for an all-unverified-criticals batch. **Before FP-L** the same finding still rendered as a 🔴 inline comment + a row in the "Requires your attention" table + a Critical-section entry — three visual surfaces shouting "blocking!" while the formal verdict whispered "advisory." **After FP-L** the verification tag propagates all the way to rendering: unverified criticals are dropped from `buildInlineComments` and from the action-items table, and surface instead in a new "⚠️ Unverified concerns (N)" sub-section with the disclaimer *"The verifier couldn't confirm these against the source. Review carefully; the PR is not blocked on them."*
+
+Pure rendering change — no model calls, no prompt changes, no schema migrations.
+
+**Setup**
+
+Branch: `fixture/52-unverified-critical-render`. The cleanest repro is to mock the W2 verifier path so a specific critical comes back as `verification: 'unverified'`. Alternatively, exercise the live path on a PR whose critical is shaped like a stale-claim (e.g. a "SQL injection" finding pointed at a Drizzle call site — the verifier cannot confirm against `db.query` and returns `unverified`).
+
+**Expected outcomes**
+
+- [x] **Inline-comment surface:** No 🔴 review comment is created at the cited line of the unverified critical (`buildInlineComments` filter rejects findings with `verification === 'unverified'`)
+- [x] **Action-items table:** The unverified critical does NOT appear in the top-of-comment "Requires your attention" table (`actionFindings` filter keeps warnings + verified criticals only)
+- [x] **Critical section:** The standard `### 🔴 Critical (N)` header counts only verified criticals — when all criticals in the batch are unverified, this header is omitted
+- [x] **Unverified concerns section:** A new `### ⚠️ Unverified concerns (M)` sub-section renders below, with the advisory subtitle *"The verifier couldn't confirm these against the source. Review carefully; the PR is not blocked on them."*
+- [x] **Empty-case omission:** When there are zero unverified criticals (the all-clean / verified-only path), the "Unverified concerns" sub-section is omitted entirely — no empty headers
+- [x] **W7 score-clamp unchanged:** The formal verdict subtitle still reads *"3/5 — Review recommended. Downgraded to advisory — the PR is not blocked on unverified concerns"* and `mergeScoreToReviewEvent` still returns `COMMENTED`
+- [x] **Back-compat:** A critical with no `verification` field at all (pre-W2 stored record OR a path where W2 didn't run) renders normally in all surfaces — inline, action-table, Critical section
+
+**Failure modes**
+- ❌ Unverified critical still renders as 🔴 inline at the cited line (Layer 1 filter regressed)
+- ❌ The action-items table still includes the unverified row (Layer 2 filter regressed)
+- ❌ The "Unverified concerns" header renders with `(0)` count when no unverified criticals exist (empty-omission check)
+- ❌ Verified criticals incorrectly land in the Unverified concerns section (the verification check is inverted)
+- ❌ Warnings tagged `verification: 'unverified'` get mis-routed to the Critical Unverified-concerns section (FP-L is explicitly critical-only; warnings retain their existing collapsed surface — see test `does not coerce unverified warnings into the Unverified concerns section`)
 
 ---
 

--- a/packages/core/src/comment-formatter.test.ts
+++ b/packages/core/src/comment-formatter.test.ts
@@ -271,6 +271,83 @@ describe('formatReviewComment', () => {
     const result = formatReviewComment(baseOptions({ deltaCaption: '   ' }));
     expect(result).not.toContain('📝');
   });
+
+  // ─── FP-L — verification-aware rendering ────────────────────────────────
+  describe('FP-L verification propagation', () => {
+    it('omits unverified critical from the "Requires your attention" action-items table', () => {
+      const findings = [
+        makeFinding({ title: 'Unverified SQL', verification: 'unverified' }),
+      ];
+      const result = formatReviewComment(baseOptions({ findings }));
+      // The action-items table header is suppressed when no action findings remain
+      expect(result).not.toContain('Requires your attention');
+      // But the finding still appears below in the Unverified concerns section
+      expect(result).toContain('Unverified SQL');
+    });
+
+    it('keeps verified criticals in the "Requires your attention" action-items table', () => {
+      const findings = [
+        makeFinding({ title: 'Confirmed SQL', verification: 'verified' }),
+      ];
+      const result = formatReviewComment(baseOptions({ findings }));
+      expect(result).toContain('Requires your attention');
+      expect(result).toContain('Confirmed SQL');
+    });
+
+    it('keeps criticals with no verification field in the action-items table (pre-W2 back-compat)', () => {
+      const findings = [makeFinding({ title: 'Legacy critical' })]; // no verification
+      const result = formatReviewComment(baseOptions({ findings }));
+      expect(result).toContain('Requires your attention');
+      expect(result).toContain('Legacy critical');
+    });
+
+    it('renders a separate "Unverified concerns" section for unverified criticals with the advisory subtitle', () => {
+      const findings = [
+        makeFinding({ title: 'Maybe-leak', verification: 'unverified' }),
+      ];
+      const result = formatReviewComment(baseOptions({ findings }));
+      expect(result).toContain('Unverified concerns (1)');
+      expect(result).toContain("verifier couldn't confirm");
+      expect(result).toContain('PR is not blocked');
+      expect(result).toContain('Maybe-leak');
+      // And the standard Critical (N) header is NOT emitted for an unverified-only batch
+      expect(result).not.toContain('Critical (1)');
+    });
+
+    it('renders both sections side by side when verified + unverified criticals coexist', () => {
+      const findings = [
+        makeFinding({ file: 'a.ts', title: 'Confirmed', verification: 'verified' }),
+        makeFinding({ file: 'b.ts', title: 'Maybe',     verification: 'unverified' }),
+      ];
+      const result = formatReviewComment(baseOptions({ findings }));
+      expect(result).toContain('Critical (1)');
+      expect(result).toContain('Unverified concerns (1)');
+      // Critical header appears before Unverified concerns
+      const criticalIdx = result.indexOf('Critical (1)');
+      const unverifiedIdx = result.indexOf('Unverified concerns');
+      expect(criticalIdx).toBeLessThan(unverifiedIdx);
+    });
+
+    it('omits the "Unverified concerns" sub-section entirely when there are no unverified criticals', () => {
+      const findings = [
+        makeFinding({ title: 'Confirmed', verification: 'verified' }),
+      ];
+      const result = formatReviewComment(baseOptions({ findings }));
+      expect(result).not.toContain('Unverified concerns');
+    });
+
+    it('does not coerce unverified warnings into the Unverified concerns section (warnings keep their own collapsed surface)', () => {
+      const findings = [
+        makeFinding({ severity: 'warning', title: 'Maybe-warning', verification: 'unverified' }),
+      ];
+      const result = formatReviewComment(baseOptions({ findings }));
+      // Sub-section is critical-only by design (issue spec — Layer 3)
+      expect(result).not.toContain('Unverified concerns');
+      // Warning still renders normally in the collapsed Warnings section + the action table
+      expect(result).toContain('Warnings (1)');
+      expect(result).toContain('Requires your attention');
+    });
+  });
 });
 
 describe('buildWorkDoneSection', () => {

--- a/packages/core/src/comment-formatter.ts
+++ b/packages/core/src/comment-formatter.ts
@@ -20,6 +20,15 @@ export interface Finding {
   title: string;
   description: string;
   suggestion: string;
+  /**
+   * FP-L — W2 verification verdict. When `'unverified'` and severity is
+   * critical, the finding is rendered in the "Unverified concerns" sub-section
+   * (advisory) instead of the "Critical" section, and excluded from the
+   * top-level "Requires your attention" table. The W7 score-clamp uses the
+   * same field; FP-L closes the propagation gap between scoring and rendering.
+   * Absent → treated as a pre-W2 record and rendered as a normal critical.
+   */
+  verification?: 'verified' | 'unverified';
 }
 
 export interface WorkDoneSection {
@@ -308,8 +317,15 @@ export function formatReviewComment(options: FormatOptions): string {
   }
 
   // 7. Action items — critical + warning findings as checkboxes (single appearance)
+  // FP-L — unverified criticals are excluded from the action-items table. They
+  // render below under "Unverified concerns" instead, so the top-of-comment
+  // "Requires your attention" surface stays aligned with the W7-clamped score.
   const grouped = groupBySeverity(findings);
-  const actionFindings = findings.filter((f) => f.severity === 'critical' || f.severity === 'warning');
+  const actionFindings = findings.filter((f) => {
+    if (f.severity === 'warning') return true;
+    if (f.severity === 'critical' && f.verification !== 'unverified') return true;
+    return false;
+  });
   const infoFindings = grouped.get('info') ?? [];
 
   if (findings.length === 0) {
@@ -344,13 +360,33 @@ export function formatReviewComment(options: FormatOptions): string {
 
   // 8. Detailed findings — critical uncollapsed, warning/info collapsed
   if (showIssuesTable && findings.length > 0) {
-    const criticalFindings = grouped.get('critical') ?? [];
+    const allCriticals = grouped.get('critical') ?? [];
+    // FP-L — split criticals on verification. Verified criticals keep the
+    // 🔴 Critical header; unverified criticals render in a separate advisory
+    // sub-section so the visual hierarchy matches the W7-clamped merge score.
+    const criticalFindings = allCriticals.filter((f) => f.verification !== 'unverified');
+    const unverifiedCriticals = allCriticals.filter((f) => f.verification === 'unverified');
     const warningFindings = grouped.get('warning') ?? [];
 
-    // Critical — shown open (not collapsed)
+    // Critical (verified only) — shown open (not collapsed)
     if (criticalFindings.length > 0) {
       lines.push(`### ${SEVERITY_META.critical.emoji} Critical (${criticalFindings.length})`);
       for (const f of criticalFindings) {
+        lines.push(renderFinding(f, showConfidence));
+      }
+      lines.push('');
+    }
+
+    // FP-L — Unverified concerns (advisory). Only emitted when at least one
+    // unverified critical exists; otherwise the sub-section is omitted entirely
+    // so there's no empty header on the clean path.
+    if (unverifiedCriticals.length > 0) {
+      lines.push(`### ⚠️ Unverified concerns (${unverifiedCriticals.length})`);
+      lines.push(
+        "> The verifier couldn't confirm these against the source. Review carefully; the PR is not blocked on them.",
+      );
+      lines.push('');
+      for (const f of unverifiedCriticals) {
         lines.push(renderFinding(f, showConfidence));
       }
       lines.push('');

--- a/packages/core/src/github/client.test.ts
+++ b/packages/core/src/github/client.test.ts
@@ -150,6 +150,41 @@ describe('buildInlineComments', () => {
     const result = buildInlineComments(findings, changedFiles);
     expect(result[0].body.startsWith(INLINE_BOT_COMMENT_MARKER)).toBe(true);
   });
+
+  // ─── FP-L — verification-aware skipping ─────────────────────────────────
+  it('FP-L: skips unverified critical findings — they render in the top-level body, not inline', () => {
+    const findings = [
+      { file: 'src/app.ts', line: 10, severity: 'critical' as const, title: 'Maybe SQL', description: 'd', suggestion: '', verification: 'unverified' as const },
+    ];
+    const result = buildInlineComments(findings, changedFiles);
+    expect(result).toHaveLength(0);
+  });
+
+  it('FP-L: keeps verified critical findings inline', () => {
+    const findings = [
+      { file: 'src/app.ts', line: 10, severity: 'critical' as const, title: 'Confirmed SQL', description: 'd', suggestion: '', verification: 'verified' as const },
+    ];
+    const result = buildInlineComments(findings, changedFiles);
+    expect(result).toHaveLength(1);
+  });
+
+  it('FP-L: keeps criticals with no verification field (pre-W2 back-compat)', () => {
+    const findings = [
+      { file: 'src/app.ts', line: 10, severity: 'critical' as const, title: 'Bug', description: 'd', suggestion: '' },
+    ];
+    const result = buildInlineComments(findings, changedFiles);
+    expect(result).toHaveLength(1);
+  });
+
+  it('FP-L: in a mixed batch, drops only the unverified critical', () => {
+    const findings = [
+      { file: 'src/app.ts',   line: 10, severity: 'critical' as const, title: 'Verified',     description: 'd', suggestion: '', verification: 'verified' as const },
+      { file: 'src/utils.ts', line: 20, severity: 'critical' as const, title: 'Unverified',   description: 'd', suggestion: '', verification: 'unverified' as const },
+    ];
+    const result = buildInlineComments(findings, changedFiles);
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe('src/app.ts');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/github/client.ts
+++ b/packages/core/src/github/client.ts
@@ -460,6 +460,13 @@ interface InlineCommentCandidate {
   title: string;
   description: string;
   suggestion: string;
+  /**
+   * FP-L — W2 verification verdict. When `'unverified'` the finding is dropped
+   * from the inline-comment surface entirely (it still appears in the top-level
+   * review comment under "Unverified concerns"). Absent → treated as a pre-W2
+   * record and surfaces normally for back-compat.
+   */
+  verification?: 'verified' | 'unverified';
 }
 
 /**
@@ -468,6 +475,11 @@ interface InlineCommentCandidate {
  * Only critical-severity findings whose file is in the changed file list
  * become inline comments. All are batched in a single createReview call
  * so GitHub sends only one notification.
+ *
+ * FP-L — unverified criticals (W2 couldn't confirm the defect) are skipped
+ * here so the most-disruptive surface (inline red-emoji comment at the cited
+ * line) doesn't fire on advisory-confidence findings. They still render in
+ * the top-level review comment under the "Unverified concerns" sub-section.
  */
 export function buildInlineComments(
   findings: InlineCommentCandidate[],
@@ -479,6 +491,10 @@ export function buildInlineComments(
   return findings
     .filter((f) => {
       if (f.severity !== 'critical' || !changedSet.has(f.file) || f.line <= 0) return false;
+      // FP-L — unverified criticals are demoted off the inline-comment surface.
+      // They still appear in the top-level review body under "Unverified
+      // concerns" so the finding isn't lost — just no inline red marker.
+      if (f.verification === 'unverified') return false;
       // When changedLines is available, require line to be exactly on a changed line
       if (changedLines) {
         const fileLines = changedLines.get(f.file);


### PR DESCRIPTION
Closes #175.

## Why

On PR #172 round-2, MW's verdict and its rendering disagreed: W7 clamped the merge score to 3 with the subtitle *"Downgraded to advisory — the PR is not blocked on unverified concerns"* — but **three of five rendering surfaces still shouted "🔴 CRITICAL"**:

| Surface | Before FP-L | After FP-L |
|---|---|---|
| Review state (`mergeScoreToReviewEvent`) | ✓ COMMENTED (advisory) | ✓ unchanged |
| Score subtitle | ✓ "3/5 — Review recommended. Downgraded to advisory…" | ✓ unchanged |
| **Inline review comment at the cited line** | ✗ 🔴 fires a GitHub notification | ✅ skipped — moves to the top-level body |
| **"Requires your attention" action-items table** | ✗ 🔴 blocking-shaped row | ✅ excluded |
| **"🔴 Critical (N)" detailed section** | ✗ counted in the critical header | ✅ moved to "⚠️ Unverified concerns (M)" with advisory subtitle |

W2 already tags critical findings with `verification: 'unverified'`. W7 already uses it for the score clamp. The rendering layer just never got the memo.

## What

Pure rendering change — no prompt changes, no LLM calls, no schema migrations.

### Layer 1 — `buildInlineComments` (`packages/core/src/github/client.ts`)
Adds `verification?: 'verified' | 'unverified'` to `InlineCommentCandidate` and rejects findings with `verification === 'unverified'` in the filter. The most-disruptive surface (inline 🔴 + GitHub notification + red diff marker) no longer fires on advisory-confidence findings.

### Layer 2 — action-items table (`packages/core/src/comment-formatter.ts`)
`actionFindings` filter now keeps warnings + `(critical && verification !== 'unverified')`. The table at the top of the review comment matches the W7-clamped score.

### Layer 3 — split Critical section (`packages/core/src/comment-formatter.ts`)
Verified criticals keep `### 🔴 Critical (N)`. Unverified criticals get a new `### ⚠️ Unverified concerns (M)` sub-section with subtitle *"The verifier couldn't confirm these against the source. Review carefully; the PR is not blocked on them."* Sub-section is **omitted entirely** when no unverified criticals exist — no empty headers.

### Back-compat
A finding with `verification` absent (pre-W2 record OR a path where W2 didn't run) renders normally in all three surfaces. Zero behaviour change for callers that don't run W2.

### Scope — why critical-only?
Warnings already render in a collapsed `<details>` section, so the rendering inconsistency is much smaller there (no inline placement to begin with). The issue spec flagged unverified-warning routing as a future consideration once data accumulates; deliberately not in this PR to keep blast radius isolated.

## Tests

- **`packages/core/src/github/client.test.ts`** — 4 new tests:
  - skips unverified critical
  - keeps verified critical
  - keeps pre-W2 criticals (no `verification` field) — back-compat
  - mixed batch only drops the unverified row
- **`packages/core/src/comment-formatter.test.ts`** — 7 new tests:
  - unverified critical omitted from "Requires your attention" table
  - verified critical retained in action table
  - pre-W2 critical retained in action table
  - "Unverified concerns (N)" section rendered with advisory subtitle
  - both sections render in correct order when verified + unverified coexist
  - sub-section omitted when no unverified criticals
  - unverified warnings NOT coerced into Unverified-concerns section (critical-only by design)

Core 605/605 · Build 12/12 · Typecheck 20/20.

## Fixture

`e2e/RUNBOOK.md` — new card **E2E-52** (✅ SHIPPED) with full repro steps + acceptance + failure modes.

## Plan doc

`docs/false-positive-reduction-plan.md` — adds `### FP-L` section + priority-order row + sequencing rationale.

## Cross-references

- Issue: #175
- Original evidence: PR #172 round-2 review thread
- Sibling: #173 (FP-K, abstraction-aware verifier — still open, prompt-side fix)
- Earlier in the same propagation arc: W2/FP-E (verification capture) + W7 (score clamp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)