### PR TITLE
fix(fb-a): hoist FINDING_DISPOSITIONS_TABLE + FP_INSIGHTS_TABLE env vars to Globals

### DIFF
--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -98,6 +98,11 @@ Globals:
         REVIEWS_TABLE: !Ref ReviewsTable
         API_KEYS_TABLE: !Ref ApiKeysTable
         SESSIONS_TABLE: !Ref SessionsTable
+        # FB-A / FB-E: shared across ReviewAgent (writes) and InsightsRollup (reads/writes).
+        # Must be in Globals so ReviewAgent's best-effort writes don't silently fall back
+        # to the unsuffixed default name and ResourceNotFoundException into a void.
+        FINDING_DISPOSITIONS_TABLE: !Ref FindingDispositionsTable
+        FP_INSIGHTS_TABLE: !Ref FpInsightsTable
 
         # SSM parameter paths for GitHub App credentials.
         # The Lambda functions read these at runtime via the AWS SDK.
@@ -398,12 +403,8 @@ Resources:
 
       Role: !GetAtt LambdaExecutionRole.Arn
 
-      Environment:
-        Variables:
-          STAGE: !Ref Stage
-          INSTALLATIONS_TABLE: !Ref InstallationsTable
-          FINDING_DISPOSITIONS_TABLE: !Ref FindingDispositionsTable
-          FP_INSIGHTS_TABLE: !Ref FpInsightsTable
+      # No Environment block — inherits STAGE / INSTALLATIONS_TABLE /
+      # FINDING_DISPOSITIONS_TABLE / FP_INSIGHTS_TABLE from Globals.
 
       # EventBridge schedule trigger — 03:00 UTC daily.
       Events:

--- a/packages/lambda/src/template.test.ts
+++ b/packages/lambda/src/template.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const TEMPLATE_PATH = resolve(__dirname, '../../../infra/template.yaml');
+const template = readFileSync(TEMPLATE_PATH, 'utf8');
+
+const globalsBlock = (() => {
+  const start = template.indexOf('\nGlobals:');
+  const next = template.indexOf('\nResources:');
+  if (start < 0 || next < 0 || next < start) {
+    throw new Error('Could not locate Globals / Resources sections in template.yaml');
+  }
+  return template.slice(start, next);
+})();
+
+describe('infra/template.yaml — Globals.Function.Environment.Variables', () => {
+  // Regression guard for #181 (FB-A writers silently writing to a non-existent
+  // table because the env var only existed on InsightsRollupFunction). These
+  // table names MUST live in Globals so every Lambda — current and future —
+  // inherits them and resolves to the stage-suffixed table.
+  it.each([
+    'FINDING_DISPOSITIONS_TABLE',
+    'FP_INSIGHTS_TABLE',
+    'INSTALLATIONS_TABLE',
+    'REVIEWS_TABLE',
+  ])('exposes %s as a shared Lambda env var', (varName) => {
+    expect(globalsBlock).toMatch(new RegExp(`^\\s+${varName}:`, 'm'));
+  });
+});


### PR DESCRIPTION
Fixes #181.

## Root cause

`ReviewAgent` Lambda did **not** receive the `FINDING_DISPOSITIONS_TABLE` or `FP_INSIGHTS_TABLE` env vars — they were only declared on `InsightsRollupFunction`. Because `review-agent.ts` falls back to the *unsuffixed* defaults when the env var is unset:

```ts
const FINDING_DISPOSITIONS_TABLE = process.env.FINDING_DISPOSITIONS_TABLE ?? DEFAULT_FINDING_DISPOSITIONS_TABLE;
// DEFAULT_FINDING_DISPOSITIONS_TABLE = 'mergewatch-finding-dispositions'
```

every `PutItem` from `recordFindingSurfacings`, `recordDisputes`, `appendRejectReason`, and `recordQuietDrops` targeted a non-existent table name (`mergewatch-finding-dispositions` rather than `mergewatch-finding-dispositions-prod`). The disposition store treats writes as best-effort, so `ResourceNotFoundException` was silently swallowed in both dev and prod.

That explains everything observed in #181:
- Both `mergewatch-finding-dispositions-{dev,prod}` tables empty across 19+ fixture PRs
- FB-E rollup running on schedule but reading zeros → every `installation-fp-insights` row showing `totalFindingsSurfaced: 0`, `topClusters: []`, etc.

## Fix

Move both env vars into `Globals.Function.Environment.Variables` so every Lambda (current and future) inherits the stage-suffixed table name — matches the existing pattern for `INSTALLATIONS_TABLE` / `REVIEWS_TABLE` / `API_KEYS_TABLE` / `SESSIONS_TABLE`. The local overrides on `InsightsRollupFunction` are now redundant and removed.

## Regression test

Adds `packages/lambda/src/template.test.ts` — parses `infra/template.yaml` and asserts the four shared table-name env vars (`FINDING_DISPOSITIONS_TABLE`, `FP_INSIGHTS_TABLE`, `INSTALLATIONS_TABLE`, `REVIEWS_TABLE`) are declared in the `Globals` block. So a future writer-handler can't get wired up without its table name also being shared. Test fails on pre-fix state, passes after.

## Blast radius / what unblocks

Per #181, this unblocks the entire feedback/dashboard family:
- E2E-37 FB-A storage writers (direct)
- E2E-38 FB-B silent-drop counter
- E2E-39 FB-C reactions → dispute/agreement counts
- E2E-40 FB-D `/mergewatch reject` rejectReasons persistence
- E2E-42–47 dashboard charts
- E2E-48 FB-L `{{KNOWN_FP_PATTERNS}}` injection
- E2E-53 FP-J L1 dispute-aware reconcile

## Validation

- `pnpm --filter @mergewatch/lambda test` — 61/61 pass
- `pnpm run typecheck` — 20/20 pass
- Verified test fails on pre-fix state (2 of 4 new assertions fail), passes after

## Test plan (post-merge)

- [ ] Deploy via `scripts/deploy.sh` to dev
- [ ] Apply a finding-producing fixture (e.g. `03-critical-finding`)
- [ ] Wait ~60s for review
- [ ] `aws dynamodb scan --table-name mergewatch-finding-dispositions-dev --select COUNT` — expect Count ≥ 1
- [ ] Confirm next nightly FB-E rollup populates `totalFindingsSurfaced > 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)