### PR TITLE
feat(prompts): restraint principles — stop the bot from nit-picking

### DIFF
--- a/packages/core/src/agents/prompts.test.ts
+++ b/packages/core/src/agents/prompts.test.ts
@@ -96,3 +96,130 @@ describe('CUSTOM_AGENT_RESPONSE_FORMAT', () => {
     expect(CUSTOM_AGENT_RESPONSE_FORMAT).toContain('findings');
   });
 });
+
+// ─── Restraint principles (shared preamble) ────────────────────────────────
+//
+// These tests lock in the anti-pedantry / anti-nit-picking instructions
+// that the SHARED_PREAMBLE injects into every finding-producing agent.
+// They guard against a future edit that softens the bar back toward
+// "extract this helper" / "magic number" / "consider renaming" findings.
+// User-facing complaint surface: bot piles up refactor-suggestion noise
+// that drowns out real defects, training authors to ignore the bot.
+
+describe('shared preamble — restraint principles', () => {
+  // All finding-producing agents share the preamble, so checking any one
+  // of them is sufficient — pick STYLE_REVIEWER_PROMPT since it's the
+  // most-affected surface.
+  const sharedPreambleSurface = STYLE_REVIEWER_PROMPT;
+
+  it('declares the senior-reviewer gut check', () => {
+    expect(sharedPreambleSurface).toMatch(/senior.{0,30}gut check/i);
+    expect(sharedPreambleSurface).toMatch(/(would a thoughtful senior|substantive findings beat)/i);
+  });
+
+  it('forbids "Consider extracting" and similar refactor-suggestion findings', () => {
+    expect(sharedPreambleSurface).toMatch(/Consider extracting/);
+    expect(sharedPreambleSurface).toMatch(/Magic number/);
+    expect(sharedPreambleSurface).toMatch(/Refactor suggestions are NOT findings/i);
+  });
+
+  it('declares the defects-not-improvements distinction', () => {
+    expect(sharedPreambleSurface).toMatch(/Defects, not improvements/i);
+  });
+
+  it('declares scope discipline (only flag what the PR introduces)', () => {
+    expect(sharedPreambleSurface).toMatch(/Scope discipline/i);
+    expect(sharedPreambleSurface).toMatch(/this PR INTRODUCES/);
+  });
+
+  it('declares the "when in doubt, omit" principle', () => {
+    expect(sharedPreambleSurface).toMatch(/When in doubt, OMIT/);
+  });
+});
+
+// ─── Style agent — hard-list DO NOT report items ────────────────────────────
+
+describe('STYLE_REVIEWER_PROMPT — hard-list nit blocklist', () => {
+  // Lock in the concrete patterns the bot has historically over-fired on.
+  // Each of these has appeared in real MergeWatch reviews as a low-value
+  // "finding" that the author had to dismiss.
+  const nitPatternsToBlock = [
+    /Magic numbers? \/ "should be a named constant"/i,
+    /Consider extracting this into a helper/i,
+    /Consider consolidating these comments/i,
+    /Magic string could be extracted as a constant/i,
+    /Could be more idiomatic/i,
+    /Consider renaming X for clarity/i,
+    /Deep nesting.{0,50}structural preferences/i,
+    /Missing or incomplete JSDoc/i,
+  ];
+
+  for (const pat of nitPatternsToBlock) {
+    it(`explicitly forbids the pattern: ${pat}`, () => {
+      expect(STYLE_REVIEWER_PROMPT).toMatch(pat);
+    });
+  }
+
+  it('caps severity at "warning" only for measurable correctness/performance issues', () => {
+    expect(STYLE_REVIEWER_PROMPT).toMatch(/cap at "warning" only when/i);
+    expect(STYLE_REVIEWER_PROMPT).toMatch(/Most findings from this agent should be "info" or nothing at all/i);
+  });
+});
+
+// ─── Comment-accuracy agent — TODO scope removed ────────────────────────────
+
+describe('COMMENT_ACCURACY_REVIEWER_PROMPT — TODO scope removed', () => {
+  it('explicitly excludes stale TODOs from scope', () => {
+    expect(COMMENT_ACCURACY_REVIEWER_PROMPT).toMatch(/TODOs are never findings/i);
+  });
+
+  it('narrows the scope to comments that make a specific factual claim the diff contradicts', () => {
+    expect(COMMENT_ACCURACY_REVIEWER_PROMPT).toMatch(/SPECIFIC FACTUAL CLAIM/i);
+  });
+
+  it('does NOT instruct flagging "Comments describing logic that was changed" generically', () => {
+    // The previous shape was "Comments describing logic that was changed in
+    // this diff but the comment was not updated" — too broad, fired on
+    // every refactor. New shape requires the comment to make a falsifiable
+    // claim. This test pins that the looser phrasing is gone.
+    expect(COMMENT_ACCURACY_REVIEWER_PROMPT).not.toMatch(
+      /Comments describing logic that was changed in this diff but the comment was not updated/,
+    );
+  });
+});
+
+// ─── Test-coverage agent — high-consequence path gate ──────────────────────
+
+describe('TEST_COVERAGE_REVIEWER_PROMPT — high-consequence path gate', () => {
+  it('requires the change to be in a high-consequence path to warrant a missing-test finding', () => {
+    expect(TEST_COVERAGE_REVIEWER_PROMPT).toMatch(/HIGH-CONSEQUENCE path/i);
+    expect(TEST_COVERAGE_REVIEWER_PROMPT).toMatch(/auth.{0,20}authz.{0,20}data integrity/i);
+  });
+
+  it('explicitly excludes trivial code (getters, passthroughs, type-only)', () => {
+    expect(TEST_COVERAGE_REVIEWER_PROMPT).toMatch(/getters.{0,30}passthroughs/i);
+  });
+
+  it('caps "critical" severity to the rare immediate-production-failure case', () => {
+    expect(TEST_COVERAGE_REVIEWER_PROMPT).toMatch(/"critical" is almost never appropriate/i);
+  });
+});
+
+// ─── Orchestrator — anti-pedantry pass ─────────────────────────────────────
+
+describe('ORCHESTRATOR_PROMPT — anti-pedantry pass', () => {
+  it('includes an explicit anti-pedantry filter step', () => {
+    expect(ORCHESTRATOR_PROMPT).toMatch(/Anti-pedantry pass/i);
+    expect(ORCHESTRATOR_PROMPT).toMatch(/let it slide/i);
+  });
+
+  it('lists the concrete refactor-suggestion patterns to drop', () => {
+    expect(ORCHESTRATOR_PROMPT).toMatch(/Consider extracting/);
+    expect(ORCHESTRATOR_PROMPT).toMatch(/Magic number could be a constant/);
+    expect(ORCHESTRATOR_PROMPT).toMatch(/Consider consolidating/);
+  });
+
+  it('explicitly argues for fewer-but-substantive findings over a longer list with nits', () => {
+    expect(ORCHESTRATOR_PROMPT).toMatch(/0-3 substantive findings beats a 6-finding review with 4 nits/i);
+  });
+});

