### PR TITLE
fix(fp-f): enrich inline-resolve keys with fingerprint + diagnose drop points

### DIFF
--- a/packages/core/src/agents/inline-reply.test.ts
+++ b/packages/core/src/agents/inline-reply.test.ts
@@ -5,6 +5,7 @@ import {
   handleInlineReply,
   detectResolveIntent,
   parseRejectIntent,
+  enrichResolvedFindingKeys,
   REJECT_CATEGORIES,
   MAX_BOT_REPLIES,
 } from './inline-reply.js';
@@ -53,6 +54,86 @@ describe('detectResolveIntent', () => {
     expect(detectResolveIntent('resolves the issue in the next PR')).toBe(false);
     expect(detectResolveIntent('I cannot resolve this right now')).toBe(false);
     expect(detectResolveIntent('the bug will resolve itself')).toBe(false);
+  });
+});
+
+// ─── enrichResolvedFindingKeys (FP-F regression #182) ─────────────────────
+
+describe('enrichResolvedFindingKeys', () => {
+  it('adds the fingerprint key for any prior finding whose title key matches a resolved key', () => {
+    // Title-only persistence is brittle when the next review's LLM
+    // rewords the title; adding the fingerprint key from the prior
+    // round's findings makes suppression survive the rewording.
+    const resolved = ['src/admin.ts::T::Unauthenticated admin endpoint'];
+    const prev = [
+      { file: 'src/admin.ts', line: 8, title: 'Unauthenticated admin endpoint', fingerprint: 'abc123' },
+    ];
+    const enriched = enrichResolvedFindingKeys(resolved, prev);
+    expect(enriched).toContain('src/admin.ts::T::Unauthenticated admin endpoint');
+    expect(enriched).toContain('src/admin.ts::F::abc123');
+    expect(enriched).toHaveLength(2);
+  });
+
+  it('returns the seed unchanged when the prior finding has no fingerprint', () => {
+    const resolved = ['src/admin.ts::T::Title'];
+    const prev = [{ file: 'src/admin.ts', line: 8, title: 'Title' }];
+    const enriched = enrichResolvedFindingKeys(resolved, prev);
+    expect(enriched).toEqual(['src/admin.ts::T::Title']);
+  });
+
+  it('passes through resolved keys when previousFindings is empty / undefined / null', () => {
+    const resolved = ['src/admin.ts::T::Title'];
+    expect(enrichResolvedFindingKeys(resolved, undefined)).toEqual(resolved);
+    expect(enrichResolvedFindingKeys(resolved, null)).toEqual(resolved);
+    expect(enrichResolvedFindingKeys(resolved, [])).toEqual(resolved);
+  });
+
+  it('ignores prior findings that do not intersect the seed', () => {
+    // The join is "any of finding's keys is in the seed". If neither
+    // title nor fingerprint key matches a resolved key, do not enrich.
+    const resolved = ['src/a.ts::T::Resolved'];
+    const prev = [
+      { file: 'src/b.ts', line: 1, title: 'Unrelated', fingerprint: 'xyz' },
+      { file: 'src/a.ts', line: 1, title: 'Different title same file', fingerprint: 'qqq' },
+    ];
+    const enriched = enrichResolvedFindingKeys(resolved, prev);
+    expect(enriched).toEqual(['src/a.ts::T::Resolved']);
+  });
+
+  it('matches via fingerprint key when the seed already carries one', () => {
+    // Defensive: a future caller that hands enrich a fingerprint key
+    // should still pick up the title key from the matching prior finding.
+    const resolved = ['src/a.ts::F::fp1'];
+    const prev = [{ file: 'src/a.ts', line: 1, title: 'T', fingerprint: 'fp1' }];
+    const enriched = enrichResolvedFindingKeys(resolved, prev);
+    expect(new Set(enriched)).toEqual(new Set(['src/a.ts::F::fp1', 'src/a.ts::T::T']));
+  });
+
+  it('handles multiple resolved findings independently', () => {
+    const resolved = [
+      'src/a.ts::T::Alpha',
+      'src/b.ts::T::Beta',
+    ];
+    const prev = [
+      { file: 'src/a.ts', line: 1, title: 'Alpha', fingerprint: 'aaa' },
+      { file: 'src/b.ts', line: 1, title: 'Beta', fingerprint: 'bbb' },
+      { file: 'src/c.ts', line: 1, title: 'Gamma', fingerprint: 'ccc' },
+    ];
+    const enriched = new Set(enrichResolvedFindingKeys(resolved, prev));
+    expect(enriched).toEqual(new Set([
+      'src/a.ts::T::Alpha',
+      'src/a.ts::F::aaa',
+      'src/b.ts::T::Beta',
+      'src/b.ts::F::bbb',
+    ]));
+  });
+
+  it('deduplicates when seed and prior finding produce the same key', () => {
+    const resolved = ['src/a.ts::T::T', 'src/a.ts::F::fp'];
+    const prev = [{ file: 'src/a.ts', line: 1, title: 'T', fingerprint: 'fp' }];
+    const enriched = enrichResolvedFindingKeys(resolved, prev);
+    expect(enriched).toHaveLength(2);
+    expect(new Set(enriched)).toEqual(new Set(['src/a.ts::T::T', 'src/a.ts::F::fp']));
   });
 });
 

