### PR TITLE
fix(fp-l): downgrade blocking verdict when verifier drops all criticals (#183)

### DIFF
--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -2397,6 +2397,131 @@ describe('reconcileMergeScore', () => {
     expect(r.mergeScoreReason).toMatch(/net improvement/);
   });
 
+  // ─── FP-L regression (#183) — verifier-dropped criticals ────────────────
+  //
+  // Scenario: orchestrator emitted a critical and scored 2 (blocking). The
+  // verifier (FP-E / FP-I L2 / FP-K "valid:false") subsequently dropped
+  // the critical entirely. Pre-fix: orchestrator score + reason pass
+  // through, producing a 3-way mismatch — verdict prose names a critical
+  // that doesn't render, review state is REQUEST_CHANGES, check
+  // conclusion is success. Post-fix: tier downgrades to 3 and the reason
+  // is regenerated from a deterministic template that matches what
+  // actually renders.
+  describe('FP-L #183 — verifier dropped all criticals from a blocking verdict', () => {
+    it('downgrades to 3 when orchestrator emitted criticals, post-filter has none, score ≤2, warnings remain', () => {
+      // The PR #71 scenario — orchestrator scored 2 because of a
+      // path-traversal critical the verifier subsequently dropped.
+      const r = reconcileMergeScore({
+        filteredFindings: [warning(), warning()],
+        previousFindings: undefined,
+        orchestratorScore: 2,
+        orchestratorReason: 'Critical path traversal and warnings; needs fixes before merging.',
+        orchestratorCriticalsCount: 1,
+      });
+      expect(r.mergeScore).toBe(3);
+      // Reason regenerated from the deterministic template — explicitly
+      // attributes the downgrade to post-orchestrator dropping rather
+      // than letting the stale orchestrator prose stand.
+      expect(r.mergeScoreReason).toMatch(/1 critical finding was dropped/i);
+      expect(r.mergeScoreReason).toMatch(/2 warnings remain/);
+      expect(r.mergeScoreReason).toMatch(/not blocked/i);
+      // The stale orchestrator prose ("Critical path traversal and …
+      // needs fixes before merging") must NOT leak into the reconciled
+      // reason — that exact phrase is the user-facing bug.
+      expect(r.mergeScoreReason).not.toContain('needs fixes before merging');
+    });
+
+    it('downgrades on orchestratorScore=1 (the strictest blocking tier) the same way', () => {
+      const r = reconcileMergeScore({
+        filteredFindings: [warning()],
+        previousFindings: undefined,
+        orchestratorScore: 1,
+        orchestratorReason: 'multiple criticals',
+        orchestratorCriticalsCount: 3,
+      });
+      expect(r.mergeScore).toBe(3);
+      expect(r.mergeScoreReason).toMatch(/3 critical findings were dropped/);
+      expect(r.mergeScoreReason).toMatch(/1 warning\b/);
+    });
+
+    it('does NOT fire when even one Critical survives post-filter (the surviving one still blocks)', () => {
+      const r = reconcileMergeScore({
+        filteredFindings: [critical({ verification: 'verified' }), warning()],
+        previousFindings: undefined,
+        orchestratorScore: 2,
+        orchestratorReason: 'one critical + warning',
+        orchestratorCriticalsCount: 1,
+      });
+      expect(r.mergeScore).toBe(2);
+      expect(r.mergeScoreReason).toBe('one critical + warning');
+    });
+
+    it('does NOT fire when the orchestrator score is already ≥3 (only clamps a blocking verdict)', () => {
+      const r = reconcileMergeScore({
+        filteredFindings: [warning()],
+        previousFindings: undefined,
+        orchestratorScore: 3,
+        orchestratorReason: 'yellow',
+        orchestratorCriticalsCount: 1,
+      });
+      expect(r.mergeScore).toBe(3);
+      expect(r.mergeScoreReason).toBe('yellow');
+    });
+
+    it('does NOT fire without orchestratorCriticalsCount (back-compat with callers that pre-date this fix)', () => {
+      // The exact same shape as the first case but with the count omitted.
+      // Behavior must match pre-#183: orchestrator score stands.
+      const r = reconcileMergeScore({
+        filteredFindings: [warning(), warning()],
+        previousFindings: undefined,
+        orchestratorScore: 2,
+        orchestratorReason: 'two warnings, blocking',
+      });
+      expect(r.mergeScore).toBe(2);
+      expect(r.mergeScoreReason).toBe('two warnings, blocking');
+    });
+
+    it('does NOT fire when orchestratorCriticalsCount is 0 (orchestrator never had criticals; warnings-only block is its judgment)', () => {
+      const r = reconcileMergeScore({
+        filteredFindings: [warning(), warning()],
+        previousFindings: undefined,
+        orchestratorScore: 2,
+        orchestratorReason: 'two SQL injection warnings',
+        orchestratorCriticalsCount: 0,
+      });
+      expect(r.mergeScore).toBe(2);
+    });
+
+    it('falls through to the no-action-items branch (mergeScore=5) when the only critical was dropped AND only info remains', () => {
+      // No warnings either — actionFindings.length === 0 → noActionItems
+      // branch wins before the FP-L clamp is consulted, returning 5/5.
+      const r = reconcileMergeScore({
+        filteredFindings: [{ ...warning(), severity: 'info' }],
+        previousFindings: undefined,
+        orchestratorScore: 1,
+        orchestratorReason: 'critical security vuln',
+        orchestratorCriticalsCount: 1,
+      });
+      expect(r.mergeScore).toBe(5);
+      expect(r.mergeScoreReason).toMatch(/only informational/i);
+    });
+
+    it('W7 unverified-criticals clamp still takes precedence when criticals are present (FP-L only fires when post-filter criticals are 0)', () => {
+      // Documents the ordering: this new clamp checks
+      // `currentCriticals.length === 0`, so it never competes with W7
+      // (which only fires when criticals exist but are unverified).
+      const r = reconcileMergeScore({
+        filteredFindings: [critical({ verification: 'unverified' })],
+        previousFindings: undefined,
+        orchestratorScore: 1,
+        orchestratorReason: 'one critical',
+        orchestratorCriticalsCount: 1,
+      });
+      expect(r.mergeScore).toBe(3);
+      expect(r.mergeScoreReason).toMatch(/could not be confirmed|verification inconclusive/i);
+    });
+  });
+
   // ─── FP-J L1 — dispute-aware verdict softening ────────────────────────
   describe('FP-J L1 — categoryDisputeRates', () => {
     it('back-compat: absent categoryDisputeRates behaves identically to today (orchestrator score stands)', () => {

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -1844,8 +1844,22 @@ export function reconcileMergeScore(input: {
    * Lambda wires the FP-insight store).
    */
   categoryDisputeRates?: Record<string, number>;
+  /**
+   * FP-L (regression #183) — number of Critical findings the orchestrator
+   * emitted **before** any post-orchestrator filtering (grounding /
+   * verification / line-proximity / W3 dispute). When this is > 0 but
+   * `filteredFindings` contains no criticals, the orchestrator's score
+   * and reason were based on findings the downstream pipeline dropped —
+   * the FP-L clamp below regenerates both so the verdict surfaces agree
+   * with what actually renders.
+   *
+   * Defaults to 0 / treated as absent for back-compat. Callers without
+   * the pre-filter count get the original "trust the orchestrator"
+   * behavior — the same as before this regression fix.
+   */
+  orchestratorCriticalsCount?: number;
 }): { mergeScore: number; mergeScoreReason: string; disputeDisclosure?: string } {
-  const { filteredFindings, previousFindings, orchestratorScore, orchestratorReason, categoryDisputeRates } = input;
+  const { filteredFindings, previousFindings, orchestratorScore, orchestratorReason, categoryDisputeRates, orchestratorCriticalsCount } = input;
 
   const actionFindings = filteredFindings.filter(
     (f) => f.severity === 'critical' || f.severity === 'warning',
@@ -1917,6 +1931,32 @@ export function reconcileMergeScore(input: {
     return {
       mergeScore: 3,
       mergeScoreReason: `${n} critical finding${n === 1 ? '' : 's'} could not be confirmed against the source (W2 verification inconclusive). Downgraded to advisory — review carefully, but the PR is not blocked on unverified concerns.`,
+      ...(disputeDisclosure ? { disputeDisclosure } : {}),
+    };
+  }
+  // FP-L (regression #183) — orchestrator scored blocking because of a
+  // critical that a downstream stage (verifier / grounding / line-filter /
+  // W3 dispute) subsequently dropped entirely. The orchestrator's reason
+  // text still names the dropped critical and the score still maps to
+  // REQUEST_CHANGES, but the rendered body has no critical row and the
+  // check conclusion is success (since it follows post-filter criticals).
+  // Three surfaces disagree.
+  //
+  // Gated on `orchestratorCriticalsCount > 0` so callers without the
+  // pre-filter count keep the legacy "trust the orchestrator" behavior.
+  // When the count is present and the post-filter view has zero criticals,
+  // downgrade to the warning tier and regenerate the reason from a
+  // deterministic template — the verdict prose stops referencing findings
+  // that no longer appear, and the review-event state matches the check
+  // conclusion.
+  const droppedAllCriticals =
+    (orchestratorCriticalsCount ?? 0) > 0 && currentCriticals.length === 0;
+  if (droppedAllCriticals && orchestratorScore <= 2 && actionFindings.length > 0) {
+    const w = actionFindings.length;
+    const dropped = orchestratorCriticalsCount!;
+    return {
+      mergeScore: 3,
+      mergeScoreReason: `${dropped} critical finding${dropped === 1 ? ' was' : 's were'} dropped by post-orchestrator verification — ${w} warning${w === 1 ? '' : 's'} remain. Downgraded from a blocking verdict to advisory; review the warnings, but the PR is not blocked.`,
       ...(disputeDisclosure ? { disputeDisclosure } : {}),
     };
   }
@@ -2215,6 +2255,15 @@ export async function runReviewPipeline(
     ? await runDeltaCaptionAgent(delta, lightModelId, llm)
     : null;
 
+  // FP-L (regression #183) — count the criticals the orchestrator emitted
+  // *before* any downstream stage (grounding / verification / line-filter /
+  // W3 dispute) dropped them. Passed through to reconcileMergeScore so the
+  // verdict reconciler can detect when a blocking score was driven by a
+  // critical that no longer appears in the rendered surfaces.
+  const orchestratorCriticalsCount = orchestratorResult.findings.filter(
+    (f) => f.severity === 'critical',
+  ).length;
+
   // Reconcile the orchestrator's verdict with the post-filter findings.
   const { mergeScore, mergeScoreReason, disputeDisclosure } = reconcileMergeScore({
     filteredFindings,
@@ -2222,6 +2271,7 @@ export async function runReviewPipeline(
     orchestratorScore: orchestratorResult.mergeScore,
     orchestratorReason: orchestratorResult.mergeScoreReason,
     categoryDisputeRates: options.categoryDisputeRates,
+    orchestratorCriticalsCount,
   });
 
   return {


### PR DESCRIPTION
Refs #183.

## The 3-way mismatch

On [mergewatch-fixtures#71](https://github.com/santthosh/mergewatch-fixtures/pull/71) (E2E-36a, linter-present case):

- **Verdict subtitle:** *"2/5 — Needs fixes — Critical security vulnerability (path traversal) and unhandled file system errors present; multiple warnings on code quality; needs fixes before merging."*
- **Rendered body:** 1 warning + 1 info row only. No `### 🔴 Critical (N)` section, no `### ⚠️ Unverified concerns` section.
- **Formal Review state:** `CHANGES_REQUESTED`
- **MergeWatch Review check conclusion:** `SUCCESS`

The same overlay code on [PR #72](https://github.com/santthosh-mb/mergewatch-fixtures/pull/72) (E2E-36b, no eslint config) renders the critical normally — so the verifier disagreed about the critical's validity on the linter-present run.

## Root cause

The verifier (FP-E / FP-I L2 / FP-K) can return `{ keep: false }` — dropping a finding entirely, not just marking it `unverified`. When the orchestrator scored 2 (blocking) because of a critical, and that critical gets dropped post-orchestrator:

- `result.findings` (post-filter): no criticals → `criticalCount = 0` → check conclusion = `success` ✓
- `mergeScoreToReviewEvent(result.mergeScore)`: `result.mergeScore` came from `reconcileMergeScore(orchestratorScore=2, ...)` which trusted the orchestrator → still 2 → REQUEST_CHANGES ✗
- The rendered comment uses `result.mergeScoreReason` — the orchestrator's stale prose that names the dropped critical ✗

Three surfaces, three different snapshots of what the review found.

## Fix

Thread the orchestrator's pre-drop critical count through to `reconcileMergeScore` (`orchestratorCriticalsCount`). When the count is positive but post-filter criticals are zero AND the orchestrator wanted to block (score ≤ 2) AND warnings remain, downgrade to 3 and regenerate the reason from a deterministic template:

\`\`\`
1 critical finding was dropped by post-orchestrator verification — 2 warnings remain.
Downgraded from a blocking verdict to advisory; review the warnings, but the PR is not blocked.
\`\`\`

Stale orchestrator prose stops leaking into the rendered verdict; `mergeScoreToReviewEvent(3)` = `COMMENT` matches the success check conclusion; the three surfaces agree.

### Back-compat

`orchestratorCriticalsCount` is optional (defaults to 0 / treated as absent). Callers that pre-date this fix keep the legacy "trust the orchestrator" behavior — most importantly, the existing FP-J L1 dispute-aware-softening tests intentionally exercise the "orchestrator blocks on warnings alone" path; those tests don't pass the count and continue to pass unchanged. The pipeline caller (`runReviewPipeline`) computes the count from `orchestratorResult.findings` and passes it through.

## Hypothesis mapping (from #183)

| Hypothesis | Verdict |
|---|---|
| 1. FP-L dropped Critical from `actionFindings` / inline / header but `reviewEventForScore` wasn't re-evaluated | Closest to the truth — but the *root* cause is verifier-drop (not FP-L demotion); the *symptom* is that the score/event chain isn't re-evaluated against post-filter criticals. This PR fixes the re-evaluation. |
| 2. Unverified concerns section render not firing | Not the bug here — the critical was *dropped*, not demoted to `unverified`, so the Unverified section had nothing to render. (Hence "no Unverified section either" in the report.) |
| 3. Verdict text generator runs before FP-L filter | Conceptually equivalent to what we fix — verdict text + score are committed at orchestrator time, never reconciled against the post-filter set. This PR adds that reconciliation. |

## Validation

- `pnpm run typecheck` — 20/20 pass
- `pnpm --filter @mergewatch/core test` — 653/653 (8 new FP-L cases)
- `pnpm --filter @mergewatch/lambda test` — 57/57
- `pnpm --filter @mergewatch/server test` — 79/79
- Pre-existing FP-J L1 tests unchanged — back-compat verified

## Test plan (post-merge)

- [ ] Re-run E2E-36a on [mergewatch-fixtures#71](https://github.com/santthosh-mb/mergewatch-fixtures/pull/71)
- [ ] Confirm verdict subtitle reads *"3/5 — ... 1 critical finding was dropped by post-orchestrator verification — N warnings remain ..."* (or stays unchanged on PR #72 where the critical is not dropped)
- [ ] Confirm Formal Review state is `COMMENTED` (not `CHANGES_REQUESTED`)
- [ ] Confirm MergeWatch Review check conclusion is `success` (unchanged — check was already correct)
- [ ] Spot-check that FP-J L1 dispute-rate softening still fires on installations with `categoryDisputeRates` data

🤖 Generated with [Claude Code](https://claude.com/claude-code)