### PR TITLE
docs(ttm): feature doc + E2E runbook for time-to-merge (#194)

### DIFF
--- a/docs/time-to-merge.md
+++ b/docs/time-to-merge.md
@@ -1,0 +1,179 @@
+# Time-to-Merge (Cycle Time)
+
+**Status:** ✅ Shipped. Tracking issue [#194](https://github.com/mergewatch/mergewatch.ai/issues/194). Delivered in three staged PRs: capture ([#196](https://github.com/mergewatch/mergewatch.ai/pull/196)) → rollup ([#198](https://github.com/mergewatch/mergewatch.ai/pull/198)) → dashboard ([#199](https://github.com/mergewatch/mergewatch.ai/pull/199)).
+**Purpose:** Surface **time-to-PR-merge** (cycle time) as a headline outcome metric, segmented to show MergeWatch's impact (reviewed vs not-reviewed). Cycle time is the metric engineering leaders already budget against; if MergeWatch shortens the review loop, it should show up as faster merges. Pairs with cost ([#193](https://github.com/mergewatch/mergewatch.ai/issues/193)) and engagement (NPS) to form a complete ROI view.
+
+---
+
+## What we measure
+
+For every pull request MergeWatch sees, we capture its lifecycle and, in the nightly rollup, compute per rolling window (7d / 30d / 90d):
+
+- **Time to merge** — `created_at` → `merged_at`.
+- **Time from first MergeWatch review → merge** — does our feedback land early enough to matter?
+- **Round-trips before merge** — pushes after the first review (a proxy for iteration cost).
+- **Distribution stats** — **median / p75 / p90**, never a mean. Merge times are heavily right-skewed; a mean is dominated by a handful of stale PRs.
+
+**Segmentation** isolates the signal:
+
+- **Reviewed vs not-reviewed/skipped merged PRs** — the "did MergeWatch make us faster?" comparison.
+- Counts of still-open and closed-without-merge PRs are reported but excluded from the time percentiles.
+
+---
+
+## Architecture
+
+Three stages, each shipped independently, mirroring the existing FB-A (disposition store) → FB-E (rollup) → FB-F..J (dashboard) pipeline.
+
+```
+GitHub webhook                  Nightly rollup                 Dashboard
+──────────────                  ──────────────                 ─────────
+pull_request opened    ┐        listByInstallation       ┐     /api/insights
+            synchronize │  ───►  buildCycleTimeInsight()  │ ──► InsightsClient
+            closed      ┘        → InstallationFPInsight   ┘     CycleTimeSection
+review complete/skip            .cycleTime block
+   │
+   ▼
+PRLifecycleRecord  (one row per PR)
+  DynamoDB: mergewatch-pr-lifecycle   |   Postgres: pr_lifecycle
+```
+
+### Stage 1 — Capture (#196)
+
+A dedicated **`PRLifecycleRecord`** — one row per PR — independent of the per-commit `ReviewItem`. A merge is a per-PR event, but `ReviewItem` is keyed per-commit (`{prNumber}#{sha}`) and a PR has N review rows; unreviewed PRs may have no review row at all. A separate lifecycle store is the clean home.
+
+- **Type:** `PRLifecycleRecord` in `packages/core/src/types/db.ts`.
+- **Interface:** `IPRLifecycleStore` in `packages/core/src/storage/types.ts` — `upsertOpened`, `recordPush`, `markReviewed`, `markSkipped`, `markMerged`, `markClosedUnmerged`, `listByInstallation`.
+- **Implementations:** `DynamoPRLifecycleStore` (PK `${installationId}#${repoFullName}`, SK `prNumber`; TTL-reaped ~90d past close) and `PostgresPRLifecycleStore` (`pr_lifecycle` table). Both mirror the FB-A disposition store: best-effort writes that never block the review pipeline, with terminal-state discipline enforced via conditional writes.
+
+**Write triggers** (both the Lambda and self-hosted webhook paths):
+
+| Event | Method | Effect |
+|---|---|---|
+| `pull_request` `opened` / `reopened` / `ready_for_review` | `upsertOpened` | create row, anchor `prCreatedAt`, `state=open` |
+| `pull_request` `synchronize` | `recordPush` | `totalPushes++`; `pushesAfterFirstReview++` once a review has landed |
+| `pull_request` `closed` (merged) | `markMerged` | terminal: `mergedAt`, `state=merged` (authoritative `prCreatedAt`) |
+| `pull_request` `closed` (unmerged) | `markClosedUnmerged` | terminal: `closedAt`, `state=closed_unmerged` |
+| review completes | `markReviewed` | set-once `firstReviewAt`, `reviewed=true` |
+| `shouldSkipPR` fires | `markSkipped` | `skipped=true` |
+
+### Stage 2 — Rollup (#198)
+
+A pure module, `packages/core/src/insights/cycle-time.ts`:
+
+- `percentile(sortedAsc, p)` — R-7 linear interpolation (Excel `PERCENTILE.INC`).
+- `percentilesOf(values)` — `{ p50, p75, p90 }` or `null` for an empty sample.
+- `buildCycleTimeInsight(window, windowEnd, records)` — windows PRs by their terminal (or, for open PRs, creation) timestamp and computes the block below.
+
+The nightly orchestrator (`runInsightRollup`) gained an optional `prLifecycleStore`; when wired it pages each installation's lifecycle rows (same cursor pagination as dispositions) and attaches a `cycleTime` block to every window's `InstallationFPInsight`. **Back-compat:** when the store isn't wired (e.g. mid-deploy), `cycleTime` stays `undefined` and the rollup behaves exactly as before.
+
+### Stage 3 — Dashboard (#199)
+
+`CycleTimeSection` in `packages/dashboard/components/InsightsClient.tsx`, rendered above the FP-feedback charts on `/dashboard/insights`:
+
+- **StatCards** — median time-to-merge, time-from-first-review, round-trips, merged count, each with a `p75 · p90` spread.
+- **Reviewed-vs-unreviewed comparison** — a grouped bar chart of time-to-merge (median/p75/p90) split by whether MergeWatch reviewed the PR.
+
+No new API route — `/api/insights` already returns the `cycleTime` block via the fp-insight store. The zero-state gate was relaxed so the page renders when **either** FP-feedback **or** cycle-time has data, gated independently (a repo can have merges but a clean review history).
+
+---
+
+## Storage shapes
+
+### `PRLifecycleRecord`
+
+```ts
+interface PRLifecycleRecord {
+  installationId: string;
+  repoFullName: string;
+  prNumber: number;
+  prCreatedAt: string;               // ISO 8601 — anchor for time-to-merge
+  firstReviewAt?: string;            // ISO 8601 — set once, anchor for first-review→merge
+  mergedAt?: string;                 // ISO 8601 — set on merge
+  closedAt?: string;                 // ISO 8601 — set on close-without-merge
+  state: 'open' | 'merged' | 'closed_unmerged';
+  reviewed: boolean;                 // segmentation: reviewed vs not
+  skipped: boolean;                  // shouldSkipPR fired
+  totalPushes: number;
+  pushesAfterFirstReview: number;    // round-trip proxy
+  updatedAt: string;
+  ttl?: number;                      // DynamoDB TTL (epoch s), ~90d past terminal
+}
+```
+
+### `InstallationFPInsight.cycleTime`
+
+```ts
+cycleTime?: {
+  mergedCount: number;               // merged in-window — denominator for time stats
+  reviewedMergedCount: number;
+  unreviewedMergedCount: number;
+  closedUnmergedCount: number;       // counted, excluded from time stats
+  openCount: number;                 // counted, no merge time yet
+  timeToMergeHours: Percentiles | null;                 // created → merged, all
+  timeToMergeHoursReviewed: Percentiles | null;         //   …reviewed only
+  timeToMergeHoursUnreviewed: Percentiles | null;       //   …unreviewed only
+  timeToMergeFromFirstReviewHours: Percentiles | null;  // firstReview → merged
+  roundTripsBeforeMerge: Percentiles | null;            // pushesAfterFirstReview
+};
+// Percentiles = { p50: number; p75: number; p90: number }  — durations in HOURS
+```
+
+Each percentile object is `null` (not `0`) when its sample is empty, so the dashboard distinguishes "0 hours" from "no data".
+
+---
+
+## Edge cases (handled)
+
+- **Empty installation** → all-zero counts, `null` percentiles.
+- **Closed-without-merge** and **still-open** PRs → counted but excluded from the duration percentiles.
+- **Unknown `prCreatedAt` sentinel (`''`)** — a row first created via a non-`opened` entry point (a push or review that arrived before we saw the open) carries `''`. It still counts toward `mergedCount` but is omitted from the created→merged percentiles, since its anchor is unknown. `markMerged` repairs it from the authoritative closed payload.
+- **Negative spans** (clock skew / bad data) → dropped, never fed to stats.
+- **Terminal-state discipline** — a merged row never downgrades to `closed_unmerged`; `upsertOpened` / `recordPush` never resurrect a terminal row; `firstReviewAt` is set once and later reviews don't move it.
+- **Window boundary** — a merge before `windowStart` is excluded from the narrow window and appears in the wider one.
+
+---
+
+## Cost & privacy notes
+
+- **No extra LLM cost.** Lifecycle capture is webhook + storage only; the percentile math is a pure function over a bounded record set in the existing nightly rollup.
+- **Storage is bounded.** One row per PR; DynamoDB rows TTL-reap ~90 days past the terminal event (long enough for the 90d window). Postgres rows persist (no TTL) but are small.
+- **No PR content stored** — only timestamps, counts, and booleans. The lifecycle row carries no titles, diffs, or author PII beyond what `ReviewItem` already holds.
+
+---
+
+## Configuration
+
+Nothing to configure. Cycle-time tracking activates automatically once the PR-lifecycle store is provisioned:
+
+- **SaaS:** the `mergewatch-pr-lifecycle-${Stage}` table (in `infra/template.yaml`) + the `PR_LIFECYCLE_TABLE` env var wired into the webhook, review-agent, and insights-rollup Lambdas.
+- **Self-hosted:** the `pr_lifecycle` table (auto-migrated on startup, migration `0008`) + `cycle_time` column (migration `0009`). The Express server wires the store into the webhook handler and nightly cron.
+
+---
+
+## Out of scope / future
+
+- **Historical backfill** (deferred — separate follow-up). The dashboard already holds a GitHub token; an on-demand backfill could fetch historical `merged_at` for already-reviewed PRs to populate cycle-time immediately on deploy rather than waiting for new merges.
+- **Full DORA suite** (deploy frequency, MTTR, change-fail rate).
+- **Causal attribution** beyond simple reviewed-vs-unreviewed segmentation.
+- **Before/after-enablement segmentation** — comparing cycle time before vs after MergeWatch was activated on a repo (needs installation-activation dating).
+
+---
+
+## Cross-references
+
+- Tracking issue: [#194](https://github.com/mergewatch/mergewatch.ai/issues/194).
+- E2E coverage: `e2e/RUNBOOK.md` → **E2E-55** (capture), **E2E-56** (rollup), **E2E-57** (dashboard).
+- Sibling analytics surface: [`false-positive-feedback-plan.md`](./false-positive-feedback-plan.md) (the FB-A→FB-E→FB-F..J pipeline this feature mirrors).
+- Architecture overview: [`architecture.md`](./architecture.md).
+
+---
+
+## Update protocol
+
+When you change cycle-time behavior:
+
+1. Update the storage shapes / write-trigger table above if the lifecycle state machine changes.
+2. Keep the percentile methodology note accurate (the R-7 method is load-bearing for reproducibility).
+3. Update the corresponding E2E cards (E2E-55..57) in `e2e/RUNBOOK.md` in the same PR.
+4. If backfill ships, move it from "Out of scope / future" into the architecture section.

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -181,6 +181,9 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-52](#e2e-52-fp-l--propagate-w2-verification-to-rendering-surfaces) | An unverified critical drops off the inline / action-table surfaces and lands in a dedicated "Unverified concerns" sub-section (FP-L) | 2m | 60s | FP-L |
 | [E2E-53](#e2e-53-fp-j-l1l3--dispute-aware-verdict-softening--disclosure) | Red verdict (orchestrator score ≤ 2) is softened to advisory when majority of action findings come from chronically-disputed categories (FP-J L1); disclosure footer renders under the merge score (FP-J L3) | 3m | 60s | FP-J |
 | [E2E-54](#e2e-54-fp-k--abstraction-aware-verifier) | Findings alleging "SQL injection on Drizzle eq()", "URL injection on encodeURIComponent", "XSS on JSX text" are dropped by the verifier as abstraction-safe; raw string-concat SQL is still kept (FP-K) | 4m | 90s | FP-K |
+| [E2E-55](#e2e-55-ttm--pr-lifecycle-capture-time-to-merge-stage-1) | Every PR writes one `PRLifecycleRecord`; open/synchronize/merge/close transitions captured; `closed` doesn't trigger a review; terminal-state + set-once discipline holds (TTM) | 3m | 90s | #196 |
+| [E2E-56](#e2e-56-ttm--cycle-time-rollup-time-to-merge-stage-2) | Nightly rollup attaches a `cycleTime` block (merge counts + median/p75/p90 time-to-merge, from-first-review, round-trips) segmented reviewed vs unreviewed; open/closed excluded from time stats (TTM) | 3m | 90s | #198 |
+| [E2E-57](#e2e-57-ttm--dashboard-cycle-time-section-time-to-merge-stage-3) | `/dashboard/insights` Cycle time section: StatCards + reviewed-vs-unreviewed bar chart; relaxed zero-state gate; `null` percentile renders `—` (TTM) | 2m | 30s | #199 |
 
 ---
 
@@ -2034,6 +2037,86 @@ Branch: `fixture/54-abstraction-aware`. Three test PRs in sequence:
 - ❌ Verifier drops an "XSS via dangerouslySetInnerHTML" finding (the React JSX clause should NOT cover `dangerouslySetInnerHTML` — only plain `{x}` interpolation)
 - ❌ FP-K block fails to render on first reviews (the block must be in the static body of `FINDING_VERIFICATION_PROMPT`, not gated by `previousFindings.length > 0`)
 - ❌ The model over-suppresses on infrastructure-shaped ambiguous data flows (`store.query(input)` where the store's internal sanitization isn't visible from the cited file) — the fail-safe rule should bias toward VALID; if it fires INVALID anyway, the prompt didn't communicate the fail-safe clearly
+
+---
+
+### E2E-55: TTM — PR-lifecycle capture (time-to-merge, stage 1)
+
+**Status:** ✅ SHIPPED (#196). See [`docs/time-to-merge.md` → Stage 1](./../docs/time-to-merge.md#stage-1--capture-196).
+
+**Behavior:** every PR MergeWatch sees writes one `PRLifecycleRecord` (DynamoDB `mergewatch-pr-lifecycle`, Postgres `pr_lifecycle`) — one row per PR, independent of the per-commit `ReviewItem`. The webhook records `opened`/`reopened`/`ready_for_review` → `upsertOpened`, `synchronize` → `recordPush`, and the newly-handled `closed` → `markMerged` (merged) or `markClosedUnmerged` (closed without merge). The review pipeline sets `markReviewed` (set-once `firstReviewAt`) on completion and `markSkipped` when `shouldSkipPR` fires. Writes are best-effort and never block the pipeline.
+
+**Setup**
+
+Branch: `fixture/55-ttm-capture`. Open a PR, push once more to it, then merge it. Separately, open a second PR and close it **without** merging.
+
+**Expected outcomes**
+
+- [ ] After open: a lifecycle row exists with `state=open`, `prCreatedAt` set, counters 0.
+- [ ] After the extra push: `totalPushes` increments; `pushesAfterFirstReview` increments only once a review has landed (`firstReviewAt` set).
+- [ ] After the review completes: `reviewed=true`, `firstReviewAt` set once (a later re-review does NOT move it).
+- [ ] After merge: `state=merged`, `mergedAt` set, `prCreatedAt` authoritative from the closed payload, `ttl` populated.
+- [ ] The closed-without-merge PR: `state=closed_unmerged`, `closedAt` set, NO `mergedAt`.
+- [ ] The `closed` action does NOT trigger a review (no eyes reaction, no new review comment on close).
+
+**Failure modes**
+- ❌ A `closed` event triggers a fresh review (the close path must terminate the lifecycle, not enqueue a job).
+- ❌ A merged row downgrades to `closed_unmerged`, or `upsertOpened`/`recordPush` resurrects a terminal row (terminal-state discipline regressed).
+- ❌ A lifecycle write throwing blocks or fails the review (writes must be best-effort).
+- ❌ `firstReviewAt` moves on a re-review (it must be set-once).
+
+---
+
+### E2E-56: TTM — cycle-time rollup (time-to-merge, stage 2)
+
+**Status:** ✅ SHIPPED (#198). See [`docs/time-to-merge.md` → Stage 2](./../docs/time-to-merge.md#stage-2--rollup-198).
+
+**Behavior:** the nightly rollup pages each installation's `PRLifecycleRecord` rows and attaches a `cycleTime` block to every window's `InstallationFPInsight`: merge counts (merged / reviewed / unreviewed / closed-unmerged / open) plus **median/p75/p90** percentiles (in hours) for time-to-merge, time-from-first-review-to-merge, and round-trips — segmented reviewed vs unreviewed. Percentiles use R-7 linear interpolation; an empty sample yields `null`, not `0`. Back-compat: when the PR-lifecycle store isn't wired, `cycleTime` is omitted and the rollup is unchanged.
+
+**Setup**
+
+Branch: `fixture/56-ttm-rollup`. Pre-seed an installation with ~15 lifecycle rows: a mix of reviewed-merged, unreviewed-merged, closed-without-merge, and still-open PRs, with merge spans spread across hours/days. Trigger the rollup manually (SaaS: invoke `mergewatch-insights-rollup-prod`; self-hosted: the nightly cron / admin trigger).
+
+**Expected outcomes**
+
+- [ ] Each window's insight row carries a `cycleTime` block with the right counts (`mergedCount = reviewedMergedCount + unreviewedMergedCount`).
+- [ ] `timeToMergeHours` p50/p75/p90 match a hand-computed percentile of the seeded merge spans.
+- [ ] `timeToMergeHoursReviewed` and `timeToMergeHoursUnreviewed` segment correctly; a segment with no PRs is `null` (not `0`).
+- [ ] Closed-without-merge and still-open PRs are counted but excluded from every duration percentile.
+- [ ] A row with the `prCreatedAt=''` sentinel still counts toward `mergedCount` but is omitted from created→merged percentiles.
+- [ ] An installation with no merges yields all-zero counts and `null` percentiles (no crash).
+
+**Failure modes**
+- ❌ Open or closed-unmerged PRs leak into the time percentiles (skews "faster merges" upward/downward).
+- ❌ A negative span (clock skew) feeds the stats instead of being dropped.
+- ❌ An empty sample serializes as `{p50:0,p75:0,p90:0}` rather than `null` (dashboard then shows a misleading "0h").
+- ❌ Wiring the lifecycle store changes the FP-feedback numbers (the two rollups must be independent).
+
+---
+
+### E2E-57: TTM — dashboard cycle-time section (time-to-merge, stage 3)
+
+**Status:** ✅ SHIPPED (#199). See [`docs/time-to-merge.md` → Stage 3](./../docs/time-to-merge.md#stage-3--dashboard-199).
+
+**Behavior:** `/dashboard/insights` renders a **Cycle time** section above the FP-feedback charts: StatCards (median time-to-merge, from-first-review, round-trips, merged count, each with a p75 · p90 spread) plus a reviewed-vs-unreviewed time-to-merge bar comparison. Durations format as `m`/`h`/`d`; a `null` percentile renders as `—`. The zero-state gate is relaxed so the page shows when **either** FP-feedback **or** cycle-time has data, each section gated independently. No new API route — `/api/insights` returns the `cycleTime` block.
+
+**Setup**
+
+Branch: `fixture/57-ttm-dashboard`. Use the E2E-56 seeded installation. Open `/dashboard/insights?org=<installationId>` and switch the 7d/30d/90d window selector.
+
+**Expected outcomes**
+
+- [ ] The Cycle time section renders above the FP funnel with correct StatCard values for the active window.
+- [ ] The reviewed-vs-unreviewed bar chart shows both series; a tooltip formats hours as `m`/`h`/`d`.
+- [ ] Switching the window selector updates the cycle-time numbers.
+- [ ] A `null` percentile (e.g. no unreviewed merges) renders `—`, never `0h`.
+- [ ] A repo with merges but **zero findings ever surfaced** still shows the Cycle time section (the relaxed gate); a fresh install with neither shows the "No insights yet" panel.
+- [ ] An older rollup row without a `cycleTime` block renders the page unchanged (no Cycle time section, FP charts as before).
+
+**Failure modes**
+- ❌ The page hides everything when `totalFindingsSurfaced === 0`, hiding cycle-time for a merge-active repo (the old gate; must be relaxed).
+- ❌ A `null` percentile renders as `0h` (misleading "instant merge").
+- ❌ The section throws on a pre-Stage-2 rollup with no `cycleTime` (must be optional).
 
 ---
 


### PR DESCRIPTION
## Docs for the now-complete time-to-merge feature (#194)

The implementation shipped across #196 (capture) + #198 (rollup) + #199 (dashboard), all merged. This PR adds the documentation that was meant to accompany #199 but didn't make it into that merge.

Docs-only — no code changes.

### What's here
- **`docs/time-to-merge.md`** — feature doc for the full #194 arc: what we measure, the three-stage capture→rollup→dashboard architecture (with data-flow diagram), storage shapes (`PRLifecycleRecord` + the `cycleTime` block), the lifecycle write-trigger table, percentile methodology (R-7), edge cases, cost/privacy, configuration, and the deferred backfill.
- **`e2e/RUNBOOK.md`** — `E2E-55` (capture) / `E2E-56` (rollup) / `E2E-57` (dashboard) fixture cards + regression-checklist rows, matching the existing `E2E-N` card format and referencing the new doc.

All three stages are now merged, so the doc's "✅ Shipped" status and PR cross-references are accurate.

Closes the documentation gap for #194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)