### PR TITLE
feat(ttm): cycle-time rollup — time-to-merge percentiles (#194, stage 2)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -165,6 +165,10 @@ export { buildInsightFromDispositions, WINDOW_LENGTH_MS } from './insights/rollu
 export { runInsightRollup } from './insights/run-rollup.js';
 export type { RollupStores, RollupRunResult } from './insights/run-rollup.js';
 
+// ─── Cycle-time rollup (TTM / #194) ────────────────────────────────────────
+export { buildCycleTimeInsight, percentile, percentilesOf } from './insights/cycle-time.js';
+export type { CycleTimeInsight } from './insights/cycle-time.js';
+
 // ─── Dispute-rate loader (FP-J L1) ─────────────────────────────────────────
 export { loadCategoryDisputeRates } from './insights/dispute-rates.js';
 
@@ -251,6 +255,7 @@ export type {
   UpdateReviewInput,
   FindingDispositionRecord,
   InstallationFPInsight,
+  CycleTimePercentiles,
   PRLifecycleRecord,
 } from './types/db.js';
 

--- a/packages/core/src/insights/cycle-time.test.ts
+++ b/packages/core/src/insights/cycle-time.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import { buildCycleTimeInsight, percentile, percentilesOf } from './cycle-time.js';
+import type { PRLifecycleRecord } from '../types/db.js';
+
+const WINDOW_END = '2026-05-22T00:00:00.000Z';
+
+/** A merged PR whose timestamps default to "inside the 7d window". */
+function pr(over: Partial<PRLifecycleRecord> = {}): PRLifecycleRecord {
+  return {
+    installationId: '42',
+    repoFullName: 'org/repo',
+    prNumber: 1,
+    prCreatedAt: '2026-05-20T00:00:00.000Z',
+    mergedAt: '2026-05-21T00:00:00.000Z', // 24h to merge, 1d before window end
+    state: 'merged',
+    reviewed: true,
+    skipped: false,
+    totalPushes: 0,
+    pushesAfterFirstReview: 0,
+    updatedAt: '2026-05-21T00:00:00.000Z',
+    ...over,
+  };
+}
+
+describe('percentile (R-7 linear interpolation)', () => {
+  it('returns the single value for a 1-element array', () => {
+    expect(percentile([7], 0.5)).toBe(7);
+    expect(percentile([7], 0.9)).toBe(7);
+  });
+
+  it('computes median of an odd-length sample', () => {
+    expect(percentile([1, 2, 3], 0.5)).toBe(2);
+  });
+
+  it('interpolates the median of an even-length sample', () => {
+    expect(percentile([1, 2, 3, 4], 0.5)).toBe(2.5);
+  });
+
+  it('computes p90 by interpolating between ranks', () => {
+    // n=10, rank = 0.9*(9) = 8.1 → between sorted[8]=9 and sorted[9]=10
+    const data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    expect(percentile(data, 0.9)).toBeCloseTo(9.1, 10);
+  });
+
+  it('p75 of 1..4 interpolates to 3.25', () => {
+    expect(percentile([1, 2, 3, 4], 0.75)).toBeCloseTo(3.25, 10);
+  });
+});
+
+describe('percentilesOf', () => {
+  it('returns null for an empty sample', () => {
+    expect(percentilesOf([])).toBeNull();
+  });
+
+  it('returns p50/p75/p90 for a non-empty sample', () => {
+    expect(percentilesOf([10, 20, 30, 40])).toEqual({ p50: 25, p75: 32.5, p90: 37 });
+  });
+});
+
+describe('buildCycleTimeInsight', () => {
+  it('counts a merged reviewed PR and computes time-to-merge in hours', () => {
+    const out = buildCycleTimeInsight('7d', WINDOW_END, [pr()]);
+    expect(out.mergedCount).toBe(1);
+    expect(out.reviewedMergedCount).toBe(1);
+    expect(out.unreviewedMergedCount).toBe(0);
+    expect(out.timeToMergeHours).toEqual({ p50: 24, p75: 24, p90: 24 });
+    expect(out.timeToMergeHoursReviewed).toEqual({ p50: 24, p75: 24, p90: 24 });
+    expect(out.timeToMergeHoursUnreviewed).toBeNull();
+  });
+
+  it('segments reviewed vs unreviewed merged PRs', () => {
+    const records = [
+      pr({ prNumber: 1, reviewed: true, prCreatedAt: '2026-05-21T00:00:00.000Z', mergedAt: '2026-05-21T12:00:00.000Z' }), // 12h
+      pr({ prNumber: 2, reviewed: false, prCreatedAt: '2026-05-19T00:00:00.000Z', mergedAt: '2026-05-21T00:00:00.000Z' }), // 48h
+    ];
+    const out = buildCycleTimeInsight('7d', WINDOW_END, records);
+    expect(out.mergedCount).toBe(2);
+    expect(out.reviewedMergedCount).toBe(1);
+    expect(out.unreviewedMergedCount).toBe(1);
+    expect(out.timeToMergeHoursReviewed?.p50).toBe(12);
+    expect(out.timeToMergeHoursUnreviewed?.p50).toBe(48);
+    // The combined sample is [12, 48] → median 30.
+    expect(out.timeToMergeHours?.p50).toBe(30);
+  });
+
+  it('computes time-from-first-review-to-merge and round-trips for reviewed PRs', () => {
+    const out = buildCycleTimeInsight('7d', WINDOW_END, [
+      pr({
+        reviewed: true,
+        prCreatedAt: '2026-05-20T00:00:00.000Z',
+        firstReviewAt: '2026-05-20T06:00:00.000Z', // 18h before merge
+        mergedAt: '2026-05-21T00:00:00.000Z',
+        pushesAfterFirstReview: 3,
+      }),
+    ]);
+    expect(out.timeToMergeFromFirstReviewHours).toEqual({ p50: 18, p75: 18, p90: 18 });
+    expect(out.roundTripsBeforeMerge).toEqual({ p50: 3, p75: 3, p90: 3 });
+  });
+
+  it('excludes closed-without-merge and still-open PRs from time stats but counts them', () => {
+    const records = [
+      pr({ prNumber: 1 }), // merged in-window
+      pr({ prNumber: 2, state: 'closed_unmerged', mergedAt: undefined, closedAt: '2026-05-21T00:00:00.000Z' }),
+      pr({ prNumber: 3, state: 'open', mergedAt: undefined, prCreatedAt: '2026-05-21T00:00:00.000Z' }),
+    ];
+    const out = buildCycleTimeInsight('7d', WINDOW_END, records);
+    expect(out.mergedCount).toBe(1);
+    expect(out.closedUnmergedCount).toBe(1);
+    expect(out.openCount).toBe(1);
+    expect(out.timeToMergeHours).toEqual({ p50: 24, p75: 24, p90: 24 }); // only the merged PR
+  });
+
+  it('returns all-zero counts and null percentiles for an empty installation', () => {
+    const out = buildCycleTimeInsight('30d', WINDOW_END, []);
+    expect(out).toEqual({
+      mergedCount: 0,
+      reviewedMergedCount: 0,
+      unreviewedMergedCount: 0,
+      closedUnmergedCount: 0,
+      openCount: 0,
+      timeToMergeHours: null,
+      timeToMergeHoursReviewed: null,
+      timeToMergeHoursUnreviewed: null,
+      timeToMergeFromFirstReviewHours: null,
+      roundTripsBeforeMerge: null,
+    });
+  });
+
+  it('windows by mergedAt — a merge before windowStart is excluded', () => {
+    const old = pr({ mergedAt: '2026-05-10T00:00:00.000Z', prCreatedAt: '2026-05-09T00:00:00.000Z' }); // 12d before end
+    expect(buildCycleTimeInsight('7d', WINDOW_END, [old]).mergedCount).toBe(0);
+    expect(buildCycleTimeInsight('30d', WINDOW_END, [old]).mergedCount).toBe(1);
+  });
+
+  it('counts a merge with an unknown prCreatedAt sentinel but omits it from created→merged percentiles', () => {
+    const out = buildCycleTimeInsight('7d', WINDOW_END, [
+      pr({ prCreatedAt: '', reviewed: false }), // '' sentinel — anchor unknown
+    ]);
+    expect(out.mergedCount).toBe(1);
+    expect(out.unreviewedMergedCount).toBe(1);
+    expect(out.timeToMergeHours).toBeNull(); // no computable created→merged span
+  });
+
+  it('drops negative spans (clock skew) rather than feeding them to stats', () => {
+    const out = buildCycleTimeInsight('7d', WINDOW_END, [
+      pr({ prCreatedAt: '2026-05-21T12:00:00.000Z', mergedAt: '2026-05-21T00:00:00.000Z' }), // merged before created
+    ]);
+    expect(out.mergedCount).toBe(1);
+    expect(out.timeToMergeHours).toBeNull();
+  });
+});

--- a/packages/core/src/insights/cycle-time.ts
+++ b/packages/core/src/insights/cycle-time.ts
@@ -1,0 +1,127 @@
+/**
+ * TTM (#194) — aggregate `PRLifecycleRecord` rows into the cycle-time block
+ * of an `InstallationFPInsight` for one rolling window.
+ *
+ * Pure function: takes already-fetched lifecycle records + a window length,
+ * returns the typed block. Doesn't touch storage; window bounds come in as
+ * an ISO string. Mirrors `buildInsightFromDispositions` (FB-E) so the rollup
+ * orchestrator can compute both from the same windowEnd.
+ *
+ * Merge times are heavily right-skewed, so we report percentiles
+ * (median / p75 / p90), never a mean. All durations are in HOURS.
+ */
+
+import type { PRLifecycleRecord, InstallationFPInsight, CycleTimePercentiles } from '../types/db.js';
+import { WINDOW_LENGTH_MS } from './rollup.js';
+
+const MS_PER_HOUR = 60 * 60 * 1000;
+
+export type CycleTimeInsight = NonNullable<InstallationFPInsight['cycleTime']>;
+
+/**
+ * Linear-interpolation percentile (the "R-7" / Excel `PERCENTILE.INC`
+ * method) over an ascending-sorted, non-empty array. `p` is a fraction in
+ * [0, 1]. Returns the single value for a 1-element array.
+ */
+export function percentile(sortedAsc: readonly number[], p: number): number {
+  if (sortedAsc.length === 1) return sortedAsc[0];
+  const rank = p * (sortedAsc.length - 1);
+  const lo = Math.floor(rank);
+  const hi = Math.ceil(rank);
+  if (lo === hi) return sortedAsc[lo];
+  const frac = rank - lo;
+  return sortedAsc[lo] * (1 - frac) + sortedAsc[hi] * frac;
+}
+
+/** p50 / p75 / p90 of a sample, or null when the sample is empty. */
+export function percentilesOf(values: readonly number[]): CycleTimePercentiles | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  return {
+    p50: percentile(sorted, 0.5),
+    p75: percentile(sorted, 0.75),
+    p90: percentile(sorted, 0.9),
+  };
+}
+
+/** Hours between two ISO timestamps, or null if either is missing/unparseable
+ *  or the span is negative (clock skew / bad data — never feed it to stats). */
+function hoursBetween(startIso: string | undefined, endIso: string | undefined): number | null {
+  if (!startIso || !endIso) return null;
+  const a = Date.parse(startIso);
+  const b = Date.parse(endIso);
+  if (Number.isNaN(a) || Number.isNaN(b)) return null;
+  const hours = (b - a) / MS_PER_HOUR;
+  return hours >= 0 ? hours : null;
+}
+
+/**
+ * Build the cycle-time block for one window.
+ *
+ *   - merged PRs (mergedAt in window) drive every time stat;
+ *   - closed-without-merge and still-open PRs are counted but excluded
+ *     from the duration percentiles (no merge time);
+ *   - a row whose `prCreatedAt` is the '' sentinel (created via a non-`opened`
+ *     entry point) still counts toward `mergedCount` but is excluded from the
+ *     created→merged percentiles, since its anchor is unknown.
+ */
+export function buildCycleTimeInsight(
+  window: InstallationFPInsight['window'],
+  windowEndIso: string,
+  records: readonly PRLifecycleRecord[],
+): CycleTimeInsight {
+  const windowEndMs = new Date(windowEndIso).getTime();
+  const windowStartMs = windowEndMs - WINDOW_LENGTH_MS[window];
+  const inWindow = (iso: string | undefined): boolean => {
+    if (!iso) return false;
+    const t = Date.parse(iso);
+    return !Number.isNaN(t) && t >= windowStartMs && t <= windowEndMs;
+  };
+
+  let mergedCount = 0;
+  let reviewedMergedCount = 0;
+  let unreviewedMergedCount = 0;
+  let closedUnmergedCount = 0;
+  let openCount = 0;
+
+  const ttmAll: number[] = [];
+  const ttmReviewed: number[] = [];
+  const ttmUnreviewed: number[] = [];
+  const ttmFromFirstReview: number[] = [];
+  const roundTrips: number[] = [];
+
+  for (const r of records) {
+    if (r.state === 'merged' && inWindow(r.mergedAt)) {
+      mergedCount++;
+      const ttm = hoursBetween(r.prCreatedAt, r.mergedAt);
+      if (ttm !== null) ttmAll.push(ttm);
+      if (r.reviewed) {
+        reviewedMergedCount++;
+        if (ttm !== null) ttmReviewed.push(ttm);
+        const fromReview = hoursBetween(r.firstReviewAt, r.mergedAt);
+        if (fromReview !== null) ttmFromFirstReview.push(fromReview);
+        roundTrips.push(r.pushesAfterFirstReview);
+      } else {
+        unreviewedMergedCount++;
+        if (ttm !== null) ttmUnreviewed.push(ttm);
+      }
+    } else if (r.state === 'closed_unmerged' && inWindow(r.closedAt)) {
+      closedUnmergedCount++;
+    } else if (r.state === 'open' && inWindow(r.prCreatedAt)) {
+      openCount++;
+    }
+  }
+
+  return {
+    mergedCount,
+    reviewedMergedCount,
+    unreviewedMergedCount,
+    closedUnmergedCount,
+    openCount,
+    timeToMergeHours: percentilesOf(ttmAll),
+    timeToMergeHoursReviewed: percentilesOf(ttmReviewed),
+    timeToMergeHoursUnreviewed: percentilesOf(ttmUnreviewed),
+    timeToMergeFromFirstReviewHours: percentilesOf(ttmFromFirstReview),
+    roundTripsBeforeMerge: percentilesOf(roundTrips),
+  };
+}

