### PR TITLE
fix(fp-l): append narrative-staleness note when post-orchestrator filtering drops findings

### DIFF
--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -2522,6 +2522,144 @@ describe('reconcileMergeScore', () => {
     });
   });
 
+  // ─── FP-L narrative-staleness fix (follow-up to PR #185 review) ────────
+  //
+  // Scenario: orchestrator emits a richer set of findings than the
+  // post-filter pipeline keeps (verifier drops, W10 clustering, line-
+  // filter, W3 dispute). The orchestrator's narrative text references
+  // findings that no longer render — "Multiple warnings present
+  // regarding X, Y, and Z" when only X is in the table. The reconciled
+  // reason appends a clarifying note so the reader knows the rendered
+  // list is authoritative.
+  describe('FP-L narrative-staleness append', () => {
+    it('appends a clarifying note when orchestrator pre-filter action count exceeds post-filter count', () => {
+      // The PR #185 scenario: orchestrator emitted 3 warnings; W10
+      // clustered one + the verifier dropped one; rendered = 1 warning.
+      const r = reconcileMergeScore({
+        filteredFindings: [warning()],
+        previousFindings: undefined,
+        orchestratorScore: 3,
+        orchestratorReason: 'Multiple warnings present regarding error handling, code duplication, and DoS — review recommended before merging.',
+        orchestratorWarningsCount: 3,
+        orchestratorCriticalsCount: 0,
+      });
+      expect(r.mergeScore).toBe(3);
+      // Original narrative preserved.
+      expect(r.mergeScoreReason).toContain('Multiple warnings present');
+      // Clarifying note appended.
+      expect(r.mergeScoreReason).toMatch(/2 findings were dropped or clustered/);
+      expect(r.mergeScoreReason).toMatch(/rendered list is authoritative/);
+    });
+
+    it('uses singular grammar when exactly one finding was dropped', () => {
+      const r = reconcileMergeScore({
+        filteredFindings: [warning(), warning()],
+        previousFindings: undefined,
+        orchestratorScore: 3,
+        orchestratorReason: 'Two warnings plus a DoS concern.',
+        orchestratorWarningsCount: 3,
+        orchestratorCriticalsCount: 0,
+      });
+      expect(r.mergeScoreReason).toMatch(/1 finding was dropped or clustered/);
+    });
+
+    it('counts criticals + warnings together for the staleness threshold', () => {
+      // Orchestrator: 1 critical + 2 warnings = 3 action findings.
+      // Post-filter: 1 critical + 1 warning = 2.  Delta = 1.
+      const r = reconcileMergeScore({
+        filteredFindings: [critical({ verification: 'verified' }), warning()],
+        previousFindings: undefined,
+        orchestratorScore: 2,
+        orchestratorReason: 'One critical, two warnings.',
+        orchestratorWarningsCount: 2,
+        orchestratorCriticalsCount: 1,
+      });
+      // Surviving critical → orchestrator score stands; note appended.
+      expect(r.mergeScore).toBe(2);
+      expect(r.mergeScoreReason).toMatch(/1 finding was dropped or clustered/);
+    });
+
+    it('does NOT append when post-filter action count equals orchestrator action count (nothing dropped)', () => {
+      const r = reconcileMergeScore({
+        filteredFindings: [warning(), warning()],
+        previousFindings: undefined,
+        orchestratorScore: 3,
+        orchestratorReason: 'Two style warnings.',
+        orchestratorWarningsCount: 2,
+        orchestratorCriticalsCount: 0,
+      });
+      expect(r.mergeScoreReason).toBe('Two style warnings.');
+    });
+
+    it('back-compat: omitting both counts leaves the orchestrator reason verbatim (pre-fix behavior)', () => {
+      // Same shape as the first test but without the counts passed.
+      const r = reconcileMergeScore({
+        filteredFindings: [warning()],
+        previousFindings: undefined,
+        orchestratorScore: 3,
+        orchestratorReason: 'Multiple warnings present regarding X, Y, and Z.',
+      });
+      expect(r.mergeScoreReason).toBe('Multiple warnings present regarding X, Y, and Z.');
+    });
+
+    it('partial counts (only criticals OR only warnings) are conservatively treated as absent', () => {
+      // PR #187 review feedback: the prior "fill missing with 0" shape
+      // could spuriously fire the note when a caller passed
+      // orchestratorCriticalsCount but omitted the warnings count and
+      // the post-filter set was warnings-only. Guard: require BOTH or
+      // skip. Documents the partial-provision contract.
+      const criticalsOnly = reconcileMergeScore({
+        filteredFindings: [warning()],
+        previousFindings: undefined,
+        orchestratorScore: 3,
+        orchestratorReason: 'Original prose.',
+        orchestratorCriticalsCount: 2,
+      });
+      expect(criticalsOnly.mergeScoreReason).toBe('Original prose.');
+      const warningsOnly = reconcileMergeScore({
+        filteredFindings: [warning()],
+        previousFindings: undefined,
+        orchestratorScore: 3,
+        orchestratorReason: 'Original prose.',
+        orchestratorWarningsCount: 2,
+      });
+      expect(warningsOnly.mergeScoreReason).toBe('Original prose.');
+    });
+
+    it('idempotent: a reason that already carries the marker phrase is not double-appended', () => {
+      // Defensive — if a future caller passes a previously-reconciled
+      // reason back through, we should NOT stack two notes on it.
+      const alreadyAppended = 'Original prose.\n\nNote: 2 findings were dropped or clustered by post-orchestrator filtering — the rendered list is authoritative.';
+      const r = reconcileMergeScore({
+        filteredFindings: [warning()],
+        previousFindings: undefined,
+        orchestratorScore: 3,
+        orchestratorReason: alreadyAppended,
+        orchestratorWarningsCount: 4,
+        orchestratorCriticalsCount: 0,
+      });
+      // Count the marker — should appear exactly once, not twice.
+      const occurrences = (r.mergeScoreReason.match(/rendered list is authoritative/g) ?? []).length;
+      expect(occurrences).toBe(1);
+    });
+
+    it('does NOT apply when an earlier branch returned its own reason (noActionItems, W7, FP-J L1, pure improvement)', () => {
+      // noActionItems branch returns 5/5 with its own reason — the FP-L
+      // append only runs on the orchestrator-passthrough branch, so the
+      // earlier-branch reasons are never touched.
+      const r = reconcileMergeScore({
+        filteredFindings: [],
+        previousFindings: undefined,
+        orchestratorScore: 2,
+        orchestratorReason: 'Multiple things flagged.',
+        orchestratorWarningsCount: 3,
+        orchestratorCriticalsCount: 1,
+      });
+      expect(r.mergeScore).toBe(5);
+      expect(r.mergeScoreReason).not.toMatch(/dropped or clustered/);
+    });
+  });
+
   // ─── FP-J L1 — dispute-aware verdict softening ────────────────────────
   describe('FP-J L1 — categoryDisputeRates', () => {
     it('back-compat: absent categoryDisputeRates behaves identically to today (orchestrator score stands)', () => {

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -1844,22 +1844,27 @@ export function reconcileMergeScore(input: {
    * Lambda wires the FP-insight store).
    */
   categoryDisputeRates?: Record<string, number>;
-  /**
-   * FP-L (regression #183) — number of Critical findings the orchestrator
-   * emitted **before** any post-orchestrator filtering (grounding /
-   * verification / line-proximity / W3 dispute). When this is > 0 but
-   * `filteredFindings` contains no criticals, the orchestrator's score
-   * and reason were based on findings the downstream pipeline dropped —
-   * the FP-L clamp below regenerates both so the verdict surfaces agree
-   * with what actually renders.
-   *
-   * Defaults to 0 / treated as absent for back-compat. Callers without
-   * the pre-filter count get the original "trust the orchestrator"
-   * behavior — the same as before this regression fix.
-   */
+  // FP-L — counts of findings the orchestrator emitted *before* any post-
+  // orchestrator stage (grounding, W2 verification, line-proximity filter,
+  // W3 dispute, W10 clustering). Two distinct uses:
+  //   • Criticals count drives the verifier-dropped clamp (#183) — if
+  //     the orchestrator scored blocking because of a critical that's
+  //     now gone, downgrade tier and regenerate the reason.
+  //   • Sum of both drives the narrative-staleness note (#185 follow-up)
+  //     — if the orchestrator's prose names more action findings than
+  //     render, append a "rendered list is authoritative" note so the
+  //     reader knows.
+  // Both default absent for back-compat with callers that pre-date the
+  // fixes; the narrative-staleness path requires both together (see
+  // `hasFullOrchestratorCounts` guard below).
   orchestratorCriticalsCount?: number;
+  orchestratorWarningsCount?: number;
 }): { mergeScore: number; mergeScoreReason: string; disputeDisclosure?: string } {
-  const { filteredFindings, previousFindings, orchestratorScore, orchestratorReason, categoryDisputeRates, orchestratorCriticalsCount } = input;
+  const {
+    filteredFindings, previousFindings, orchestratorScore, orchestratorReason,
+    categoryDisputeRates,
+    orchestratorCriticalsCount, orchestratorWarningsCount,
+  } = input;
 
   const actionFindings = filteredFindings.filter(
     (f) => f.severity === 'critical' || f.severity === 'warning',
@@ -1972,11 +1977,68 @@ export function reconcileMergeScore(input: {
       ...(disputeDisclosure ? { disputeDisclosure } : {}),
     };
   }
+  // FP-L narrative-staleness fix (#185 follow-up). The branches above all
+  // return their own deterministic reasons; this fall-through passes
+  // through the orchestrator's narrative. When the orchestrator's
+  // pre-filter action-finding count exceeded the post-filter count, the
+  // narrative may name findings that no longer render (the "Multiple
+  // warnings present regarding X, Y, and Z" case where only X is in the
+  // rendered table). The helper appends a single clarifying note.
   return {
     mergeScore: orchestratorScore,
-    mergeScoreReason: orchestratorReason,
+    mergeScoreReason: reconcileNarrativeStaleness(
+      orchestratorReason,
+      orchestratorCriticalsCount,
+      orchestratorWarningsCount,
+      actionFindings.length,
+    ),
     ...(disputeDisclosure ? { disputeDisclosure } : {}),
   };
+}
+
+/**
+ * Substring guard for idempotency: a re-reconcile of an already-appended
+ * reason must not stack duplicate notes. Used both for the staleness-note
+ * append below and as the back-out check that lets callers chain calls.
+ */
+const STALENESS_NOTE_MARKER = 'rendered list is authoritative';
+
+/**
+ * Decide whether the orchestrator's narrative needs a staleness note and
+ * return either the unmodified reason or the reason with the note appended.
+ *
+ * Requires **both** orchestrator counts together — partial provision
+ * (e.g. only `orchestratorCriticalsCount` with warnings omitted) could
+ * make `actionCount` artificially small and trigger the note spuriously
+ * when the orchestrator emitted warnings the caller didn't account for.
+ * Callers that can only supply one count get the no-op behavior, matching
+ * pre-fix semantics.
+ */
+function reconcileNarrativeStaleness(
+  reason: string,
+  orchestratorCriticalsCount: number | undefined,
+  orchestratorWarningsCount: number | undefined,
+  postFilterActionCount: number,
+): string {
+  if (orchestratorCriticalsCount === undefined || orchestratorWarningsCount === undefined) {
+    return reason;
+  }
+  const orchestratorActionCount = orchestratorCriticalsCount + orchestratorWarningsCount;
+  if (orchestratorActionCount <= 0 || postFilterActionCount >= orchestratorActionCount) {
+    return reason;
+  }
+  return appendStalenessNote(reason, orchestratorActionCount - postFilterActionCount);
+}
+
+/**
+ * Append a single-line clarifying note to the orchestrator's narrative.
+ * Idempotent via `STALENESS_NOTE_MARKER` — re-reconciles return unchanged.
+ */
+function appendStalenessNote(reason: string, droppedCount: number): string {
+  if (reason.includes(STALENESS_NOTE_MARKER)) return reason;
+  const noun = droppedCount === 1 ? 'finding was' : 'findings were';
+  const note = `Note: ${droppedCount} ${noun} dropped or clustered by post-orchestrator filtering — the ${STALENESS_NOTE_MARKER}.`;
+  return `${reason.trimEnd()}\n\n${note}`;
 }
 
 /**
@@ -2255,13 +2317,17 @@ export async function runReviewPipeline(
     ? await runDeltaCaptionAgent(delta, lightModelId, llm)
     : null;
 
-  // FP-L (regression #183) — count the criticals the orchestrator emitted
-  // *before* any downstream stage (grounding / verification / line-filter /
-  // W3 dispute) dropped them. Passed through to reconcileMergeScore so the
-  // verdict reconciler can detect when a blocking score was driven by a
-  // critical that no longer appears in the rendered surfaces.
+  // FP-L — count the orchestrator's pre-filter criticals + warnings on
+  // `orchestratorResult.findings` (the snapshot before grounding /
+  // verification / line-filter / W3 dispute / W10 clustering). Both
+  // counts feed `reconcileMergeScore`: criticals drive the
+  // verifier-dropped clamp (#183); their sum drives the narrative-
+  // staleness note (#185 follow-up).
   const orchestratorCriticalsCount = orchestratorResult.findings.filter(
     (f) => f.severity === 'critical',
+  ).length;
+  const orchestratorWarningsCount = orchestratorResult.findings.filter(
+    (f) => f.severity === 'warning',
   ).length;
 
   // Reconcile the orchestrator's verdict with the post-filter findings.
@@ -2272,6 +2338,7 @@ export async function runReviewPipeline(
     orchestratorReason: orchestratorResult.mergeScoreReason,
     categoryDisputeRates: options.categoryDisputeRates,
     orchestratorCriticalsCount,
+    orchestratorWarningsCount,
   });
 
   return {


### PR DESCRIPTION
Follow-up to PR #186 (which addresses #183) and PR #185 review feedback.

## What's broken

On [PR #185](https://github.com/santthosh/mergewatch.ai/pull/185) the verdict subtitle read:

> *"🟡 3/5 — Review recommended — **Multiple warnings present** regarding error-handling (misleading success logs on database failures), code duplication across handlers, and potential **DoS vulnerability** in array processing — review and fixes recommended before merging."*

But the rendered "Requires your attention" table contained **1 warning + 1 info** — with the duplication concern W10-clustered as a *related concern* under the success-log warning, and the DoS vulnerability nowhere to be found (verifier-dropped). The orchestrator's prose named 3 issues; the rendered table surfaces 1. The reader has no way to know that two of the named issues were dropped or clustered.

PR #186 addresses the closely-related case where dropped *criticals* leave both the score and the prose stale. This PR handles the residual case where the *score* is fine but the *prose* names dropped/clustered findings.

## Fix

Extends `reconcileMergeScore` with an `orchestratorWarningsCount` parameter (paired with the existing `orchestratorCriticalsCount` from #186). On the orchestrator-passthrough branch (where neither the noActionItems / pure-improvement / net-improvement / W7 / FP-J L1 / FP-L #186 branches fire), when the pre-filter action-finding count exceeds the post-filter count, append a single-line clarifying note:

> *"Note: 2 findings were dropped or clustered by post-orchestrator filtering — the rendered list is authoritative."*

What it preserves:
- The orchestrator's *specific narrative* (it's often valuable when it's accurate)
- The score (we're not clamping; this is purely a prose-staleness fix)
- All earlier branches' deterministic reasons (they're unaffected — the append only fires on the orchestrator-passthrough fall-through)

What it adds:
- A factual note when the post-filter set is meaningfully smaller than what the orchestrator saw
- Idempotent guard: a marker-phrase check prevents a re-reconcile from stacking duplicate notes
- Full back-compat: callers that omit both counts get the verbatim orchestrator reason (pre-fix behavior)

The pipeline caller (`runReviewPipeline`) now computes both counts from `orchestratorResult.findings` and passes them through.

## What the rendered verdict will look like

For the PR #185 case (orchestrator emitted 3 warnings, post-filter has 1):

> *"🟡 3/5 — Review recommended — Multiple warnings present regarding error-handling (misleading success logs on database failures), code duplication across handlers, and potential DoS vulnerability in array processing — review and fixes recommended before merging.*
>
> *Note: 2 findings were dropped or clustered by post-orchestrator filtering — the rendered list is authoritative."*

For the no-shrinkage case (everything the orchestrator named still renders): nothing changes.

## Tests

7 new cases in the `FP-L narrative-staleness append` describe block:
- PR #185 scenario (orch=3, post=1, plural grammar)
- Singular grammar (delta=1)
- Mixed critical + warning counting
- No-op when nothing was dropped
- Back-compat without counts
- Idempotent guard against double-appending
- Earlier-branch precedence (noActionItems wins, no append)

## Validation

- `pnpm run typecheck` — 20/20 pass
- `pnpm --filter @mergewatch/core test` — 652/652
- `pnpm --filter @mergewatch/lambda test` — 57/57
- `pnpm --filter @mergewatch/server test` — 79/79

## Test plan (post-merge)

- [ ] Inspect a few recent reviews where W10 clustering or verifier drops likely fired — confirm the note appears on the ones with actual shrinkage and doesn't appear on the clean ones
- [ ] Confirm reviews with no orchestrator dropping (score=5 noActionItems, pure-security-improvement, etc.) don't pick up a spurious note

## Sequencing note

This PR is independent of #186 but reads more naturally if reviewed after it (the `orchestratorCriticalsCount` parameter shape was introduced there). If #186 lands first, this becomes a small extension. If this lands first, #186 just needs a trivial rebase to add `orchestratorWarningsCount` to its own input destructuring (already present here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)