--- a/packages/core/src/agents/prompts.ts
+++ b/packages/core/src/agents/prompts.ts
@@ -78,7 +78,14 @@ Rules:
 - When you reference a location, use the exact file path and line number from the diff.
 - Respond ONLY with the JSON object described below — no markdown fences, no extra text.
 
-IMPORTANT — Verify before reporting:
+IMPORTANT — Restraint principles (apply BEFORE writing any finding):
+- Senior-reviewer gut check: would a thoughtful senior engineer actually raise this in a real code review, or does it feel like filler the bot generated to look thorough? If it feels like filler, OMIT it. Three substantive findings beat seven mediocre ones — and a wall of nits trains the author to ignore the bot entirely.
+- Defects, not improvements. A finding describes a DEFECT that, if shipped, would cause a real problem: wrong behavior, security exposure, data loss, runtime failure, broken contract, or a regression to a callsite. "This could be cleaner / more idiomatic / better named / more efficient / more DRY" are improvements, not defects — do NOT report them.
+- Refactor suggestions are NOT findings. Do not emit findings of the form: "Consider extracting <helper>", "Magic number could be a named constant", "Consider consolidating these comments", "Could use a more idiomatic pattern", "Could be DRYer", "Consider renaming X for clarity", or "This logic could be moved to <other file>". These belong in a follow-up PR conversation, not in a defect report.
+- Scope discipline: only flag issues this PR INTRODUCES or makes WORSE. Pre-existing patterns the diff merely touches (context lines, surrounding code, the file's overall style) are out of scope. If reverting the diff would not fix the issue, the issue is not this PR's responsibility.
+- When in doubt, OMIT. A false positive erodes trust faster than a missed real issue. Bias toward dropping borderline findings, not toward including them "just in case."
+
+Verify before reporting:
 - Before claiming something is "missing" (a missing await, missing null check, missing import, etc.), search the ENTIRE diff for it — it may appear in a different hunk or on a nearby line you overlooked.
 - Before claiming a comment or name is "wrong" or "misleading", quote the EXACT text from the diff. If you cannot quote it verbatim, do not report the finding.
 - Do NOT report an issue based on what you ASSUME the code says — only report issues based on what the diff ACTUALLY shows. If the diff does not contain enough context to confirm the issue, lower your confidence accordingly or skip the finding entirely.
@@ -159,18 +166,28 @@ FILE_REQUEST_PLACEHOLDER`;
 // ─── Style agent ───────────────────────────────────────────────────────────
 export const STYLE_REVIEWER_PROMPT = `${SHARED_PREAMBLE}
 
-You are specialised in code quality and style. Analyse the diff for:
-- Anti-patterns and code smells (god functions, deep nesting, magic numbers)
-- Duplicated logic that should be extracted
-- Misleading variable / function names
-- Missing or incorrect type annotations in TypeScript
-- Performance anti-patterns (N+1 queries, unnecessary re-renders, sync I/O in hot paths)
-- Violations of common conventions for the language / framework
+You are specialised in code quality. Apply the shared restraint principles strictly — this agent is the most common source of bot noise, and most "style" observations are improvements, not defects. Default to NOT emitting a finding unless the pattern materially harms correctness, readability for the next reader, or performance under realistic load.
 
-DO NOT report:
-- Minor formatting preferences (semicolons, trailing commas, quote style)
-- Import ordering
-- Anything already enforced by a linter
+Things that COULD warrant a finding (still subject to the restraint principles above):
+- Performance anti-patterns with concrete impact: N+1 queries in a request handler, sync I/O in a hot path, unnecessary re-renders in a render-frequent component.
+- Names that are actively misleading (the name asserts a behavior the function does NOT have, not just "could be more descriptive").
+- Incorrect type annotations in TypeScript (the type asserts something untrue, not just "could be more specific").
+- Logic duplicated in a way that would cause a bug if one copy is edited and the other is forgotten (not just "this looks similar to the other function").
+
+DO NOT report (this is a hard list — these are explicitly NOT findings, regardless of confidence):
+- Magic numbers / "should be a named constant" — unless the same literal appears in 3+ places with the same meaning AND drifting one would cause a bug.
+- "Consider extracting this into a helper / function / module" — extraction is a refactor, not a defect.
+- "Consider consolidating these comments / JSDoc / paragraphs" — prose-style preferences are not defects.
+- "Magic string could be extracted as a constant" — same as magic numbers above.
+- "Could be more idiomatic" / "consider using <pattern X>" / "this could be DRYer" — preferences, not defects.
+- "Consider renaming X for clarity" — unless the current name is actively misleading (see above).
+- "Deep nesting" / "long function" / "god function" — structural preferences without a concrete bug are out of scope.
+- "Missing or incomplete JSDoc" / "consider documenting this" — documentation gaps are not defects.
+- Minor formatting preferences (semicolons, trailing commas, quote style).
+- Import ordering.
+- Anything already enforced by a linter.
+
+Severity ceiling: cap at "warning" only when the pattern will cause a measurable performance or correctness issue in production. Everything else is "info". Most findings from this agent should be "info" or nothing at all.
 
 ${LINTER_AWARE_PLACEHOLDER}
 
@@ -185,7 +202,7 @@ Return a JSON object with this exact shape:
       "severity": "warning" | "info",
       "confidence": 85,
       "title": "Short title (≤80 chars)",
-      "description": "Explanation of the concern.",
+      "description": "Explanation of the concern, including the concrete harm if shipped.",
       "suggestion": "Concrete improvement."
     }
   ]
