### PR TITLE
feat(ttm): PR-lifecycle capture + storage for time-to-merge (#194, stage 1)

### DIFF
--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -103,6 +103,10 @@ Globals:
         # to the unsuffixed default name and ResourceNotFoundException into a void.
         FINDING_DISPOSITIONS_TABLE: !Ref FindingDispositionsTable
         FP_INSIGHTS_TABLE: !Ref FpInsightsTable
+        # TTM (#194): one row per PR. WebhookHandler writes lifecycle transitions
+        # (opened/synchronize/closed); ReviewAgent marks reviewed/skipped; the
+        # nightly InsightsRollup reads for cycle-time percentiles.
+        PR_LIFECYCLE_TABLE: !Ref PRLifecycleTable
 
         # SSM parameter paths for GitHub App credentials.
         # The Lambda functions read these at runtime via the AWS SDK.
@@ -755,6 +759,60 @@ Resources:
     UpdateReplacePolicy: Retain
 
   # ===========================================================================
+  # DynamoDB: PRLifecycle (TTM / #194)
+  # ===========================================================================
+  # One row per pull request MergeWatch saw — independent of the per-commit
+  # Reviews table. Drives the nightly cycle-time rollup (time-to-merge,
+  # time-from-first-review-to-merge, round-trips).
+  #
+  # Schema:
+  #   PK: pk  (String)  — "${installationId}#${repoFullName}"
+  #   SK: sk  (String)  — prNumber (stringified)
+  #
+  # Attributes (best-effort writes from webhook + review pipeline):
+  #   - prCreatedAt / firstReviewAt / mergedAt / closedAt / updatedAt (String, ISO 8601)
+  #   - state (String — open | merged | closed_unmerged)
+  #   - reviewed / skipped (Bool)
+  #   - totalPushes / pushesAfterFirstReview (Number)
+  #   - ttl (Number) — epoch seconds, ~90d past the terminal event
+  #
+  # TimeToLiveSpecification reaps terminal rows after the 90d window passes.
+
+  PRLifecycleTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub 'mergewatch-pr-lifecycle-${Stage}'
+      BillingMode: PAY_PER_REQUEST
+
+      KeySchema:
+        - AttributeName: pk
+          KeyType: HASH
+        - AttributeName: sk
+          KeyType: RANGE
+
+      AttributeDefinitions:
+        - AttributeName: pk
+          AttributeType: S
+        - AttributeName: sk
+          AttributeType: S
+
+      TimeToLiveSpecification:
+        AttributeName: ttl
+        Enabled: true
+
+      SSESpecification:
+        SSEEnabled: true
+
+      Tags:
+        - Key: Project
+          Value: MergeWatch
+        - Key: Stage
+          Value: !Ref Stage
+
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+
+  # ===========================================================================
   # IAM Role: Lambda Execution Role
   # ===========================================================================
   # A single shared role for both Lambda functions. This simplifies management
@@ -830,6 +888,7 @@ Resources:
                   - !GetAtt SessionsTable.Arn
                   - !GetAtt FindingDispositionsTable.Arn
                   - !GetAtt FpInsightsTable.Arn
+                  - !GetAtt PRLifecycleTable.Arn
                   # Index ARNs (for future GSIs)
                   - !Sub '${InstallationsTable.Arn}/index/*'
                   - !Sub '${ReviewsTable.Arn}/index/*'
@@ -837,6 +896,7 @@ Resources:
                   - !Sub '${SessionsTable.Arn}/index/*'
                   - !Sub '${FindingDispositionsTable.Arn}/index/*'
                   - !Sub '${FpInsightsTable.Arn}/index/*'
+                  - !Sub '${PRLifecycleTable.Arn}/index/*'
 
         # --- SSM Parameter Store ---
         # Read-only access to GitHub credentials stored in SSM.
@@ -939,6 +999,10 @@ Outputs:
   FpInsightsTableName:
     Description: Name of the DynamoDB installation-fp-insights table (FB-E)
     Value: !Ref FpInsightsTable
+
+  PRLifecycleTableName:
+    Description: Name of the DynamoDB pr-lifecycle table (TTM / #194)
+    Value: !Ref PRLifecycleTable
 
   # The IAM role ARN — useful for debugging permission issues
   LambdaRoleArn:

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,9 @@ export type {
   IMcpSessionStore,
   IFindingDispositionStore,
   IFPInsightStore,
+  IPRLifecycleStore,
+  PRLifecycleOpenInput,
+  PRLifecycleCloseInput,
   FindingDispositionAttribution,
   ApiKeyRecord,
   McpSessionRecord,
@@ -248,6 +251,7 @@ export type {
   UpdateReviewInput,
   FindingDispositionRecord,
   InstallationFPInsight,
+  PRLifecycleRecord,
 } from './types/db.js';
 
 export { DEFAULT_INSTALLATION_SETTINGS } from './types/db.js';

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -11,6 +11,7 @@ import type {
   ReviewItem, ReviewStatus,
   FindingDispositionRecord,
   InstallationFPInsight,
+  PRLifecycleRecord,
 } from '../types/db.js';
 
 export interface IInstallationStore {
@@ -175,4 +176,73 @@ export interface IFPInsightStore {
    * Returns the rows in `window` order ('7d', '30d', '90d').
    */
   listByInstallation(installationId: string): Promise<InstallationFPInsight[]>;
+}
+
+// ─── TTM — PR-lifecycle store (#194) ───────────────────────────────────────
+
+/** Identity + creation data for the open-state upsert. */
+export interface PRLifecycleOpenInput {
+  installationId: string;
+  repoFullName: string;
+  prNumber: number;
+  /** ISO 8601 — PR `created_at` from GitHub. */
+  prCreatedAt: string;
+}
+
+/** Identity + timestamps for a terminal (merged / closed) transition. */
+export interface PRLifecycleCloseInput {
+  installationId: string;
+  repoFullName: string;
+  prNumber: number;
+  /** ISO 8601 — PR `created_at` (authoritative from the closed payload). */
+  prCreatedAt: string;
+  /** ISO 8601 — `merged_at` (markMerged) or `closed_at` (markClosedUnmerged). */
+  at: string;
+}
+
+/**
+ * Persists one `PRLifecycleRecord` per pull request. All writes are
+ * best-effort (swallow-and-log) so a lifecycle write can never block the
+ * review pipeline — mirrors `IFindingDispositionStore`.
+ *
+ * Terminal-state discipline: once a row reaches `merged` / `closed_unmerged`,
+ * `upsertOpened` / `recordPush` must not resurrect it to `open`.
+ */
+export interface IPRLifecycleStore {
+  /**
+   * Create the row on first sight (state='open', prCreatedAt set, counters 0).
+   * On an existing OPEN row, only refresh `updatedAt`. No-op on a terminal row.
+   */
+  upsertOpened(rec: PRLifecycleOpenInput): Promise<void>;
+
+  /**
+   * Increment `totalPushes`; when `firstReviewAt` is already set, also bump
+   * `pushesAfterFirstReview`. Creates the row (open) if missing.
+   */
+  recordPush(installationId: string, repoFullName: string, prNumber: number): Promise<void>;
+
+  /**
+   * Set `firstReviewAt` (only if currently unset) and `reviewed=true`.
+   * Creates the row if missing. Idempotent — later reviews don't move the
+   * first-review anchor.
+   */
+  markReviewed(installationId: string, repoFullName: string, prNumber: number, atIso: string): Promise<void>;
+
+  /** Set `skipped=true` (leaves `reviewed` untouched). Creates the row if missing. */
+  markSkipped(installationId: string, repoFullName: string, prNumber: number, atIso: string): Promise<void>;
+
+  /** Terminal: PR merged. Sets `mergedAt`, `state='merged'`, authoritative `prCreatedAt`. */
+  markMerged(rec: PRLifecycleCloseInput): Promise<void>;
+
+  /** Terminal: PR closed without merge. Sets `closedAt`, `state='closed_unmerged'`. */
+  markClosedUnmerged(rec: PRLifecycleCloseInput): Promise<void>;
+
+  /**
+   * Page through all lifecycle rows for an installation. Used by the nightly
+   * cycle-time rollup. Optional limit + cursor pagination (cap ~1000/page).
+   */
+  listByInstallation(
+    installationId: string,
+    opts?: { limit?: number; cursor?: string },
+  ): Promise<{ items: PRLifecycleRecord[]; nextCursor?: string }>;
 }

--- a/packages/core/src/types/db.ts
+++ b/packages/core/src/types/db.ts
@@ -520,6 +520,72 @@ export interface FindingDispositionRecord {
 }
 
 /**
+ * TTM — Per-PR lifecycle record. One row per pull request MergeWatch saw,
+ * independent of the per-commit `ReviewItem` (a PR has N review rows, one per
+ * push, but exactly one lifecycle row). Drives the time-to-merge / cycle-time
+ * rollup (#194).
+ *
+ * Storage:
+ *   - DynamoDB (SaaS) table: mergewatch-pr-lifecycle
+ *     PK: `${installationId}#${repoFullName}`   SK: `prNumber` (string)
+ *   - Postgres (self-hosted) table: pr_lifecycle
+ *     PK: (installation_id, repo_full_name, pr_number)
+ *
+ * Write path (all best-effort — never blocks the review pipeline):
+ *   - webhook `opened` / `reopened` → upsertOpened (sets prCreatedAt, state=open)
+ *   - webhook `synchronize`         → recordPush (bumps push counters)
+ *   - webhook `closed` (merged)     → markMerged (terminal)
+ *   - webhook `closed` (unmerged)   → markClosedUnmerged (terminal)
+ *   - review processor on complete  → markReviewed (firstReviewAt set-once)
+ *   - review processor on skip      → markSkipped
+ *
+ * Read path: the nightly cycle-time rollup (Stage 2) pages these rows per
+ * installation and computes time-to-merge percentiles.
+ */
+export interface PRLifecycleRecord {
+  installationId: string;
+  repoFullName: string;
+  prNumber: number;
+
+  /** ISO 8601 — PR `created_at` from GitHub. The anchor for time-to-merge. */
+  prCreatedAt: string;
+  /**
+   * ISO 8601 — when MergeWatch first completed a review for this PR. Set once
+   * (never overwritten by later pushes). Unset if the PR was never reviewed.
+   * The anchor for time-from-first-review-to-merge.
+   */
+  firstReviewAt?: string;
+  /** ISO 8601 — PR `merged_at`. Set only on a merge. */
+  mergedAt?: string;
+  /** ISO 8601 — PR `closed_at` when closed WITHOUT merging. */
+  closedAt?: string;
+
+  /** Terminal-aware lifecycle state. Never downgrades once merged/closed. */
+  state: 'open' | 'merged' | 'closed_unmerged';
+
+  /** True once MergeWatch completed a review (segmentation: reviewed vs not). */
+  reviewed: boolean;
+  /** True when `shouldSkipPR` short-circuited the review (docs-only / lockfile / …). */
+  skipped: boolean;
+
+  /** Total `synchronize` (push) events seen on this PR. */
+  totalPushes: number;
+  /**
+   * Pushes observed AFTER `firstReviewAt` was set — the round-trip / iteration
+   * proxy the rollup reports. 0 until the first review lands.
+   */
+  pushesAfterFirstReview: number;
+
+  /** ISO 8601 — last time any field on this row was written. */
+  updatedAt: string;
+  /**
+   * Unix epoch seconds for DynamoDB TTL (≈90 days past the terminal event).
+   * Unset while open. Postgres ignores this (no TTL).
+   */
+  ttl?: number;
+}
+
+/**
  * FB-E — Per-installation FP insight rollup. Produced nightly by aggregating
  * `FindingDispositionRecord` rows over a rolling window (7d / 30d / 90d).
  *

--- a/packages/core/src/types/github.ts
+++ b/packages/core/src/types/github.ts
@@ -57,6 +57,16 @@ export interface GitHubPullRequest {
   /** ISO-8601 timestamps. */
   created_at: string;
   updated_at: string;
+  /**
+   * Whether the PR has been merged. Present on `closed` webhook payloads
+   * (true when the close was a merge, false when closed without merging)
+   * and on the REST PR object. Absent on some narrower API responses.
+   */
+  merged?: boolean;
+  /** ISO-8601 — set when the PR was merged; null otherwise. */
+  merged_at?: string | null;
+  /** ISO-8601 — set when the PR was closed (merged or not); null while open. */
+  closed_at?: string | null;
   /** List of changed file paths — only present on certain API responses. */
   changed_files?: number;
 }

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -71,6 +71,8 @@ import {
   DEFAULT_FINDING_DISPOSITIONS_TABLE,
   DynamoFPInsightStore,
   DEFAULT_FP_INSIGHTS_TABLE,
+  DynamoPRLifecycleStore,
+  DEFAULT_PR_LIFECYCLE_TABLE,
 } from '@mergewatch/storage-dynamo';
 import { BedrockLLMProvider, SUPPORTED_MODELS } from '@mergewatch/llm-bedrock';
 import { isSaas, billingCheck, recordReview, postBlockedCheckRun, ensureBillingIssue, updateBillingFields, getStripe } from '@mergewatch/billing';
@@ -84,6 +86,7 @@ const INSTALLATIONS_TABLE = process.env.INSTALLATIONS_TABLE ?? 'mergewatch-insta
 const REVIEWS_TABLE = process.env.REVIEWS_TABLE ?? 'mergewatch-reviews';
 const FINDING_DISPOSITIONS_TABLE = process.env.FINDING_DISPOSITIONS_TABLE ?? DEFAULT_FINDING_DISPOSITIONS_TABLE;
 const FP_INSIGHTS_TABLE = process.env.FP_INSIGHTS_TABLE ?? DEFAULT_FP_INSIGHTS_TABLE;
+const PR_LIFECYCLE_TABLE = process.env.PR_LIFECYCLE_TABLE ?? DEFAULT_PR_LIFECYCLE_TABLE;
 const DEFAULT_BEDROCK_MODEL_ID = process.env.DEFAULT_BEDROCK_MODEL_ID ?? 'us.anthropic.claude-sonnet-4-20250514-v1:0';
 const DASHBOARD_BASE_URL = process.env.DASHBOARD_BASE_URL ?? 'https://mergewatch.ai';
 
@@ -97,6 +100,9 @@ const dispositionStore = new DynamoFindingDispositionStore(dynamodb, FINDING_DIS
 // so the verdict tier behaves identically to pre-FP-J when the table is
 // empty or unprovisioned (back-compat for the SaaS rollout window).
 const fpInsightStore = new DynamoFPInsightStore(dynamodb, FP_INSIGHTS_TABLE);
+// TTM (#194) — marks reviewed/skipped on the PR-lifecycle row the webhook
+// opened. Best-effort; swallows if the table isn't provisioned yet.
+const prLifecycleStore = new DynamoPRLifecycleStore(dynamodb, PR_LIFECYCLE_TABLE);
 const llm = new BedrockLLMProvider();
 const authProvider = new SSMGitHubAuthProvider();
 
@@ -402,6 +408,7 @@ export async function handler(
       agentKind: event.agentKind,
     };
     await reviewStore.upsert(skippedRecord);
+    await prLifecycleStore.markSkipped(String(installationId), repoFullName, prNumber, new Date().toISOString());
 
     await createCheckRun(octokit, owner, repo, headSha, {
       status: 'completed',
@@ -518,6 +525,7 @@ export async function handler(
         completedAt: new Date().toISOString(),
         skipReason: rulesSkip.reason,
       });
+      await prLifecycleStore.markSkipped(String(installationId), repoFullName, prNumber, new Date().toISOString());
 
       // autoReviewOff is handled silently earlier (before any GitHub side
       // effect). Any rulesSkip seen here is a visible-skip kind: draft,
@@ -889,6 +897,10 @@ export async function handler(
         ? { inlineReactionsSnapshot: updatedReactionsSnapshot }
         : {}),
     });
+
+    // TTM (#194) — anchor the first-review timestamp (set-once) for the
+    // time-from-first-review-to-merge metric.
+    await prLifecycleStore.markReviewed(String(installationId), repoFullName, prNumber, completedAt);
 
     // ── Record billing (SaaS only) ────
     // Retry once on failure. If both attempts fail, log as ERROR (not warn)

--- a/packages/lambda/src/handlers/webhook.ts
+++ b/packages/lambda/src/handlers/webhook.ts
@@ -165,6 +165,12 @@ async function recordPrLifecycle(event: PullRequestEvent, installationId: number
       if (pr.merged && pr.merged_at) {
         await prLifecycleStore.markMerged({ installationId: instId, repoFullName, prNumber, prCreatedAt: pr.created_at, at: pr.merged_at });
       } else {
+        // GitHub always sends closed_at on a `closed` action; a missing value
+        // signals an unexpected payload, so surface it rather than silently
+        // substituting now() (which would skew the cycle-time stat).
+        if (!pr.closed_at) {
+          console.warn('[ttm] closed PR missing closed_at — using now() (%s#%d):', repoFullName, prNumber);
+        }
         await prLifecycleStore.markClosedUnmerged({
           installationId: instId, repoFullName, prNumber,
           prCreatedAt: pr.created_at,

--- a/packages/lambda/src/handlers/webhook.ts
+++ b/packages/lambda/src/handlers/webhook.ts
@@ -34,6 +34,7 @@ import type {
   ReviewJobPayload,
   AgentReviewConfig,
 } from '@mergewatch/core';
+import { DynamoPRLifecycleStore, DEFAULT_PR_LIFECYCLE_TABLE } from '@mergewatch/storage-dynamo';
 import { SSMGitHubAuthProvider, getWebhookSecret } from '../github-auth-ssm.js';
 
 // ---------------------------------------------------------------------------
@@ -43,6 +44,11 @@ import { SSMGitHubAuthProvider, getWebhookSecret } from '../github-auth-ssm.js';
 const lambda = new LambdaClient({});
 const dynamodb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const authProvider = new SSMGitHubAuthProvider();
+
+// TTM (#194) — PR-lifecycle store. The webhook records open/push/close
+// transitions directly (no review needed); ReviewAgent marks reviewed/skipped.
+const PR_LIFECYCLE_TABLE = process.env.PR_LIFECYCLE_TABLE ?? DEFAULT_PR_LIFECYCLE_TABLE;
+const prLifecycleStore = new DynamoPRLifecycleStore(dynamodb, PR_LIFECYCLE_TABLE);
 
 // ---------------------------------------------------------------------------
 // Signature verification
@@ -145,18 +151,52 @@ async function storeInstallation(event: InstallationEvent): Promise<void> {
 // Pull request event handler
 // ---------------------------------------------------------------------------
 
+/**
+ * TTM (#194) — record PR-lifecycle transitions. Best-effort (the store
+ * swallows its own errors); mirrors the self-hosted webhook handler.
+ */
+async function recordPrLifecycle(event: PullRequestEvent, installationId: number): Promise<void> {
+  const { action, pull_request: pr, repository } = event;
+  const instId = String(installationId);
+  const repoFullName = repository.full_name;
+  const prNumber = pr.number;
+  try {
+    if (action === 'closed') {
+      if (pr.merged && pr.merged_at) {
+        await prLifecycleStore.markMerged({ installationId: instId, repoFullName, prNumber, prCreatedAt: pr.created_at, at: pr.merged_at });
+      } else {
+        await prLifecycleStore.markClosedUnmerged({
+          installationId: instId, repoFullName, prNumber,
+          prCreatedAt: pr.created_at,
+          at: pr.closed_at ?? new Date().toISOString(),
+        });
+      }
+    } else if (action === 'synchronize') {
+      await prLifecycleStore.recordPush(instId, repoFullName, prNumber);
+    } else if (action === 'opened' || action === 'reopened' || action === 'ready_for_review') {
+      await prLifecycleStore.upsertOpened({ installationId: instId, repoFullName, prNumber, prCreatedAt: pr.created_at });
+    }
+  } catch (err) {
+    console.warn('[ttm] lifecycle record failed for %s#%d (%s):', repoFullName, prNumber, action, err);
+  }
+}
+
 async function handlePullRequestEvent(
   event: PullRequestEvent
 ): Promise<void> {
   const { action, pull_request: pr, repository, installation } = event;
-
-  if (!(REVIEW_TRIGGERING_ACTIONS as readonly string[]).includes(action)) return;
 
   const installationId = installation?.id;
   if (!installationId) {
     console.warn("pull_request event missing installation ID — skipping");
     return;
   }
+
+  // Record lifecycle for every relevant action (incl. `closed`) before the
+  // review gate — merges/closes terminate the lifecycle without a review.
+  await recordPrLifecycle(event, installationId);
+
+  if (!(REVIEW_TRIGGERING_ACTIONS as readonly string[]).includes(action)) return;
 
   const owner = repository.owner.login;
   const repo = repository.name;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -9,6 +9,7 @@ import {
   PostgresReviewStore,
   PostgresFindingDispositionStore,
   PostgresFPInsightStore,
+  PostgresPRLifecycleStore,
   runMigrations,
 } from '@mergewatch/storage-postgres';
 import { EnvGitHubAuthProvider } from './github-auth-env.js';
@@ -67,6 +68,7 @@ async function main() {
   const reviewStore = new PostgresReviewStore(db);
   const dispositionStore = new PostgresFindingDispositionStore(db);
   const fpInsightStore = new PostgresFPInsightStore(db);
+  const prLifecycleStore = new PostgresPRLifecycleStore(db);
   const authProvider = new EnvGitHubAuthProvider(githubAppId, githubPrivateKey);
   const llm = createLLMProvider();
 
@@ -122,6 +124,7 @@ async function main() {
     reviewStore,
     dispositionStore,
     fpInsightStore,
+    prLifecycleStore,
     authProvider,
     llm,
     dashboardBaseUrl,

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -231,7 +231,7 @@ async function handleInlineReplyJob(
 
 export async function processReviewJob(
   job: ReviewJobPayload,
-  deps: Pick<WebhookDeps, 'installationStore' | 'reviewStore' | 'dispositionStore' | 'fpInsightStore' | 'authProvider' | 'llm' | 'dashboardBaseUrl'>,
+  deps: Pick<WebhookDeps, 'installationStore' | 'reviewStore' | 'dispositionStore' | 'fpInsightStore' | 'prLifecycleStore' | 'authProvider' | 'llm' | 'dashboardBaseUrl'>,
 ): Promise<void> {
   const { installationId, owner, repo, prNumber, mode } = job;
   const instId = String(installationId);
@@ -327,6 +327,7 @@ export async function processReviewJob(
     : shouldSkipPR(prContext.files || [], includePatterns);
   if (skipReason) {
     await deps.reviewStore.updateStatus(repoFullName, prNumberCommitSha, 'skipped', { completedAt: now, skipReason });
+    await deps.prLifecycleStore?.markSkipped(instId, repoFullName, prNumber, now);
     await createCheckRun(octokit, owner, repo, headSha, {
       status: 'completed',
       conclusion: 'neutral',
@@ -384,6 +385,7 @@ export async function processReviewJob(
   });
   if (rulesSkip) {
     await deps.reviewStore.updateStatus(repoFullName, prNumberCommitSha, 'skipped', { completedAt: now, skipReason: rulesSkip.reason });
+    await deps.prLifecycleStore?.markSkipped(instId, repoFullName, prNumber, now);
     // autoReviewOff is handled silently earlier (before any GitHub side
     // effect). Any rulesSkip seen here is a visible-skip kind: draft,
     // maxFiles, labelIgnored, reviewOnMentionOff.
@@ -768,6 +770,10 @@ export async function processReviewJob(
         ? { inlineReactionsSnapshot: updatedReactionsSnapshot }
         : {}),
     });
+
+    // TTM (#194) — anchor the first-review timestamp (set-once) for the
+    // time-from-first-review-to-merge metric. Later re-reviews don't move it.
+    await deps.prLifecycleStore?.markReviewed(instId, repoFullName, prNumber, new Date().toISOString());
 
     // Create structured check run (matches Lambda pattern)
     const hasCritical = criticalCount > 0;

--- a/packages/server/src/webhook-handler.test.ts
+++ b/packages/server/src/webhook-handler.test.ts
@@ -25,7 +25,7 @@ vi.mock('@mergewatch/core', async (importOriginal) => {
 import { verifySignature, parseReviewMode, isMergeWatchCheckRun, createWebhookHandler } from './webhook-handler.js';
 import type { WebhookDeps } from './webhook-handler.js';
 import { MERGEWATCH_CHECK_RUN_NAME } from '@mergewatch/core';
-import type { IInstallationStore, IReviewStore, IGitHubAuthProvider, ILLMProvider, PullRequestEvent, CheckRunEvent, IssueCommentEvent, PullRequestReviewCommentEvent } from '@mergewatch/core';
+import type { IInstallationStore, IReviewStore, IGitHubAuthProvider, ILLMProvider, IPRLifecycleStore, PullRequestEvent, CheckRunEvent, IssueCommentEvent, PullRequestReviewCommentEvent } from '@mergewatch/core';
 
 // ---------------------------------------------------------------------------
 // verifySignature
@@ -281,6 +281,117 @@ describe('createWebhookHandler — pull_request classification', () => {
     expect(callArgs[2]).toBeDefined();
     expect(callArgs[2].enabled).toBe(true);
     expect(callArgs[2].detection).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TTM (#194) — PR-lifecycle recording on pull_request events
+// ---------------------------------------------------------------------------
+
+function makeLifecycleStore(): IPRLifecycleStore {
+  return {
+    upsertOpened: vi.fn().mockResolvedValue(undefined),
+    recordPush: vi.fn().mockResolvedValue(undefined),
+    markReviewed: vi.fn().mockResolvedValue(undefined),
+    markSkipped: vi.fn().mockResolvedValue(undefined),
+    markMerged: vi.fn().mockResolvedValue(undefined),
+    markClosedUnmerged: vi.fn().mockResolvedValue(undefined),
+    listByInstallation: vi.fn().mockResolvedValue({ items: [] }),
+  };
+}
+
+describe('createWebhookHandler — PR lifecycle recording', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchRepoConfig.mockResolvedValue(null);
+    mockClassifyPrSource.mockResolvedValue({ source: 'human' });
+    mockFindExistingBotComment.mockResolvedValue(null);
+  });
+
+  async function run(event: PullRequestEvent) {
+    const prLifecycleStore = makeLifecycleStore();
+    const deps = { ...makeDeps(), prLifecycleStore };
+    const handler = createWebhookHandler(deps);
+    const body = JSON.stringify(event);
+    const { req, res } = makeReqRes(body);
+    await handler(req, res);
+    await new Promise((resolve) => setImmediate(resolve));
+    return prLifecycleStore;
+  }
+
+  it('records upsertOpened on `opened` and still enqueues the review', async () => {
+    const store = await run(makePullRequestEvent({ action: 'opened' }));
+    expect(store.upsertOpened).toHaveBeenCalledTimes(1);
+    expect(store.upsertOpened).toHaveBeenCalledWith({
+      installationId: '999',
+      repoFullName: 'octo/repo',
+      prNumber: 7,
+      prCreatedAt: '2026-04-01T00:00:00Z',
+    });
+    expect(mockProcessReviewJob).toHaveBeenCalledTimes(1);
+  });
+
+  it('records recordPush on `synchronize`', async () => {
+    const store = await run(makePullRequestEvent({ action: 'synchronize' }));
+    expect(store.recordPush).toHaveBeenCalledWith('999', 'octo/repo', 7);
+    expect(mockProcessReviewJob).toHaveBeenCalledTimes(1);
+  });
+
+  it('records markMerged on `closed` with merged=true and does NOT enqueue a review', async () => {
+    const base = makePullRequestEvent({ action: 'closed' });
+    const event: PullRequestEvent = {
+      ...base,
+      pull_request: {
+        ...base.pull_request,
+        state: 'closed',
+        merged: true,
+        merged_at: '2026-04-03T12:00:00Z',
+        closed_at: '2026-04-03T12:00:00Z',
+      },
+    };
+    const store = await run(event);
+    expect(store.markMerged).toHaveBeenCalledWith({
+      installationId: '999',
+      repoFullName: 'octo/repo',
+      prNumber: 7,
+      prCreatedAt: '2026-04-01T00:00:00Z',
+      at: '2026-04-03T12:00:00Z',
+    });
+    expect(store.markClosedUnmerged).not.toHaveBeenCalled();
+    expect(mockProcessReviewJob).not.toHaveBeenCalled();
+  });
+
+  it('records markClosedUnmerged on `closed` with merged=false and does NOT enqueue a review', async () => {
+    const base = makePullRequestEvent({ action: 'closed' });
+    const event: PullRequestEvent = {
+      ...base,
+      pull_request: {
+        ...base.pull_request,
+        state: 'closed',
+        merged: false,
+        closed_at: '2026-04-03T12:00:00Z',
+      },
+    };
+    const store = await run(event);
+    expect(store.markClosedUnmerged).toHaveBeenCalledWith({
+      installationId: '999',
+      repoFullName: 'octo/repo',
+      prNumber: 7,
+      prCreatedAt: '2026-04-01T00:00:00Z',
+      at: '2026-04-03T12:00:00Z',
+    });
+    expect(store.markMerged).not.toHaveBeenCalled();
+    expect(mockProcessReviewJob).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when no prLifecycleStore is wired (best-effort no-op)', async () => {
+    const deps = makeDeps(); // no prLifecycleStore
+    const handler = createWebhookHandler(deps);
+    const body = JSON.stringify(makePullRequestEvent({ action: 'opened' }));
+    const { req, res } = makeReqRes(body);
+    await handler(req, res);
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(mockProcessReviewJob).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/server/src/webhook-handler.ts
+++ b/packages/server/src/webhook-handler.ts
@@ -1,6 +1,6 @@
 import { createHmac, timingSafeEqual } from 'crypto';
 import type { Request, Response } from 'express';
-import type { IInstallationStore, IReviewStore, IFindingDispositionStore, IFPInsightStore, IGitHubAuthProvider, ILLMProvider, AgentReviewConfig } from '@mergewatch/core';
+import type { IInstallationStore, IReviewStore, IFindingDispositionStore, IFPInsightStore, IPRLifecycleStore, IGitHubAuthProvider, ILLMProvider, AgentReviewConfig } from '@mergewatch/core';
 import type { ReviewJobPayload, ReviewMode, PullRequestEvent, IssueCommentEvent, PullRequestReviewCommentEvent, InstallationEvent, CheckRunEvent } from '@mergewatch/core';
 import { REVIEW_TRIGGERING_ACTIONS, COMMENT_LOOKUP_ACTIONS, MERGEWATCH_CHECK_RUN_NAME, findExistingBotComment, classifyPrSource, fetchRepoConfig, mergeConfig, isBotActor } from '@mergewatch/core';
 import { processReviewJob } from './review-processor.js';
@@ -19,6 +19,11 @@ export interface WebhookDeps {
    * the pre-FP-J shape — no down-weighting.
    */
   fpInsightStore?: IFPInsightStore;
+  /**
+   * TTM (#194) — optional PR-lifecycle store. Best-effort: when unset, merge
+   * tracking is a no-op and the review pipeline runs unchanged.
+   */
+  prLifecycleStore?: IPRLifecycleStore;
   authProvider: IGitHubAuthProvider;
   llm: ILLMProvider;
   dashboardBaseUrl: string;
@@ -72,9 +77,52 @@ export function createWebhookHandler(deps: WebhookDeps) {
   };
 }
 
+/**
+ * TTM (#194) — record PR-lifecycle transitions on the webhook path. Best-effort
+ * (the store swallows its own errors) and a no-op when no store is wired.
+ *
+ *   opened / reopened / ready_for_review → upsertOpened (anchors prCreatedAt)
+ *   synchronize                          → recordPush (round-trip proxy)
+ *   closed (merged)                      → markMerged (terminal)
+ *   closed (unmerged)                    → markClosedUnmerged (terminal)
+ */
+async function recordPrLifecycle(payload: PullRequestEvent, deps: WebhookDeps) {
+  const store = deps.prLifecycleStore;
+  if (!store || !payload.installation) return;
+  const { action, pull_request: pr, repository, installation } = payload;
+  const installationId = String(installation.id);
+  const repoFullName = repository.full_name;
+  const prNumber = pr.number;
+  try {
+    if (action === 'closed') {
+      if (pr.merged && pr.merged_at) {
+        await store.markMerged({ installationId, repoFullName, prNumber, prCreatedAt: pr.created_at, at: pr.merged_at });
+      } else {
+        await store.markClosedUnmerged({
+          installationId, repoFullName, prNumber,
+          prCreatedAt: pr.created_at,
+          at: pr.closed_at ?? new Date().toISOString(),
+        });
+      }
+    } else if (action === 'synchronize') {
+      await store.recordPush(installationId, repoFullName, prNumber);
+    } else if (action === 'opened' || action === 'reopened' || action === 'ready_for_review') {
+      await store.upsertOpened({ installationId, repoFullName, prNumber, prCreatedAt: pr.created_at });
+    }
+  } catch (err) {
+    console.warn('[ttm] lifecycle record failed for %s#%d (%s):', repoFullName, prNumber, action, err);
+  }
+}
+
 async function handlePullRequest(payload: PullRequestEvent, deps: WebhookDeps) {
   const { action, pull_request, repository, installation } = payload;
-  if (!installation || !(REVIEW_TRIGGERING_ACTIONS as readonly string[]).includes(action)) return;
+  if (!installation) return;
+
+  // Record lifecycle for every relevant action (incl. `closed`) before the
+  // review gate — merges/closes terminate the lifecycle without a review.
+  await recordPrLifecycle(payload, deps);
+
+  if (!(REVIEW_TRIGGERING_ACTIONS as readonly string[]).includes(action)) return;
 
   const owner = repository.owner.login;
   const repo = repository.name;

--- a/packages/server/src/webhook-handler.ts
+++ b/packages/server/src/webhook-handler.ts
@@ -98,6 +98,12 @@ async function recordPrLifecycle(payload: PullRequestEvent, deps: WebhookDeps) {
       if (pr.merged && pr.merged_at) {
         await store.markMerged({ installationId, repoFullName, prNumber, prCreatedAt: pr.created_at, at: pr.merged_at });
       } else {
+        // GitHub always sends closed_at on a `closed` action; a missing value
+        // signals an unexpected payload, so surface it rather than silently
+        // substituting now() (which would skew the cycle-time stat).
+        if (!pr.closed_at) {
+          console.warn('[ttm] closed PR missing closed_at — using now() (%s#%d):', repoFullName, prNumber);
+        }
         await store.markClosedUnmerged({
           installationId, repoFullName, prNumber,
           prCreatedAt: pr.created_at,

--- a/packages/storage-dynamo/src/index.ts
+++ b/packages/storage-dynamo/src/index.ts
@@ -16,3 +16,7 @@ export {
   DynamoFPInsightStore,
   DEFAULT_FP_INSIGHTS_TABLE,
 } from './fp-insight-store.js';
+export {
+  DynamoPRLifecycleStore,
+  DEFAULT_PR_LIFECYCLE_TABLE,
+} from './pr-lifecycle-store.js';

--- a/packages/storage-dynamo/src/pr-lifecycle-store.test.ts
+++ b/packages/storage-dynamo/src/pr-lifecycle-store.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { UpdateCommand, ScanCommand } from '@aws-sdk/lib-dynamodb';
+import { DynamoPRLifecycleStore } from './pr-lifecycle-store.js';
+
+const TABLE = 'test-pr-lifecycle';
+
+function makeClient(response: unknown = {}) {
+  return { send: vi.fn().mockResolvedValue(response) } as any;
+}
+
+/** Pull every UpdateCommand the store issued. */
+function updates(client: any): UpdateCommand[] {
+  return client.send.mock.calls
+    .map((c: any[]) => c[0])
+    .filter((cmd: any) => cmd instanceof UpdateCommand);
+}
+
+describe('DynamoPRLifecycleStore key + command construction', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('keys rows by `${installationId}#${repoFullName}` / prNumber', async () => {
+    const client = makeClient();
+    const store = new DynamoPRLifecycleStore(client, TABLE);
+    await store.upsertOpened({ installationId: '42', repoFullName: 'octo/repo', prNumber: 7, prCreatedAt: '2026-04-01T00:00:00Z' });
+    const cmd = updates(client)[0];
+    expect(cmd.input.Key).toEqual({ pk: '42#octo/repo', sk: '7' });
+    expect(cmd.input.TableName).toBe(TABLE);
+  });
+
+  it('upsertOpened guards against resurrecting a terminal row', async () => {
+    const client = makeClient();
+    const store = new DynamoPRLifecycleStore(client, TABLE);
+    await store.upsertOpened({ installationId: '42', repoFullName: 'octo/repo', prNumber: 7, prCreatedAt: '2026-04-01T00:00:00Z' });
+    const cmd = updates(client)[0];
+    // Only create or touch an open row.
+    expect(cmd.input.ConditionExpression).toBe('attribute_not_exists(pk) OR #state = :open');
+    expect(cmd.input.ExpressionAttributeValues?.[':open']).toBe('open');
+  });
+
+  it('upsertOpened swallows the ConditionalCheckFailedException (terminal row no-op)', async () => {
+    const client = { send: vi.fn().mockRejectedValue({ name: 'ConditionalCheckFailedException' }) } as any;
+    const store = new DynamoPRLifecycleStore(client, TABLE);
+    await expect(
+      store.upsertOpened({ installationId: '42', repoFullName: 'octo/repo', prNumber: 7, prCreatedAt: '2026-04-01T00:00:00Z' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('recordPush issues two updates: total always, post-review guarded on firstReviewAt', async () => {
+    const client = makeClient();
+    const store = new DynamoPRLifecycleStore(client, TABLE);
+    await store.recordPush('42', 'octo/repo', 7);
+    const cmds = updates(client);
+    expect(cmds).toHaveLength(2);
+    // 1st: unconditional total_pushes bump.
+    expect(cmds[0].input.ConditionExpression).toBeUndefined();
+    expect(cmds[0].input.UpdateExpression).toContain('totalPushes = if_not_exists(totalPushes, :zero) + :one');
+    // 2nd: post-first-review counter only when a review has landed.
+    expect(cmds[1].input.ConditionExpression).toBe('attribute_exists(firstReviewAt)');
+    expect(cmds[1].input.UpdateExpression).toContain('pushesAfterFirstReview');
+  });
+
+  it('recordPush swallows the guarded conditional failure (no review yet)', async () => {
+    // First send (total bump) succeeds; second (guarded) fails the condition.
+    const send = vi.fn()
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce({ name: 'ConditionalCheckFailedException' });
+    const store = new DynamoPRLifecycleStore({ send } as any, TABLE);
+    await expect(store.recordPush('42', 'octo/repo', 7)).resolves.toBeUndefined();
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it('markReviewed sets firstReviewAt set-once and reviewed=true', async () => {
+    const client = makeClient();
+    const store = new DynamoPRLifecycleStore(client, TABLE);
+    await store.markReviewed('42', 'octo/repo', 7, '2026-04-02T09:00:00Z');
+    const cmd = updates(client)[0];
+    expect(cmd.input.UpdateExpression).toContain('firstReviewAt = if_not_exists(firstReviewAt, :at)');
+    expect(cmd.input.UpdateExpression).toContain('reviewed = :true');
+    expect(cmd.input.ExpressionAttributeValues?.[':at']).toBe('2026-04-02T09:00:00Z');
+  });
+
+  it('markMerged overwrites state + prCreatedAt unconditionally and sets a ttl', async () => {
+    const client = makeClient();
+    const store = new DynamoPRLifecycleStore(client, TABLE);
+    await store.markMerged({ installationId: '42', repoFullName: 'octo/repo', prNumber: 7, prCreatedAt: '2026-04-01T00:00:00Z', at: '2026-04-03T12:00:00Z' });
+    const cmd = updates(client)[0];
+    expect(cmd.input.ConditionExpression).toBeUndefined(); // merge is authoritative
+    expect(cmd.input.ExpressionAttributeValues?.[':merged']).toBe('merged');
+    const ttl = cmd.input.ExpressionAttributeValues?.[':ttl'];
+    const expected = Math.floor(Date.parse('2026-04-03T12:00:00Z') / 1000) + 90 * 24 * 60 * 60;
+    expect(ttl).toBe(expected);
+  });
+
+  it('markClosedUnmerged guards against downgrading a merged row', async () => {
+    const client = makeClient();
+    const store = new DynamoPRLifecycleStore(client, TABLE);
+    await store.markClosedUnmerged({ installationId: '42', repoFullName: 'octo/repo', prNumber: 7, prCreatedAt: '2026-04-01T00:00:00Z', at: '2026-04-03T12:00:00Z' });
+    const cmd = updates(client)[0];
+    expect(cmd.input.ConditionExpression).toBe('attribute_not_exists(#state) OR #state <> :merged');
+    expect(cmd.input.ExpressionAttributeValues?.[':closed']).toBe('closed_unmerged');
+  });
+
+  it('markClosedUnmerged swallows the conditional failure when already merged', async () => {
+    const client = { send: vi.fn().mockRejectedValue({ name: 'ConditionalCheckFailedException' }) } as any;
+    const store = new DynamoPRLifecycleStore(client, TABLE);
+    await expect(
+      store.markClosedUnmerged({ installationId: '42', repoFullName: 'octo/repo', prNumber: 7, prCreatedAt: '2026-04-01T00:00:00Z', at: '2026-04-03T12:00:00Z' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('listByInstallation Scans with a begins_with prefix and decodes rows', async () => {
+    const client = makeClient({
+      Items: [{
+        pk: '42#octo/repo', sk: '7',
+        prCreatedAt: '2026-04-01T00:00:00Z', state: 'merged',
+        reviewed: true, skipped: false, totalPushes: 3, pushesAfterFirstReview: 1,
+        firstReviewAt: '2026-04-02T09:00:00Z', mergedAt: '2026-04-03T12:00:00Z',
+        updatedAt: '2026-04-03T12:00:00Z', ttl: 1_900_000_000,
+      }],
+    });
+    const store = new DynamoPRLifecycleStore(client, TABLE);
+    const { items } = await store.listByInstallation('42');
+    const cmd = client.send.mock.calls[0][0];
+    expect(cmd).toBeInstanceOf(ScanCommand);
+    expect(cmd.input.ExpressionAttributeValues?.[':prefix']).toBe('42#');
+    expect(items).toEqual([{
+      installationId: '42', repoFullName: 'octo/repo', prNumber: 7,
+      prCreatedAt: '2026-04-01T00:00:00Z', state: 'merged',
+      reviewed: true, skipped: false, totalPushes: 3, pushesAfterFirstReview: 1,
+      updatedAt: '2026-04-03T12:00:00Z',
+      firstReviewAt: '2026-04-02T09:00:00Z', mergedAt: '2026-04-03T12:00:00Z',
+      ttl: 1_900_000_000,
+    }]);
+  });
+});

--- a/packages/storage-dynamo/src/pr-lifecycle-store.ts
+++ b/packages/storage-dynamo/src/pr-lifecycle-store.ts
@@ -1,0 +1,274 @@
+/**
+ * DynamoDB implementation of `IPRLifecycleStore` (TTM / #194).
+ *
+ * Table shape (created in infra/template.yaml):
+ *   PK: `${installationId}#${repoFullName}`
+ *   SK: prNumber (String — the PR number, stringified)
+ *
+ * The composite PK keeps one installation's PRs colocated for efficient
+ * listByInstallation (Scan + begins_with filter, no GSI) — same trade-off as
+ * the FB-A finding-disposition table. One row per PR (not per commit).
+ *
+ * Best-effort writes: every method swallows-and-logs on failure so a
+ * lifecycle write can never block the review pipeline. Terminal-state
+ * discipline is enforced with ConditionExpressions (swallowed when they fail).
+ */
+
+import {
+  DynamoDBDocumentClient,
+  UpdateCommand,
+  ScanCommand,
+} from '@aws-sdk/lib-dynamodb';
+import type {
+  IPRLifecycleStore,
+  PRLifecycleOpenInput,
+  PRLifecycleCloseInput,
+  PRLifecycleRecord,
+} from '@mergewatch/core';
+
+export const DEFAULT_PR_LIFECYCLE_TABLE = 'mergewatch-pr-lifecycle';
+
+/** Retain terminal rows ~90 days past close — long enough for the 90d window. */
+const TTL_DAYS_AFTER_TERMINAL = 90;
+
+/** Compose the partition key from installation + repo. */
+function pk(installationId: string, repoFullName: string): string {
+  return `${installationId}#${repoFullName}`;
+}
+
+/** Re-split the partition key. Symmetric with {@link pk}. */
+function splitPk(composite: string): { installationId: string; repoFullName: string } {
+  const idx = composite.indexOf('#');
+  return idx < 0
+    ? { installationId: composite, repoFullName: '' }
+    : { installationId: composite.slice(0, idx), repoFullName: composite.slice(idx + 1) };
+}
+
+/** Unix epoch seconds, TTL_DAYS_AFTER_TERMINAL past the given ISO timestamp. */
+function ttlFrom(iso: string): number {
+  const ms = Date.parse(iso);
+  const base = Number.isNaN(ms) ? Date.now() : ms;
+  return Math.floor(base / 1000) + TTL_DAYS_AFTER_TERMINAL * 24 * 60 * 60;
+}
+
+/**
+ * Shared bootstrap clause: defaults every non-key attribute so a row created
+ * by any entry point (open / push / review / skip / close) is internally
+ * consistent. `if_not_exists` makes each idempotent.
+ */
+const BOOTSTRAP_SET = [
+  'reviewed = if_not_exists(reviewed, :false)',
+  'skipped = if_not_exists(skipped, :false)',
+  'totalPushes = if_not_exists(totalPushes, :zero)',
+  'pushesAfterFirstReview = if_not_exists(pushesAfterFirstReview, :zero)',
+];
+
+const BOOTSTRAP_VALUES = { ':false': false, ':zero': 0 } as const;
+
+export class DynamoPRLifecycleStore implements IPRLifecycleStore {
+  constructor(
+    private readonly client: DynamoDBDocumentClient,
+    private readonly tableName: string = DEFAULT_PR_LIFECYCLE_TABLE,
+  ) {}
+
+  async upsertOpened(rec: PRLifecycleOpenInput): Promise<void> {
+    const now = new Date().toISOString();
+    try {
+      await this.client.send(new UpdateCommand({
+        TableName: this.tableName,
+        Key: { pk: pk(rec.installationId, rec.repoFullName), sk: String(rec.prNumber) },
+        UpdateExpression:
+          'SET prCreatedAt = if_not_exists(prCreatedAt, :createdAt), ' +
+          '#state = if_not_exists(#state, :open), updatedAt = :now, ' +
+          BOOTSTRAP_SET.join(', '),
+        // Only create or touch an open row — never resurrect a terminal one.
+        ConditionExpression: 'attribute_not_exists(pk) OR #state = :open',
+        ExpressionAttributeNames: { '#state': 'state' },
+        ExpressionAttributeValues: {
+          ':createdAt': rec.prCreatedAt,
+          ':open': 'open',
+          ':now': now,
+          ...BOOTSTRAP_VALUES,
+        },
+      }));
+    } catch (err) {
+      if (isConditionalFail(err)) return; // terminal row — expected no-op
+      console.warn('[ttm] upsertOpened failed (%s/%s#%d):', rec.installationId, rec.repoFullName, rec.prNumber, err);
+    }
+  }
+
+  async recordPush(installationId: string, repoFullName: string, prNumber: number): Promise<void> {
+    const now = new Date().toISOString();
+    const key = { pk: pk(installationId, repoFullName), sk: String(prNumber) };
+    // First write: bump totalPushes + bootstrap the row (creates it if missing).
+    try {
+      await this.client.send(new UpdateCommand({
+        TableName: this.tableName,
+        Key: key,
+        UpdateExpression:
+          'SET #state = if_not_exists(#state, :open), updatedAt = :now, ' +
+          'totalPushes = if_not_exists(totalPushes, :zero) + :one, ' +
+          'reviewed = if_not_exists(reviewed, :false), ' +
+          'skipped = if_not_exists(skipped, :false), ' +
+          'pushesAfterFirstReview = if_not_exists(pushesAfterFirstReview, :zero)',
+        ExpressionAttributeNames: { '#state': 'state' },
+        ExpressionAttributeValues: { ':open': 'open', ':now': now, ':zero': 0, ':one': 1, ':false': false },
+      }));
+    } catch (err) {
+      console.warn('[ttm] recordPush (total) failed (%s/%s#%d):', installationId, repoFullName, prNumber, err);
+      return;
+    }
+    // Second write: bump the post-first-review counter ONLY if a review landed.
+    // DynamoDB can't gate arithmetic on attribute existence inside one SET, so
+    // this is a separate conditional update; the conditional failure is the
+    // common (pre-review) case and is swallowed.
+    try {
+      await this.client.send(new UpdateCommand({
+        TableName: this.tableName,
+        Key: key,
+        UpdateExpression: 'SET pushesAfterFirstReview = if_not_exists(pushesAfterFirstReview, :zero) + :one',
+        ConditionExpression: 'attribute_exists(firstReviewAt)',
+        ExpressionAttributeValues: { ':zero': 0, ':one': 1 },
+      }));
+    } catch (err) {
+      if (isConditionalFail(err)) return; // no first review yet — expected
+      console.warn('[ttm] recordPush (afterReview) failed (%s/%s#%d):', installationId, repoFullName, prNumber, err);
+    }
+  }
+
+  async markReviewed(installationId: string, repoFullName: string, prNumber: number, atIso: string): Promise<void> {
+    try {
+      await this.client.send(new UpdateCommand({
+        TableName: this.tableName,
+        Key: { pk: pk(installationId, repoFullName), sk: String(prNumber) },
+        UpdateExpression:
+          'SET firstReviewAt = if_not_exists(firstReviewAt, :at), reviewed = :true, ' +
+          '#state = if_not_exists(#state, :open), updatedAt = :at, ' +
+          'skipped = if_not_exists(skipped, :false), ' +
+          'totalPushes = if_not_exists(totalPushes, :zero), ' +
+          'pushesAfterFirstReview = if_not_exists(pushesAfterFirstReview, :zero)',
+        ExpressionAttributeNames: { '#state': 'state' },
+        ExpressionAttributeValues: { ':at': atIso, ':true': true, ':open': 'open', ':false': false, ':zero': 0 },
+      }));
+    } catch (err) {
+      console.warn('[ttm] markReviewed failed (%s/%s#%d):', installationId, repoFullName, prNumber, err);
+    }
+  }
+
+  async markSkipped(installationId: string, repoFullName: string, prNumber: number, atIso: string): Promise<void> {
+    try {
+      await this.client.send(new UpdateCommand({
+        TableName: this.tableName,
+        Key: { pk: pk(installationId, repoFullName), sk: String(prNumber) },
+        UpdateExpression:
+          'SET skipped = :true, #state = if_not_exists(#state, :open), updatedAt = :at, ' +
+          'reviewed = if_not_exists(reviewed, :false), ' +
+          'totalPushes = if_not_exists(totalPushes, :zero), ' +
+          'pushesAfterFirstReview = if_not_exists(pushesAfterFirstReview, :zero)',
+        ExpressionAttributeNames: { '#state': 'state' },
+        ExpressionAttributeValues: { ':true': true, ':at': atIso, ':open': 'open', ':false': false, ':zero': 0 },
+      }));
+    } catch (err) {
+      console.warn('[ttm] markSkipped failed (%s/%s#%d):', installationId, repoFullName, prNumber, err);
+    }
+  }
+
+  async markMerged(rec: PRLifecycleCloseInput): Promise<void> {
+    try {
+      await this.client.send(new UpdateCommand({
+        TableName: this.tableName,
+        Key: { pk: pk(rec.installationId, rec.repoFullName), sk: String(rec.prNumber) },
+        // Merge is authoritative — overwrite state + prCreatedAt unconditionally
+        // (the closed payload carries the canonical created_at).
+        UpdateExpression:
+          'SET #state = :merged, mergedAt = :at, prCreatedAt = :createdAt, updatedAt = :at, #ttl = :ttl, ' +
+          BOOTSTRAP_SET.join(', '),
+        ExpressionAttributeNames: { '#state': 'state', '#ttl': 'ttl' },
+        ExpressionAttributeValues: {
+          ':merged': 'merged',
+          ':at': rec.at,
+          ':createdAt': rec.prCreatedAt,
+          ':ttl': ttlFrom(rec.at),
+          ...BOOTSTRAP_VALUES,
+        },
+      }));
+    } catch (err) {
+      console.warn('[ttm] markMerged failed (%s/%s#%d):', rec.installationId, rec.repoFullName, rec.prNumber, err);
+    }
+  }
+
+  async markClosedUnmerged(rec: PRLifecycleCloseInput): Promise<void> {
+    try {
+      await this.client.send(new UpdateCommand({
+        TableName: this.tableName,
+        Key: { pk: pk(rec.installationId, rec.repoFullName), sk: String(rec.prNumber) },
+        UpdateExpression:
+          'SET #state = :closed, closedAt = :at, prCreatedAt = if_not_exists(prCreatedAt, :createdAt), ' +
+          'updatedAt = :at, #ttl = :ttl, ' + BOOTSTRAP_SET.join(', '),
+        // Defensive: a merged row must never be downgraded to closed_unmerged.
+        ConditionExpression: 'attribute_not_exists(#state) OR #state <> :merged',
+        ExpressionAttributeNames: { '#state': 'state', '#ttl': 'ttl' },
+        ExpressionAttributeValues: {
+          ':closed': 'closed_unmerged',
+          ':merged': 'merged',
+          ':at': rec.at,
+          ':createdAt': rec.prCreatedAt,
+          ':ttl': ttlFrom(rec.at),
+          ...BOOTSTRAP_VALUES,
+        },
+      }));
+    } catch (err) {
+      if (isConditionalFail(err)) return; // already merged — keep terminal merged
+      console.warn('[ttm] markClosedUnmerged failed (%s/%s#%d):', rec.installationId, rec.repoFullName, rec.prNumber, err);
+    }
+  }
+
+  async listByInstallation(
+    installationId: string,
+    opts?: { limit?: number; cursor?: string },
+  ): Promise<{ items: PRLifecycleRecord[]; nextCursor?: string }> {
+    // Bounded Scan with begins_with(pk, '<installationId>#') — same rationale as
+    // the FB-A disposition table: the nightly rollup is the only caller and
+    // per-installation PR counts are bounded.
+    const limit = Math.min(opts?.limit ?? 1000, 1000);
+    const prefix = `${installationId}#`;
+    const resp = await this.client.send(new ScanCommand({
+      TableName: this.tableName,
+      FilterExpression: 'begins_with(#pk, :prefix)',
+      ExpressionAttributeNames: { '#pk': 'pk' },
+      ExpressionAttributeValues: { ':prefix': prefix },
+      Limit: limit,
+      ...(opts?.cursor ? { ExclusiveStartKey: JSON.parse(opts.cursor) } : {}),
+    }));
+    const items = (resp.Items ?? []).map(itemToRecord);
+    return resp.LastEvaluatedKey
+      ? { items, nextCursor: JSON.stringify(resp.LastEvaluatedKey) }
+      : { items };
+  }
+}
+
+function isConditionalFail(err: unknown): boolean {
+  return !!err && typeof err === 'object' && 'name' in err && (err as { name: string }).name === 'ConditionalCheckFailedException';
+}
+
+/** Decode a DynamoDB item into the typed record shape. */
+function itemToRecord(it: Record<string, unknown>): PRLifecycleRecord {
+  const { installationId, repoFullName } = splitPk(String(it.pk));
+  const r: PRLifecycleRecord = {
+    installationId,
+    repoFullName,
+    prNumber: Number(it.sk ?? 0),
+    prCreatedAt: String(it.prCreatedAt ?? ''),
+    state: (it.state as PRLifecycleRecord['state']) ?? 'open',
+    reviewed: Boolean(it.reviewed ?? false),
+    skipped: Boolean(it.skipped ?? false),
+    totalPushes: Number(it.totalPushes ?? 0),
+    pushesAfterFirstReview: Number(it.pushesAfterFirstReview ?? 0),
+    updatedAt: String(it.updatedAt ?? ''),
+  };
+  if (it.firstReviewAt) r.firstReviewAt = String(it.firstReviewAt);
+  if (it.mergedAt) r.mergedAt = String(it.mergedAt);
+  if (it.closedAt) r.closedAt = String(it.closedAt);
+  if (it.ttl !== undefined) r.ttl = Number(it.ttl);
+  return r;
+}

--- a/packages/storage-dynamo/src/pr-lifecycle-store.ts
+++ b/packages/storage-dynamo/src/pr-lifecycle-store.ts
@@ -122,6 +122,13 @@ export class DynamoPRLifecycleStore implements IPRLifecycleStore {
     // DynamoDB can't gate arithmetic on attribute existence inside one SET, so
     // this is a separate conditional update; the conditional failure is the
     // common (pre-review) case and is swallowed.
+    //
+    // The two writes are intentionally NON-transactional. If this second write
+    // fails for a non-conditional reason, totalPushes advances while
+    // pushesAfterFirstReview lags by one — an acceptable skew because both are
+    // best-effort analytics feeding a round-trip *proxy*, not a correctness
+    // invariant, and the lag self-heals on the next push. We log (below) so a
+    // persistent divergence is visible rather than silent.
     try {
       await this.client.send(new UpdateCommand({
         TableName: this.tableName,

--- a/packages/storage-postgres/drizzle/0008_nappy_blue_blade.sql
+++ b/packages/storage-postgres/drizzle/0008_nappy_blue_blade.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS "pr_lifecycle" (
+	"installation_id" text NOT NULL,
+	"repo_full_name" text NOT NULL,
+	"pr_number" integer NOT NULL,
+	"pr_created_at" text NOT NULL,
+	"first_review_at" text,
+	"merged_at" text,
+	"closed_at" text,
+	"state" text DEFAULT 'open' NOT NULL,
+	"reviewed" boolean DEFAULT false NOT NULL,
+	"skipped" boolean DEFAULT false NOT NULL,
+	"total_pushes" integer DEFAULT 0 NOT NULL,
+	"pushes_after_first_review" integer DEFAULT 0 NOT NULL,
+	"updated_at" text NOT NULL,
+	CONSTRAINT "pr_lifecycle_installation_id_repo_full_name_pr_number_pk" PRIMARY KEY("installation_id","repo_full_name","pr_number")
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "pr_lifecycle_installation_idx" ON "pr_lifecycle" USING btree ("installation_id");

--- a/packages/storage-postgres/drizzle/meta/0008_snapshot.json
+++ b/packages/storage-postgres/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,884 @@
+{
+  "id": "62942bef-6d9b-4d11-bf0c-12f53c12179d",
+  "prevId": "a4750bc8-11be-4af5-abe4-f8cb584b999b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_installation_idx": {
+          "name": "api_keys_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.finding_dispositions": {
+      "name": "finding_dispositions",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finding_match_key": {
+          "name": "finding_match_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_count": {
+          "name": "surface_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dispute_count": {
+          "name": "dispute_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verified_count": {
+          "name": "verified_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unverified_count": {
+          "name": "unverified_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "silent_drop_count": {
+          "name": "silent_drop_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "agreement_count": {
+          "name": "agreement_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_agent": {
+          "name": "top_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sig_tokens": {
+          "name": "sig_tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reject_reasons": {
+          "name": "reject_reasons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "finding_dispositions_installation_idx": {
+          "name": "finding_dispositions_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "finding_dispositions_installation_id_repo_full_name_finding_match_key_pk": {
+          "name": "finding_dispositions_installation_id_repo_full_name_finding_match_key_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name",
+            "finding_match_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installation_fp_insights": {
+      "name": "installation_fp_insights",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window": {
+          "name": "window",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_end": {
+          "name": "window_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_findings_surfaced": {
+          "name": "total_findings_surfaced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_disputes": {
+          "name": "total_disputes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dispute_rate": {
+          "name": "dispute_rate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_silent_drops": {
+          "name": "total_silent_drops",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_agreements": {
+          "name": "total_agreements",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "per_category": {
+          "name": "per_category",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "per_severity": {
+          "name": "per_severity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "per_repo": {
+          "name": "per_repo",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "top_clusters": {
+          "name": "top_clusters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "installation_fp_insights_installation_id_window_pk": {
+          "name": "installation_fp_insights_installation_id_window_pk",
+          "columns": [
+            "installation_id",
+            "window"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installation_settings": {
+      "name": "installation_settings",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "severity_threshold": {
+          "name": "severity_threshold",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Low'"
+        },
+        "comment_types": {
+          "name": "comment_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"syntax\":true,\"logic\":true,\"style\":true}'::jsonb"
+        },
+        "max_comments": {
+          "name": "max_comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 25
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"prSummary\":true,\"confidenceScore\":true,\"issuesTable\":true,\"diagram\":true}'::jsonb"
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "comment_header": {
+          "name": "comment_header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installations": {
+      "name": "installations",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monitored": {
+          "name": "monitored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "installations_installation_id_repo_full_name_pk": {
+          "name": "installations_installation_id_repo_full_name_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_sessions": {
+      "name": "mcp_sessions",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_billed_at": {
+          "name": "first_billed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_billed_cents": {
+          "name": "max_billed_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iteration": {
+          "name": "iteration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pr_lifecycle": {
+      "name": "pr_lifecycle",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_created_at": {
+          "name": "pr_created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_review_at": {
+          "name": "first_review_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "reviewed": {
+          "name": "reviewed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "skipped": {
+          "name": "skipped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "total_pushes": {
+          "name": "total_pushes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pushes_after_first_review": {
+          "name": "pushes_after_first_review",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pr_lifecycle_installation_idx": {
+          "name": "pr_lifecycle_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "pr_lifecycle_installation_id_repo_full_name_pr_number_pk": {
+          "name": "pr_lifecycle_installation_id_repo_full_name_pr_number_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name",
+            "pr_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number_commit_sha": {
+          "name": "pr_number_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_title": {
+          "name": "pr_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_author": {
+          "name": "pr_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_author_avatar": {
+          "name": "pr_author_avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_branch": {
+          "name": "head_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_severity": {
+          "name": "top_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_text": {
+          "name": "summary_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagram_text": {
+          "name": "diagram_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_score": {
+          "name": "merge_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_score_reason": {
+          "name": "merge_score_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "findings": {
+          "name": "findings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reactions": {
+          "name": "reactions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_used": {
+          "name": "settings_used",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_cost_usd": {
+          "name": "estimated_cost_usd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inline_resolved_keys": {
+          "name": "inline_resolved_keys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "inline_reactions_snapshot": {
+          "name": "inline_reactions_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "reviews_installation_idx": {
+          "name": "reviews_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_pr_idx": {
+          "name": "reviews_pr_idx",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "reviews_repo_full_name_pr_number_commit_sha_pk": {
+          "name": "reviews_repo_full_name_pr_number_commit_sha_pk",
+          "columns": [
+            "repo_full_name",
+            "pr_number_commit_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/storage-postgres/drizzle/meta/_journal.json
+++ b/packages/storage-postgres/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1779500194638,
       "tag": "0007_gigantic_shockwave",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1781801985919,
+      "tag": "0008_nappy_blue_blade",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/storage-postgres/src/index.ts
+++ b/packages/storage-postgres/src/index.ts
@@ -2,9 +2,10 @@ export { PostgresInstallationStore } from './installation-store.js';
 export { PostgresReviewStore } from './review-store.js';
 export { PostgresFindingDispositionStore } from './finding-disposition-store.js';
 export { PostgresFPInsightStore } from './fp-insight-store.js';
+export { PostgresPRLifecycleStore } from './pr-lifecycle-store.js';
 export {
   installations, installationSettings, reviews, apiKeys, mcpSessions,
-  findingDispositions, installationFpInsights,
+  findingDispositions, installationFpInsights, prLifecycle,
 } from './schema.js';
 export { runMigrations } from './migrate.js';
 export { createPostgresDashboardStore } from './dashboard-store.js';

--- a/packages/storage-postgres/src/pr-lifecycle-store.ts
+++ b/packages/storage-postgres/src/pr-lifecycle-store.ts
@@ -1,0 +1,163 @@
+/**
+ * Postgres implementation of `IPRLifecycleStore` (TTM / #194).
+ *
+ * One row per (installation, repo, pr_number). Lifecycle transitions are
+ * expressed as `INSERT … ON CONFLICT DO UPDATE` so each entry point is
+ * race-free and idempotent. Terminal-state discipline (a merged row never
+ * downgrades to closed; an open touch never resurrects a terminal row) is
+ * enforced with `WHERE` guards on the conflict-update.
+ *
+ * `pr_created_at` is NOT NULL; rows created by a non-`opened` entry point
+ * (e.g. a push or review that arrived before we recorded the open) seed it
+ * with '' — the same "unknown" sentinel the DynamoDB store yields — and a
+ * later upsertOpened / markMerged repairs it. The cycle-time rollup excludes
+ * '' rows from time-to-merge stats.
+ *
+ * Best-effort: every method swallows-and-logs so a lifecycle write can never
+ * block the review pipeline.
+ */
+
+import { eq, sql, desc } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import type {
+  IPRLifecycleStore,
+  PRLifecycleOpenInput,
+  PRLifecycleCloseInput,
+  PRLifecycleRecord,
+} from '@mergewatch/core';
+import { prLifecycle } from './schema.js';
+
+export class PostgresPRLifecycleStore implements IPRLifecycleStore {
+  constructor(private db: PostgresJsDatabase) {}
+
+  async upsertOpened(rec: PRLifecycleOpenInput): Promise<void> {
+    const now = new Date().toISOString();
+    try {
+      await this.db.execute(sql`
+        INSERT INTO pr_lifecycle (installation_id, repo_full_name, pr_number, pr_created_at, state, updated_at)
+        VALUES (${rec.installationId}, ${rec.repoFullName}, ${rec.prNumber}, ${rec.prCreatedAt}, 'open', ${now})
+        ON CONFLICT (installation_id, repo_full_name, pr_number)
+        DO UPDATE SET
+          pr_created_at = CASE WHEN pr_lifecycle.pr_created_at = '' THEN ${rec.prCreatedAt} ELSE pr_lifecycle.pr_created_at END,
+          updated_at = ${now}
+        WHERE pr_lifecycle.state = 'open'
+      `);
+    } catch (err) {
+      console.warn('[ttm] upsertOpened failed (%s/%s#%d):', rec.installationId, rec.repoFullName, rec.prNumber, err);
+    }
+  }
+
+  async recordPush(installationId: string, repoFullName: string, prNumber: number): Promise<void> {
+    const now = new Date().toISOString();
+    try {
+      await this.db.execute(sql`
+        INSERT INTO pr_lifecycle (installation_id, repo_full_name, pr_number, pr_created_at, state, updated_at, total_pushes, pushes_after_first_review)
+        VALUES (${installationId}, ${repoFullName}, ${prNumber}, '', 'open', ${now}, 1, 0)
+        ON CONFLICT (installation_id, repo_full_name, pr_number)
+        DO UPDATE SET
+          total_pushes = pr_lifecycle.total_pushes + 1,
+          pushes_after_first_review = pr_lifecycle.pushes_after_first_review
+            + (CASE WHEN pr_lifecycle.first_review_at IS NOT NULL THEN 1 ELSE 0 END),
+          updated_at = ${now}
+      `);
+    } catch (err) {
+      console.warn('[ttm] recordPush failed (%s/%s#%d):', installationId, repoFullName, prNumber, err);
+    }
+  }
+
+  async markReviewed(installationId: string, repoFullName: string, prNumber: number, atIso: string): Promise<void> {
+    try {
+      await this.db.execute(sql`
+        INSERT INTO pr_lifecycle (installation_id, repo_full_name, pr_number, pr_created_at, first_review_at, reviewed, state, updated_at)
+        VALUES (${installationId}, ${repoFullName}, ${prNumber}, '', ${atIso}, true, 'open', ${atIso})
+        ON CONFLICT (installation_id, repo_full_name, pr_number)
+        DO UPDATE SET
+          first_review_at = COALESCE(pr_lifecycle.first_review_at, ${atIso}),
+          reviewed = true,
+          updated_at = ${atIso}
+      `);
+    } catch (err) {
+      console.warn('[ttm] markReviewed failed (%s/%s#%d):', installationId, repoFullName, prNumber, err);
+    }
+  }
+
+  async markSkipped(installationId: string, repoFullName: string, prNumber: number, atIso: string): Promise<void> {
+    try {
+      await this.db.execute(sql`
+        INSERT INTO pr_lifecycle (installation_id, repo_full_name, pr_number, pr_created_at, skipped, state, updated_at)
+        VALUES (${installationId}, ${repoFullName}, ${prNumber}, '', true, 'open', ${atIso})
+        ON CONFLICT (installation_id, repo_full_name, pr_number)
+        DO UPDATE SET skipped = true, updated_at = ${atIso}
+      `);
+    } catch (err) {
+      console.warn('[ttm] markSkipped failed (%s/%s#%d):', installationId, repoFullName, prNumber, err);
+    }
+  }
+
+  async markMerged(rec: PRLifecycleCloseInput): Promise<void> {
+    try {
+      // Merge is authoritative — overwrite state + pr_created_at unconditionally.
+      await this.db.execute(sql`
+        INSERT INTO pr_lifecycle (installation_id, repo_full_name, pr_number, pr_created_at, merged_at, state, updated_at)
+        VALUES (${rec.installationId}, ${rec.repoFullName}, ${rec.prNumber}, ${rec.prCreatedAt}, ${rec.at}, 'merged', ${rec.at})
+        ON CONFLICT (installation_id, repo_full_name, pr_number)
+        DO UPDATE SET
+          state = 'merged',
+          merged_at = ${rec.at},
+          pr_created_at = ${rec.prCreatedAt},
+          updated_at = ${rec.at}
+      `);
+    } catch (err) {
+      console.warn('[ttm] markMerged failed (%s/%s#%d):', rec.installationId, rec.repoFullName, rec.prNumber, err);
+    }
+  }
+
+  async markClosedUnmerged(rec: PRLifecycleCloseInput): Promise<void> {
+    try {
+      await this.db.execute(sql`
+        INSERT INTO pr_lifecycle (installation_id, repo_full_name, pr_number, pr_created_at, closed_at, state, updated_at)
+        VALUES (${rec.installationId}, ${rec.repoFullName}, ${rec.prNumber}, ${rec.prCreatedAt}, ${rec.at}, 'closed_unmerged', ${rec.at})
+        ON CONFLICT (installation_id, repo_full_name, pr_number)
+        DO UPDATE SET
+          state = 'closed_unmerged',
+          closed_at = ${rec.at},
+          pr_created_at = CASE WHEN pr_lifecycle.pr_created_at = '' THEN ${rec.prCreatedAt} ELSE pr_lifecycle.pr_created_at END,
+          updated_at = ${rec.at}
+        WHERE pr_lifecycle.state <> 'merged'
+      `);
+    } catch (err) {
+      console.warn('[ttm] markClosedUnmerged failed (%s/%s#%d):', rec.installationId, rec.repoFullName, rec.prNumber, err);
+    }
+  }
+
+  async listByInstallation(
+    installationId: string,
+    opts?: { limit?: number; cursor?: string },
+  ): Promise<{ items: PRLifecycleRecord[]; nextCursor?: string }> {
+    const limit = Math.min(opts?.limit ?? 1000, 1000);
+    const rows = await this.db
+      .select()
+      .from(prLifecycle)
+      .where(eq(prLifecycle.installationId, installationId))
+      .orderBy(desc(prLifecycle.updatedAt))
+      .limit(limit);
+    const items: PRLifecycleRecord[] = rows.map((r) => ({
+      installationId: r.installationId,
+      repoFullName: r.repoFullName,
+      prNumber: r.prNumber,
+      prCreatedAt: r.prCreatedAt,
+      state: r.state as PRLifecycleRecord['state'],
+      reviewed: r.reviewed,
+      skipped: r.skipped,
+      totalPushes: r.totalPushes,
+      pushesAfterFirstReview: r.pushesAfterFirstReview,
+      updatedAt: r.updatedAt,
+      ...(r.firstReviewAt ? { firstReviewAt: r.firstReviewAt } : {}),
+      ...(r.mergedAt ? { mergedAt: r.mergedAt } : {}),
+      ...(r.closedAt ? { closedAt: r.closedAt } : {}),
+    }));
+    // Single-page for now — the rollup can extend to cursor paging if any
+    // installation exceeds the 1000-row cap.
+    return { items };
+  }
+}

--- a/packages/storage-postgres/src/schema.ts
+++ b/packages/storage-postgres/src/schema.ts
@@ -141,3 +141,26 @@ export const findingDispositions = pgTable('finding_dispositions', {
   pk: primaryKey({ columns: [t.installationId, t.repoFullName, t.findingMatchKey] }),
   installationIdx: index('finding_dispositions_installation_idx').on(t.installationId),
 }));
+
+// TTM (#194) — one row per pull request MergeWatch saw, independent of the
+// per-commit `reviews` table. Drives the nightly cycle-time rollup. See
+// PRLifecycleRecord in @mergewatch/core for the typed shape and lifecycle
+// semantics. installation_id is indexed for the rollup's per-install scan.
+export const prLifecycle = pgTable('pr_lifecycle', {
+  installationId: text('installation_id').notNull(),
+  repoFullName: text('repo_full_name').notNull(),
+  prNumber: integer('pr_number').notNull(),
+  prCreatedAt: text('pr_created_at').notNull(),
+  firstReviewAt: text('first_review_at'),
+  mergedAt: text('merged_at'),
+  closedAt: text('closed_at'),
+  state: text('state').notNull().default('open'),
+  reviewed: boolean('reviewed').notNull().default(false),
+  skipped: boolean('skipped').notNull().default(false),
+  totalPushes: integer('total_pushes').notNull().default(0),
+  pushesAfterFirstReview: integer('pushes_after_first_review').notNull().default(0),
+  updatedAt: text('updated_at').notNull(),
+}, (t) => ({
+  pk: primaryKey({ columns: [t.installationId, t.repoFullName, t.prNumber] }),
+  installationIdx: index('pr_lifecycle_installation_idx').on(t.installationId),
+}));


### PR DESCRIPTION
## Stage 1 of #194 — time-to-PR-merge

First of three staged PRs. This stage captures PR lifecycle so a later nightly rollup can compute cycle-time. **No user-visible behavior yet** — pure data capture.

Decisions (confirmed with maintainer): **dedicated PR-lifecycle store** (a merge is per-PR, but `ReviewItem` is keyed per-commit and unreviewed PRs have no review row), **staged PRs**, **backfill deferred**.

### What's in this PR
- **Core**: `PRLifecycleRecord` (one row per PR) + `IPRLifecycleStore`; `GitHubPullRequest` gains `merged` / `merged_at` / `closed_at`.
- **Storage**: `DynamoPRLifecycleStore` and `PostgresPRLifecycleStore`, mirroring the FB-A disposition store — best-effort writes, terminal-state discipline (a merged row never downgrades; `firstReviewAt` is set-once), `listByInstallation` for the rollup.
- **Webhook** (self-hosted + Lambda): record lifecycle on `opened`/`reopened`/`ready_for_review` (`upsertOpened`), `synchronize` (`recordPush`), and the **newly-handled `closed`** action (`markMerged` / `markClosedUnmerged`). Closed PRs no longer fall through — they terminate the lifecycle without triggering a review.
- **Review pipeline**: marks `reviewed` (set-once first-review anchor) / `skipped`.
- **Infra**: `mergewatch-pr-lifecycle-${Stage}` DynamoDB table (TTL-reaped ~90d past close) + IAM grant + `PR_LIFECYCLE_TABLE` env; Postgres `pr_lifecycle` table + idempotent migration `0008`.

### Tests
- Webhook event→method routing: `opened`→upsertOpened, `synchronize`→recordPush, `closed` merged→markMerged, `closed` unmerged→markClosedUnmerged, and **no review enqueued on close**; best-effort no-op when no store is wired.
- Dynamo store: key construction, terminal-state `ConditionExpression` guards, two-write push counting, TTL math, row decode.
- Full repo: `typecheck` 20/20, all suites green (server 84, lambda 61, dynamo 20); `migrations:check` clean.

### Deferred to later stages
- **Stage 2**: percentile rollup math (median/p75/p90 time-to-merge, time-from-first-review-to-merge, round-trips), reviewed-vs-unreviewed segmentation, with the heavy percentile/empty/open-PR/no-merge test coverage the acceptance criteria call for.
- **Stage 3**: dashboard "Cycle time" section.
- Historical backfill.

Part of #194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)