### PR TITLE
FP-J L1 + L3 — dispute-aware reconcileMergeScore + disclosure footer (closes #170)

### DIFF
--- a/docs/false-positive-reduction-plan.md
+++ b/docs/false-positive-reduction-plan.md
@@ -192,18 +192,26 @@ Both layers compose: Layer 1 reduces the rate at which orchestrator-emitted find
 
 ---
 
-### FP-J — Verifier honours prior recommendations  ✅ SHIPPED (Layer 2 only)
+### FP-J — Verifier honours prior recommendations  ✅ SHIPPED
 
-**Where the gap lived:** on PR #169 round-2, MW directly contradicted its own round-1 advice. Round-1 said *"re-throw on `listInstallationIds` failure so CloudWatch alarms"*. I made that change. Round-2 then flagged the very same throw as a 🔴 Critical *"unhandled promise rejection"*. The verifier had no notion of prior recommendations being binding constraints on subsequent reviews. Filed as [#170](https://github.com/santthosh/mergewatch.ai/issues/170).
+**Where the gap lived (Layer 2):** on PR #169 round-2, MW directly contradicted its own round-1 advice. Round-1 said *"re-throw on `listInstallationIds` failure so CloudWatch alarms"*. I made that change. Round-2 then flagged the very same throw as a 🔴 Critical *"unhandled promise rejection"*. The verifier had no notion of prior recommendations being binding constraints on subsequent reviews. Filed as [#170](https://github.com/santthosh/mergewatch.ai/issues/170).
 
-**The fix (Layer 2 only — Layer 1 + Layer 3 still pending):**
+**Where the gap lived (Layer 1 + 3):** the verdict tier (`COMMENTED` vs `CHANGES_REQUESTED`) was dominated by the *presence* of any non-info finding, not by the *fraction* of findings that were historically accurate. A PR with 1 valid warning + 2 false ones flipped to `CHANGES_REQUESTED` even though the average finding accuracy was 33%. The fix was deferred until FB-A/FB-E accumulated production data — once the FP-feedback plan shipped (FB-A → FB-L), the counters were available to drive the verdict softener.
+
+**The fix (three layers — all shipped):**
 
 - **Layer 2** — the same prior-context block from FP-H L2 also lists prior **recommendations** (suggestions) from `previousFindings[].suggestion`. The verifier prompt gains an additional INVALID condition: *"the current finding contradicts a prior recommendation — if the prior review suggested X and X is now present, a current finding that critiques X MUST be dropped"*. The prior advice is binding for the duration of the PR. Same single prompt-extension surface as FP-H L2 — one verifier call, three new INVALID conditions, three failure modes collapsed into one mechanism.
-- **Layer 1** (use FB-A dispute-rate counters in `reconcileMergeScore`) — **deferred**. Logically blocked on FB-A/FB-E being live in production for several weeks so the counters accumulate. Will revisit after the FB-* bundle finishes and a few weeks of dispute data exists.
-- **Layer 3** (comment-footer disclosure of dispute-rate context) — **deferred**, depends on Layer 1.
+- **Layer 1** — `reconcileMergeScore` gains an optional `categoryDisputeRates: Record<string, number>` input projected from `InstallationFPInsight.perCategory` over the 30d window. When the orchestrator wants to BLOCK (score ≤ 2) AND more than half the action findings come from chronically-disputed categories (rate ≥ 0.75 AND surfacings ≥ 5), the verdict is softened to 3 (Review recommended / advisory). Same shape as the W7 unverified-criticals clamp, but driven by FB-A dispute counters rather than W2 verification verdicts. Pure deterministic scoring — no LLM calls, no prompt changes. `loadCategoryDisputeRates(insightStore, installationId)` is the read helper; both handlers (server + lambda) wire it into the existing parallel-fetches block alongside `fetchConventions` and `detectLinters`.
+- **Layer 3** — a transparent disclosure footer (`📊 N of M action findings are from a category disputed ≥ 75% of the time in this org's recent reviews…`) renders as a quiet `<sub>` line beneath the merge-score badge whenever at least one action finding's category qualifies — even when the tier didn't change. Gives reviewers context about *why* the verdict looks the way it does without auto-suppressing the findings themselves.
 
-**Code targets (final):** `packages/core/src/agents/prompts.ts` (FINDING_VERIFICATION_PROMPT — new INVALID condition; `buildVerifierPriorContext` lists prior suggestions), `packages/core/src/agents/reviewer.ts` (PreviousFinding widened with optional `suggestion`).
-**E2E target:** [E2E-51](./../e2e/RUNBOOK.md#e2e-51-fp-j--verifier-honours-prior-recommendations).
+Back-compat is total at every layer: absent `categoryDisputeRates` (fresh installation, no rollup yet, upstream-degraded read) → identical to pre-FP-J behaviour. The loader's `{}` default behaves as "no down-weighting" in the reconcile path, and the formatter's empty `disputeDisclosure` simply omits the footer.
+
+**Code targets (final):**
+- Layer 2: `packages/core/src/agents/prompts.ts` (FINDING_VERIFICATION_PROMPT — new INVALID condition; `buildVerifierPriorContext` lists prior suggestions), `packages/core/src/agents/reviewer.ts` (PreviousFinding widened with optional `suggestion`).
+- Layer 1: `packages/core/src/agents/reviewer.ts` (`reconcileMergeScore` extended with `categoryDisputeRates` input + dispute-aware softener tier; `ReviewPipelineOptions.categoryDisputeRates?` + `ReviewPipelineResult.disputeDisclosure?`), `packages/core/src/insights/dispute-rates.ts` (new — `loadCategoryDisputeRates` helper with `MIN_SURFACED = 5` filter), handler wiring in `packages/server/src/review-processor.ts` + `packages/lambda/src/handlers/review-agent.ts` (parallel-fetch alongside conventions + linters).
+- Layer 3: `packages/core/src/comment-formatter.ts` (FormatOptions gains `disputeDisclosure?` rendered as `<sub>` beneath the score line).
+
+**E2E targets:** [E2E-51](./../e2e/RUNBOOK.md#e2e-51-fp-j--verifier-honours-prior-recommendations) (Layer 2), [E2E-53](./../e2e/RUNBOOK.md#e2e-53-fp-j-l1l3--dispute-aware-verdict-softening--disclosure) (Layer 1 + 3).
 
 ### FP-L — Propagate W2 verification to rendering surfaces  ✅ SHIPPED
 
@@ -237,7 +245,7 @@ Back-compat: a finding with `verification` absent is treated as a pre-W2 record 
 | **FP-G** | Linter-aware style agent | small | detection + prompt placeholder | ✅ SHIPPED |
 | **FP-H** | Anti-anchoring on prior findings (L1 + L2) | small | prompt extension + verifier ctx | ✅ SHIPPED |
 | **FP-I** | Verify suggestion-already-implemented (L1 + L2) | small | verifier prompt + structural helper | ✅ SHIPPED |
-| **FP-J** | Verifier honours prior recommendations | small (L2 only) | verifier prompt extension | ✅ SHIPPED (L2); L1+L3 pending FB-A data |
+| **FP-J** | Verifier honours prior recommendations + dispute-aware reconcile + disclosure | small (L2) + medium (L1 + L3) | verifier prompt + reconcile + formatter | ✅ SHIPPED (all 3 layers) |
 | **FP-L** | Propagate W2 verification tag to rendering surfaces | small | inline filter + comment-formatter split | ✅ SHIPPED |
 
 **Recommended sequencing:** **FP-A + FP-B + FP-C** as one PR (shipped — #159) — all three are tiny, deterministic, target the orchestrator boundary, and stack cleanly. Then FP-D as a separate Mermaid-focused PR (shipped — #160). Then FP-E / FP-F / FP-G as individual polish PRs (shipped — #161 / #162 / #163). **FP-H + FP-I + FP-J Layer 2** as a single follow-up bundle (#171). **FP-L** as a standalone PR (this PR) — pure rendering change, no prompt churn, isolated blast radius; tying it in with FP-K (verifier-extension) would have mixed prompt-and-render concerns in one diff.

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -177,8 +177,9 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-48](#e2e-48-fb-l--known_fp_patterns-prompt-injection-target) | Opt-in `feedback.learnFromDisputes` injects top-K disputed clusters as soft guidance into every finding agent's prompt (FB-L) — **TARGET** | 3m | 90s | FB-L |
 | [E2E-49](#e2e-49-fp-h--anti-anchoring-on-prior-findings) | Re-review on a fix commit does NOT produce findings that pattern-match against the prior round's framing (FP-H L1 + L2) | 3m | 90s | FP-H |
 | [E2E-50](#e2e-50-fp-i--verify-suggestion-already-implemented) | A finding whose `suggestion` is byte-equivalent to existing code at the cited line is dropped by the verifier (FP-I L1 + L2) | 1m | 60s | FP-I |
-| [E2E-51](#e2e-51-fp-j--verifier-honours-prior-recommendations) | Re-review on a fix commit does NOT critique the application of a prior recommendation (FP-J L2 — Layer 1 + 3 pending FB-A data) | 2m | 60s | FP-J |
+| [E2E-51](#e2e-51-fp-j--verifier-honours-prior-recommendations) | Re-review on a fix commit does NOT critique the application of a prior recommendation (FP-J L2) | 2m | 60s | FP-J |
 | [E2E-52](#e2e-52-fp-l--propagate-w2-verification-to-rendering-surfaces) | An unverified critical drops off the inline / action-table surfaces and lands in a dedicated "Unverified concerns" sub-section (FP-L) | 2m | 60s | FP-L |
+| [E2E-53](#e2e-53-fp-j-l1l3--dispute-aware-verdict-softening--disclosure) | Red verdict (orchestrator score ≤ 2) is softened to advisory when majority of action findings come from chronically-disputed categories (FP-J L1); disclosure footer renders under the merge score (FP-J L3) | 3m | 60s | FP-J |
 
 ---
 
@@ -1942,6 +1943,46 @@ Branch: `fixture/52-unverified-critical-render`. The cleanest repro is to mock t
 - ❌ The "Unverified concerns" header renders with `(0)` count when no unverified criticals exist (empty-omission check)
 - ❌ Verified criticals incorrectly land in the Unverified concerns section (the verification check is inverted)
 - ❌ Warnings tagged `verification: 'unverified'` get mis-routed to the Critical Unverified-concerns section (FP-L is explicitly critical-only; warnings retain their existing collapsed surface — see test `does not coerce unverified warnings into the Unverified concerns section`)
+
+---
+
+### E2E-53: FP-J L1/L3 — dispute-aware verdict softening + disclosure
+
+**Status:** ✅ SHIPPED. See [`docs/false-positive-reduction-plan.md` → FP-J](./../docs/false-positive-reduction-plan.md#fp-j--verifier-honours-prior-recommendations--shipped) and [`packages/core/src/agents/reviewer.ts`](./../packages/core/src/agents/reviewer.ts) (`reconcileMergeScore`) + [`packages/core/src/insights/dispute-rates.ts`](./../packages/core/src/insights/dispute-rates.ts) (`loadCategoryDisputeRates`) + [`packages/core/src/comment-formatter.ts`](./../packages/core/src/comment-formatter.ts) (disclosure render).
+
+**Behavior:** the verdict tier now incorporates each org's historical dispute rate per finding category. When the orchestrator wants to BLOCK (score ≤ 2) AND more than half of the action findings come from chronically-disputed categories (rate ≥ 75% AND ≥ 5 surfacings over the 30d FB-E window), the verdict is softened to **3 / Review recommended** (advisory) instead. The finding set is unchanged — only the blocking-tier signal is calibrated against historical accuracy.
+
+A transparent disclosure footer (`📊 N of M action findings are from a category disputed ≥ 75% of the time…`) renders as a quiet sub-line under the merge-score badge whenever at least one action finding's category qualifies — even when the tier didn't change. Gives reviewers context about *why* the verdict looks the way it does without auto-suppressing the findings themselves.
+
+Same blocking-tier softening shape as the W7 unverified-criticals clamp, but driven by FB-A dispute counters rather than W2 verification verdicts. Pure deterministic scoring change — no LLM calls, no prompt changes. Reads the latest 30d `InstallationFPInsight` once per review (single store `get` on the same path that wires `loadKnownFPPatterns` for FB-L).
+
+**Setup**
+
+Branch: `fixture/53-dispute-aware-reconcile`. Two seeding paths:
+
+1. **Direct fixture** — seed an `InstallationFPInsight.perCategory` row where one category (e.g. `style`) has `surfaceCount >= 5` AND `rate >= 0.75`. Open a PR that draws 3+ warnings, all in that category, with the orchestrator scoring 2.
+2. **Live path** — let FB-A counters accumulate naturally over several weeks of disputes on a single category; the rollup naturally feeds the verdict softener on the next review.
+
+**Expected outcomes**
+
+- [x] **L1 — clamping path:** Red verdict (orchestratorScore = 2) + majority of action findings from a 90%-disputed category → `mergeScore: 3` with reason text mentioning *"historically noisy categories"*
+- [x] **L1 — strict majority:** exactly 50% disputed findings (e.g. 1 of 2) → tier stays at 2 (the clamp requires *strict* majority — 50% isn't enough to override the orchestrator)
+- [x] **L1 — threshold respect:** category rate at 0.5 (below the 0.75 threshold) → no clamp, no disclosure
+- [x] **L1 — back-compat:** absent / empty `categoryDisputeRates` → orchestrator score stands verbatim (identical to pre-FP-J behaviour)
+- [x] **L1 — no upward uplift:** orchestrator score already ≥ 3 → no change to the score (softener only fires on the would-have-been-red path)
+- [x] **L1 — W7 interaction:** W7 unverified-criticals clamp still fires alongside FP-J L1 (both produce `mergeScore: 3`); W7's reason text takes precedence since W7 is checked first
+- [x] **L3 — disclosure renders:** footer appears as `> <sub>📊 …</sub>` beneath the merge-score line whenever at least one action finding qualifies (regardless of whether the tier shifted)
+- [x] **L3 — empty path:** zero action findings → no disclosure (nothing to disclose about)
+- [x] **L3 — ordering:** disclosure renders BELOW the merge-score line, not above
+- [x] **L3 — absent input:** `disputeDisclosure = undefined` → no footer, no `📊` glyph in the comment
+
+**Failure modes**
+- ❌ Verdict tier downgrades for installations with NO FB-A data yet (the loader's `{}` default regressed; back-compat broken)
+- ❌ A single-disputed-finding-on-noisy-category triggers the clamp (strict-majority guard regressed)
+- ❌ The disclosure footer renders on a clean / score-5 PR (the disclosure-from-zero-action-findings guard regressed)
+- ❌ The disclosure renders above the merge-score line, obscuring the primary verdict
+- ❌ A category with `surfaceCount < 5` makes it into the loader's output (small-N noise guard regressed in `loadCategoryDisputeRates`)
+- ❌ The clamp triggers when the orchestrator already scored ≥ 3 (the `orchestratorScore <= 2` gate regressed — this would be an unwanted *upward* shift since the W7-shaped clamp only ever should soften a would-be-red verdict)
 
 ---
 

--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -2154,14 +2154,21 @@ describe('buildPreviousFindingsBlock — FP-H L1 anti-anchoring counter-instruct
 
 describe('reconcileMergeScore', () => {
   // Minimal helpers — only the fields the function reads.
-  function critical(over: Partial<AgentFinding> & { verification?: 'verified' | 'unverified' } = {}) {
+  // FP-J L1 reads `category` on the finding (which lives on
+  // OrchestratedFinding, not the narrower AgentFinding), so the override
+  // type widens to include it.
+  type ReconcileFindingOverrides = Partial<AgentFinding> & {
+    category?: string;
+    verification?: 'verified' | 'unverified';
+  };
+  function critical(over: ReconcileFindingOverrides = {}) {
     return {
       file: 'a.ts', line: 1, severity: 'critical' as const,
       category: 'security', title: 'X', description: '', suggestion: '',
       ...over,
     };
   }
-  function warning(over: Partial<AgentFinding> = {}) {
+  function warning(over: ReconcileFindingOverrides = {}) {
     return {
       file: 'a.ts', line: 1, severity: 'warning' as const,
       category: 'style', title: 'W', description: '', suggestion: '',
@@ -2258,5 +2265,131 @@ describe('reconcileMergeScore', () => {
     });
     expect(r.mergeScore).toBeGreaterThanOrEqual(3);
     expect(r.mergeScoreReason).toMatch(/net improvement/);
+  });
+
+  // ─── FP-J L1 — dispute-aware verdict softening ────────────────────────
+  describe('FP-J L1 — categoryDisputeRates', () => {
+    it('back-compat: absent categoryDisputeRates behaves identically to today (orchestrator score stands)', () => {
+      const r = reconcileMergeScore({
+        filteredFindings: [warning({ category: 'style' }), warning({ category: 'style' })],
+        previousFindings: undefined,
+        orchestratorScore: 2, orchestratorReason: 'red',
+      });
+      expect(r.mergeScore).toBe(2);
+      expect(r.disputeDisclosure).toBeUndefined();
+    });
+
+    it('empty categoryDisputeRates behaves identically to absent', () => {
+      const r = reconcileMergeScore({
+        filteredFindings: [warning({ category: 'style' })],
+        previousFindings: undefined,
+        orchestratorScore: 2, orchestratorReason: 'red',
+        categoryDisputeRates: {},
+      });
+      expect(r.mergeScore).toBe(2);
+      expect(r.disputeDisclosure).toBeUndefined();
+    });
+
+    it('clamps red verdict (orchestratorScore=2) to 3 when MORE THAN HALF of action findings are from a chronically-disputed category', () => {
+      // 3 style warnings out of 3 — all from a 90% disputed category.
+      const r = reconcileMergeScore({
+        filteredFindings: [
+          warning({ category: 'style' }),
+          warning({ category: 'style' }),
+          warning({ category: 'style' }),
+        ],
+        previousFindings: undefined,
+        orchestratorScore: 2, orchestratorReason: 'three style warnings',
+        categoryDisputeRates: { style: 0.9 },
+      });
+      expect(r.mergeScore).toBe(3);
+      expect(r.mergeScoreReason).toMatch(/historically noisy|disputed/);
+      expect(r.disputeDisclosure).toBeDefined();
+      expect(r.disputeDisclosure).toMatch(/3 of 3 action findings/);
+    });
+
+    it('does NOT clamp when EXACTLY half of action findings are from disputed categories (strict majority required)', () => {
+      // 1 style (disputed) + 1 security (not disputed) → 50%, not a majority.
+      const r = reconcileMergeScore({
+        filteredFindings: [
+          warning({ category: 'style' }),
+          warning({ category: 'security' }),
+        ],
+        previousFindings: undefined,
+        orchestratorScore: 2, orchestratorReason: 'two warnings',
+        categoryDisputeRates: { style: 0.9 },
+      });
+      expect(r.mergeScore).toBe(2);
+      // Disclosure still fires because at least one finding qualified.
+      expect(r.disputeDisclosure).toMatch(/1 of 2 action findings/);
+    });
+
+    it('does NOT clamp when orchestrator score is already ≥3 (softening only fires on the would-have-been-red path)', () => {
+      const r = reconcileMergeScore({
+        filteredFindings: [warning({ category: 'style' }), warning({ category: 'style' })],
+        previousFindings: undefined,
+        orchestratorScore: 3, orchestratorReason: 'yellow',
+        categoryDisputeRates: { style: 0.9 },
+      });
+      expect(r.mergeScore).toBe(3);
+      expect(r.mergeScoreReason).toBe('yellow'); // orchestrator reason preserved
+      // Disclosure still fires on the qualified-but-not-clamped path.
+      expect(r.disputeDisclosure).toBeDefined();
+    });
+
+    it('does NOT count a category whose rate is BELOW the 0.75 threshold', () => {
+      // 2 style warnings @ 0.5 dispute rate — below threshold.
+      const r = reconcileMergeScore({
+        filteredFindings: [warning({ category: 'style' }), warning({ category: 'style' })],
+        previousFindings: undefined,
+        orchestratorScore: 2, orchestratorReason: 'red',
+        categoryDisputeRates: { style: 0.5 },
+      });
+      expect(r.mergeScore).toBe(2);
+      expect(r.disputeDisclosure).toBeUndefined();
+    });
+
+    it('disclosure fires WITHOUT clamping when a minority of findings are from disputed categories', () => {
+      // 1 of 3 from disputed category → no clamp, but disclose context.
+      const r = reconcileMergeScore({
+        filteredFindings: [
+          warning({ category: 'style' }),
+          warning({ category: 'security' }),
+          warning({ category: 'bug' }),
+        ],
+        previousFindings: undefined,
+        orchestratorScore: 2, orchestratorReason: 'three warnings',
+        categoryDisputeRates: { style: 0.9 },
+      });
+      expect(r.mergeScore).toBe(2); // not clamped (1/3 is not majority)
+      expect(r.disputeDisclosure).toMatch(/1 of 3 action findings is from a category/);
+    });
+
+    it('W7 unverified-criticals clamp still fires alongside FP-J L1 (both produce mergeScore=3 with W7\'s reason taking precedence)', () => {
+      // W7 path is checked BEFORE FP-J L1; reason text should be W7's.
+      const r = reconcileMergeScore({
+        filteredFindings: [
+          critical({ category: 'security', verification: 'unverified' }),
+        ],
+        previousFindings: undefined,
+        orchestratorScore: 1, orchestratorReason: 'one unverified critical',
+        categoryDisputeRates: { security: 0.9 },
+      });
+      expect(r.mergeScore).toBe(3);
+      expect(r.mergeScoreReason).toMatch(/could not be confirmed|verification inconclusive/i);
+      // Disclosure rides along (different signal, same surface).
+      expect(r.disputeDisclosure).toBeDefined();
+    });
+
+    it('disclosure is omitted from the no-action-items path (nothing to disclose about)', () => {
+      const r = reconcileMergeScore({
+        filteredFindings: [],
+        previousFindings: undefined,
+        orchestratorScore: 5, orchestratorReason: 'clean',
+        categoryDisputeRates: { style: 0.9 },
+      });
+      expect(r.mergeScore).toBe(5);
+      expect(r.disputeDisclosure).toBeUndefined();
+    });
   });
 });

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -1114,6 +1114,17 @@ export interface ReviewPipelineOptions {
    * directive (back-compat: prompt is byte-identical to the pre-FP-G shape).
    */
   detectedLinters?: readonly string[];
+
+  /**
+   * FP-J L1 — per-category historical dispute rate, derived from FB-E's
+   * `InstallationFPInsight.perCategory.rate` over the 30d rolling window.
+   * Passed through to `reconcileMergeScore` so the verdict tier can soften
+   * when most action findings come from chronically-disputed categories.
+   *
+   * The handler is responsible for filtering by `surfaceCount >= 5`
+   * before passing in. Absent / empty → no down-weighting (back-compat).
+   */
+  categoryDisputeRates?: Record<string, number>;
 }
 
 export interface ReviewPipelineResult {
@@ -1125,6 +1136,15 @@ export interface ReviewPipelineResult {
   diagramCaption: string;
   mergeScore: number;
   mergeScoreReason: string;
+  /**
+   * FP-J L3 — transparent footer text disclosing the dispute-rate context
+   * when one or more action findings come from chronically-disputed
+   * categories. Present when at least one action finding's category has
+   * `disputeRate >= 0.75` (FP-J L1 threshold); absent otherwise. Renders
+   * as a small annotation beneath the merge-score badge in the review
+   * comment. Does NOT change the verdict — purely contextual disclosure.
+   */
+  disputeDisclosure?: string;
   /** Number of findings suppressed by the orchestrator (deduplication + filtering) */
   suppressedCount: number;
   /** Number of enabled agents that ran */
@@ -1748,6 +1768,25 @@ function withCodeFingerprints<T extends OrchestratedFinding>(
 }
 
 /**
+ * FP-J L1 — minimum surfacing count for a category's dispute rate to be
+ * actionable in the verdict-tier softening. A category with 1 surfacing and
+ * 1 dispute reads as 100% disputed but is statistically unreliable; the
+ * floor matches FB-L's `surfaceCount >= 5` qualifier so both downstream
+ * uses (prompt injection + verdict softening) operate on the same trust
+ * threshold.
+ */
+const DISPUTE_RATE_MIN_SURFACED = 5;
+
+/**
+ * FP-J L1 — a category is considered "chronically disputed" when its rate
+ * meets or exceeds this fraction (and clears the min-surfaced floor above).
+ * 0.75 mirrors FB-L's threshold so both surfaces (verdict softening + the
+ * known-FP-patterns prompt directive) treat the same shape as "actionable
+ * dispute evidence" rather than "noisy single-event".
+ */
+const DISPUTE_RATE_HIGH_THRESHOLD = 0.75;
+
+/**
  * Reconcile the orchestrator's raw 1–5 score with the post-grounding /
  * post-line-filter / post-triage finding set. Pure function — extracted
  * from runReviewPipeline so the tiered scoring rules are directly
@@ -1768,15 +1807,45 @@ function withCodeFingerprints<T extends OrchestratedFinding>(
  *      one) still hit the orchestrator's full score (which can be ≤2).
  *      Back-compat: an absent `verification` field is treated as "W2
  *      didn't run on this finding" and does NOT trigger the clamp.
- *   5. **Default** → orchestrator's raw score (can be red).
+ *   5. **FP-J L1 — dispute-aware verdict softening** → 3 (clamped from
+ *      ≤2). When `categoryDisputeRates` is provided (via FB-A counters
+ *      aggregated through FB-E's rollup), action findings whose category
+ *      has been chronically disputed in this org get less weight. If
+ *      MORE than half of the action findings come from chronically-
+ *      disputed categories (rate ≥ 0.75 AND ≥ 5 surfacings), the verdict
+ *      tier softens from CHANGES_REQUESTED → COMMENTED. The orchestrator
+ *      score isn't lowered (the findings still surface) — only the
+ *      blocking-tier signal is calibrated against historical accuracy.
+ *      Back-compat: absent or empty `categoryDisputeRates` is identical
+ *      to today.
+ *   6. **Default** → orchestrator's raw score (can be red).
+ *
+ * `disputeDisclosure` (FP-J L3) is set whenever the L1 clamp engaged OR
+ * the action-finding set contains any chronically-disputed category —
+ * even if the tier didn't change. Gives the reviewer transparent context
+ * about WHY the verdict looks the way it does, without auto-suppressing
+ * the findings themselves.
  */
 export function reconcileMergeScore(input: {
   filteredFindings: OrchestratedFinding[];
   previousFindings: PreviousFinding[] | undefined;
   orchestratorScore: number;
   orchestratorReason: string;
-}): { mergeScore: number; mergeScoreReason: string } {
-  const { filteredFindings, previousFindings, orchestratorScore, orchestratorReason } = input;
+  /**
+   * FP-J L1 — historical dispute rate per finding `category` (security /
+   * bug / style / errorHandling / testCoverage / commentAccuracy / custom),
+   * derived from FB-E's `InstallationFPInsight.perCategory.rate` over the
+   * 30d rolling window. The handler is responsible for filtering by
+   * `surfaceCount >= DISPUTE_RATE_MIN_SURFACED` before passing in — every
+   * key present here is assumed to clear the threshold.
+   *
+   * Absent / empty → no down-weighting (back-compat with installations
+   * that lack accumulated dispute data, or with the SaaS path before
+   * Lambda wires the FP-insight store).
+   */
+  categoryDisputeRates?: Record<string, number>;
+}): { mergeScore: number; mergeScoreReason: string; disputeDisclosure?: string } {
+  const { filteredFindings, previousFindings, orchestratorScore, orchestratorReason, categoryDisputeRates } = input;
 
   const actionFindings = filteredFindings.filter(
     (f) => f.severity === 'critical' || f.severity === 'warning',
@@ -1806,6 +1875,21 @@ export function reconcileMergeScore(input: {
   const allCriticalsUnverified =
     currentCriticals.length > 0 && !hasAnyConfirmedOrUntaggedCritical;
 
+  // FP-J L1 — count action findings whose category is chronically disputed
+  // in this org. The handler has already filtered `categoryDisputeRates` to
+  // keys clearing DISPUTE_RATE_MIN_SURFACED, so any rate present here is
+  // statistically meaningful. The disclosure (L3) reuses this count
+  // regardless of whether the tier shifts.
+  const highDisputeActionCount = actionFindings.filter((f) => {
+    const rate = categoryDisputeRates?.[f.category];
+    return rate !== undefined && rate >= DISPUTE_RATE_HIGH_THRESHOLD;
+  }).length;
+  const highDisputeMajority =
+    actionFindings.length > 0 && highDisputeActionCount > actionFindings.length / 2;
+  const disputeDisclosure = highDisputeActionCount > 0
+    ? `${highDisputeActionCount} of ${actionFindings.length} action finding${actionFindings.length === 1 ? '' : 's'} ${highDisputeActionCount === 1 ? 'is' : 'are'} from a category disputed ≥ ${Math.round(DISPUTE_RATE_HIGH_THRESHOLD * 100)}% of the time in this org's recent reviews — the verdict tier reflects that historical accuracy.`
+    : undefined;
+
   if (noActionItems) {
     return {
       mergeScore: 5,
@@ -1818,12 +1902,14 @@ export function reconcileMergeScore(input: {
     return {
       mergeScore: Math.max(4, orchestratorScore),
       mergeScoreReason: `Resolved ${resolvedCriticals} critical issue${resolvedCriticals === 1 ? '' : 's'} from prior review, no new criticals introduced.`,
+      ...(disputeDisclosure ? { disputeDisclosure } : {}),
     };
   }
   if (isNetSecurityImprovement) {
     return {
       mergeScore: Math.max(3, orchestratorScore),
       mergeScoreReason: `Resolved ${resolvedCriticals} critical issue${resolvedCriticals === 1 ? '' : 's'} from prior review; introduced ${newCriticals} new — net improvement, but review the new findings.`,
+      ...(disputeDisclosure ? { disputeDisclosure } : {}),
     };
   }
   if (allCriticalsUnverified && orchestratorScore <= 2) {
@@ -1831,9 +1917,26 @@ export function reconcileMergeScore(input: {
     return {
       mergeScore: 3,
       mergeScoreReason: `${n} critical finding${n === 1 ? '' : 's'} could not be confirmed against the source (W2 verification inconclusive). Downgraded to advisory — review carefully, but the PR is not blocked on unverified concerns.`,
+      ...(disputeDisclosure ? { disputeDisclosure } : {}),
     };
   }
-  return { mergeScore: orchestratorScore, mergeScoreReason: orchestratorReason };
+  // FP-J L1 — dispute-aware softening. Only kicks in when the orchestrator
+  // wanted to BLOCK (score ≤ 2) AND the majority of action findings come
+  // from chronically-disputed categories. Same blocking-tier softening
+  // shape as the W7 unverified-criticals clamp above, but driven by FB-A
+  // dispute counters rather than W2 verification verdicts.
+  if (highDisputeMajority && orchestratorScore <= 2) {
+    return {
+      mergeScore: 3,
+      mergeScoreReason: `${highDisputeActionCount} of ${actionFindings.length} action finding${actionFindings.length === 1 ? '' : 's'} ${highDisputeActionCount === 1 ? 'comes' : 'come'} from category patterns this org has disputed ≥ ${Math.round(DISPUTE_RATE_HIGH_THRESHOLD * 100)}% of the time. Downgraded to advisory — review on the merits, but the PR is not blocked on historically noisy categories.`,
+      ...(disputeDisclosure ? { disputeDisclosure } : {}),
+    };
+  }
+  return {
+    mergeScore: orchestratorScore,
+    mergeScoreReason: orchestratorReason,
+    ...(disputeDisclosure ? { disputeDisclosure } : {}),
+  };
 }
 
 /**
@@ -2113,11 +2216,12 @@ export async function runReviewPipeline(
     : null;
 
   // Reconcile the orchestrator's verdict with the post-filter findings.
-  const { mergeScore, mergeScoreReason } = reconcileMergeScore({
+  const { mergeScore, mergeScoreReason, disputeDisclosure } = reconcileMergeScore({
     filteredFindings,
     previousFindings,
     orchestratorScore: orchestratorResult.mergeScore,
     orchestratorReason: orchestratorResult.mergeScoreReason,
+    categoryDisputeRates: options.categoryDisputeRates,
   });
 
   return {
@@ -2128,6 +2232,7 @@ export async function runReviewPipeline(
     diagramCaption: diagramResult.caption,
     mergeScore,
     mergeScoreReason,
+    ...(disputeDisclosure ? { disputeDisclosure } : {}),
     suppressedCount: Math.max(0, totalRawFindings - filteredFindings.length),
     enabledAgentCount,
     inputTokens: accumulator.totalInputTokens,

--- a/packages/core/src/comment-formatter.test.ts
+++ b/packages/core/src/comment-formatter.test.ts
@@ -348,6 +348,59 @@ describe('formatReviewComment', () => {
       expect(result).toContain('Requires your attention');
     });
   });
+
+  // ─── FP-J L3 — dispute-rate disclosure ─────────────────────────────────
+  describe('FP-J L3 disputeDisclosure', () => {
+    it('renders the disclosure as a quieter sub-line beneath the merge-score badge', () => {
+      const result = formatReviewComment(baseOptions({
+        mergeScore: 3,
+        mergeScoreReason: 'Review recommended',
+        disputeDisclosure: '2 of 3 action findings are from a category disputed ≥ 75% of the time',
+      }));
+      expect(result).toContain('📊');
+      expect(result).toContain('2 of 3 action findings');
+      // The disclosure renders inside a <sub> wrapper so it visually defers to the verdict
+      expect(result).toMatch(/<sub>.*📊.*<\/sub>/);
+    });
+
+    it('renders BELOW the merge-score line', () => {
+      const result = formatReviewComment(baseOptions({
+        mergeScore: 3,
+        mergeScoreReason: 'Review recommended',
+        disputeDisclosure: 'historically noisy categories',
+      }));
+      const scoreIdx = result.indexOf('Review recommended');
+      const disclosureIdx = result.indexOf('historically noisy');
+      expect(scoreIdx).toBeGreaterThan(-1);
+      expect(disclosureIdx).toBeGreaterThan(scoreIdx);
+    });
+
+    it('omits the disclosure entirely when disputeDisclosure is undefined', () => {
+      const result = formatReviewComment(baseOptions({
+        mergeScore: 3,
+        mergeScoreReason: 'Review recommended',
+      }));
+      expect(result).not.toContain('📊');
+    });
+
+    it('omits the disclosure when disputeDisclosure is empty whitespace', () => {
+      const result = formatReviewComment(baseOptions({
+        mergeScore: 3,
+        mergeScoreReason: 'Review recommended',
+        disputeDisclosure: '   ',
+      }));
+      expect(result).not.toContain('📊');
+    });
+
+    it('does NOT render the disclosure when mergeScore itself is omitted (the score line is the anchor)', () => {
+      // Without a merge score, there's no badge to anchor the disclosure under
+      // — skip rendering rather than dangle the sub-line.
+      const result = formatReviewComment(baseOptions({
+        disputeDisclosure: 'something',
+      }));
+      expect(result).not.toContain('📊');
+    });
+  });
 });
 
 describe('buildWorkDoneSection', () => {

--- a/packages/core/src/comment-formatter.ts
+++ b/packages/core/src/comment-formatter.ts
@@ -63,6 +63,16 @@ interface FormatOptions {
   mergeScore?: number;
   /** One-line reason for the merge score */
   mergeScoreReason?: string;
+  /**
+   * FP-J L3 — transparent dispute-rate disclosure rendered as a small
+   * annotation beneath the merge-score line. Set by `reconcileMergeScore`
+   * when one or more action findings come from chronically-disputed
+   * categories (rate ≥ 75% over the 30d FB-E window, surfacings ≥ 5).
+   * Surfaced separately from `mergeScoreReason` so the verdict line stays
+   * concise and the context renders as an opt-in audit trail rather than
+   * a primary verdict signal. Omitted when no disputed categories qualify.
+   */
+  disputeDisclosure?: string;
   /** UX configuration */
   ux?: UXConfig;
   /** Work done stats for the work-done section */
@@ -223,6 +233,7 @@ export function formatReviewComment(options: FormatOptions): string {
     reviewDetailUrl,
     mergeScore,
     mergeScoreReason,
+    disputeDisclosure,
     ux,
     workDone,
     delta,
@@ -296,6 +307,14 @@ export function formatReviewComment(options: FormatOptions): string {
     const scoreDisplay = renderMergeScore(mergeScore);
     const reasonSuffix = mergeScoreReason ? ` \u2014 ${mergeScoreReason}` : '';
     lines.push(`> ${scoreDisplay}${reasonSuffix}`);
+    // FP-J L3 \u2014 dispute-rate disclosure renders as a quieter sub-line so the
+    // primary verdict stays the most visible signal. Only emitted when the
+    // reconcile pass identified at least one action finding from a
+    // chronically-disputed category (>= 5 surfacings AND >= 75% dispute rate
+    // over the 30d window). Omitted on the clean path.
+    if (disputeDisclosure && disputeDisclosure.trim()) {
+      lines.push(`> <sub>\ud83d\udcca ${disputeDisclosure.trim()}</sub>`);
+    }
     lines.push('');
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -159,6 +159,9 @@ export { buildInsightFromDispositions, WINDOW_LENGTH_MS } from './insights/rollu
 export { runInsightRollup } from './insights/run-rollup.js';
 export type { RollupStores, RollupRunResult } from './insights/run-rollup.js';
 
+// ─── Dispute-rate loader (FP-J L1) ─────────────────────────────────────────
+export { loadCategoryDisputeRates } from './insights/dispute-rates.js';
+
 // ─── Config ─────────────────────────────────────────────────────────────────
 export {
   DEFAULT_CONFIG,

--- a/packages/core/src/insights/dispute-rates.test.ts
+++ b/packages/core/src/insights/dispute-rates.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { loadCategoryDisputeRates } from './dispute-rates.js';
+import type { IFPInsightStore, InstallationFPInsight } from '../index.js';
+
+// ─── Test fixtures ──────────────────────────────────────────────────────────
+
+function makeStore(insight: InstallationFPInsight | null | Error): IFPInsightStore {
+  return {
+    async get(_id, _window) {
+      if (insight instanceof Error) throw insight;
+      return insight;
+    },
+    async upsert() { /* unused */ },
+    async listByInstallation() { return []; },
+  };
+}
+
+function makeInsight(perCategory: Record<string, { surfaced: number; disputed: number; rate: number }>): InstallationFPInsight {
+  return {
+    installationId: '42',
+    window: '30d',
+    windowStart: '2026-04-22T00:00:00Z',
+    windowEnd: '2026-05-22T00:00:00Z',
+    generatedAt: '2026-05-22T00:00:00Z',
+    totalFindingsSurfaced: 0,
+    totalDisputes: 0,
+    disputeRate: 0,
+    totalSilentDrops: 0,
+    totalAgreements: 0,
+    perCategory,
+    perRepo: {},
+    topClusters: [],
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('loadCategoryDisputeRates (FP-J L1)', () => {
+  it('returns {} when no store is provided (back-compat)', async () => {
+    const rates = await loadCategoryDisputeRates(undefined, 42);
+    expect(rates).toEqual({});
+  });
+
+  it('returns {} when installationId is null/undefined', async () => {
+    const store = makeStore(makeInsight({ style: { surfaced: 10, disputed: 8, rate: 0.8 } }));
+    expect(await loadCategoryDisputeRates(store, undefined)).toEqual({});
+    expect(await loadCategoryDisputeRates(store, null as unknown as number)).toEqual({});
+  });
+
+  it('returns {} when the store has no insight for this installation (fresh install)', async () => {
+    const rates = await loadCategoryDisputeRates(makeStore(null), 42);
+    expect(rates).toEqual({});
+  });
+
+  it('returns {} on store read failure (logged, swallowed; pipeline must not block)', async () => {
+    const rates = await loadCategoryDisputeRates(makeStore(new Error('upstream-degraded')), 42);
+    expect(rates).toEqual({});
+  });
+
+  it('projects perCategory.rate into the simple {category: rate} map', async () => {
+    const insight = makeInsight({
+      style:    { surfaced: 20, disputed: 16, rate: 0.8  },
+      security: { surfaced: 10, disputed: 1,  rate: 0.1  },
+    });
+    const rates = await loadCategoryDisputeRates(makeStore(insight), 42);
+    expect(rates).toEqual({ style: 0.8, security: 0.1 });
+  });
+
+  it('filters out categories below the MIN_SURFACED floor (small-N noise guard)', async () => {
+    const insight = makeInsight({
+      style:    { surfaced: 20, disputed: 16, rate: 0.8  }, // kept
+      flaky:    { surfaced: 1,  disputed: 1,  rate: 1.0  }, // dropped — only 1 surfacing
+      borderline: { surfaced: 4, disputed: 3, rate: 0.75 }, // dropped — below 5
+    });
+    const rates = await loadCategoryDisputeRates(makeStore(insight), 42);
+    expect(rates).toEqual({ style: 0.8 });
+  });
+
+  it('handles installationId as a number (handler passes it through unstringified)', async () => {
+    const insight = makeInsight({ style: { surfaced: 10, disputed: 8, rate: 0.8 } });
+    const rates = await loadCategoryDisputeRates(makeStore(insight), 42);
+    expect(rates).toEqual({ style: 0.8 });
+  });
+
+  it('handles an empty perCategory bucket on an otherwise valid insight', async () => {
+    const insight = makeInsight({});
+    const rates = await loadCategoryDisputeRates(makeStore(insight), 42);
+    expect(rates).toEqual({});
+  });
+});

--- a/packages/core/src/insights/dispute-rates.ts
+++ b/packages/core/src/insights/dispute-rates.ts
@@ -1,0 +1,74 @@
+/**
+ * FP-J L1 — derive a `categoryDisputeRates` map for `reconcileMergeScore`.
+ *
+ * Reads the latest 30d `InstallationFPInsight` rollup (produced nightly by
+ * FB-E) and projects its `perCategory` bucket into the
+ * `Record<string, number>` shape that the verdict-tier softening accepts.
+ * Filters out below-threshold categories so the verdict only down-weights
+ * on statistically meaningful evidence.
+ *
+ * Best-effort by design: any read failure (no rollup yet, store unwired,
+ * upstream-degraded) returns an empty map, which is identical to "no
+ * down-weighting" in the reconcile path. The review pipeline never blocks
+ * on insights I/O.
+ */
+
+import type { IFPInsightStore } from '../storage/types.js';
+
+/**
+ * Minimum surfacing count for a category's rate to be included. Matches the
+ * `DISPUTE_RATE_MIN_SURFACED` constant in `reviewer.ts` so the loader and
+ * the verdict-tier consumer can't drift on the trust floor. A category with
+ * 1 surfacing + 1 dispute reads as 100% disputed but is statistically
+ * unreliable; the floor keeps single-event noise out of the verdict.
+ */
+const MIN_SURFACED = 5;
+
+/**
+ * Window the loader reads from. 30d is the same window FB-G's dispute-by-
+ * agent chart uses on the dashboard — keeps the verdict tier and the
+ * dashboard visualisation in agreement about what "recent dispute history"
+ * means.
+ */
+const WINDOW: '7d' | '30d' | '90d' = '30d';
+
+/**
+ * Load per-category dispute rates for an installation.
+ *
+ * Returns `{}` (which behaves identically to "no down-weighting" in
+ * `reconcileMergeScore`) when:
+ *   - no store is provided (older deployment shape)
+ *   - the installation has no rollup yet (fresh install)
+ *   - the read itself failed (logged, swallowed)
+ *
+ * The map only includes categories clearing `MIN_SURFACED`, so callers can
+ * pass the result straight to `reconcileMergeScore` without further filtering.
+ */
+export async function loadCategoryDisputeRates(
+  store: IFPInsightStore | undefined,
+  installationId: string | number | undefined,
+): Promise<Record<string, number>> {
+  if (!store || installationId == null) return {};
+
+  let insight;
+  try {
+    insight = await store.get(String(installationId), WINDOW);
+  } catch (err) {
+    console.warn(
+      '[fp-j-l1] loadCategoryDisputeRates: insight read failed for %s; defaulting to no down-weighting',
+      installationId,
+      err,
+    );
+    return {};
+  }
+
+  if (!insight || !insight.perCategory) return {};
+
+  const rates: Record<string, number> = {};
+  for (const [category, bucket] of Object.entries(insight.perCategory)) {
+    if (bucket.surfaced >= MIN_SURFACED) {
+      rates[category] = bucket.rate;
+    }
+  }
+  return rates;
+}

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -41,6 +41,7 @@ import {
   fetchRepoConfig,
   fetchConventions,
   detectLinters,
+  loadCategoryDisputeRates,
   type DetectedLinter,
   handleInlineReply,
   fetchTriageComments,
@@ -63,7 +64,13 @@ import type {
 } from '@mergewatch/core';
 import { buildWorkDoneSection, computeReviewDelta } from '@mergewatch/core';
 import { DynamoInstallationStore } from '@mergewatch/storage-dynamo';
-import { DynamoReviewStore, DynamoFindingDispositionStore, DEFAULT_FINDING_DISPOSITIONS_TABLE } from '@mergewatch/storage-dynamo';
+import {
+  DynamoReviewStore,
+  DynamoFindingDispositionStore,
+  DEFAULT_FINDING_DISPOSITIONS_TABLE,
+  DynamoFPInsightStore,
+  DEFAULT_FP_INSIGHTS_TABLE,
+} from '@mergewatch/storage-dynamo';
 import { BedrockLLMProvider, SUPPORTED_MODELS } from '@mergewatch/llm-bedrock';
 import { isSaas, billingCheck, recordReview, postBlockedCheckRun, ensureBillingIssue, updateBillingFields, getStripe } from '@mergewatch/billing';
 import { SSMGitHubAuthProvider } from '../github-auth-ssm.js';
@@ -75,6 +82,7 @@ const dynamodb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const INSTALLATIONS_TABLE = process.env.INSTALLATIONS_TABLE ?? 'mergewatch-installations';
 const REVIEWS_TABLE = process.env.REVIEWS_TABLE ?? 'mergewatch-reviews';
 const FINDING_DISPOSITIONS_TABLE = process.env.FINDING_DISPOSITIONS_TABLE ?? DEFAULT_FINDING_DISPOSITIONS_TABLE;
+const FP_INSIGHTS_TABLE = process.env.FP_INSIGHTS_TABLE ?? DEFAULT_FP_INSIGHTS_TABLE;
 const DEFAULT_BEDROCK_MODEL_ID = process.env.DEFAULT_BEDROCK_MODEL_ID ?? 'us.anthropic.claude-sonnet-4-20250514-v1:0';
 const DASHBOARD_BASE_URL = process.env.DASHBOARD_BASE_URL ?? 'https://mergewatch.ai';
 
@@ -83,6 +91,11 @@ const reviewStore = new DynamoReviewStore(dynamodb, REVIEWS_TABLE);
 // FB-A — per-finding cross-PR dispositions. Best-effort writes; if the
 // table doesn't exist yet (mid-deploy state) the store layer swallows.
 const dispositionStore = new DynamoFindingDispositionStore(dynamodb, FINDING_DISPOSITIONS_TABLE);
+// FP-J L1 — read-only on the review path; the FB-E rollup writes here
+// nightly. loadCategoryDisputeRates returns `{}` on every failure path,
+// so the verdict tier behaves identically to pre-FP-J when the table is
+// empty or unprovisioned (back-compat for the SaaS rollout window).
+const fpInsightStore = new DynamoFPInsightStore(dynamodb, FP_INSIGHTS_TABLE);
 const llm = new BedrockLLMProvider();
 const authProvider = new SSMGitHubAuthProvider();
 
@@ -640,7 +653,10 @@ export async function handler(
     // marker files in parallel. detectLinters performs at most one
     // root-listing API call + one extra pyproject.toml fetch on Python
     // repos; both are bounded and best-effort.
-    const [conventionsResult, detectedLinters] = await Promise.all([
+    // FP-J L1 — fetch category dispute rates in parallel. Same fail-open
+    // semantics as detectLinters above (the helper returns `{}` on every
+    // failure path, identical to "no down-weighting" downstream).
+    const [conventionsResult, detectedLinters, categoryDisputeRates] = await Promise.all([
       fetchConventions(octokit, owner, repo, headSha, runtimeConfig.conventions),
       detectLinters(octokit, owner, repo, headSha).catch((err) => {
         // Fail-open by design — see server/review-processor.ts for the
@@ -652,6 +668,7 @@ export async function handler(
         console.warn('[fp-g] linter detection failed (status=%s):', status ?? 'n/a', err);
         return [] as DetectedLinter[];
       }),
+      loadCategoryDisputeRates(fpInsightStore, installationId),
     ]);
     if (conventionsResult) {
       console.log(`Loaded repo conventions from ${conventionsResult.sourcePath}${conventionsResult.truncated ? ' (truncated)' : ''}`);
@@ -687,6 +704,7 @@ export async function handler(
       conventions: conventionsResult?.content,
       agentAuthored: event.source === 'agent',
       detectedLinters,
+      categoryDisputeRates,
     }, { llm });
 
     const reviewDetailUrl = `${DASHBOARD_BASE_URL}/dashboard/reviews/${encodeURIComponent(`${repoFullName}:${prNumberCommitSha}`)}`;
@@ -745,6 +763,7 @@ export async function handler(
       reviewDetailUrl,
       mergeScore: result.mergeScore,
       mergeScoreReason: result.mergeScoreReason || undefined,
+      disputeDisclosure: result.disputeDisclosure,
       ux: runtimeConfig.ux,
       workDone,
       delta,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -121,6 +121,7 @@ async function main() {
     installationStore,
     reviewStore,
     dispositionStore,
+    fpInsightStore,
     authProvider,
     llm,
     dashboardBaseUrl,

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -3,6 +3,7 @@ import {
   getPRDiff, getPRContext, addPRReaction, removePRReaction, postReviewComment, updateReviewComment,
   findExistingBotComment, getCommentReactions, createCheckRun,
   formatReviewComment, runReviewPipeline, shouldSkipPR, shouldSkipByRules, isAutoReviewOff, extractIncludePatterns,
+  loadCategoryDisputeRates,
   filterDiff,
   DEFAULT_CONFIG, mergeConfig,
   BOT_COMMENT_MARKER, submitPRReview, dismissStaleReviews, mergeScoreToReviewEvent,
@@ -245,7 +246,7 @@ async function handleInlineReplyJob(
 
 export async function processReviewJob(
   job: ReviewJobPayload,
-  deps: Pick<WebhookDeps, 'installationStore' | 'reviewStore' | 'dispositionStore' | 'authProvider' | 'llm' | 'dashboardBaseUrl'>,
+  deps: Pick<WebhookDeps, 'installationStore' | 'reviewStore' | 'dispositionStore' | 'fpInsightStore' | 'authProvider' | 'llm' | 'dashboardBaseUrl'>,
 ): Promise<void> {
   const { installationId, owner, repo, prNumber, mode } = job;
   const instId = String(installationId);
@@ -525,7 +526,11 @@ export async function processReviewJob(
     // and (FP-G) probe the repo root for known linter marker files in parallel.
     // detectLinters performs at most one root-listing API call + one extra
     // pyproject.toml fetch on Python repos; both are bounded and best-effort.
-    const [conventionsResult, detectedLinters] = await Promise.all([
+    // FP-J L1 — fetch category dispute rates in parallel. The helper
+    // returns `{}` on every failure path (no rollup yet, store unwired,
+    // upstream-degraded), which is identical to "no down-weighting" in
+    // the verdict-tier softener — so the await is safe to bundle here.
+    const [conventionsResult, detectedLinters, categoryDisputeRates] = await Promise.all([
       fetchConventions(octokit, owner, repo, ref, config.conventions),
       detectLinters(octokit, owner, repo, ref).catch((err) => {
         // Fail-open by design: linter detection is best-effort and a
@@ -539,6 +544,7 @@ export async function processReviewJob(
         console.warn('[fp-g] linter detection failed (status=%s):', status ?? 'n/a', err);
         return [] as DetectedLinter[];
       }),
+      loadCategoryDisputeRates(deps.fpInsightStore, job.installationId),
     ]);
     if (conventionsResult) {
       console.log(`Loaded repo conventions from ${conventionsResult.sourcePath}${conventionsResult.truncated ? ' (truncated)' : ''}`);
@@ -577,6 +583,7 @@ export async function processReviewJob(
         conventions: conventionsResult?.content,
         agentAuthored: job.source === 'agent',
         detectedLinters,
+        categoryDisputeRates,
       },
       { llm: deps.llm },
     );
@@ -647,6 +654,7 @@ export async function processReviewJob(
       showDiagram: instSettings.summary?.diagram !== false,
       mergeScore: result.mergeScore,
       mergeScoreReason: result.mergeScoreReason,
+      disputeDisclosure: result.disputeDisclosure,
       commentFooter: instSettings.commentHeader || undefined,
       reviewDetailUrl: deps.dashboardBaseUrl
         ? `${deps.dashboardBaseUrl}/dashboard/reviews/${encodeURIComponent(repoFullName)}/${prNumberCommitSha}`

--- a/packages/server/src/webhook-handler.ts
+++ b/packages/server/src/webhook-handler.ts
@@ -1,6 +1,6 @@
 import { createHmac, timingSafeEqual } from 'crypto';
 import type { Request, Response } from 'express';
-import type { IInstallationStore, IReviewStore, IFindingDispositionStore, IGitHubAuthProvider, ILLMProvider, AgentReviewConfig } from '@mergewatch/core';
+import type { IInstallationStore, IReviewStore, IFindingDispositionStore, IFPInsightStore, IGitHubAuthProvider, ILLMProvider, AgentReviewConfig } from '@mergewatch/core';
 import type { ReviewJobPayload, ReviewMode, PullRequestEvent, IssueCommentEvent, PullRequestReviewCommentEvent, InstallationEvent, CheckRunEvent } from '@mergewatch/core';
 import { REVIEW_TRIGGERING_ACTIONS, COMMENT_LOOKUP_ACTIONS, MERGEWATCH_CHECK_RUN_NAME, findExistingBotComment, classifyPrSource, fetchRepoConfig, mergeConfig, isBotActor } from '@mergewatch/core';
 import { processReviewJob } from './review-processor.js';
@@ -12,6 +12,13 @@ export interface WebhookDeps {
   /** FB-A — optional disposition store. Best-effort: when unset, writes are
    *  no-ops and the review pipeline runs unchanged. */
   dispositionStore?: IFindingDispositionStore;
+  /**
+   * FP-J L1 — optional FP-insight store. Read-only on the review path; the
+   * processor projects `perCategory` rates into the verdict-tier softener.
+   * When unset (or empty rollup), the verdict tier behaves identically to
+   * the pre-FP-J shape — no down-weighting.
+   */
+  fpInsightStore?: IFPInsightStore;
   authProvider: IGitHubAuthProvider;
   llm: ILLMProvider;
   dashboardBaseUrl: string;


### PR DESCRIPTION
Closes #170 (FP-J L1 + L3 — the deferred halves). FP-J is now fully shipped across all three layers.

## Why now

Layer 2 (verifier honours prior recommendations) shipped earlier as a prompt extension. Layers 1 + 3 were **deferred** until FB-A/FB-E had accumulated production data — without dispute counters there's nothing to weight against. With FB-A → FB-L now fully shipped (PR #178 merged), the counters are live and FP-J's remaining layers unblock cleanly.

## Layer 1 — dispute-aware verdict softening

`reconcileMergeScore` gains an optional `categoryDisputeRates: Record<string, number>` input. When the orchestrator wants to BLOCK (score ≤ 2) **AND** more than half of the action findings come from chronically-disputed categories (rate ≥ 0.75 AND surfacings ≥ 5), the verdict is softened to **3** (Review recommended / advisory).

Same blocking-tier softening shape as the W7 unverified-criticals clamp, but driven by FB-A dispute counters rather than W2 verification.

`loadCategoryDisputeRates(insightStore, installationId)` (new helper in `packages/core/src/insights/dispute-rates.ts`) reads the latest **30d** `InstallationFPInsight` and projects `perCategory.rate` into the simple map. Returns `{}` on every failure path (no rollup yet, store unwired, upstream-degraded read) — identical to "no down-weighting" downstream. The `MIN_SURFACED = 5` floor is shared with FB-L's known-FP-patterns threshold so both surfaces treat the same shape as actionable.

Handlers (server + lambda) wire the loader into the existing parallel-fetches block alongside `fetchConventions` + `detectLinters`. Lambda gets a new `DynamoFPInsightStore` singleton with `FP_INSIGHTS_TABLE` env var; server adds `fpInsightStore?` to `WebhookDeps`.

**Pure deterministic scoring** — no LLM calls, no prompt changes, no schema migrations.

## Layer 3 — transparent disclosure footer

A `disputeDisclosure?: string` field flows from reconcile → `ReviewPipelineResult` → `formatReviewComment`. When at least one action finding's category qualifies, the footer renders as a quiet `<sub>📊 …</sub>` line beneath the merge-score badge:

```
> 🟡 3/5 — Review recommended. Downgraded to advisory…
> <sub>📊 3 of 3 action findings are from a category disputed ≥ 75%
>       of the time in this org's recent reviews — the verdict tier
>       reflects that historical accuracy.</sub>
```

Fires even when the tier didn't shift (e.g. minority of findings qualified) — gives reviewers context about *why* the verdict looks the way it does without auto-suppressing the findings themselves. The `<sub>` wrapper keeps the verdict line as the most visible signal; the disclosure is an opt-in audit trail, not a primary verdict.

## Back-compat (total at every layer)

| Path | Behavior |
|---|---|
| Absent / empty `categoryDisputeRates` | Identical to pre-FP-J — orchestrator score stands |
| Fresh installation (no rollup yet) | Loader returns `{}` → no down-weighting |
| Store read failure (upstream-degraded) | Logged + swallowed, returns `{}` → no down-weighting |
| Category with `surfaceCount < 5` | Filtered out of the loader's map (small-N noise guard) |
| W7 unverified-criticals clamp + FP-J L1 both fire | Both produce `mergeScore: 3`; W7's reason takes precedence (W7 is checked first in `reconcileMergeScore`) |
| `disputeDisclosure` undefined / empty | Footer is omitted entirely |
| No `mergeScore` set on the formatter call | Disclosure is omitted (no anchor to hang the sub-line on) |

## Design call: strict majority

The clamp requires *strict majority* (more than half) rather than ≥ half. So 1-of-2 disputed findings doesn't trigger the softener — it's a 50/50 split. This avoids the edge case where one disputed warning could unilaterally soften a verdict on a 2-finding PR.

## Tests

| File | New tests | Coverage |
|---|---|---|
| `packages/core/src/agents/reviewer.test.ts` | 9 | back-compat, clamping, strict-majority guard, threshold respect, no upward uplift, W7 interaction, disclosure-without-clamp, empty-path |
| `packages/core/src/comment-formatter.test.ts` | 5 | `<sub>` render shape, ordering below score, omission paths, no-score guard |
| `packages/core/src/insights/dispute-rates.test.ts` | 8 (new file) | back-compat (no store + no id), fresh install, read failure, projection correctness, MIN_SURFACED filtering, numeric id, empty bucket |

**Core 633/633 · Build 12/12 · Typecheck 20/20 · Migrations check clean.**

## Fixture

`e2e/RUNBOOK.md` — new card **E2E-53** (✅ SHIPPED) with full repro steps + acceptance + failure modes including: strict-majority guard, threshold respect, W7 interaction, the disclosure-without-clamp path.

## Plan doc

`docs/false-positive-reduction-plan.md` — FP-J section rewritten from "✅ SHIPPED (Layer 2 only)" to "✅ SHIPPED" across all three layers. Final code targets enumerated; back-compat notes spelled out; priority-order row updated.

## What this completes

With this PR, the full FP-* arc closes:

| ID | Title | Status |
|---|---|---|
| FP-A | Hard confidence-floor filter | ✅ SHIPPED |
| FP-B | Pre-filter `previousFindings` by disputedKeys | ✅ SHIPPED |
| FP-C | Pre-orchestrator same-file-same-line dedup | ✅ SHIPPED |
| FP-D | Diagram path validation | ✅ SHIPPED |
| FP-E | Extend W2 verification to warnings | ✅ SHIPPED |
| FP-F | Inline-reply resolve memory → disputedKeys | ✅ SHIPPED |
| FP-G | Linter-aware style agent | ✅ SHIPPED |
| FP-H | Anti-anchoring on prior findings (L1 + L2) | ✅ SHIPPED |
| FP-I | Verify suggestion-already-implemented (L1 + L2) | ✅ SHIPPED |
| FP-J | Verifier honours prior recommendations + dispute-aware reconcile + disclosure (L1 + L2 + L3) | ✅ SHIPPED (this PR completes L1 + L3) |
| FP-L | Propagate W2 verification tag to rendering surfaces | ✅ SHIPPED |

Remaining open: **FP-K #173** (abstraction-aware verifier). That's the last FP-* in the queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)