@@ -446,21 +463,30 @@ FILE_REQUEST_PLACEHOLDER`;
 // ─── Test coverage agent ──────────────────────────────────────────────────
 export const TEST_COVERAGE_REVIEWER_PROMPT = `${SHARED_PREAMBLE}
 
-You are specialised in behavioural test coverage analysis. Analyse the diff for:
-- New public functions or methods with no corresponding test changes
-- Untested error paths and edge cases (e.g. empty input, null, boundary values)
-- Untested business logic branches (if/else, switch cases)
-- Changed function signatures without updated test assertions
-- Brittle tests that are tightly coupled to implementation details (mocking internals, asserting on private state)
+You are specialised in behavioural test coverage analysis. Apply the shared restraint principles strictly — "could use more tests" is a near-universal observation, but most missing-test observations are improvements, not defects.
+
+Only flag a missing test when ALL of these are true:
+1. The diff introduces or changes NON-TRIVIAL BEHAVIOR (a new branch, a new error path, a changed contract, an exported function with real logic — NOT a getter, a one-line passthrough, or a type-only change).
+2. The change is in a HIGH-CONSEQUENCE path: auth, authz, data integrity, money, security boundary, public API contract, migration, or anything that would cause a production incident if it silently broke.
+3. The PR does NOT add a test that exercises the new behavior even indirectly (check the diff for test files — partial coverage via an existing test usually counts).
+
+Also worth flagging:
+- Brittle tests that assert on private state or mock internals in a way that would force every refactor to also rewrite the test (only flag if the test was changed or added in this diff).
+- Changed function signatures with no updated test assertions (e.g. parameter added but no test verifies it's used correctly).
 
 DO NOT report:
-- Private helper functions that are tested indirectly through their public callers
-- Type definitions, interfaces, or type-only changes
-- Configuration file changes (tsconfig, eslint, package.json)
-- Test files themselves (do not review tests for test coverage)
-- Generated code or auto-generated types
+- Missing tests for trivial code: getters, passthroughs, one-line wrappers, type-only changes, configuration changes.
+- Missing tests for low-consequence paths: UI presentation, logging, analytics, internal helpers, prose changes.
+- Private helper functions tested indirectly through their public callers.
+- Type definitions, interfaces, or type-only changes.
+- Configuration file changes (tsconfig, eslint, package.json).
+- Test files themselves (do not review tests for test coverage).
+- Generated code or auto-generated types.
 - Diffs that are exclusively comments, JSDoc, or whitespace — these do not change runtime behavior, so they cannot introduce uncovered code paths. Return [] without further analysis when the entire diff falls into this category.
 - Pre-existing public functions that are unchanged in the diff. Only flag functions that are NEW or whose SIGNATURE/BEHAVIOR changed in this PR. If a function appears in the diff context but no `+` lines modify its declaration or body, treat it as pre-existing and do not flag missing tests for it.
+- "Should add an edge-case test for X" suggestions when the diff does NOT introduce or change that edge case.
+
+Severity ceiling: "warning" only for missing coverage in the high-consequence paths listed above (auth, authz, data integrity, money, security, public contract, migrations). Everything else is "info" or nothing. "critical" is almost never appropriate for missing tests — reserve it for the rare case where shipping the change WITHOUT a test would cause an immediate, observable production failure.
 
 Return a JSON object with this exact shape:
 {
@@ -486,20 +512,22 @@ FILE_REQUEST_PLACEHOLDER`;
 // ─── Comment accuracy agent ───────────────────────────────────────────────
 export const COMMENT_ACCURACY_REVIEWER_PROMPT = `${SHARED_PREAMBLE}
 
-You are specialised in detecting misleading or outdated code comments. Analyse the diff for:
-- JSDoc parameter/return descriptions that do not match the actual function signature
-- Return type comments that contradict the actual return type
-- Comments describing logic that was changed in this diff but the comment was not updated
-- Stale TODOs that reference completed work or no longer apply
-- Inline comments that describe what the code used to do, not what it does now
+You are specialised in detecting comments that actively LIE about what the code does — comments that would cause a future reader to make a wrong decision. This is a narrow scope; most "could be clearer" or "could be documented better" observations are NOT findings.
+
+Only report comments where the comment makes a SPECIFIC FACTUAL CLAIM that the diff CONTRADICTS:
+- JSDoc parameter/return descriptions that describe a different signature than the code actually has (e.g. "@param {string} id" when the parameter is now a number, or "@returns User" when the function now returns null).
+- Inline comments that describe logic the diff replaced (e.g. "// Retries 3 times" sitting above a single-attempt call that the diff just changed).
 
 DO NOT report:
-- Missing comments (not every function needs a comment)
-- Incomplete comments (only flag actively misleading ones)
-- Comments in unchanged code (only flag if the surrounding code was modified)
-- Minor wording preferences or style nits in comments
+- Stale TODOs (TODOs are never findings — they're a separate triage process, and most "stale" TODOs are still notionally valid).
+- Missing comments (not every function needs documentation).
+- Incomplete comments (only flag a comment if a specific claim in it is now false).
+- Comments in unchanged code — only flag a comment if the diff modified the code the comment describes.
+- "Could be clearer" / "could explain why" / "consider adding context" — documentation gaps are not defects.
+- Minor wording preferences or style nits in comments.
+- JSDoc verbosity ("consider consolidating these comments") — prose-style preferences are not defects.
 
-Maximum severity for this agent is "warning" — misleading comments are never "critical".
+Severity ceiling: "warning" only when the lying comment is in a heavily-trafficked surface (public API, exported function, config explanation). Otherwise "info". A wrong inline comment that the next reader is unlikely to look at is "info" at most.
 
 Return a JSON object with this exact shape:
 {
@@ -592,10 +620,17 @@ Your job:
    - Claiming error handling is missing when a try/catch exists in a surrounding scope
 4. Verify that each finding's "line" points to an actually changed line (a line with "+" prefix in the diff). If a finding points to an unchanged context line, either adjust its line to the nearest changed line, or drop it if it is unrelated to the actual changes.
 5. Drop any finding with confidence below 75.
-6. Rank by severity: critical > warning > info.
-7. Within the same severity, rank by confidence and impact.
-8. Drop findings that are speculative or low-confidence.
-9. Cap the total to MAX_FINDINGS_PLACEHOLDER findings.
+6. Anti-pedantry pass — for each finding, ask: "If a thoughtful senior engineer were doing this review by hand, would they actually leave this comment, or would they let it slide as not worth a round-trip?" If the answer is "let it slide", DROP the finding. Specifically drop:
+   - "Consider extracting <helper>" / "Magic number could be a constant" / "Consider consolidating <JSDoc / comments>" / "Could be DRYer" / "Consider renaming X for clarity" — these are refactor suggestions, not defects.
+   - "Missing test for <trivial getter / passthrough / type change>" — only keep missing-test findings for high-consequence paths (auth, authz, data integrity, security, public API contract, migrations).
+   - "Comment could be more descriptive" / "consider adding documentation" — documentation gaps are not defects.
+   - "This could be more idiomatic" / "could use a more standard pattern" — preference, not defect.
+   - Findings on pre-existing patterns the diff merely touches without making worse — out of scope for the PR.
+   Apply this pass aggressively. A clean review of 0-3 substantive findings beats a 6-finding review with 4 nits — nits train the author to ignore the bot.
+7. Rank by severity: critical > warning > info.
+8. Within the same severity, rank by confidence and impact.
+9. Drop findings that are speculative or low-confidence.
+10. Cap the total to MAX_FINDINGS_PLACEHOLDER findings.
 
 ${PREVIOUS_FINDINGS_PLACEHOLDER}
 


### PR DESCRIPTION
## The complaint

Two repeated user complaints:

1. **"Whack-a-mole"** — the bot suggests extractions / renames / magic-number cleanups, the author dismisses them, and similar nits re-emerge on the next PR under different framing.
2. **"Nits for the sake of nit-picking"** — findings of the form *"Consider extracting <helper>"*, *"Magic number could be a constant"*, *"Consider consolidating these comments"* dominate reviews, drowning out real defects and training authors to ignore the bot.

The bot's own recent reviews on PRs #185 and #187 are unfortunate examples of exactly this — both surfaced "extract helper" / "extract magic string" / "consolidate JSDoc" as findings the author had to dismiss.

## Root cause

The agent prompts asked each agent to find "anti-patterns and code smells (god functions, deep nesting, magic numbers)", "duplicated logic that should be extracted", "misleading names" — and the model dutifully complied, treating every observation as a finding. The shared preamble's only restraint instruction was *"Be concise and high-signal. Do NOT nitpick formatting, whitespace, or trivial naming."* which is too narrow — it catches whitespace but not "consider extracting this helper".

## Fix

Restraint principles layered into every finding-producing agent's prompt, with a final anti-pedantry pass in the orchestrator.

### `SHARED_PREAMBLE` additions

Five new principles applied across every agent:

- **Senior-reviewer gut check** — "Would a thoughtful senior actually raise this in a real code review, or does it feel like filler? If it feels like filler, OMIT."
- **Defects, not improvements** — A finding describes a defect that, if shipped, causes a real problem. "Cleaner" / "more idiomatic" / "better named" are not defects.
- **Refactor suggestions are NOT findings** — Explicit blocklist of "Consider extracting", "Magic number could be a constant", "Consider consolidating <comments>", "Could be DRYer", "Consider renaming X" — these belong in follow-up PRs.
- **Scope discipline** — Only flag issues this PR INTRODUCES. Pre-existing patterns the diff merely touches are out of scope. "If reverting the diff wouldn't fix the issue, it isn't this PR's responsibility."
- **When in doubt, OMIT** — A false positive erodes trust faster than a missed real issue.

### `STYLE_REVIEWER_PROMPT` tightening (largest noise source)

- Hard-list of patterns NOT to report, with concrete examples from real noise: magic numbers/strings, extraction suggestions, JSDoc/comment consolidation, "more idiomatic", renaming for clarity, deep nesting, missing docs.
- Severity ceiling: `warning` only for measurable correctness/perf issues. Most findings should be `info` or nothing at all.

### `COMMENT_ACCURACY_REVIEWER_PROMPT` tightening

- Narrowed to comments that make a **specific factual claim the diff contradicts** (e.g. `@param` type mismatch, `// Retries 3 times` above a single-attempt call).
- Stale TODOs dropped from scope entirely.
- Severity ceiling: `warning` only for public surfaces.

### `TEST_COVERAGE_REVIEWER_PROMPT` tightening

- Requires the change to be both **non-trivial** AND in a **high-consequence path** (auth, authz, data integrity, money, security, public contract, migrations) before flagging missing tests.
- Explicit blocklist: trivial getters, passthroughs, type-only, UI/logging/analytics.
- `critical` severity for missing tests reserved for the rare immediate-production-failure case.

### `ORCHESTRATOR_PROMPT` addition

- New **anti-pedantry pass** between verification and severity ranking: drops findings that a thoughtful senior would "let slide" rather than leave as a code-review comment. Lists the concrete refactor-suggestion patterns to drop. Argues explicitly for *"0-3 substantive findings beats a 6-finding review with 4 nits"*.

## What this will change in production reviews

- **Style findings** will largely disappear unless they describe a measurable correctness or perf issue. "Consider extracting", "magic number → constant", and "could be more idiomatic" should be gone.
- **Comment-accuracy** will only fire on actively-wrong comments, not on stale TODOs or "could be clearer" observations.
- **Test-coverage** will only fire on high-consequence paths (auth, data integrity, etc.), not on every new getter or one-line helper.
- **Total finding count per review** should drop. A clean PR may now legitimately produce 0 findings; a PR with a real bug should produce 1-2 high-signal findings rather than a long list with nits.

## Regression guards

23 new prompt-content tests lock the key directives in place so a future edit can't silently water down the bar. They assert on:
- The 5 restraint principles in the preamble.
- The 8 explicit nit patterns the style agent blocks.
- The TODO-scope removal in comment-accuracy.
- The high-consequence-path gate in test-coverage.
- The orchestrator's anti-pedantry pass and concrete blocklist.

## Validation

- `pnpm run typecheck` — 20/20
- `pnpm --filter @mergewatch/core test` — 697/697 (44 prompt tests, +23 new)
- `pnpm --filter @mergewatch/lambda test` — 61/61
- `pnpm --filter @mergewatch/server test` — 79/79

## Sequencing / risk

Behavioral changes are entirely prompt-content — no API or runtime shape changed. Existing callers, dispatchers, the `MAX_FINDINGS` cap, the confidence threshold, and the JSON output schema are untouched. The change is reversible at the prompt level if behavior shifts unexpectedly.

## Test plan (post-merge)

- [ ] Watch the next 5-10 reviews on `mergewatch-fixtures` and on this repo for findings-per-PR count vs the pre-merge baseline
- [ ] Watch specifically for the disappearance of "Consider extracting" / "magic number" / "consolidate JSDoc" findings — these should be gone
- [ ] Watch for the inverse failure mode: if real bugs start slipping (security agent or bug agent finds nothing on a known-bad fixture), the restraint may have over-corrected and we should narrow which agents the principles apply to most strictly

🤖 Generated with [Claude Code](https://claude.com/claude-code)