--- a/packages/core/src/insights/run-rollup.test.ts
+++ b/packages/core/src/insights/run-rollup.test.ts
@@ -186,3 +186,74 @@ describe('runInsightRollup (FB-E orchestrator)', () => {
     expect(result.elapsedMs).toBeGreaterThanOrEqual(0);
   });
 });
+
+// ─── TTM (#194) — cycle-time wiring ────────────────────────────────────────
+
+import type { PRLifecycleRecord } from '../types/db.js';
+
+function prRecord(over: Partial<PRLifecycleRecord> = {}): PRLifecycleRecord {
+  return {
+    installationId: '42',
+    repoFullName: 'org/repo',
+    prNumber: 1,
+    prCreatedAt: '2026-05-20T00:00:00.000Z',
+    mergedAt: '2026-05-21T00:00:00.000Z',
+    state: 'merged',
+    reviewed: true,
+    skipped: false,
+    totalPushes: 2,
+    pushesAfterFirstReview: 1,
+    updatedAt: '2026-05-21T00:00:00.000Z',
+    ...over,
+  };
+}
+
+describe('runInsightRollup — cycle-time block', () => {
+  it('attaches a cycleTime block to every window when prLifecycleStore is wired', async () => {
+    const stores = makeStores({ installationIds: ['42'], recordsByInstallation: { '42': [] } });
+    const prCalls: Array<{ id: string; cursor?: string }> = [];
+    const withPr: RollupStores & { upserts: InstallationFPInsight[] } = {
+      ...stores,
+      prLifecycleStore: {
+        listByInstallation: vi.fn(async (id: string, opts?: { cursor?: string }) => {
+          prCalls.push({ id, cursor: opts?.cursor });
+          return { items: [prRecord()] };
+        }),
+      },
+    };
+    await runInsightRollup(withPr, WINDOW_END);
+    expect(prCalls).toEqual([{ id: '42', cursor: undefined }]);
+    expect(stores.upserts).toHaveLength(3);
+    for (const u of stores.upserts) {
+      expect(u.cycleTime).toBeDefined();
+      expect(u.cycleTime?.mergedCount).toBe(1);
+      expect(u.cycleTime?.reviewedMergedCount).toBe(1);
+      expect(u.cycleTime?.timeToMergeHours).toEqual({ p50: 24, p75: 24, p90: 24 });
+      expect(u.cycleTime?.roundTripsBeforeMerge).toEqual({ p50: 1, p75: 1, p90: 1 });
+    }
+  });
+
+  it('omits cycleTime entirely when no prLifecycleStore is wired (back-compat)', async () => {
+    const stores = makeStores({ installationIds: ['42'], recordsByInstallation: { '42': [] } });
+    await runInsightRollup(stores, WINDOW_END);
+    for (const u of stores.upserts) {
+      expect(u.cycleTime).toBeUndefined();
+    }
+  });
+
+  it('follows cursor pagination across multiple pages of PR-lifecycle records', async () => {
+    const stores = makeStores({ installationIds: ['42'], recordsByInstallation: { '42': [] } });
+    const withPr: RollupStores & { upserts: InstallationFPInsight[] } = {
+      ...stores,
+      prLifecycleStore: {
+        listByInstallation: async (_id: string, opts?: { cursor?: string }) => {
+          if (!opts?.cursor) return { items: [prRecord({ prNumber: 1 })], nextCursor: 'p2' };
+          return { items: [prRecord({ prNumber: 2 })] };
+        },
+      },
+    };
+    await runInsightRollup(withPr, WINDOW_END);
+    // Both pages' merged PRs counted into each window.
+    expect(stores.upserts[0].cycleTime?.mergedCount).toBe(2);
+  });
+});