--- a/packages/core/src/agents/inline-reply.test.ts
+++ b/packages/core/src/agents/inline-reply.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Octokit } from '@octokit/rest';
 import type { ILLMProvider } from '../llm/types.js';
 import {
@@ -6,9 +6,13 @@ import {
   detectResolveIntent,
   parseRejectIntent,
   enrichResolvedFindingKeys,
+  persistInlineResolveMemory,
+  MAX_INLINE_RESOLVED_KEYS,
   REJECT_CATEGORIES,
   MAX_BOT_REPLIES,
 } from './inline-reply.js';
+import type { IReviewStore } from '../storage/types.js';
+import type { ReviewItem } from '../types/db.js';
 
 // ─── detectResolveIntent ────────────────────────────────────────────────────
 
@@ -134,6 +138,173 @@ describe('enrichResolvedFindingKeys', () => {
     const enriched = enrichResolvedFindingKeys(resolved, prev);
     expect(enriched).toHaveLength(2);
     expect(new Set(enriched)).toEqual(new Set(['src/a.ts::T::T', 'src/a.ts::F::fp']));
+  });
+});
+
+// ─── persistInlineResolveMemory (FP-F regression #182 + review feedback) ───
+
+describe('persistInlineResolveMemory', () => {
+  type UpdateStatusArgs = Parameters<IReviewStore['updateStatus']>;
+  type UpdateStatusFn = (...args: UpdateStatusArgs) => Promise<void>;
+  interface MockReviewStore extends IReviewStore {
+    updateStatusCalls: UpdateStatusArgs[];
+    updateStatusImpl: UpdateStatusFn;
+  }
+
+  function makeReviewStore(): MockReviewStore {
+    const updateStatusCalls: UpdateStatusArgs[] = [];
+    let updateStatusImpl: UpdateStatusFn = async () => {};
+    const store: MockReviewStore = {
+      updateStatusCalls,
+      get updateStatusImpl() { return updateStatusImpl; },
+      set updateStatusImpl(v: UpdateStatusFn) { updateStatusImpl = v; },
+      async upsert() {},
+      async claimReview() { return true; },
+      async updateStatus(repoFullName, key, status, extra) {
+        const args: UpdateStatusArgs = [repoFullName, key, status, extra];
+        updateStatusCalls.push(args);
+        return updateStatusImpl(...args);
+      },
+      async queryByPR() { return []; },
+    };
+    return store;
+  }
+
+  function makeLatestReview(over: Partial<ReviewItem> = {}): ReviewItem {
+    return {
+      repoFullName: 'o/r',
+      prNumberCommitSha: '42#abc',
+      status: 'complete',
+      createdAt: '2026-05-01T00:00:00Z',
+      ...over,
+    } as ReviewItem;
+  }
+
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  it('no-ops + logs the no-prior-review diagnostic when latestReview is undefined', async () => {
+    const store = makeReviewStore();
+    const r = await persistInlineResolveMemory({
+      reviewStore: store,
+      latestReview: undefined,
+      resolvedFindingKeys: ['a::T::x'],
+      repoFullName: 'o/r',
+      prNumber: 42,
+    });
+    expect(r).toEqual({ persisted: false, enrichedCount: 0 });
+    expect(store.updateStatusCalls).toHaveLength(0);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/no prior complete review found/),
+      'o/r', 42,
+    );
+  });
+
+  it('no-ops + logs the no-keys diagnostic when resolvedFindingKeys is empty', async () => {
+    const store = makeReviewStore();
+    const r = await persistInlineResolveMemory({
+      reviewStore: store,
+      latestReview: makeLatestReview(),
+      resolvedFindingKeys: [],
+      repoFullName: 'o/r',
+      prNumber: 42,
+    });
+    expect(r).toEqual({ persisted: false, enrichedCount: 0 });
+    expect(store.updateStatusCalls).toHaveLength(0);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/no resolved keys derived/),
+      'o/r', 42,
+    );
+  });
+
+  it('persists + logs success on the happy path, enriching with fingerprints from the prior findings', async () => {
+    const store = makeReviewStore();
+    const latestReview = makeLatestReview({
+      findings: [
+        { file: 'src/a.ts', line: 1, severity: 'critical', title: 'T', description: '', suggestion: '', fingerprint: 'fp1' } as ReviewItem['findings'] extends (infer X)[] | undefined ? X : never,
+      ],
+    });
+    const r = await persistInlineResolveMemory({
+      reviewStore: store,
+      latestReview,
+      resolvedFindingKeys: ['src/a.ts::T::T'],
+      repoFullName: 'o/r',
+      prNumber: 42,
+    });
+    expect(r.persisted).toBe(true);
+    expect(r.enrichedCount).toBe(2);
+    expect(store.updateStatusCalls).toHaveLength(1);
+    const [repo, key, status, extra] = store.updateStatusCalls[0];
+    expect(repo).toBe('o/r');
+    expect(key).toBe('42#abc');
+    expect(status).toBe('complete');
+    expect(new Set((extra as { inlineResolvedKeys: string[] }).inlineResolvedKeys)).toEqual(
+      new Set(['src/a.ts::T::T', 'src/a.ts::F::fp1']),
+    );
+    expect(logSpy).toHaveBeenCalled();
+  });
+
+  it('unions enriched keys with the existing inlineResolvedKeys on the review (preserves prior memory)', async () => {
+    const store = makeReviewStore();
+    const latestReview = makeLatestReview({
+      inlineResolvedKeys: ['old/key::T::Foo'],
+      findings: [],
+    });
+    await persistInlineResolveMemory({
+      reviewStore: store,
+      latestReview,
+      resolvedFindingKeys: ['new/key::T::Bar'],
+      repoFullName: 'o/r',
+      prNumber: 42,
+    });
+    const merged = (store.updateStatusCalls[0][3] as { inlineResolvedKeys: string[] }).inlineResolvedKeys;
+    expect(new Set(merged)).toEqual(new Set(['old/key::T::Foo', 'new/key::T::Bar']));
+  });
+
+  it('caps the merged set at MAX_INLINE_RESOLVED_KEYS (defensive row-size guard)', async () => {
+    const store = makeReviewStore();
+    const existing = Array.from({ length: MAX_INLINE_RESOLVED_KEYS + 50 }, (_, i) => `e::T::${i}`);
+    await persistInlineResolveMemory({
+      reviewStore: store,
+      latestReview: makeLatestReview({ inlineResolvedKeys: existing, findings: [] }),
+      resolvedFindingKeys: ['new::T::X'],
+      repoFullName: 'o/r',
+      prNumber: 42,
+    });
+    const merged = (store.updateStatusCalls[0][3] as { inlineResolvedKeys: string[] }).inlineResolvedKeys;
+    expect(merged).toHaveLength(MAX_INLINE_RESOLVED_KEYS);
+  });
+
+  it('reports persisted=false + warn-logs (does NOT log success) when updateStatus throws — fixes the misleading-log bug from the PR #185 review', async () => {
+    // The pre-fix bug: success log fired regardless of `.catch`. The new
+    // contract: log success ONLY on actual await completion, log failure
+    // on throw, never both. This guards against the regression.
+    const store = makeReviewStore();
+    store.updateStatusImpl = async () => { throw new Error('dynamo blew up'); };
+    const r = await persistInlineResolveMemory({
+      reviewStore: store,
+      latestReview: makeLatestReview({ findings: [] }),
+      resolvedFindingKeys: ['a::T::x'],
+      repoFullName: 'o/r',
+      prNumber: 42,
+    });
+    expect(r.persisted).toBe(false);
+    expect(r.enrichedCount).toBe(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/failed to persist inline-resolve keys/),
+      'o/r', 42,
+      expect.any(Error),
+    );
+    // Success log MUST NOT fire.
+    expect(logSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/core/src/agents/inline-reply.ts
+++ b/packages/core/src/agents/inline-reply.ts
@@ -38,6 +38,8 @@ import {
   type ReviewThreadComment,
 } from '../github/client.js';
 import { findingMatchKeys, type FindingLike } from '../review-delta.js';
+import type { IReviewStore } from '../storage/types.js';
+import type { ReviewItem } from '../types/db.js';
 import type { Octokit } from '@octokit/rest';
 
 /** Max number of bot replies permitted in a single thread before we stop engaging. */
@@ -277,6 +279,94 @@ export function enrichResolvedFindingKeys(
     }
   }
   return Array.from(enriched);
+}
+
+/**
+ * FP-F — defensive cap on the persisted `inlineResolvedKeys` set.
+ *
+ * Each key is roughly `<file>::T::<title>` or `<file>::F::<fingerprint>` —
+ * a few hundred bytes at most. 500 keys keeps the field comfortably under
+ * the row-size limits both backends impose (DynamoDB items: 400 KB hard
+ * limit; Postgres jsonb: practically unbounded but rebuild time matters
+ * once you cross the page boundary). Matches the same defensive cap the
+ * W3 triage path uses for its disputed-keys list, so a misbehaving caller
+ * can't blow up either column independently.
+ */
+export const MAX_INLINE_RESOLVED_KEYS = 500;
+
+/**
+ * FP-F — persist the developer's inline-resolve memory onto the prior
+ * review record's `inlineResolvedKeys`. Encapsulates: the diagnostic
+ * drop-point logs (no prior review / no resolved keys derived), the
+ * fingerprint enrichment, the bounded merge, the actual store write,
+ * and the success-conditional log.
+ *
+ * Extracted so the lambda and server wrappers can share one path —
+ * eliminates ~30 lines of duplicate logic per handler and fixes the
+ * "success-log fires regardless of `.catch`" misleading-logging bug
+ * by gating the log on actual `await` completion via try/catch.
+ *
+ * Best-effort: failures log a warning and return `persisted: false`,
+ * never throw — the caller's PR review must not crash on a failed
+ * `inlineResolvedKeys` write.
+ */
+export async function persistInlineResolveMemory(opts: {
+  reviewStore: IReviewStore;
+  /**
+   * Latest complete review for this PR. The persist target. When
+   * `undefined`, the no-prior-review diagnostic fires and the call
+   * is a no-op — handlers can pass through whatever `find` returned
+   * without pre-checking.
+   */
+  latestReview: ReviewItem | undefined;
+  /**
+   * The match keys the inline-resolve fast path derived from the thread
+   * root. When empty/undefined, the no-keys-derived diagnostic fires and
+   * the call is a no-op — handlers can pass `result.resolvedFindingKeys`
+   * directly without pre-checking.
+   */
+  resolvedFindingKeys: string[] | undefined;
+  repoFullName: string;
+  prNumber: number;
+}): Promise<{ persisted: boolean; enrichedCount: number }> {
+  const { reviewStore, latestReview, resolvedFindingKeys, repoFullName, prNumber } = opts;
+  if (!latestReview) {
+    console.warn(
+      '[fp-f] no prior complete review found for %s#%d — inline-resolve memory not persisted',
+      repoFullName, prNumber,
+    );
+    return { persisted: false, enrichedCount: 0 };
+  }
+  if (!resolvedFindingKeys || resolvedFindingKeys.length === 0) {
+    console.warn(
+      '[fp-f] resolve fired but no resolved keys derived for %s#%d — root inline comment likely missing path or `**🔴 <title>**` shape',
+      repoFullName, prNumber,
+    );
+    return { persisted: false, enrichedCount: 0 };
+  }
+  const enriched = enrichResolvedFindingKeys(resolvedFindingKeys, latestReview.findings);
+  const existing = new Set(latestReview.inlineResolvedKeys ?? []);
+  for (const k of enriched) existing.add(k);
+  const merged = Array.from(existing).slice(0, MAX_INLINE_RESOLVED_KEYS);
+  try {
+    await reviewStore.updateStatus(
+      repoFullName,
+      latestReview.prNumberCommitSha as string,
+      latestReview.status as 'complete',
+      { inlineResolvedKeys: merged },
+    );
+    console.log(
+      '[fp-f] persisted %d inline-resolved key%s (%d after fingerprint enrichment) on %s#%d',
+      resolvedFindingKeys.length,
+      resolvedFindingKeys.length === 1 ? '' : 's',
+      enriched.length,
+      repoFullName, prNumber,
+    );
+    return { persisted: true, enrichedCount: enriched.length };
+  } catch (err) {
+    console.warn('[fp-f] failed to persist inline-resolve keys for %s#%d:', repoFullName, prNumber, err);
+    return { persisted: false, enrichedCount: enriched.length };
+  }
 }
 
 /** Parsed JSON response from the inline reply agent. */

