### PR TITLE
feat(insights): capture /resolve as an engagement signal (#195, stage 1)

### DIFF
--- a/docs/feat/20260620-01-engagement-metrics.plan.md
+++ b/docs/feat/20260620-01-engagement-metrics.plan.md
@@ -70,7 +70,7 @@ All fields optional-by-block: pre-feature rollups have no `engagement`; consumer
 
 ## Phased breakdown — one PR per phase, strict dep order
 
-### Phase 1 — `/resolve` capture completeness (storage) — [ ]
+### Phase 1 — `/resolve` capture completeness (storage) — [x] PR #207 (MergeWatch 5/5, 0 findings)
 - **Goal:** make `/mergewatch` command usage fully aggregatable before the rollup consumes it.
 - **Files:** `packages/core/src/types/db.ts` (`FindingDispositionRecord.resolveCount?`), `packages/core/src/storage/types.ts` (`IFindingDispositionStore.incrementResolve`), both `finding-disposition-store.ts` impls (atomic increment, mirror `incrementDispute`), `packages/storage-postgres/src/schema.ts` + generated migration (`ADD COLUMN IF NOT EXISTS resolve_count`), and the `/resolve` handler path (`inline-reply.ts` + `review-processor.ts` + Lambda review-agent) to call `incrementResolve` for each resolved key.
 - **RUNBOOK:** E2E-58 — `/resolve` increments `resolveCount` on the disposition record.

--- a/docs/feat/20260620-01-engagement-metrics.plan.md
+++ b/docs/feat/20260620-01-engagement-metrics.plan.md
@@ -1,0 +1,108 @@
+# Developer engagement / NPS metrics
+
+**Status:** In progress
+**Issue:** [#195 — Add developer engagement / NPS metrics to validate usage and value](https://github.com/mergewatch/mergewatch.ai/issues/195)
+**Author:** `/ship-feature`
+
+## Summary
+
+Add high-signal developer-engagement metrics that show MergeWatch is *used and valued*, not just that reviews ran. Two tiers:
+
+- **Tier 1 — behavioral (passive):** acceptance/agreement rate, `/mergewatch` command usage, re-review rate, per-installation activity/retention, and an *approximate* finding-action rate — all derived from data we already capture (`FindingDispositionRecord`, `PRLifecycleRecord`) in the nightly insights rollup.
+- **Tier 2 — explicit satisfaction:** a one-click "Was this review helpful? 👍 / 👎" prompt on the summary-comment footer, and a throttled dashboard NPS prompt (0–10, once / 90 days per admin) → NPS = %promoters − %detractors.
+
+All of it rides as an **optional `engagement?` block** on `InstallationFPInsight`, surfaced in a new **Engagement** section on `/dashboard/insights`. This mirrors exactly how time-to-merge (#194) shipped its `cycleTime?` block.
+
+## Why
+
+We can see *that* reviews run but not whether developers find them useful. Behavioral signals are higher-fidelity than surveys (passive, unbiased) and we already collect most of the raw events. An explicit 👍/👎 + NPS gives a direct satisfaction read for ourselves and prospective adopters. See #195.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Scope | **Full — Tier 1 + Tier 2 footer 👍/👎 + dashboard NPS** | User opted into the complete feature; ship in strict dep order. |
+| Finding-action rate | **Approximate now, defer exact** | No persisted per-commit diff exists to confirm cited code was edited. Ship a labeled proxy from existing signals (agreements + `/resolve`); file a follow-up ticket for true diff-based capture. |
+| Carrier type | **Extend `InstallationFPInsight` with optional `engagement?` block** | Mirrors `cycleTime?` (#194). No new read path for the dashboard; rides the existing fp-insight store + `/api/insights`. |
+| Aggregation | **New pure module `packages/core/src/insights/engagement.ts`** | Mirrors `cycle-time.ts` — pure, table-testable, wired into `runInsightRollup`. |
+| `/resolve` tracking | **Add `resolveCount` counter to `FindingDispositionRecord`** | `/resolve` is currently recorded only on `ReviewItem.inlineResolvedKeys` (per-commit, not aggregatable in the rollup). A first-class disposition counter closes the gap without dragging the review store into the rollup. |
+| Satisfaction storage | **New `ISatisfactionStore` (helpful votes + NPS responses), both backends** | 👍/👎 footer votes and NPS responses are timestamped events that don't fit the per-finding disposition or per-PR lifecycle shapes. |
+| Fleet-wide retention | **Per-installation only (`activeInstallation` + `reviewedPrCount`)** | `InstallationFPInsight` and `/dashboard/insights` are installation-scoped. Cross-installation WoW-retained-% needs an admin/fleet view that doesn't exist — deferred (see Out of scope). |
+
+## Architecture
+
+How it plugs into the existing pipeline (real paths):
+
+- **Type:** `packages/core/src/types/db.ts` — add optional `engagement?` block to `InstallationFPInsight` (alongside `cycleTime?`, ~L658-691). Re-exported from `@mergewatch/core` index.
+- **Aggregation (Tier 1):** new `packages/core/src/insights/engagement.ts` — pure `buildEngagementInsight(window, windowEndIso, dispositionRecords, prLifecycleRecords, satisfactionRecords?)`, mirroring `cycle-time.ts`'s `buildCycleTimeInsight` (L68-127) and reusing the `WINDOW_LENGTH_MS` windowing from `rollup.ts` (L14-18).
+- **Rollup wiring:** `packages/core/src/insights/run-rollup.ts` — `runInsightRollup` already paginates disposition + PR-lifecycle records per installation (L89-108). Add an optional `satisfactionStore?` to `RollupStores` (mirror the optional `prLifecycleStore`, L29-34) and assign `insight.engagement` (mirror L112-114).
+- **Persistence:** `packages/storage-dynamo/src/fp-insight-store.ts` + `packages/storage-postgres/src/fp-insight-store.ts` — add `engagement` to `upsert` and the `itemToInsight`/`rowToInsight` coercion (null↔undefined), exactly as `cycleTime` is handled.
+- **Capture:**
+  - `/resolve` → `packages/core/src/agents/inline-reply.ts` resolve handler + `packages/server/src/review-processor.ts` / Lambda review-agent → `IFindingDispositionStore.incrementResolve` (new).
+  - Footer 👍/👎 → `packages/core/src/comment-formatter.ts` footer (L515-525) renders the prompt; reaction polling for the **summary** comment (new, alongside `pollAndRecordInlineReactions` in `packages/core/src/insights/disposition-writer.ts`) → `ISatisfactionStore.recordHelpfulVote`.
+  - NPS → new dashboard prompt + `packages/dashboard/app/api/nps/route.ts` → `ISatisfactionStore.recordNpsResponse`.
+- **Dashboard:** `packages/dashboard/components/InsightsClient.tsx` — new `EngagementSection` (mirror `CycleTimeSection`, L718-810; reuse `StatCard` L695-704 + recharts), rendered after `CycleTimeSection`; relax the zero-state gate (L281) to also fire on `hasEngagementData`. No `/api/insights` change.
+
+## `engagement` block shape (target)
+
+```ts
+engagement?: {
+  // Tier 1 — behavioral (phase 2)
+  acceptanceRate: number | null;        // agreements / (agreements + disputes + silentDrops); null = no signal
+  totalResolves: number;                // /resolve command usage (new resolveCount, summed in-window)
+  totalRejectCommands: number;          // /mergewatch reject usage (rejectReasons[].at in-window)
+  commandUsageCount: number;            // totalResolves + totalRejectCommands
+  findingActionRateApprox: number | null; // PROXY: (agreements + resolves) / surfaced — exact deferred (#195 follow-up)
+  reReviewRate: number | null;          // reviewed PRs with pushesAfterFirstReview>0 / reviewed PRs
+  reviewedPrCount: number;              // PRs this installation had reviewed in-window
+  activeInstallation: boolean;          // reviewedPrCount > 0 (per-installation retention signal)
+
+  // Tier 2 — satisfaction (phase 4 fills helpful*, phase 5 fills nps*)
+  helpfulUp: number;
+  helpfulDown: number;
+  helpfulRate: number | null;           // up / (up + down)
+  npsResponses: number;
+  npsScore: number | null;              // %promoters − %detractors, integer −100..100
+};
+```
+
+All fields optional-by-block: pre-feature rollups have no `engagement`; consumers handle `undefined`. `null` (not `0`) distinguishes "no data" from a real zero, exactly like `cycleTime`'s percentiles.
+
+## Phased breakdown — one PR per phase, strict dep order
+
+### Phase 1 — `/resolve` capture completeness (storage) — [ ]
+- **Goal:** make `/mergewatch` command usage fully aggregatable before the rollup consumes it.
+- **Files:** `packages/core/src/types/db.ts` (`FindingDispositionRecord.resolveCount?`), `packages/core/src/storage/types.ts` (`IFindingDispositionStore.incrementResolve`), both `finding-disposition-store.ts` impls (atomic increment, mirror `incrementDispute`), `packages/storage-postgres/src/schema.ts` + generated migration (`ADD COLUMN IF NOT EXISTS resolve_count`), and the `/resolve` handler path (`inline-reply.ts` + `review-processor.ts` + Lambda review-agent) to call `incrementResolve` for each resolved key.
+- **RUNBOOK:** E2E-58 — `/resolve` increments `resolveCount` on the disposition record.
+- **Tests:** store increment (both backends, mock), handler wiring, migration idempotency (`migrations:check`).
+
+### Phase 2 — Engagement rollup (Tier 1 KPIs, core) — [ ]
+- **Goal:** compute and persist the Tier 1 `engagement` block per 7d/30d/90d window. Depends on Phase 1 (`resolveCount`).
+- **Files:** `packages/core/src/types/db.ts` (`engagement?` block), new `packages/core/src/insights/engagement.ts` (pure `buildEngagementInsight` + helpers, exported via core index), `run-rollup.ts` (assign `insight.engagement`), both `fp-insight-store.ts` impls (persist + coerce), `schema.ts` + migration (`engagement` jsonb, idempotent).
+- **RUNBOOK:** E2E-59 — nightly rollup attaches an `engagement` block (acceptance rate, command usage, re-review rate, approx action rate, reviewed-PR count) over each window; empty/low-volume installation yields `null` rates not crashes.
+- **Tests:** KPI math (acceptance/action/re-review rates, command counts, windowing), empty + single-record edge cases, back-compat when `satisfactionStore` absent.
+
+### Phase 3 — Engagement dashboard section (Tier 1 surfaced) — [ ]
+- **Goal:** render the Tier 1 engagement metrics. Depends on Phase 2.
+- **Files:** `packages/dashboard/components/InsightsClient.tsx` — `EngagementSection` (StatCards: acceptance rate, command usage, re-review rate, approx action rate; trend across windows where useful), render after `CycleTimeSection`, relax zero-state gate (L281) to include `hasEngagementData`. No API route change.
+- **RUNBOOK:** E2E-60 — `/dashboard/insights` Engagement section: StatCards render; `null` rates show `—`; the action-rate card is labeled "approx."
+- **Tests:** component render with populated / null / absent `engagement`; gate logic.
+
+### Phase 4 — Tier 2: footer 👍/👎 helpful prompt — [ ]
+- **Goal:** one-click satisfaction signal on the summary comment, captured + aggregated into `engagement.helpful*`. Depends on Phase 2 (block exists) + Phase 3 (section to surface it).
+- **Files:** new `ISatisfactionStore` (helpful votes) in `packages/core/src/storage/types.ts` + both backends + `schema.ts`/migration + Dynamo table in `infra/template.yaml`; `comment-formatter.ts` footer renders "Was this review helpful? 👍 / 👎"; summary-comment reaction polling (new fn near `disposition-writer.ts`) → `recordHelpfulVote`; `run-rollup.ts` wires optional `satisfactionStore` and `engagement.ts` fills `helpfulUp/Down/Rate`; `EngagementSection` shows helpful rate.
+- **RUNBOOK:** E2E-61 — 👍/👎 prompt renders on the summary footer; reactions captured; rollup fills helpful rate; dashboard shows it.
+- **Tests:** vote store (both backends), reaction→vote mapping + snapshot delta, helpful-rate math, migration idempotency.
+
+### Phase 5 — Tier 2: dashboard NPS survey (capstone) — [ ]
+- **Goal:** throttled NPS prompt (0–10, once / 90d per admin), NPS computed + displayed. Depends on Phase 4 (`ISatisfactionStore`). **Carries the docs graduation.**
+- **Files:** extend `ISatisfactionStore` with NPS responses (both backends + migration); `packages/dashboard/app/api/nps/route.ts` (GET eligibility + POST response, 90d throttle per `githubUserId`); throttled prompt component in the dashboard; `engagement.ts` computes `npsScore`/`npsResponses`; `EngagementSection` renders NPS; graduate `docs/pending/engagement-metrics.md` → `docs/engagement-metrics.md`, flip RUNBOOK E2E-58..62 to ✅ SHIPPED.
+- **RUNBOOK:** E2E-62 — NPS prompt shown to admin, throttled to once / 90d; response recorded; NPS = %promoters − %detractors rendered.
+- **Tests:** NPS store, throttle logic, NPS math (promoters/detractors buckets, empty case), API route auth/throttle.
+
+## Out of scope / deferred (file follow-up tickets)
+
+- **Exact finding-action rate** — true per-commit diff confirmation that cited code changed (Phase 2 ships an `(agreements + resolves)/surfaced` proxy). Needs new capture (`addressedCount` counter at review time, mirroring `silentDropCount` in `review-delta.ts`).
+- **Fleet-wide / WoW retention** — cross-installation %-active and week-over-week retained installations. `InstallationFPInsight` and `/dashboard/insights` are installation-scoped; needs an admin/fleet aggregate view.
+- **Per-developer attribution & leaderboards** — commands/votes aren't attributed to a GitHub login today; explicitly out of scope per #195.
+- **Email/Slack survey campaigns** — out of scope per #195.

--- a/docs/pending/engagement-metrics.md
+++ b/docs/pending/engagement-metrics.md
@@ -1,0 +1,97 @@
+# Developer engagement / NPS metrics
+
+**Status:** 🚧 In progress — see [`docs/feat/20260620-01-engagement-metrics.plan.md`](../feat/20260620-01-engagement-metrics.plan.md)
+**Issue:** [#195](https://github.com/mergewatch/mergewatch.ai/issues/195)
+
+High-signal metrics that show MergeWatch is *used and valued*, not just that reviews ran. Two tiers, shipped in stacked PRs:
+
+- **Tier 1 — behavioral (passive):** acceptance/agreement rate, `/mergewatch` command usage, re-review rate, per-installation activity, and an *approximate* finding-action rate — derived in the nightly insights rollup from data we already capture (`FindingDispositionRecord`, `PRLifecycleRecord`).
+- **Tier 2 — explicit satisfaction:** a one-click "Was this review helpful? 👍 / 👎" prompt on the summary-comment footer, and a throttled dashboard NPS prompt (0–10) → NPS = %promoters − %detractors.
+
+All of it rides as an optional `engagement?` block on `InstallationFPInsight` and surfaces in a new **Engagement** section on `/dashboard/insights` — mirroring how time-to-merge (#194) shipped its `cycleTime?` block.
+
+## Architecture
+
+```
+capture (per finding / per PR)        aggregation (nightly)         surface
+─────────────────────────────        ─────────────────────         ───────────────
+FindingDispositionRecord  ─┐
+  .agreementCount          │
+  .disputeCount            ├─► buildEngagementInsight() ─► InstallationFPInsight
+  .silentDropCount         │     (packages/core/src/         .engagement  ─► /api/insights
+  .resolveCount  (#195)    │      insights/engagement.ts)                    └► EngagementSection
+  .rejectReasons[]         │                                                    (InsightsClient.tsx)
+PRLifecycleRecord  ────────┘
+  .reviewed / .pushesAfterFirstReview
+SatisfactionStore (Tier 2) ─────────► helpful votes + NPS responses
+```
+
+The rollup (`runInsightRollup`, `packages/core/src/insights/run-rollup.ts`) already paginates disposition + PR-lifecycle records per installation over the 7d / 30d / 90d windows. The engagement block is computed alongside the existing FP-funnel and cycle-time blocks and persisted in the same fp-insight store (DynamoDB + Postgres).
+
+## `engagement` block shape (target)
+
+```ts
+engagement?: {
+  // Tier 1 — behavioral
+  acceptanceRate: number | null;          // agreements / (agreements + disputes + silentDrops)
+  totalResolves: number;                  // /resolve command usage (resolveCount, summed)
+  totalRejectCommands: number;            // /mergewatch reject usage (rejectReasons[].at in-window)
+  commandUsageCount: number;              // totalResolves + totalRejectCommands
+  findingActionRateApprox: number | null; // PROXY: (agreements + resolves) / surfaced — exact deferred
+  reReviewRate: number | null;            // reviewed PRs with pushesAfterFirstReview>0 / reviewed PRs
+  reviewedPrCount: number;
+  activeInstallation: boolean;            // reviewedPrCount > 0
+
+  // Tier 2 — satisfaction
+  helpfulUp: number;
+  helpfulDown: number;
+  helpfulRate: number | null;             // up / (up + down)
+  npsResponses: number;
+  npsScore: number | null;                // %promoters − %detractors
+};
+```
+
+All fields are optional-by-block: pre-feature rollups have no `engagement`; consumers handle `undefined`. `null` (not `0`) means "no data", exactly like `cycleTime`'s percentiles.
+
+---
+
+## Stage 1 — `/resolve` capture
+
+Adds a first-class `resolveCount` counter to the per-finding disposition record so `/mergewatch` command usage is fully aggregatable before the rollup consumes it.
+
+**What changed**
+
+- `FindingDispositionRecord.resolveCount: number` (`packages/core/src/types/db.ts`) — defaults to 0 on records written before the counter existed.
+- `IFindingDispositionStore.incrementResolve(...)` (`packages/core/src/storage/types.ts`), implemented atomically in both backends:
+  - DynamoDB: `resolveCount = if_not_exists(resolveCount, :zero) + :one`, pre-seeded on `upsertSurface`.
+  - Postgres: `resolve_count + 1`; new column `resolve_count integer NOT NULL DEFAULT 0` via idempotent migration `0010_lying_dracula.sql` (`ADD COLUMN IF NOT EXISTS`).
+- `recordResolves(...)` helper (`packages/core/src/insights/disposition-writer.ts`), exported from `@mergewatch/core`, mirroring `recordDisputes`.
+- Both runtimes call it when an inline thread is resolved (`packages/server/src/review-processor.ts`, `packages/lambda/src/handlers/review-agent.ts`): on `action === 'resolved'` we now `recordResolves` **in addition to** the existing `recordDisputes`. Resolve still counts toward the FP funnel (`disputeCount`); `resolveCount` is the separate positive-engagement signal.
+
+**Edge cases**
+
+- A pre-#195 record reads `resolveCount: 0` (Dynamo `Number(it.resolveCount ?? 0)`, Postgres column default), never `undefined`/`NaN`.
+- Best-effort writes: a failed `incrementResolve` logs and never blocks the pipeline.
+- Double-channel resolves (rare) may double-count, same accepted bias as `recordDisputes`.
+
+**Tests:** `recordResolves` increments once per key, records independently of dispute, no-ops on empty/no-store, and logs-but-doesn't-throw on store rejection (`disposition-writer.test.ts`).
+
+**E2E:** [E2E-58](../../e2e/RUNBOOK.md#e2e-58-engagement--resolve-capture-engagement-metrics-stage-1).
+
+---
+
+## Stage 2 — Engagement rollup (Tier 1 KPIs) — _planned_
+
+## Stage 3 — Engagement dashboard section — _planned_
+
+## Stage 4 — Tier 2 footer 👍/👎 helpful prompt — _planned_
+
+## Stage 5 — Tier 2 dashboard NPS survey — _planned_
+
+---
+
+## Deferred (follow-up tickets)
+
+- **Exact finding-action rate** — true per-commit diff confirmation that cited code changed (Stage 2 ships an `(agreements + resolves)/surfaced` proxy).
+- **Fleet-wide / WoW retention** — cross-installation %-active and week-over-week retained installations (insights page is installation-scoped).
+- **Per-developer attribution & leaderboards** — out of scope per #195.

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -184,7 +184,7 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-55](#e2e-55-ttm--pr-lifecycle-capture-time-to-merge-stage-1) | Every PR writes one `PRLifecycleRecord`; open/synchronize/merge/close transitions captured; `closed` doesn't trigger a review; terminal-state + set-once discipline holds (TTM) | 3m | 90s | #196 |
 | [E2E-56](#e2e-56-ttm--cycle-time-rollup-time-to-merge-stage-2) | Nightly rollup attaches a `cycleTime` block (merge counts + median/p75/p90 time-to-merge, from-first-review, round-trips) segmented reviewed vs unreviewed; open/closed excluded from time stats (TTM) | 3m | 90s | #198 |
 | [E2E-57](#e2e-57-ttm--dashboard-cycle-time-section-time-to-merge-stage-3) | `/dashboard/insights` Cycle time section: StatCards + reviewed-vs-unreviewed bar chart; relaxed zero-state gate; `null` percentile renders `—` (TTM) | 2m | 30s | #199 |
-| [E2E-58](#e2e-58-engagement--resolve-capture-engagement-metrics-stage-1) | `/resolve` on an inline thread increments a new `resolveCount` on the `FindingDispositionRecord` (positive engagement signal) alongside the existing `disputeCount`; defaults to 0 with no backfill; both backends (engagement) | 2m | 30s | #TBD |
+| [E2E-58](#e2e-58-engagement--resolve-capture-engagement-metrics-stage-1) | `/resolve` on an inline thread increments a new `resolveCount` on the `FindingDispositionRecord` (positive engagement signal) alongside the existing `disputeCount`; defaults to 0 with no backfill; both backends (engagement) | 2m | 30s | #207 |
 
 ---
 
@@ -2123,7 +2123,7 @@ Branch: `fixture/57-ttm-dashboard`. Use the E2E-56 seeded installation. Open `/d
 
 ### E2E-58: Engagement — `/resolve` capture (engagement metrics, stage 1)
 
-**Status:** ⏳ IN REVIEW (#TBD). See [`docs/pending/engagement-metrics.md` → Stage 1](./../docs/pending/engagement-metrics.md#stage-1--resolve-capture).
+**Status:** ✅ SHIPPED (#207). See [`docs/pending/engagement-metrics.md` → Stage 1](./../docs/pending/engagement-metrics.md#stage-1--resolve-capture).
 
 **Behavior:** Replying `/resolve` (or `/mergewatch resolve`) on a MergeWatch inline-finding thread increments a new `resolveCount` on that finding's `FindingDispositionRecord` — a first-class positive engagement signal, recorded **in addition to** the existing FP-F `disputeCount` increment (resolve still counts toward the FP funnel). The thread is resolved as before. New records and pre-#195 records both default `resolveCount` to 0 (no backfill). Works for both DynamoDB (SaaS) and Postgres (self-hosted).
 

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -184,6 +184,7 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-55](#e2e-55-ttm--pr-lifecycle-capture-time-to-merge-stage-1) | Every PR writes one `PRLifecycleRecord`; open/synchronize/merge/close transitions captured; `closed` doesn't trigger a review; terminal-state + set-once discipline holds (TTM) | 3m | 90s | #196 |
 | [E2E-56](#e2e-56-ttm--cycle-time-rollup-time-to-merge-stage-2) | Nightly rollup attaches a `cycleTime` block (merge counts + median/p75/p90 time-to-merge, from-first-review, round-trips) segmented reviewed vs unreviewed; open/closed excluded from time stats (TTM) | 3m | 90s | #198 |
 | [E2E-57](#e2e-57-ttm--dashboard-cycle-time-section-time-to-merge-stage-3) | `/dashboard/insights` Cycle time section: StatCards + reviewed-vs-unreviewed bar chart; relaxed zero-state gate; `null` percentile renders `—` (TTM) | 2m | 30s | #199 |
+| [E2E-58](#e2e-58-engagement--resolve-capture-engagement-metrics-stage-1) | `/resolve` on an inline thread increments a new `resolveCount` on the `FindingDispositionRecord` (positive engagement signal) alongside the existing `disputeCount`; defaults to 0 with no backfill; both backends (engagement) | 2m | 30s | #TBD |
 
 ---
 
@@ -2117,6 +2118,31 @@ Branch: `fixture/57-ttm-dashboard`. Use the E2E-56 seeded installation. Open `/d
 - ❌ The page hides everything when `totalFindingsSurfaced === 0`, hiding cycle-time for a merge-active repo (the old gate; must be relaxed).
 - ❌ A `null` percentile renders as `0h` (misleading "instant merge").
 - ❌ The section throws on a pre-Stage-2 rollup with no `cycleTime` (must be optional).
+
+---
+
+### E2E-58: Engagement — `/resolve` capture (engagement metrics, stage 1)
+
+**Status:** ⏳ IN REVIEW (#TBD). See [`docs/pending/engagement-metrics.md` → Stage 1](./../docs/pending/engagement-metrics.md#stage-1--resolve-capture).
+
+**Behavior:** Replying `/resolve` (or `/mergewatch resolve`) on a MergeWatch inline-finding thread increments a new `resolveCount` on that finding's `FindingDispositionRecord` — a first-class positive engagement signal, recorded **in addition to** the existing FP-F `disputeCount` increment (resolve still counts toward the FP funnel). The thread is resolved as before. New records and pre-#195 records both default `resolveCount` to 0 (no backfill). Works for both DynamoDB (SaaS) and Postgres (self-hosted).
+
+**Setup**
+
+Branch: `fixture/58-engagement-resolve`. On a repo with an active review that surfaced ≥1 inline finding, reply `/resolve` on the inline-finding thread. Inspect the disposition record (DynamoDB `mergewatch-finding-dispositions` item, or Postgres `finding_dispositions` row) for the finding's match key.
+
+**Expected outcomes**
+
+- [ ] The inline thread is resolved (GraphQL `resolveReviewThread`), as in the pre-#195 behavior.
+- [ ] The finding's disposition record shows `resolveCount` incremented by 1 (per resolved match key).
+- [ ] `disputeCount` is also incremented by 1 (existing FP-F behavior is unchanged).
+- [ ] A record that has never been resolved reads `resolveCount: 0` (default, not missing/`NaN`).
+- [ ] Both backends behave identically (Dynamo atomic `if_not_exists` + Postgres `resolve_count + 1`).
+
+**Failure modes**
+- ❌ `/resolve` only increments `disputeCount` (the resolve engagement signal is lost — the #195 regression).
+- ❌ A pre-#195 row throws or reads `undefined`/`NaN` for `resolveCount` (must coerce to 0).
+- ❌ The Postgres migration is non-idempotent (no `ADD COLUMN IF NOT EXISTS`) and fails `migrations:check` or a re-run.
 
 ---
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -155,6 +155,7 @@ export type { ClusterableFinding, ClusterOptions, TaggedClusterableFindings } fr
 export {
   recordFindingSurfacings,
   recordDisputes,
+  recordResolves,
   detectQuietDrops,
   recordQuietDrops,
   pollAndRecordInlineReactions,

--- a/packages/core/src/insights/disposition-writer.test.ts
+++ b/packages/core/src/insights/disposition-writer.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   recordFindingSurfacings,
   recordDisputes,
+  recordResolves,
   detectQuietDrops,
   recordQuietDrops,
   pollAndRecordInlineReactions,
@@ -20,6 +21,7 @@ function makeMockStore(): IFindingDispositionStore & {
     incrementUnverified: string[][];
     incrementSilentDrop: string[][];
     incrementAgreement: string[][];
+    incrementResolve: string[][];
     appendRejectReason: Array<[string, string, string, unknown]>;
   };
 } {
@@ -30,6 +32,7 @@ function makeMockStore(): IFindingDispositionStore & {
     incrementUnverified: [] as string[][],
     incrementSilentDrop: [] as string[][],
     incrementAgreement: [] as string[][],
+    incrementResolve: [] as string[][],
     appendRejectReason: [] as Array<[string, string, string, unknown]>,
   };
   return {
@@ -42,6 +45,7 @@ function makeMockStore(): IFindingDispositionStore & {
     async incrementUnverified(i, r, k)  { calls.incrementUnverified.push([i, r, k]); },
     async incrementSilentDrop(i, r, k)  { calls.incrementSilentDrop.push([i, r, k]); },
     async incrementAgreement(i, r, k)   { calls.incrementAgreement.push([i, r, k]); },
+    async incrementResolve(i, r, k)     { calls.incrementResolve.push([i, r, k]); },
     async appendRejectReason(i, r, k, reason) {
       calls.appendRejectReason.push([i, r, k, reason]);
     },
@@ -189,6 +193,48 @@ describe('recordDisputes (FB-A)', () => {
     const store = makeMockStore();
     await recordDisputes(store, 42, 'org/repo', []);
     expect(store.calls.incrementDispute).toHaveLength(0);
+  });
+});
+
+// ─── recordResolves (#195) ──────────────────────────────────────────────────
+
+describe('recordResolves (#195)', () => {
+  it('calls incrementResolve once per key', async () => {
+    const store = makeMockStore();
+    await recordResolves(store, 42, 'org/repo', [
+      'src/a.ts::T::Foo',
+      'src/a.ts::F::abc123',
+    ]);
+    expect(store.calls.incrementResolve).toEqual([
+      ['42', 'org/repo', 'src/a.ts::T::Foo'],
+      ['42', 'org/repo', 'src/a.ts::F::abc123'],
+    ]);
+  });
+
+  it('records resolve independently of dispute (no incrementDispute side-effect)', async () => {
+    const store = makeMockStore();
+    await recordResolves(store, 42, 'org/repo', ['src/a.ts::T::Foo']);
+    expect(store.calls.incrementResolve).toHaveLength(1);
+    expect(store.calls.incrementDispute).toHaveLength(0);
+  });
+
+  it('is a no-op when the key list is empty', async () => {
+    const store = makeMockStore();
+    await recordResolves(store, 42, 'org/repo', []);
+    expect(store.calls.incrementResolve).toHaveLength(0);
+  });
+
+  it('is a no-op when no store is provided (back-compat)', async () => {
+    await expect(recordResolves(undefined, 42, 'org/repo', ['k'])).resolves.toBeUndefined();
+  });
+
+  it('logs but does not throw when the store rejects', async () => {
+    const store = makeMockStore();
+    store.incrementResolve = vi.fn(async () => { throw new Error('disk full'); }) as never;
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await expect(recordResolves(store, 42, 'org/repo', ['k'])).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
   });
 });
 

--- a/packages/core/src/insights/disposition-writer.ts
+++ b/packages/core/src/insights/disposition-writer.ts
@@ -106,6 +106,30 @@ export async function recordDisputes(
   }
 }
 
+/**
+ * #195 — record one resolveCount increment per key. A `/resolve` is an
+ * explicit "I acted on this" engagement signal. It is recorded ALONGSIDE the
+ * existing FP-F dispute increment (resolve still counts toward the FP funnel),
+ * not in place of it — `resolveCount` is the separate positive-engagement
+ * counter the engagement rollup reads. Best-effort, same as `recordDisputes`.
+ */
+export async function recordResolves(
+  store: IFindingDispositionStore | undefined,
+  installationId: string | number | undefined,
+  repoFullName: string,
+  matchKeys: readonly string[],
+): Promise<void> {
+  if (!store || installationId == null || matchKeys.length === 0) return;
+  const inst = String(installationId);
+  for (const key of matchKeys) {
+    try {
+      await store.incrementResolve(inst, repoFullName, key);
+    } catch (err) {
+      console.warn('[fb-a] recordResolves: write failed for %s', key, err);
+    }
+  }
+}
+
 // ─── FB-B — quiet-drop derived counter ─────────────────────────────────────
 
 /**

--- a/packages/core/src/insights/rollup.test.ts
+++ b/packages/core/src/insights/rollup.test.ts
@@ -24,6 +24,7 @@ function record(over: Partial<FindingDispositionRecord> = {}): FindingDispositio
     unverifiedCount: 0,
     silentDropCount: 0,
     agreementCount: 0,
+    resolveCount: 0,
     category: 'bug',
     topAgent: 'bug',
     sigTokens: ['missing', 'await', 'fetch'],

--- a/packages/core/src/insights/run-rollup.test.ts
+++ b/packages/core/src/insights/run-rollup.test.ts
@@ -17,6 +17,7 @@ function record(over: Partial<FindingDispositionRecord> = {}): FindingDispositio
     unverifiedCount: 0,
     silentDropCount: 0,
     agreementCount: 0,
+    resolveCount: 0,
     ...over,
   };
 }

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -139,6 +139,9 @@ export interface IFindingDispositionStore {
   /** FB-C — increment agreementCount by 1. */
   incrementAgreement(installationId: string, repoFullName: string, findingMatchKey: string): Promise<void>;
 
+  /** #195 — increment resolveCount by 1 (a `/resolve` command on the bot's inline thread). */
+  incrementResolve(installationId: string, repoFullName: string, findingMatchKey: string): Promise<void>;
+
   /** FB-D — append a rejectReason entry. Idempotent at the record level; appends always extend. */
   appendRejectReason(
     installationId: string,

--- a/packages/core/src/types/db.ts
+++ b/packages/core/src/types/db.ts
@@ -494,6 +494,14 @@ export interface FindingDispositionRecord {
   silentDropCount: number;
   /** FB-C — 👍 / ❤️ / 🚀 reactions on the bot's inline comment for a finding with this key. */
   agreementCount: number;
+  /**
+   * #195 — `/resolve` (or `/mergewatch resolve`) command invocations on the
+   * bot's inline thread for a finding with this key. A first-class engagement
+   * signal: an explicit "I acted on this" distinct from a 👎 dispute. Drives
+   * the command-usage and approximate finding-action KPIs in the FB-E rollup.
+   * Defaults to 0 on records written before this counter existed.
+   */
+  resolveCount: number;
 
   /** Last-seen finding category for this key (the few seen are stable; we keep the most recent). */
   category?: 'security' | 'bug' | 'style' | 'errorHandling' | 'testCoverage' | 'commentAccuracy' | 'custom';

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -50,6 +50,7 @@ import {
   partitionDisputed,
   recordFindingSurfacings,
   recordDisputes,
+  recordResolves,
   detectQuietDrops,
   recordQuietDrops,
   pollAndRecordInlineReactions,
@@ -258,6 +259,9 @@ async function handleInlineReplyMode(
       });
       if (result.resolvedFindingKeys && result.resolvedFindingKeys.length > 0) {
         await recordDisputes(dispositionStore, installationId, repoFullName, result.resolvedFindingKeys);
+        // #195 — also record the positive engagement signal (separate from the
+        // FP-F dispute increment above) so command-usage / action KPIs see it.
+        await recordResolves(dispositionStore, installationId, repoFullName, result.resolvedFindingKeys);
       }
     }
 

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -14,7 +14,7 @@ import {
   handleInlineReply,
   persistInlineResolveMemory,
   fetchTriageComments, computeDisputedKeys, partitionDisputed,
-  recordFindingSurfacings, recordDisputes, detectQuietDrops, recordQuietDrops,
+  recordFindingSurfacings, recordDisputes, recordResolves, detectQuietDrops, recordQuietDrops,
   pollAndRecordInlineReactions,
 } from '@mergewatch/core';
 import type { WebhookDeps } from './webhook-handler.js';
@@ -164,6 +164,9 @@ async function handleInlineReplyJob(
       });
       if (result.resolvedFindingKeys && result.resolvedFindingKeys.length > 0) {
         await recordDisputes(deps.dispositionStore, installationId, repoFullName, result.resolvedFindingKeys);
+        // #195 — also record the positive engagement signal (separate from the
+        // FP-F dispute increment above) so command-usage / action KPIs see it.
+        await recordResolves(deps.dispositionStore, installationId, repoFullName, result.resolvedFindingKeys);
       }
     }
 

--- a/packages/storage-dynamo/src/finding-disposition-store.ts
+++ b/packages/storage-dynamo/src/finding-disposition-store.ts
@@ -74,6 +74,7 @@ export class DynamoFindingDispositionStore implements IFindingDispositionStore {
       'unverifiedCount = if_not_exists(unverifiedCount, :zero)',
       'silentDropCount = if_not_exists(silentDropCount, :zero)',
       'agreementCount = if_not_exists(agreementCount, :zero)',
+      'resolveCount = if_not_exists(resolveCount, :zero)',
     ];
     const exprValues: Record<string, unknown> = {
       ':now': nowIso,
@@ -114,7 +115,7 @@ export class DynamoFindingDispositionStore implements IFindingDispositionStore {
     installationId: string,
     repoFullName: string,
     findingMatchKey: string,
-    attrName: 'disputeCount' | 'verifiedCount' | 'unverifiedCount' | 'silentDropCount' | 'agreementCount',
+    attrName: 'disputeCount' | 'verifiedCount' | 'unverifiedCount' | 'silentDropCount' | 'agreementCount' | 'resolveCount',
   ): Promise<void> {
     try {
       await this.client.send(new UpdateCommand({
@@ -134,6 +135,7 @@ export class DynamoFindingDispositionStore implements IFindingDispositionStore {
   incrementUnverified(i: string, r: string, k: string)  { return this.incrementCounter(i, r, k, 'unverifiedCount'); }
   incrementSilentDrop(i: string, r: string, k: string)  { return this.incrementCounter(i, r, k, 'silentDropCount'); }
   incrementAgreement(i: string, r: string, k: string)   { return this.incrementCounter(i, r, k, 'agreementCount'); }
+  incrementResolve(i: string, r: string, k: string)     { return this.incrementCounter(i, r, k, 'resolveCount'); }
 
   async appendRejectReason(
     installationId: string,
@@ -201,6 +203,7 @@ function itemToRecord(it: Record<string, unknown>): FindingDispositionRecord {
     unverifiedCount: Number(it.unverifiedCount ?? 0),
     silentDropCount: Number(it.silentDropCount ?? 0),
     agreementCount: Number(it.agreementCount ?? 0),
+    resolveCount: Number(it.resolveCount ?? 0),
   };
   if (it.category) r.category = it.category as FindingDispositionRecord['category'];
   if (it.topAgent) r.topAgent = String(it.topAgent);

--- a/packages/storage-postgres/drizzle/0010_lying_dracula.sql
+++ b/packages/storage-postgres/drizzle/0010_lying_dracula.sql
@@ -1,0 +1,4 @@
+-- #195 — /resolve command counter on the per-finding disposition record. An
+-- explicit engagement signal (distinct from a 👎 dispute). Default 0 so rows
+-- written before this counter existed need no backfill.
+ALTER TABLE "finding_dispositions" ADD COLUMN IF NOT EXISTS "resolve_count" integer DEFAULT 0 NOT NULL;

--- a/packages/storage-postgres/drizzle/meta/0010_snapshot.json
+++ b/packages/storage-postgres/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,897 @@
+{
+  "id": "b39dbdee-c42a-4fae-bb10-8bcf9931eb17",
+  "prevId": "26864348-f19b-4c60-9177-fd98b6e42067",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_installation_idx": {
+          "name": "api_keys_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.finding_dispositions": {
+      "name": "finding_dispositions",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finding_match_key": {
+          "name": "finding_match_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_count": {
+          "name": "surface_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dispute_count": {
+          "name": "dispute_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verified_count": {
+          "name": "verified_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unverified_count": {
+          "name": "unverified_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "silent_drop_count": {
+          "name": "silent_drop_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "agreement_count": {
+          "name": "agreement_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resolve_count": {
+          "name": "resolve_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_agent": {
+          "name": "top_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sig_tokens": {
+          "name": "sig_tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reject_reasons": {
+          "name": "reject_reasons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "finding_dispositions_installation_idx": {
+          "name": "finding_dispositions_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "finding_dispositions_installation_id_repo_full_name_finding_match_key_pk": {
+          "name": "finding_dispositions_installation_id_repo_full_name_finding_match_key_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name",
+            "finding_match_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installation_fp_insights": {
+      "name": "installation_fp_insights",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window": {
+          "name": "window",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_end": {
+          "name": "window_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_findings_surfaced": {
+          "name": "total_findings_surfaced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_disputes": {
+          "name": "total_disputes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dispute_rate": {
+          "name": "dispute_rate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_silent_drops": {
+          "name": "total_silent_drops",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_agreements": {
+          "name": "total_agreements",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "per_category": {
+          "name": "per_category",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "per_severity": {
+          "name": "per_severity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "per_repo": {
+          "name": "per_repo",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "top_clusters": {
+          "name": "top_clusters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "cycle_time": {
+          "name": "cycle_time",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "installation_fp_insights_installation_id_window_pk": {
+          "name": "installation_fp_insights_installation_id_window_pk",
+          "columns": [
+            "installation_id",
+            "window"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installation_settings": {
+      "name": "installation_settings",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "severity_threshold": {
+          "name": "severity_threshold",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Low'"
+        },
+        "comment_types": {
+          "name": "comment_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"syntax\":true,\"logic\":true,\"style\":true}'::jsonb"
+        },
+        "max_comments": {
+          "name": "max_comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 25
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"prSummary\":true,\"confidenceScore\":true,\"issuesTable\":true,\"diagram\":true}'::jsonb"
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "comment_header": {
+          "name": "comment_header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installations": {
+      "name": "installations",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monitored": {
+          "name": "monitored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "installations_installation_id_repo_full_name_pk": {
+          "name": "installations_installation_id_repo_full_name_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_sessions": {
+      "name": "mcp_sessions",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_billed_at": {
+          "name": "first_billed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_billed_cents": {
+          "name": "max_billed_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iteration": {
+          "name": "iteration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pr_lifecycle": {
+      "name": "pr_lifecycle",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_created_at": {
+          "name": "pr_created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_review_at": {
+          "name": "first_review_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "reviewed": {
+          "name": "reviewed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "skipped": {
+          "name": "skipped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "total_pushes": {
+          "name": "total_pushes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pushes_after_first_review": {
+          "name": "pushes_after_first_review",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pr_lifecycle_installation_idx": {
+          "name": "pr_lifecycle_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "pr_lifecycle_installation_id_repo_full_name_pr_number_pk": {
+          "name": "pr_lifecycle_installation_id_repo_full_name_pr_number_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name",
+            "pr_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number_commit_sha": {
+          "name": "pr_number_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_title": {
+          "name": "pr_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_author": {
+          "name": "pr_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_author_avatar": {
+          "name": "pr_author_avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_branch": {
+          "name": "head_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_severity": {
+          "name": "top_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_text": {
+          "name": "summary_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagram_text": {
+          "name": "diagram_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_score": {
+          "name": "merge_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_score_reason": {
+          "name": "merge_score_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "findings": {
+          "name": "findings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reactions": {
+          "name": "reactions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_used": {
+          "name": "settings_used",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_cost_usd": {
+          "name": "estimated_cost_usd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inline_resolved_keys": {
+          "name": "inline_resolved_keys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "inline_reactions_snapshot": {
+          "name": "inline_reactions_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "reviews_installation_idx": {
+          "name": "reviews_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_pr_idx": {
+          "name": "reviews_pr_idx",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "reviews_repo_full_name_pr_number_commit_sha_pk": {
+          "name": "reviews_repo_full_name_pr_number_commit_sha_pk",
+          "columns": [
+            "repo_full_name",
+            "pr_number_commit_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/storage-postgres/drizzle/meta/_journal.json
+++ b/packages/storage-postgres/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1781923071656,
       "tag": "0009_parallel_stark_industries",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1782001388109,
+      "tag": "0010_lying_dracula",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/storage-postgres/src/finding-disposition-store.ts
+++ b/packages/storage-postgres/src/finding-disposition-store.ts
@@ -84,7 +84,7 @@ export class PostgresFindingDispositionStore implements IFindingDispositionStore
     installationId: string,
     repoFullName: string,
     findingMatchKey: string,
-    column: 'disputeCount' | 'verifiedCount' | 'unverifiedCount' | 'silentDropCount' | 'agreementCount',
+    column: 'disputeCount' | 'verifiedCount' | 'unverifiedCount' | 'silentDropCount' | 'agreementCount' | 'resolveCount',
   ): Promise<void> {
     try {
       const colMap = {
@@ -93,6 +93,7 @@ export class PostgresFindingDispositionStore implements IFindingDispositionStore
         unverifiedCount: findingDispositions.unverifiedCount,
         silentDropCount: findingDispositions.silentDropCount,
         agreementCount:  findingDispositions.agreementCount,
+        resolveCount:    findingDispositions.resolveCount,
       } as const;
       const dbCol = colMap[column];
       await this.db
@@ -113,6 +114,7 @@ export class PostgresFindingDispositionStore implements IFindingDispositionStore
   incrementUnverified(i: string, r: string, k: string)  { return this.incrementCounter(i, r, k, 'unverifiedCount'); }
   incrementSilentDrop(i: string, r: string, k: string)  { return this.incrementCounter(i, r, k, 'silentDropCount'); }
   incrementAgreement(i: string, r: string, k: string)   { return this.incrementCounter(i, r, k, 'agreementCount'); }
+  incrementResolve(i: string, r: string, k: string)     { return this.incrementCounter(i, r, k, 'resolveCount'); }
 
   async appendRejectReason(
     installationId: string,
@@ -163,6 +165,7 @@ export class PostgresFindingDispositionStore implements IFindingDispositionStore
       unverifiedCount: r.unverifiedCount,
       silentDropCount: r.silentDropCount,
       agreementCount: r.agreementCount,
+      resolveCount: r.resolveCount,
       ...(r.category ? { category: r.category as FindingDispositionRecord['category'] } : {}),
       ...(r.topAgent ? { topAgent: r.topAgent } : {}),
       ...(r.severity ? { severity: r.severity as FindingDispositionRecord['severity'] } : {}),

--- a/packages/storage-postgres/src/schema.ts
+++ b/packages/storage-postgres/src/schema.ts
@@ -133,6 +133,9 @@ export const findingDispositions = pgTable('finding_dispositions', {
   unverifiedCount: integer('unverified_count').notNull().default(0),
   silentDropCount: integer('silent_drop_count').notNull().default(0),
   agreementCount: integer('agreement_count').notNull().default(0),
+  // #195 — `/resolve` command invocations (engagement signal). Default 0 so
+  // rows written before this counter existed need no backfill.
+  resolveCount: integer('resolve_count').notNull().default(0),
   category: text('category'),
   topAgent: text('top_agent'),
   // FB-I — severity for the severity-shopping detector rollup. Optional


### PR DESCRIPTION
**Stage 1 of 5** of the developer-engagement / NPS feature ([#195](https://github.com/mergewatch/mergewatch.ai/issues/195)). Plan: `docs/feat/20260620-01-engagement-metrics.plan.md`.

## What this ships
A first-class `resolveCount` counter on `FindingDispositionRecord`, so `/mergewatch` command usage is fully aggregatable before the engagement rollup (stage 2) consumes it. A `/resolve` is an explicit "I acted on this" — recorded **alongside** the existing FP-F `disputeCount` increment (resolve still counts toward the FP funnel), not in place of it.

- **core** — `resolveCount` on the record; `IFindingDispositionStore.incrementResolve`; `recordResolves()` helper exported from `@mergewatch/core` (mirrors `recordDisputes`).
- **storage (both backends, at parity)** — atomic increment; Postgres `resolve_count integer NOT NULL DEFAULT 0` via **idempotent** migration `0010` (`ADD COLUMN IF NOT EXISTS`); Dynamo `if_not_exists` pre-seed + coercion to `0` for pre-#195 items.
- **runtimes** — server + Lambda call `recordResolves` on `action === 'resolved'`.

## Edge cases handled
- Pre-#195 records read `resolveCount: 0`, never `undefined`/`NaN` (Dynamo coercion + Postgres column default).
- Best-effort writes: a failed `incrementResolve` logs and never blocks the pipeline.
- Existing FP-F `disputeCount` semantics are **unchanged** — this is purely additive.

## Verification
- `pnpm run build` ✅ · `pnpm run typecheck` ✅ · `pnpm run test` ✅ (all packages green)
- `migrations:check` ✅ (migration matches schema, idempotent)
- New tests: `recordResolves` increments per key, is independent of dispute, no-ops on empty/no-store, logs-but-doesn't-throw on rejection.
- E2E: `e2e/RUNBOOK.md` → E2E-58.

## Deferred to later stages
Engagement rollup + dashboard section (Tier 1, stages 2–3); 👍/👎 footer prompt + dashboard NPS survey (Tier 2, stages 4–5). Exact diff-based finding-action rate → follow-up ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)