--- a/packages/core/src/insights/run-rollup.ts
+++ b/packages/core/src/insights/run-rollup.ts
@@ -13,9 +13,11 @@ import type {
   IFindingDispositionStore,
   IFPInsightStore,
   IInstallationStore,
+  IPRLifecycleStore,
 } from '../storage/types.js';
-import type { FindingDispositionRecord, InstallationFPInsight } from '../types/db.js';
+import type { FindingDispositionRecord, InstallationFPInsight, PRLifecycleRecord } from '../types/db.js';
 import { buildInsightFromDispositions } from './rollup.js';
+import { buildCycleTimeInsight } from './cycle-time.js';
 
 const WINDOWS: InstallationFPInsight['window'][] = ['7d', '30d', '90d'];
 
@@ -23,6 +25,13 @@ export interface RollupStores {
   installationStore: Pick<IInstallationStore, 'listInstallationIds'>;
   dispositionStore: Pick<IFindingDispositionStore, 'listByInstallation'>;
   fpInsightStore: Pick<IFPInsightStore, 'upsert'>;
+  /**
+   * TTM (#194) — optional. When wired, each insight row gains a `cycleTime`
+   * block built from this installation's PR-lifecycle records. When absent
+   * (e.g. a deploy that hasn't provisioned the table yet) the rollup behaves
+   * exactly as before and `cycleTime` stays undefined.
+   */
+  prLifecycleStore?: Pick<IPRLifecycleStore, 'listByInstallation'>;
 }
 
 export interface RollupRunResult {
@@ -85,8 +94,24 @@ export async function runInsightRollup(
         cursor = page.nextCursor;
       } while (cursor);
 
+      // TTM (#194) — page the PR-lifecycle rows the same way (when the store
+      // is wired). Same cursor-pagination discipline so we never silently
+      // truncate a high-volume installation.
+      const prRecords: PRLifecycleRecord[] = [];
+      if (stores.prLifecycleStore) {
+        let prCursor: string | undefined;
+        do {
+          const page = await stores.prLifecycleStore.listByInstallation(installationId, { limit: 1000, cursor: prCursor });
+          prRecords.push(...page.items);
+          prCursor = page.nextCursor;
+        } while (prCursor);
+      }
+
       for (const window of WINDOWS) {
         const insight = buildInsightFromDispositions(installationId, window, windowEndIso, records);
+        if (stores.prLifecycleStore) {
+          insight.cycleTime = buildCycleTimeInsight(window, windowEndIso, prRecords);
+        }
         await stores.fpInsightStore.upsert(insight);
         rowsWritten++;
       }

--- a/packages/core/src/types/db.ts
+++ b/packages/core/src/types/db.ts
@@ -654,6 +654,48 @@ export interface InstallationFPInsight {
     disputeCount: number;
     rate: number;
   }>;
+
+  /**
+   * TTM (#194) — time-to-merge / cycle-time block, computed from
+   * `PRLifecycleRecord` rows in the same window. Optional: present only on
+   * rollups generated after Stage 2 shipped AND when a PR-lifecycle store is
+   * wired into the rollup. Consumers must handle the undefined case.
+   *
+   * A PR is windowed by its terminal (or, for still-open PRs, creation)
+   * timestamp: merged → `mergedAt`, closed-unmerged → `closedAt`, open →
+   * `prCreatedAt`. Percentiles are in HOURS; each percentile object is null
+   * when its underlying sample is empty (no merged PRs, no reviewed merges,
+   * etc.) so the dashboard can distinguish "0 hours" from "no data".
+   */
+  cycleTime?: {
+    /** Merged in-window. The denominator for the time-to-merge stats. */
+    mergedCount: number;
+    /** Of `mergedCount`, those MergeWatch reviewed vs not (segmentation). */
+    reviewedMergedCount: number;
+    unreviewedMergedCount: number;
+    /** Closed without merging in-window — excluded from time stats. */
+    closedUnmergedCount: number;
+    /** Still open (created in-window) — no merge time yet. */
+    openCount: number;
+
+    /** created_at → merged_at, all merged PRs. */
+    timeToMergeHours: CycleTimePercentiles | null;
+    /** created_at → merged_at, reviewed merged PRs only. */
+    timeToMergeHoursReviewed: CycleTimePercentiles | null;
+    /** created_at → merged_at, unreviewed merged PRs only. */
+    timeToMergeHoursUnreviewed: CycleTimePercentiles | null;
+    /** first_review_at → merged_at, reviewed merged PRs only. */
+    timeToMergeFromFirstReviewHours: CycleTimePercentiles | null;
+    /** pushesAfterFirstReview distribution, reviewed merged PRs only. */
+    roundTripsBeforeMerge: CycleTimePercentiles | null;
+  };
+}
+
+/** Median / p75 / p90 of a cycle-time sample. */
+export interface CycleTimePercentiles {
+  p50: number;
+  p75: number;
+  p90: number;
 }
 
 /**

--- a/packages/lambda/src/handlers/insights-rollup.ts
+++ b/packages/lambda/src/handlers/insights-rollup.ts
@@ -28,8 +28,10 @@ import {
   DynamoInstallationStore,
   DynamoFindingDispositionStore,
   DynamoFPInsightStore,
+  DynamoPRLifecycleStore,
   DEFAULT_FINDING_DISPOSITIONS_TABLE,
   DEFAULT_FP_INSIGHTS_TABLE,
+  DEFAULT_PR_LIFECYCLE_TABLE,
 } from '@mergewatch/storage-dynamo';
 
 const dynamodb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
@@ -37,10 +39,13 @@ const dynamodb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const INSTALLATIONS_TABLE = process.env.INSTALLATIONS_TABLE ?? 'mergewatch-installations';
 const FINDING_DISPOSITIONS_TABLE = process.env.FINDING_DISPOSITIONS_TABLE ?? DEFAULT_FINDING_DISPOSITIONS_TABLE;
 const FP_INSIGHTS_TABLE = process.env.FP_INSIGHTS_TABLE ?? DEFAULT_FP_INSIGHTS_TABLE;
+const PR_LIFECYCLE_TABLE = process.env.PR_LIFECYCLE_TABLE ?? DEFAULT_PR_LIFECYCLE_TABLE;
 
 const installationStore = new DynamoInstallationStore(dynamodb, INSTALLATIONS_TABLE);
 const dispositionStore = new DynamoFindingDispositionStore(dynamodb, FINDING_DISPOSITIONS_TABLE);
 const fpInsightStore = new DynamoFPInsightStore(dynamodb, FP_INSIGHTS_TABLE);
+// TTM (#194) — feeds the cycle-time block of each insight row.
+const prLifecycleStore = new DynamoPRLifecycleStore(dynamodb, PR_LIFECYCLE_TABLE);
 
 export async function handler(): Promise<{ statusCode: number; body: string }> {
   console.log('[fb-e] insights rollup starting');
@@ -48,6 +53,7 @@ export async function handler(): Promise<{ statusCode: number; body: string }> {
     installationStore,
     dispositionStore,
     fpInsightStore,
+    prLifecycleStore,
   });
   console.log(
     '[fb-e] rollup complete — processed=%d, rows=%d, failed=[%s], elapsed=%dms, windowEnd=%s',

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -76,7 +76,7 @@ async function main() {
   // (60s after init to let migrations complete) and every 24h after.
   // Errors are caught + logged inside; the cron handle is kept for
   // future graceful-shutdown support.
-  startInsightsCron({ installationStore, dispositionStore, fpInsightStore });
+  startInsightsCron({ installationStore, dispositionStore, fpInsightStore, prLifecycleStore });
 
   // Express app
   const app = express();

--- a/packages/server/src/insights-cron.ts
+++ b/packages/server/src/insights-cron.ts
@@ -14,6 +14,7 @@ import type {
   IFindingDispositionStore,
   IFPInsightStore,
   IInstallationStore,
+  IPRLifecycleStore,
 } from '@mergewatch/core';
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
@@ -25,6 +26,8 @@ export interface InsightsCronStores {
   installationStore: IInstallationStore;
   dispositionStore: IFindingDispositionStore;
   fpInsightStore: IFPInsightStore;
+  /** TTM (#194) — feeds the cycle-time block of each insight row. */
+  prLifecycleStore?: IPRLifecycleStore;
 }
 
 export interface InsightsCronHandle {

--- a/packages/storage-dynamo/src/fp-insight-store.test.ts
+++ b/packages/storage-dynamo/src/fp-insight-store.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PutCommand } from '@aws-sdk/lib-dynamodb';
+import { DynamoFPInsightStore } from './fp-insight-store.js';
+import type { InstallationFPInsight } from '@mergewatch/core';
+
+const TABLE = 'test-fp-insights';
+
+function makeClient(response: unknown = {}) {
+  return { send: vi.fn().mockResolvedValue(response) } as any;
+}
+
+const baseInsight: InstallationFPInsight = {
+  installationId: '42',
+  window: '7d',
+  windowStart: '2026-05-15T00:00:00.000Z',
+  windowEnd: '2026-05-22T00:00:00.000Z',
+  generatedAt: '2026-05-22T00:00:00.000Z',
+  totalFindingsSurfaced: 0,
+  totalDisputes: 0,
+  disputeRate: 0,
+  totalSilentDrops: 0,
+  totalAgreements: 0,
+  perCategory: {},
+  perRepo: {},
+  topClusters: [],
+};
+
+const cycleTime: NonNullable<InstallationFPInsight['cycleTime']> = {
+  mergedCount: 2,
+  reviewedMergedCount: 1,
+  unreviewedMergedCount: 1,
+  closedUnmergedCount: 0,
+  openCount: 3,
+  timeToMergeHours: { p50: 24, p75: 36, p90: 48 },
+  timeToMergeHoursReviewed: { p50: 12, p75: 12, p90: 12 },
+  timeToMergeHoursUnreviewed: { p50: 48, p75: 48, p90: 48 },
+  timeToMergeFromFirstReviewHours: { p50: 6, p75: 6, p90: 6 },
+  roundTripsBeforeMerge: { p50: 2, p75: 2, p90: 2 },
+};
+
+describe('DynamoFPInsightStore — cycleTime (TTM #194)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('writes the cycleTime block when present', async () => {
+    const client = makeClient();
+    const store = new DynamoFPInsightStore(client, TABLE);
+    await store.upsert({ ...baseInsight, cycleTime });
+    const cmd = client.send.mock.calls[0][0];
+    expect(cmd).toBeInstanceOf(PutCommand);
+    expect(cmd.input.Item.cycleTime).toEqual(cycleTime);
+  });
+
+  it('writes null (not undefined) when cycleTime is absent', async () => {
+    const client = makeClient();
+    const store = new DynamoFPInsightStore(client, TABLE);
+    await store.upsert(baseInsight);
+    const cmd = client.send.mock.calls[0][0];
+    expect(cmd.input.Item.cycleTime).toBeNull();
+  });
+
+  it('round-trips cycleTime back on read', async () => {
+    const client = makeClient({ Item: { ...baseInsight, disputeRate: '0', cycleTime } });
+    const store = new DynamoFPInsightStore(client, TABLE);
+    const got = await store.get('42', '7d');
+    expect(got?.cycleTime).toEqual(cycleTime);
+  });
+
+  it('leaves cycleTime undefined for pre-Stage-2 rows (null/absent)', async () => {
+    const client = makeClient({ Item: { ...baseInsight, disputeRate: '0', cycleTime: null } });
+    const store = new DynamoFPInsightStore(client, TABLE);
+    const got = await store.get('42', '7d');
+    expect(got?.cycleTime).toBeUndefined();
+  });
+});