--- a/packages/core/src/agents/inline-reply.ts
+++ b/packages/core/src/agents/inline-reply.ts
@@ -37,7 +37,7 @@ import {
   extractInlineCommentTitle,
   type ReviewThreadComment,
 } from '../github/client.js';
-import { findingMatchKeys } from '../review-delta.js';
+import { findingMatchKeys, type FindingLike } from '../review-delta.js';
 import type { Octokit } from '@octokit/rest';
 
 /** Max number of bot replies permitted in a single thread before we stop engaging. */
@@ -243,6 +243,40 @@ function deriveResolvedFindingKeys(root: ReviewThreadComment): string[] {
   // the emitted keys — the title key is `file::T::title`, which is exactly
   // what we want here (no fingerprint is recoverable from the comment body).
   return findingMatchKeys({ file: root.path, line: 0, title });
+}
+
+/**
+ * FP-F (regression #182) — Title-only persistence is fragile: the next
+ * review round's LLM can reword the title even when the cited code is
+ * unchanged, defeating the title-key match. The previous review's
+ * findings array carries the fingerprint for each finding (set by W8/W9
+ * during the original pipeline run), so the caller can union the
+ * fingerprint key with the resolved title key. With *both* keys in
+ * `inlineResolvedKeys`, the next round's `partitionDisputed` will
+ * suppress the finding via the fingerprint even if the title drifts.
+ *
+ * Looks up findings whose `findingMatchKeys` intersect `resolvedKeys`
+ * (the title key acts as the join), then unions in all of that
+ * finding's keys (which includes the `file::F::<fingerprint>` form when
+ * present). Pure / no I/O — safe to call from any handler wrapper.
+ *
+ * Returns `resolvedKeys` unchanged when `previousFindings` is missing
+ * or empty; never throws.
+ */
+export function enrichResolvedFindingKeys(
+  resolvedKeys: string[],
+  previousFindings: FindingLike[] | undefined | null,
+): string[] {
+  if (!previousFindings || previousFindings.length === 0) return [...resolvedKeys];
+  const seed = new Set(resolvedKeys);
+  const enriched = new Set(seed);
+  for (const f of previousFindings) {
+    const keys = findingMatchKeys(f);
+    if (keys.some((k) => seed.has(k))) {
+      for (const k of keys) enriched.add(k);
+    }
+  }
+  return Array.from(enriched);
 }
 
 /** Parsed JSON response from the inline reply agent. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -48,6 +48,8 @@ export {
   detectResolveIntent,
   parseRejectIntent,
   enrichResolvedFindingKeys,
+  persistInlineResolveMemory,
+  MAX_INLINE_RESOLVED_KEYS,
   REJECT_CATEGORIES,
   MAX_BOT_REPLIES,
 } from './agents/inline-reply.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,6 +47,7 @@ export {
   handleInlineReply,
   detectResolveIntent,
   parseRejectIntent,
+  enrichResolvedFindingKeys,
   REJECT_CATEGORIES,
   MAX_BOT_REPLIES,
 } from './agents/inline-reply.js';

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -44,7 +44,7 @@ import {
   loadCategoryDisputeRates,
   type DetectedLinter,
   handleInlineReply,
-  enrichResolvedFindingKeys,
+  persistInlineResolveMemory,
   fetchTriageComments,
   computeDisputedKeys,
   partitionDisputed,
@@ -236,44 +236,21 @@ async function handleInlineReplyMode(
       ).catch((err) => console.warn('Failed to roll up inline reply cost:', err));
     }
 
-    // FP-F — persist inline-resolve memory; mirrors the server handler. See
-    // packages/server/src/review-processor.ts for the rationale.
+    // FP-F — persist inline-resolve memory + record dispute analytics.
+    // The shared helper handles drop-point diagnostics, fingerprint
+    // enrichment, the bounded merge, and the success-conditional log
+    // (only fires on actual await completion via try/catch, not
+    // `.then`-orphaned). recordDisputes runs independently — its
+    // analytics signal is decoupled from inlineResolvedKeys persistence.
     if (result.action === 'resolved') {
-      // Diagnostic — fixes #182 silent-failure mode. Each drop point logs
-      // *why* the persist would have skipped, so the next time inline-resolve
-      // fails to suppress on re-review the CloudWatch trail makes the cause
-      // obvious instead of leaving the operator to guess between 4 hypotheses.
-      if (!latestReview) {
-        console.warn('[fp-f] no prior complete review found for %s#%d — inline-resolve memory not persisted', repoFullName, prNumber);
-      } else if (!result.resolvedFindingKeys || result.resolvedFindingKeys.length === 0) {
-        console.warn('[fp-f] resolve fired but no resolved keys derived for %s#%d — root inline comment likely missing path or `**🔴 <title>**` shape', repoFullName, prNumber);
-      } else {
-        // Enrich with fingerprint keys from the prior review's findings.
-        // Title-only persistence is brittle: the next round's LLM can
-        // reword the title even when the cited code is unchanged, and a
-        // pure title match would miss. Looking up the matching prior
-        // finding by title key and unioning its `findingMatchKeys` adds
-        // the `file::F::<fingerprint>` form so suppression survives
-        // title drift.
-        const enriched = enrichResolvedFindingKeys(result.resolvedFindingKeys, latestReview.findings);
-        const existing = new Set(latestReview.inlineResolvedKeys ?? []);
-        for (const k of enriched) existing.add(k);
-        const merged = Array.from(existing).slice(0, 500);
-        await reviewStore.updateStatus(
-          repoFullName,
-          latestReview.prNumberCommitSha as string,
-          latestReview.status as 'complete',
-          { inlineResolvedKeys: merged },
-        ).catch((err) => console.warn('[fp-f] failed to persist inline-resolve keys:', err));
-        console.log(
-          '[fp-f] persisted %d inline-resolved key%s (%d after fingerprint enrichment) on %s#%d',
-          result.resolvedFindingKeys.length,
-          result.resolvedFindingKeys.length === 1 ? '' : 's',
-          enriched.length,
-          repoFullName,
-          prNumber,
-        );
-        // FB-A — every inline-resolve is also an explicit dispute for analytics.
+      await persistInlineResolveMemory({
+        reviewStore,
+        latestReview,
+        resolvedFindingKeys: result.resolvedFindingKeys,
+        repoFullName,
+        prNumber,
+      });
+      if (result.resolvedFindingKeys && result.resolvedFindingKeys.length > 0) {
         await recordDisputes(dispositionStore, installationId, repoFullName, result.resolvedFindingKeys);
       }
     }

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -44,6 +44,7 @@ import {
   loadCategoryDisputeRates,
   type DetectedLinter,
   handleInlineReply,
+  enrichResolvedFindingKeys,
   fetchTriageComments,
   computeDisputedKeys,
   partitionDisputed,
@@ -237,30 +238,44 @@ async function handleInlineReplyMode(
 
     // FP-F — persist inline-resolve memory; mirrors the server handler. See
     // packages/server/src/review-processor.ts for the rationale.
-    if (
-      latestReview &&
-      result.action === 'resolved' &&
-      result.resolvedFindingKeys &&
-      result.resolvedFindingKeys.length > 0
-    ) {
-      const existing = new Set(latestReview.inlineResolvedKeys ?? []);
-      for (const k of result.resolvedFindingKeys) existing.add(k);
-      const merged = Array.from(existing).slice(0, 500);
-      await reviewStore.updateStatus(
-        repoFullName,
-        latestReview.prNumberCommitSha as string,
-        latestReview.status as 'complete',
-        { inlineResolvedKeys: merged },
-      ).catch((err) => console.warn('[fp-f] failed to persist inline-resolve keys:', err));
-      console.log(
-        '[fp-f] persisted %d inline-resolved key%s on %s#%d',
-        result.resolvedFindingKeys.length,
-        result.resolvedFindingKeys.length === 1 ? '' : 's',
-        repoFullName,
-        prNumber,
-      );
-      // FB-A — every inline-resolve is also an explicit dispute for analytics.
-      await recordDisputes(dispositionStore, installationId, repoFullName, result.resolvedFindingKeys);
+    if (result.action === 'resolved') {
+      // Diagnostic — fixes #182 silent-failure mode. Each drop point logs
+      // *why* the persist would have skipped, so the next time inline-resolve
+      // fails to suppress on re-review the CloudWatch trail makes the cause
+      // obvious instead of leaving the operator to guess between 4 hypotheses.
+      if (!latestReview) {
+        console.warn('[fp-f] no prior complete review found for %s#%d — inline-resolve memory not persisted', repoFullName, prNumber);
+      } else if (!result.resolvedFindingKeys || result.resolvedFindingKeys.length === 0) {
+        console.warn('[fp-f] resolve fired but no resolved keys derived for %s#%d — root inline comment likely missing path or `**🔴 <title>**` shape', repoFullName, prNumber);
+      } else {
+        // Enrich with fingerprint keys from the prior review's findings.
+        // Title-only persistence is brittle: the next round's LLM can
+        // reword the title even when the cited code is unchanged, and a
+        // pure title match would miss. Looking up the matching prior
+        // finding by title key and unioning its `findingMatchKeys` adds
+        // the `file::F::<fingerprint>` form so suppression survives
+        // title drift.
+        const enriched = enrichResolvedFindingKeys(result.resolvedFindingKeys, latestReview.findings);
+        const existing = new Set(latestReview.inlineResolvedKeys ?? []);
+        for (const k of enriched) existing.add(k);
+        const merged = Array.from(existing).slice(0, 500);
+        await reviewStore.updateStatus(
+          repoFullName,
+          latestReview.prNumberCommitSha as string,
+          latestReview.status as 'complete',
+          { inlineResolvedKeys: merged },
+        ).catch((err) => console.warn('[fp-f] failed to persist inline-resolve keys:', err));
+        console.log(
+          '[fp-f] persisted %d inline-resolved key%s (%d after fingerprint enrichment) on %s#%d',
+          result.resolvedFindingKeys.length,
+          result.resolvedFindingKeys.length === 1 ? '' : 's',
+          enriched.length,
+          repoFullName,
+          prNumber,
+        );
+        // FB-A — every inline-resolve is also an explicit dispute for analytics.
+        await recordDisputes(dispositionStore, installationId, repoFullName, result.resolvedFindingKeys);
+      }
     }
 
     // FB-D — `/mergewatch reject` persists a categorised rejection per

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -12,7 +12,7 @@ import {
   buildWorkDoneSection, computeReviewDelta,
   RESPOND_PROMPT, postReplyComment,
   handleInlineReply,
-  enrichResolvedFindingKeys,
+  persistInlineResolveMemory,
   fetchTriageComments, computeDisputedKeys, partitionDisputed,
   recordFindingSurfacings, recordDisputes, detectQuietDrops, recordQuietDrops,
   pollAndRecordInlineReactions,
@@ -148,51 +148,21 @@ async function handleInlineReplyJob(
       ).catch((err) => console.warn('Failed to roll up inline reply cost:', err));
     }
 
-    // FP-F — persist inline-resolve memory. When the developer resolved an
-    // inline thread, append the finding's stable identity keys to the latest
-    // review record's `inlineResolvedKeys` set. The next full review unions
-    // these with the live-computed W3 disputedKeys so the finding doesn't
-    // get re-emitted under a slightly-different framing.
+    // FP-F — persist inline-resolve memory + record dispute analytics.
+    // The shared helper handles drop-point diagnostics, fingerprint
+    // enrichment, the bounded merge, and the success-conditional log
+    // (only fires on actual await completion via try/catch, not
+    // `.then`-orphaned). recordDisputes runs independently — its
+    // analytics signal is decoupled from inlineResolvedKeys persistence.
     if (result.action === 'resolved') {
-      // Diagnostic — fixes #182 silent-failure mode. Each drop point logs
-      // *why* the persist would have skipped, so the next time inline-resolve
-      // fails to suppress on re-review the operator log makes the cause
-      // obvious instead of leaving the operator to guess between hypotheses.
-      if (!latestReview) {
-        console.warn('[fp-f] no prior complete review found for %s#%d — inline-resolve memory not persisted', repoFullName, prNumber);
-      } else if (!result.resolvedFindingKeys || result.resolvedFindingKeys.length === 0) {
-        console.warn('[fp-f] resolve fired but no resolved keys derived for %s#%d — root inline comment likely missing path or `**🔴 <title>**` shape', repoFullName, prNumber);
-      } else {
-        // Enrich with fingerprint keys from the prior review's findings.
-        // Title-only persistence is brittle: the next round's LLM can
-        // reword the title even when the cited code is unchanged, and a
-        // pure title match would miss. Looking up the matching prior
-        // finding by title key and unioning its `findingMatchKeys` adds
-        // the `file::F::<fingerprint>` form so suppression survives
-        // title drift.
-        const enriched = enrichResolvedFindingKeys(result.resolvedFindingKeys, latestReview.findings);
-        const existing = new Set(latestReview.inlineResolvedKeys ?? []);
-        for (const k of enriched) existing.add(k);
-        // Bound the persisted set defensively — even a misbehaving caller
-        // can't blow up the row size. Same order-preserving cap as the W3
-        // path uses for triage keys.
-        const merged = Array.from(existing).slice(0, 500);
-        await deps.reviewStore.updateStatus(
-          repoFullName,
-          latestReview.prNumberCommitSha as string,
-          latestReview.status as 'complete',
-          { inlineResolvedKeys: merged },
-        ).catch((err) => console.warn('[fp-f] failed to persist inline-resolve keys:', err));
-        console.log(
-          '[fp-f] persisted %d inline-resolved key%s (%d after fingerprint enrichment) on %s#%d',
-          result.resolvedFindingKeys.length,
-          result.resolvedFindingKeys.length === 1 ? '' : 's',
-          enriched.length,
-          repoFullName,
-          prNumber,
-        );
-        // FB-A — every inline-resolve also counts as an explicit per-finding
-        // dispute. Best-effort write; the helper logs+swallows on failure.
+      await persistInlineResolveMemory({
+        reviewStore: deps.reviewStore,
+        latestReview,
+        resolvedFindingKeys: result.resolvedFindingKeys,
+        repoFullName,
+        prNumber,
+      });
+      if (result.resolvedFindingKeys && result.resolvedFindingKeys.length > 0) {
         await recordDisputes(deps.dispositionStore, installationId, repoFullName, result.resolvedFindingKeys);
       }
     }

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -12,6 +12,7 @@ import {
   buildWorkDoneSection, computeReviewDelta,
   RESPOND_PROMPT, postReplyComment,
   handleInlineReply,
+  enrichResolvedFindingKeys,
   fetchTriageComments, computeDisputedKeys, partitionDisputed,
   recordFindingSurfacings, recordDisputes, detectQuietDrops, recordQuietDrops,
   pollAndRecordInlineReactions,
@@ -152,34 +153,48 @@ async function handleInlineReplyJob(
     // review record's `inlineResolvedKeys` set. The next full review unions
     // these with the live-computed W3 disputedKeys so the finding doesn't
     // get re-emitted under a slightly-different framing.
-    if (
-      latestReview &&
-      result.action === 'resolved' &&
-      result.resolvedFindingKeys &&
-      result.resolvedFindingKeys.length > 0
-    ) {
-      const existing = new Set(latestReview.inlineResolvedKeys ?? []);
-      for (const k of result.resolvedFindingKeys) existing.add(k);
-      // Bound the persisted set defensively — even a misbehaving caller
-      // can't blow up the row size. Same order-preserving cap as the W3
-      // path uses for triage keys.
-      const merged = Array.from(existing).slice(0, 500);
-      await deps.reviewStore.updateStatus(
-        repoFullName,
-        latestReview.prNumberCommitSha as string,
-        latestReview.status as 'complete',
-        { inlineResolvedKeys: merged },
-      ).catch((err) => console.warn('[fp-f] failed to persist inline-resolve keys:', err));
-      console.log(
-        '[fp-f] persisted %d inline-resolved key%s on %s#%d',
-        result.resolvedFindingKeys.length,
-        result.resolvedFindingKeys.length === 1 ? '' : 's',
-        repoFullName,
-        prNumber,
-      );
-      // FB-A — every inline-resolve also counts as an explicit per-finding
-      // dispute. Best-effort write; the helper logs+swallows on failure.
-      await recordDisputes(deps.dispositionStore, installationId, repoFullName, result.resolvedFindingKeys);
+    if (result.action === 'resolved') {
+      // Diagnostic — fixes #182 silent-failure mode. Each drop point logs
+      // *why* the persist would have skipped, so the next time inline-resolve
+      // fails to suppress on re-review the operator log makes the cause
+      // obvious instead of leaving the operator to guess between hypotheses.
+      if (!latestReview) {
+        console.warn('[fp-f] no prior complete review found for %s#%d — inline-resolve memory not persisted', repoFullName, prNumber);
+      } else if (!result.resolvedFindingKeys || result.resolvedFindingKeys.length === 0) {
+        console.warn('[fp-f] resolve fired but no resolved keys derived for %s#%d — root inline comment likely missing path or `**🔴 <title>**` shape', repoFullName, prNumber);
+      } else {
+        // Enrich with fingerprint keys from the prior review's findings.
+        // Title-only persistence is brittle: the next round's LLM can
+        // reword the title even when the cited code is unchanged, and a
+        // pure title match would miss. Looking up the matching prior
+        // finding by title key and unioning its `findingMatchKeys` adds
+        // the `file::F::<fingerprint>` form so suppression survives
+        // title drift.
+        const enriched = enrichResolvedFindingKeys(result.resolvedFindingKeys, latestReview.findings);
+        const existing = new Set(latestReview.inlineResolvedKeys ?? []);
+        for (const k of enriched) existing.add(k);
+        // Bound the persisted set defensively — even a misbehaving caller
+        // can't blow up the row size. Same order-preserving cap as the W3
+        // path uses for triage keys.
+        const merged = Array.from(existing).slice(0, 500);
+        await deps.reviewStore.updateStatus(
+          repoFullName,
+          latestReview.prNumberCommitSha as string,
+          latestReview.status as 'complete',
+          { inlineResolvedKeys: merged },
+        ).catch((err) => console.warn('[fp-f] failed to persist inline-resolve keys:', err));
+        console.log(
+          '[fp-f] persisted %d inline-resolved key%s (%d after fingerprint enrichment) on %s#%d',
+          result.resolvedFindingKeys.length,
+          result.resolvedFindingKeys.length === 1 ? '' : 's',
+          enriched.length,
+          repoFullName,
+          prNumber,
+        );
+        // FB-A — every inline-resolve also counts as an explicit per-finding
+        // dispute. Best-effort write; the helper logs+swallows on failure.
+        await recordDisputes(deps.dispositionStore, installationId, repoFullName, result.resolvedFindingKeys);
+      }
     }
 
     // FB-D — `/mergewatch reject` persists a categorised rejection per


### PR DESCRIPTION
Refs #182.

## What's in the issue

The PR author replied `resolved` on a MergeWatch inline thread. The GraphQL `resolveReviewThread` mutation fired (an empty `COMMENTED` Review event landed at the same second), but on the next sync the same critical re-emitted as **↻ Still present**. No bot acknowledgement, no actionable logs — the operator was left to choose between 4 hypotheses.

## What I could and couldn't verify from code alone

I could not reproduce against live CloudWatch logs from this repo. What I *did* verify by reading the SaaS code path on `upstream/main`:

| Hypothesis from #182 | Verdict from code review |
|---|---|
| 1. `extractInlineCommentTitle` tripping on `**🔴 <title>**` | Regex is single-line non-greedy; title `Unauthenticated admin endpoint exposes sensitive user data` matches cleanly. Not the bug. |
| 2. `detectResolveIntent` regex narrower than RUNBOOK | `affirmative: /^(resolved|please resolve|mergewatch resolve|yes,? resolve)[.!\s]*$/` matches bare `resolved`. Unit-tested at `inline-reply.test.ts:27-32`. Not the bug. |
| 3. `inline_resolved_keys` column missing | Migration `0002_bouncy_sally_floyd.sql` adds it for Postgres; Dynamo is schemaless and `updateStatus` writes the attribute dynamically. Not the bug. |
| 4. Cross-cutting with #181 | Author already noted this only affects the analytics side-effect, not suppression. |

## What this PR actually fixes

Two issues that are real either way and worth fixing on their own merits:

### 1. Title-only persistence is brittle (very plausible root cause for #182)

`deriveResolvedFindingKeys` builds keys via `findingMatchKeys({ file, line: 0, title })` — only the **title** key (`file::T::title`), because the function has no access to the original finding's fingerprint. If the next round's LLM rewords the title even slightly on unchanged code, `partitionDisputed`'s union check misses (no title-key match, and the fingerprint key was never persisted).

Fix: add a small exported helper `enrichResolvedFindingKeys(resolvedKeys, previousFindings)` that joins the resolved seed against the prior review's findings on shared keys, then unions in the full `findingMatchKeys(f)` — which carries `file::F::<fingerprint>` when present. Both handler wrappers (lambda `review-agent.ts` and server `review-processor.ts`) now persist the enriched set, so suppression survives title drift on unchanged code.

### 2. The persistence block is silent on the unhappy paths

The original guard was four ANDed conditions (`latestReview` present, action resolved, resolved keys present, length > 0) producing zero log lines on any miss. That's exactly what made #182 hard to diagnose.

Fix: invert the structure to log *why* a drop happened at each gate:

- `[fp-f] no prior complete review found for <repo>#<pr> — inline-resolve memory not persisted` (covers hypothesis: \`prevReviews\` query returned nothing)
- `[fp-f] resolve fired but no resolved keys derived ... — root inline comment likely missing path or **🔴 <title>** shape` (covers hypothesis 1 + 2 above + the older-comment-shape regression)
- On success: `[fp-f] persisted N inline-resolved key(s) (M after fingerprint enrichment) on <repo>#<pr>` — the M-vs-N gap surfaces whether enrichment fired

So the next time inline-resolve fails to suppress, the CloudWatch trail makes the cause obvious instead of forcing a 4-hypothesis dance.

## Tests

6 new cases for `enrichResolvedFindingKeys` covering: title-drift enrichment, missing-fingerprint passthrough, no-match (independent findings), seed-already-carries-fingerprint, multi-finding parallelism, and dedup. Existing 35 inline-reply tests unchanged.

## Validation

- `pnpm run typecheck` — 20/20 pass
- `pnpm --filter @mergewatch/core test` — 652/652 (41 in inline-reply.test.ts)
- `pnpm --filter @mergewatch/lambda test` — 57/57
- `pnpm --filter @mergewatch/server test` — 79/79

## Test plan (post-merge)

- [ ] Re-run the E2E-35 fixture flow on [mergewatch-fixtures#70](https://github.com/santthosh/mergewatch-fixtures/pull/70):
  1. Apply fixture, wait for round-1 review with inline critical
  2. Reply `resolved` to the inline thread
  3. Empty `--allow-empty` sync commit
  4. Confirm next review *does not* re-raise the critical
  5. Confirm CloudWatch shows `[fp-f] persisted ... (2 after fingerprint enrichment)` then `[fp-f] unioned 2 inline-resolved key(s) into disputedKeys` on the re-review
- [ ] If suppression *still* fails, the new warn lines should now name the gate that dropped — file a follow-up with that log line

🤖 Generated with [Claude Code](https://claude.com/claude-code)