--- a/packages/storage-dynamo/src/fp-insight-store.ts
+++ b/packages/storage-dynamo/src/fp-insight-store.ts
@@ -52,6 +52,9 @@ export class DynamoFPInsightStore implements IFPInsightStore {
         perSeverity: insight.perSeverity ?? {},
         perRepo: insight.perRepo,
         topClusters: insight.topClusters,
+        // TTM (#194) — null (not undefined) when absent: DynamoDB rejects
+        // undefined attribute values, and null round-trips back to undefined.
+        cycleTime: insight.cycleTime ?? null,
       },
     }));
   }
@@ -92,5 +95,7 @@ function itemToInsight(it: Record<string, unknown>): InstallationFPInsight {
     perSeverity: (it.perSeverity as InstallationFPInsight['perSeverity']) ?? {},
     perRepo: (it.perRepo as InstallationFPInsight['perRepo']) ?? {},
     topClusters: (it.topClusters as InstallationFPInsight['topClusters']) ?? [],
+    // TTM (#194) — absent on pre-Stage-2 rows; null coerces back to undefined.
+    ...(it.cycleTime ? { cycleTime: it.cycleTime as InstallationFPInsight['cycleTime'] } : {}),
   };
 }

--- a/packages/storage-postgres/drizzle/0009_parallel_stark_industries.sql
+++ b/packages/storage-postgres/drizzle/0009_parallel_stark_industries.sql
@@ -1,0 +1,3 @@
+-- TTM (#194) — cycle-time block on the insight rollup. Nullable; pre-Stage-2
+-- rows and rollups without a PR-lifecycle store leave it NULL (→ undefined).
+ALTER TABLE "installation_fp_insights" ADD COLUMN IF NOT EXISTS "cycle_time" jsonb;

--- a/packages/storage-postgres/drizzle/meta/0009_snapshot.json
+++ b/packages/storage-postgres/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,890 @@
+{
+  "id": "26864348-f19b-4c60-9177-fd98b6e42067",
+  "prevId": "62942bef-6d9b-4d11-bf0c-12f53c12179d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_installation_idx": {
+          "name": "api_keys_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.finding_dispositions": {
+      "name": "finding_dispositions",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finding_match_key": {
+          "name": "finding_match_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_count": {
+          "name": "surface_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dispute_count": {
+          "name": "dispute_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verified_count": {
+          "name": "verified_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unverified_count": {
+          "name": "unverified_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "silent_drop_count": {
+          "name": "silent_drop_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "agreement_count": {
+          "name": "agreement_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_agent": {
+          "name": "top_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sig_tokens": {
+          "name": "sig_tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reject_reasons": {
+          "name": "reject_reasons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "finding_dispositions_installation_idx": {
+          "name": "finding_dispositions_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "finding_dispositions_installation_id_repo_full_name_finding_match_key_pk": {
+          "name": "finding_dispositions_installation_id_repo_full_name_finding_match_key_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name",
+            "finding_match_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installation_fp_insights": {
+      "name": "installation_fp_insights",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window": {
+          "name": "window",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_end": {
+          "name": "window_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_findings_surfaced": {
+          "name": "total_findings_surfaced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_disputes": {
+          "name": "total_disputes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dispute_rate": {
+          "name": "dispute_rate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_silent_drops": {
+          "name": "total_silent_drops",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_agreements": {
+          "name": "total_agreements",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "per_category": {
+          "name": "per_category",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "per_severity": {
+          "name": "per_severity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "per_repo": {
+          "name": "per_repo",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "top_clusters": {
+          "name": "top_clusters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "cycle_time": {
+          "name": "cycle_time",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "installation_fp_insights_installation_id_window_pk": {
+          "name": "installation_fp_insights_installation_id_window_pk",
+          "columns": [
+            "installation_id",
+            "window"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installation_settings": {
+      "name": "installation_settings",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "severity_threshold": {
+          "name": "severity_threshold",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Low'"
+        },
+        "comment_types": {
+          "name": "comment_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"syntax\":true,\"logic\":true,\"style\":true}'::jsonb"
+        },
+        "max_comments": {
+          "name": "max_comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 25
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"prSummary\":true,\"confidenceScore\":true,\"issuesTable\":true,\"diagram\":true}'::jsonb"
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "comment_header": {
+          "name": "comment_header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installations": {
+      "name": "installations",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monitored": {
+          "name": "monitored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "installations_installation_id_repo_full_name_pk": {
+          "name": "installations_installation_id_repo_full_name_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_sessions": {
+      "name": "mcp_sessions",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_billed_at": {
+          "name": "first_billed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_billed_cents": {
+          "name": "max_billed_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iteration": {
+          "name": "iteration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pr_lifecycle": {
+      "name": "pr_lifecycle",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_created_at": {
+          "name": "pr_created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_review_at": {
+          "name": "first_review_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "reviewed": {
+          "name": "reviewed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "skipped": {
+          "name": "skipped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "total_pushes": {
+          "name": "total_pushes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pushes_after_first_review": {
+          "name": "pushes_after_first_review",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pr_lifecycle_installation_idx": {
+          "name": "pr_lifecycle_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "pr_lifecycle_installation_id_repo_full_name_pr_number_pk": {
+          "name": "pr_lifecycle_installation_id_repo_full_name_pr_number_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name",
+            "pr_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number_commit_sha": {
+          "name": "pr_number_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_title": {
+          "name": "pr_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_author": {
+          "name": "pr_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_author_avatar": {
+          "name": "pr_author_avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_branch": {
+          "name": "head_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_severity": {
+          "name": "top_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_text": {
+          "name": "summary_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagram_text": {
+          "name": "diagram_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_score": {
+          "name": "merge_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_score_reason": {
+          "name": "merge_score_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "findings": {
+          "name": "findings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reactions": {
+          "name": "reactions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_used": {
+          "name": "settings_used",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_cost_usd": {
+          "name": "estimated_cost_usd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inline_resolved_keys": {
+          "name": "inline_resolved_keys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "inline_reactions_snapshot": {
+          "name": "inline_reactions_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "reviews_installation_idx": {
+          "name": "reviews_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_pr_idx": {
+          "name": "reviews_pr_idx",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "reviews_repo_full_name_pr_number_commit_sha_pk": {
+          "name": "reviews_repo_full_name_pr_number_commit_sha_pk",
+          "columns": [
+            "repo_full_name",
+            "pr_number_commit_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/storage-postgres/drizzle/meta/_journal.json
+++ b/packages/storage-postgres/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1781801985919,
       "tag": "0008_nappy_blue_blade",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1781923071656,
+      "tag": "0009_parallel_stark_industries",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/storage-postgres/src/fp-insight-store.ts
+++ b/packages/storage-postgres/src/fp-insight-store.ts
@@ -41,6 +41,7 @@ export class PostgresFPInsightStore implements IFPInsightStore {
         perSeverity: (insight.perSeverity ?? {}) as unknown,
         perRepo: insight.perRepo as unknown,
         topClusters: insight.topClusters as unknown,
+        cycleTime: (insight.cycleTime ?? null) as unknown,
       })
       .onConflictDoUpdate({
         target: [installationFpInsights.installationId, installationFpInsights.window],
@@ -57,6 +58,7 @@ export class PostgresFPInsightStore implements IFPInsightStore {
           perSeverity: (insight.perSeverity ?? {}) as unknown,
           perRepo: insight.perRepo as unknown,
           topClusters: insight.topClusters as unknown,
+          cycleTime: (insight.cycleTime ?? null) as unknown,
         },
       });
   }
@@ -100,5 +102,7 @@ function rowToInsight(row: Record<string, unknown>): InstallationFPInsight {
     perSeverity: (row.perSeverity as InstallationFPInsight['perSeverity']) ?? {},
     perRepo: (row.perRepo as InstallationFPInsight['perRepo']) ?? {},
     topClusters: (row.topClusters as InstallationFPInsight['topClusters']) ?? [],
+    // TTM (#194) — NULL on pre-Stage-2 rows; omit so the field stays undefined.
+    ...(row.cycleTime ? { cycleTime: row.cycleTime as InstallationFPInsight['cycleTime'] } : {}),
   };
 }

--- a/packages/storage-postgres/src/schema.ts
+++ b/packages/storage-postgres/src/schema.ts
@@ -110,6 +110,10 @@ export const installationFpInsights = pgTable('installation_fp_insights', {
   perSeverity: jsonb('per_severity').notNull().default({}),
   perRepo: jsonb('per_repo').notNull().default({}),
   topClusters: jsonb('top_clusters').notNull().default([]),
+  // TTM (#194) — cycle-time block (merge counts + time-to-merge percentiles).
+  // Nullable: pre-Stage-2 rows and rollups run without a PR-lifecycle store
+  // simply leave it NULL, which maps back to `undefined` on the typed shape.
+  cycleTime: jsonb('cycle_time'),
 }, (t) => ({
   pk: primaryKey({ columns: [t.installationId, t.window] }),
 }));


### PR DESCRIPTION
## Stage 2 of #194 — time-to-PR-merge

Builds on the lifecycle capture from #196. This stage turns the per-PR `PRLifecycleRecord` rows into **cycle-time stats on the nightly insight rollup**. Still no user-visible UI — that's Stage 3 — but the data is now computed and persisted, readable via the existing `/api/insights` endpoint.

### What's in this PR
- **`packages/core/src/insights/cycle-time.ts`** (pure, fully unit-tested):
  - `percentile()` — R-7 linear interpolation; `percentilesOf()` — p50/p75/p90 or `null` for an empty sample.
  - `buildCycleTimeInsight(window, windowEnd, records)` — windows PRs by terminal timestamp (merged→`mergedAt`, closed→`closedAt`, open→`prCreatedAt`) and computes, in **hours**:
    - time-to-merge (`created_at`→`merged_at`), segmented **reviewed vs unreviewed**
    - time-from-first-review-to-merge
    - round-trips before merge (`pushesAfterFirstReview`)
  - Merge times are right-skewed, so it reports **percentiles, never means**.
- **`InstallationFPInsight`** gains an optional `cycleTime` block. `runInsightRollup` takes an optional `prLifecycleStore` and attaches the block per window — **back-compat**: when the store isn't wired (older deploy), `cycleTime` stays `undefined` and the rollup behaves exactly as before. Lambda rollup handler + self-hosted cron both pass the store.
- **Persistence**: both fp-insight stores round-trip `cycleTime` (with `null`↔`undefined` coercion so pre-Stage-2 rows read clean); Postgres adds a nullable `cycle_time` jsonb column + idempotent migration `0009`.

### Edge cases handled (per acceptance criteria)
- Empty installation → all-zero counts, `null` percentiles (distinguishes "0 hours" from "no data").
- Closed-without-merge and still-open PRs → counted but **excluded** from time stats.
- `prCreatedAt === ''` sentinel (row created via a non-`opened` entry point) → counts toward `mergedCount` but omitted from created→merged percentiles.
- Negative spans (clock skew / bad data) → dropped, never fed to stats.
- Window boundary (a merge before `windowStart` is excluded; appears in the wider window).

### Tests
- `cycle-time.test.ts`: percentile correctness (odd/even/interpolated p75/p90), segmentation, first-review→merge, round-trips, empty/open/no-merge/closed-unmerged, `''` sentinel, clock-skew guard, window filtering.
- `run-rollup.test.ts`: cycleTime attached to all 3 windows when wired, omitted when not, cursor pagination over PR records.
- `fp-insight-store.test.ts` (Dynamo): write/read round-trip + null→undefined coercion.
- Full repo: `typecheck` 20/20, all suites green (core 715, dynamo 24, postgres 14, server 84, lambda 61); `migrations:check` clean.

### Deferred to Stage 3
- Dashboard "Cycle time" section in `InsightsClient.tsx` (StatCards + reviewed-vs-unreviewed comparison). No new API route needed — `/api/insights` already returns the extended insight.

Part of #194. Stacked on #196 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)