### PR TITLE
feat(insights): Tier-1 engagement KPIs in the nightly rollup (#195, stage 2)

### DIFF
--- a/docs/feat/20260620-01-engagement-metrics.plan.md
+++ b/docs/feat/20260620-01-engagement-metrics.plan.md
@@ -76,7 +76,7 @@ All fields optional-by-block: pre-feature rollups have no `engagement`; consumer
 - **RUNBOOK:** E2E-58 — `/resolve` increments `resolveCount` on the disposition record.
 - **Tests:** store increment (both backends, mock), handler wiring, migration idempotency (`migrations:check`).
 
-### Phase 2 — Engagement rollup (Tier 1 KPIs, core) — [x] (in review)
+### Phase 2 — Engagement rollup (Tier 1 KPIs, core) — [x] PR #208 (MergeWatch 5/5, 0 findings)
 - **Goal:** compute and persist the Tier 1 `engagement` block per 7d/30d/90d window. Depends on Phase 1 (`resolveCount`).
 - **Files:** `packages/core/src/types/db.ts` (`engagement?` block), new `packages/core/src/insights/engagement.ts` (pure `buildEngagementInsight` + helpers, exported via core index), `run-rollup.ts` (assign `insight.engagement`), both `fp-insight-store.ts` impls (persist + coerce), `schema.ts` + migration (`engagement` jsonb, idempotent).
 - **RUNBOOK:** E2E-59 — nightly rollup attaches an `engagement` block (acceptance rate, command usage, re-review rate, approx action rate, reviewed-PR count) over each window; empty/low-volume installation yields `null` rates not crashes.

--- a/docs/feat/20260620-01-engagement-metrics.plan.md
+++ b/docs/feat/20260620-01-engagement-metrics.plan.md
@@ -76,7 +76,7 @@ All fields optional-by-block: pre-feature rollups have no `engagement`; consumer
 - **RUNBOOK:** E2E-58 — `/resolve` increments `resolveCount` on the disposition record.
 - **Tests:** store increment (both backends, mock), handler wiring, migration idempotency (`migrations:check`).
 
-### Phase 2 — Engagement rollup (Tier 1 KPIs, core) — [ ]
+### Phase 2 — Engagement rollup (Tier 1 KPIs, core) — [x] (in review)
 - **Goal:** compute and persist the Tier 1 `engagement` block per 7d/30d/90d window. Depends on Phase 1 (`resolveCount`).
 - **Files:** `packages/core/src/types/db.ts` (`engagement?` block), new `packages/core/src/insights/engagement.ts` (pure `buildEngagementInsight` + helpers, exported via core index), `run-rollup.ts` (assign `insight.engagement`), both `fp-insight-store.ts` impls (persist + coerce), `schema.ts` + migration (`engagement` jsonb, idempotent).
 - **RUNBOOK:** E2E-59 — nightly rollup attaches an `engagement` block (acceptance rate, command usage, re-review rate, approx action rate, reviewed-PR count) over each window; empty/low-volume installation yields `null` rates not crashes.

--- a/docs/pending/engagement-metrics.md
+++ b/docs/pending/engagement-metrics.md
@@ -80,7 +80,47 @@ Adds a first-class `resolveCount` counter to the per-finding disposition record 
 
 ---
 
-## Stage 2 — Engagement rollup (Tier 1 KPIs) — _planned_
+## Stage 2 — Engagement rollup (Tier 1 KPIs)
+
+Computes and persists the Tier-1 `engagement` block per window in the nightly insights rollup.
+
+**`engagement` block (Tier 1)**
+
+```ts
+engagement?: {
+  acceptanceRate: number | null;          // agreements / (agreements + disputes + silentDrops)
+  totalResolves: number;                  // /resolve usage (resolveCount, summed)
+  totalRejectCommands: number;            // /mergewatch reject usage (rejectReasons[].at in-window)
+  commandUsageCount: number;              // totalResolves + totalRejectCommands
+  findingActionRateApprox: number | null; // (agreements + resolves) / surfaced, capped at 1 — PROXY
+  reReviewRate: number | null;            // reviewed PRs re-pushed after first review / reviewed PRs
+  reviewedPrCount: number;
+  activeInstallation: boolean;            // reviewedPrCount > 0
+};
+```
+
+**What changed**
+
+- `InstallationFPInsight.engagement?` block (`packages/core/src/types/db.ts`) — optional, nullable rates, exactly like `cycleTime`.
+- New pure module `packages/core/src/insights/engagement.ts` — `buildEngagementInsight(window, windowEndIso, dispositionRecords, prLifecycleRecords)`, exported from `@mergewatch/core` along with the `EngagementInsight` type. Mirrors `cycle-time.ts`.
+- `runInsightRollup` (`run-rollup.ts`) computes `insight.engagement` **unconditionally** — it only needs the mandatory disposition records; PR-lifecycle records refine the re-review KPIs when that store is wired and are empty otherwise.
+- Persistence in both fp-insight stores (`engagement` jsonb / attribute, null↔undefined coercion); Postgres column via idempotent migration `0011_soft_liz_osborn.sql` (`ADD COLUMN IF NOT EXISTS`).
+
+**Windowing**
+
+- Disposition counters (agreement / dispute / silentDrop / resolve / surface) are summed over records whose `lastSeen` is in-window — the same convention the FP-funnel rollup uses.
+- `/mergewatch reject` commands carry their own `at` timestamp, so they're windowed precisely by that (independent of `lastSeen`).
+- PR-lifecycle engagement (reviewed / re-review) windows by `firstReviewAt`.
+
+**Edge cases**
+
+- Rates are `null` when their denominator is 0 — the dashboard tells "no signal" from a real `0`.
+- `findingActionRateApprox` is capped at 1 (a finding can carry both a 👍 and a `/resolve`).
+- Pre-#195 rollup rows have no `engagement` block; consumers handle `undefined`.
+
+**Tests:** `engagement.test.ts` — acceptance/action/command/re-review math, the empty/low-volume case, windowing (7d vs 30d, out-of-window exclusion), and the cap.
+
+**E2E:** [E2E-59](../../e2e/RUNBOOK.md#e2e-59-engagement--tier-1-rollup-engagement-metrics-stage-2).
 
 ## Stage 3 — Engagement dashboard section — _planned_
 

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -185,7 +185,7 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-56](#e2e-56-ttm--cycle-time-rollup-time-to-merge-stage-2) | Nightly rollup attaches a `cycleTime` block (merge counts + median/p75/p90 time-to-merge, from-first-review, round-trips) segmented reviewed vs unreviewed; open/closed excluded from time stats (TTM) | 3m | 90s | #198 |
 | [E2E-57](#e2e-57-ttm--dashboard-cycle-time-section-time-to-merge-stage-3) | `/dashboard/insights` Cycle time section: StatCards + reviewed-vs-unreviewed bar chart; relaxed zero-state gate; `null` percentile renders `—` (TTM) | 2m | 30s | #199 |
 | [E2E-58](#e2e-58-engagement--resolve-capture-engagement-metrics-stage-1) | `/resolve` on an inline thread increments a new `resolveCount` on the `FindingDispositionRecord` (positive engagement signal) alongside the existing `disputeCount`; defaults to 0 with no backfill; both backends (engagement) | 2m | 30s | #207 |
-| [E2E-59](#e2e-59-engagement--tier-1-rollup-engagement-metrics-stage-2) | Nightly rollup attaches an `engagement` block (acceptance rate, command usage, approx finding-action rate, re-review rate, reviewed-PR count) per window; `null` rates for empty denominators; rejects windowed by `at`; both backends (engagement) | 3m | 90s | #TBD |
+| [E2E-59](#e2e-59-engagement--tier-1-rollup-engagement-metrics-stage-2) | Nightly rollup attaches an `engagement` block (acceptance rate, command usage, approx finding-action rate, re-review rate, reviewed-PR count) per window; `null` rates for empty denominators; rejects windowed by `at`; both backends (engagement) | 3m | 90s | #208 |
 
 ---
 
@@ -2149,7 +2149,7 @@ Branch: `fixture/58-engagement-resolve`. On a repo with an active review that su
 
 ### E2E-59: Engagement — Tier 1 rollup (engagement metrics, stage 2)
 
-**Status:** ✅ SHIPPED (#TBD). See [`docs/pending/engagement-metrics.md` → Stage 2](./../docs/pending/engagement-metrics.md#stage-2--engagement-rollup-tier-1-kpis).
+**Status:** ✅ SHIPPED (#208). See [`docs/pending/engagement-metrics.md` → Stage 2](./../docs/pending/engagement-metrics.md#stage-2--engagement-rollup-tier-1-kpis).
 
 **Behavior:** The nightly insights rollup attaches an `engagement` block to each `InstallationFPInsight` (7d / 30d / 90d) with Tier-1 behavioral KPIs: **acceptance rate** (`agreements / (agreements + disputes + silentDrops)`), **command usage** (`/resolve` + `/mergewatch reject` counts), an **approximate finding-action rate** (`(agreements + resolves) / surfaced`, capped at 1), **re-review rate** (reviewed PRs re-pushed after first review), `reviewedPrCount`, and `activeInstallation`. Rates are `null` (not `0`) when their denominator is empty. The block computes from the disposition records alone (re-review KPIs refine when the PR-lifecycle store is wired). Persisted on both backends as a nullable `engagement` jsonb/attribute.
 

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -185,6 +185,7 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-56](#e2e-56-ttm--cycle-time-rollup-time-to-merge-stage-2) | Nightly rollup attaches a `cycleTime` block (merge counts + median/p75/p90 time-to-merge, from-first-review, round-trips) segmented reviewed vs unreviewed; open/closed excluded from time stats (TTM) | 3m | 90s | #198 |
 | [E2E-57](#e2e-57-ttm--dashboard-cycle-time-section-time-to-merge-stage-3) | `/dashboard/insights` Cycle time section: StatCards + reviewed-vs-unreviewed bar chart; relaxed zero-state gate; `null` percentile renders `—` (TTM) | 2m | 30s | #199 |
 | [E2E-58](#e2e-58-engagement--resolve-capture-engagement-metrics-stage-1) | `/resolve` on an inline thread increments a new `resolveCount` on the `FindingDispositionRecord` (positive engagement signal) alongside the existing `disputeCount`; defaults to 0 with no backfill; both backends (engagement) | 2m | 30s | #207 |
+| [E2E-59](#e2e-59-engagement--tier-1-rollup-engagement-metrics-stage-2) | Nightly rollup attaches an `engagement` block (acceptance rate, command usage, approx finding-action rate, re-review rate, reviewed-PR count) per window; `null` rates for empty denominators; rejects windowed by `at`; both backends (engagement) | 3m | 90s | #TBD |
 
 ---
 
@@ -2143,6 +2144,34 @@ Branch: `fixture/58-engagement-resolve`. On a repo with an active review that su
 - ❌ `/resolve` only increments `disputeCount` (the resolve engagement signal is lost — the #195 regression).
 - ❌ A pre-#195 row throws or reads `undefined`/`NaN` for `resolveCount` (must coerce to 0).
 - ❌ The Postgres migration is non-idempotent (no `ADD COLUMN IF NOT EXISTS`) and fails `migrations:check` or a re-run.
+
+---
+
+### E2E-59: Engagement — Tier 1 rollup (engagement metrics, stage 2)
+
+**Status:** ✅ SHIPPED (#TBD). See [`docs/pending/engagement-metrics.md` → Stage 2](./../docs/pending/engagement-metrics.md#stage-2--engagement-rollup-tier-1-kpis).
+
+**Behavior:** The nightly insights rollup attaches an `engagement` block to each `InstallationFPInsight` (7d / 30d / 90d) with Tier-1 behavioral KPIs: **acceptance rate** (`agreements / (agreements + disputes + silentDrops)`), **command usage** (`/resolve` + `/mergewatch reject` counts), an **approximate finding-action rate** (`(agreements + resolves) / surfaced`, capped at 1), **re-review rate** (reviewed PRs re-pushed after first review), `reviewedPrCount`, and `activeInstallation`. Rates are `null` (not `0`) when their denominator is empty. The block computes from the disposition records alone (re-review KPIs refine when the PR-lifecycle store is wired). Persisted on both backends as a nullable `engagement` jsonb/attribute.
+
+**Setup**
+
+Branch: `fixture/59-engagement-rollup`. Use an installation with disposition + PR-lifecycle history (👍/👎 reactions, `/resolve`, `/mergewatch reject`, reviewed PRs with later pushes). Trigger the nightly rollup (EventBridge → `insights-rollup` Lambda on SaaS, or the self-hosted cron) and inspect the stored insight rows.
+
+**Expected outcomes**
+
+- [ ] Each window row carries an `engagement` block with the seven Tier-1 fields.
+- [ ] `acceptanceRate` matches `agreements / (agreements + disputes + silentDrops)` for in-window records; `null` when nothing was acted on.
+- [ ] `commandUsageCount` = `totalResolves + totalRejectCommands`; rejects are windowed by their own `rejectReasons[].at`.
+- [ ] `findingActionRateApprox` is capped at 1 even when a finding has both a 👍 and a `/resolve`.
+- [ ] `reReviewRate` = reviewed-PRs-re-pushed / reviewed-PRs in-window; `null` and `activeInstallation: false` when no reviewed PRs.
+- [ ] A pre-#195 rollup row (no `engagement`) still reads back fine — the field stays `undefined`.
+- [ ] Identical numbers on DynamoDB and Postgres for the same inputs.
+
+**Failure modes**
+- ❌ A rate reads `0` where it should be `null` (no data), making an empty install look like a 0% install.
+- ❌ Rejects windowed by `lastSeen` instead of `rejectReasons[].at` (drops in-window rejects on long-lived records).
+- ❌ `findingActionRateApprox` exceeds 1 (uncapped proxy).
+- ❌ The `engagement` jsonb migration is non-idempotent (no `ADD COLUMN IF NOT EXISTS`).
 
 ---
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -170,6 +170,10 @@ export type { RollupStores, RollupRunResult } from './insights/run-rollup.js';
 export { buildCycleTimeInsight, percentile, percentilesOf } from './insights/cycle-time.js';
 export type { CycleTimeInsight } from './insights/cycle-time.js';
 
+// ─── Engagement rollup (#195) ──────────────────────────────────────────────
+export { buildEngagementInsight } from './insights/engagement.js';
+export type { EngagementInsight } from './insights/engagement.js';
+
 // ─── Dispute-rate loader (FP-J L1) ─────────────────────────────────────────
 export { loadCategoryDisputeRates } from './insights/dispute-rates.js';
 

--- a/packages/core/src/insights/engagement.test.ts
+++ b/packages/core/src/insights/engagement.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest';
+import { buildEngagementInsight } from './engagement.js';
+import type { FindingDispositionRecord, PRLifecycleRecord } from '../types/db.js';
+
+// 7d window ends here; "in window" means lastSeen/at/firstReviewAt ≥ 2026-05-15.
+const WINDOW_END = '2026-05-22T00:00:00.000Z';
+const IN_WINDOW = '2026-05-20T00:00:00.000Z'; // 2d before end
+const OUT_OF_WINDOW = '2026-05-01T00:00:00.000Z'; // 21d before end (outside 7d)
+
+/** A disposition record with every counter at 0; override as needed. */
+function disp(over: Partial<FindingDispositionRecord> = {}): FindingDispositionRecord {
+  return {
+    installationId: '42',
+    repoFullName: 'org/repo',
+    findingMatchKey: 'src/a.ts::T::X',
+    firstSeen: IN_WINDOW,
+    lastSeen: IN_WINDOW,
+    surfaceCount: 0,
+    disputeCount: 0,
+    verifiedCount: 0,
+    unverifiedCount: 0,
+    silentDropCount: 0,
+    agreementCount: 0,
+    resolveCount: 0,
+    ...over,
+  };
+}
+
+/** A reviewed, in-window PR-lifecycle record; override as needed. */
+function pr(over: Partial<PRLifecycleRecord> = {}): PRLifecycleRecord {
+  return {
+    installationId: '42',
+    repoFullName: 'org/repo',
+    prNumber: 1,
+    prCreatedAt: IN_WINDOW,
+    firstReviewAt: IN_WINDOW,
+    state: 'open',
+    reviewed: true,
+    skipped: false,
+    totalPushes: 0,
+    pushesAfterFirstReview: 0,
+    updatedAt: IN_WINDOW,
+    ...over,
+  };
+}
+
+describe('buildEngagementInsight (#195)', () => {
+  describe('empty / low-volume', () => {
+    it('returns null rates and zero counts when there are no records', () => {
+      const e = buildEngagementInsight('7d', WINDOW_END, [], []);
+      expect(e).toEqual({
+        acceptanceRate: null,
+        totalResolves: 0,
+        totalRejectCommands: 0,
+        commandUsageCount: 0,
+        findingActionRateApprox: null,
+        reReviewRate: null,
+        reviewedPrCount: 0,
+        activeInstallation: false,
+      });
+    });
+
+    it('action rate is null when findings were acted on but none surfaced', () => {
+      // A record with agreements but surfaceCount 0 (defensive against bad data).
+      const e = buildEngagementInsight('7d', WINDOW_END, [disp({ agreementCount: 1 })], []);
+      expect(e.findingActionRateApprox).toBeNull();
+      expect(e.acceptanceRate).toBe(1); // 1 agreement / (1 acted-on) = 1
+    });
+  });
+
+  describe('acceptanceRate', () => {
+    it('is agreements / (agreements + disputes + silentDrops)', () => {
+      const e = buildEngagementInsight('7d', WINDOW_END, [
+        disp({ agreementCount: 6, disputeCount: 2, silentDropCount: 2 }),
+      ], []);
+      expect(e.acceptanceRate).toBe(0.6); // 6 / 10
+    });
+
+    it('is null when nothing was acted on in the window', () => {
+      const e = buildEngagementInsight('7d', WINDOW_END, [disp({ surfaceCount: 5 })], []);
+      expect(e.acceptanceRate).toBeNull();
+    });
+  });
+
+  describe('command usage', () => {
+    it('sums resolveCount across in-window records', () => {
+      const e = buildEngagementInsight('7d', WINDOW_END, [
+        disp({ resolveCount: 2 }),
+        disp({ resolveCount: 3 }),
+      ], []);
+      expect(e.totalResolves).toBe(5);
+    });
+
+    it('counts /mergewatch reject entries by their own `at` timestamp', () => {
+      const e = buildEngagementInsight('7d', WINDOW_END, [
+        disp({
+          // record itself drifted out of window, but a reject lands in-window
+          lastSeen: OUT_OF_WINDOW,
+          rejectReasons: [
+            { category: 'out-of-scope', at: IN_WINDOW },
+            { category: 'other', at: OUT_OF_WINDOW }, // excluded
+          ],
+        }),
+      ], []);
+      expect(e.totalRejectCommands).toBe(1);
+    });
+
+    it('commandUsageCount is resolves + reject commands', () => {
+      const e = buildEngagementInsight('7d', WINDOW_END, [
+        disp({ resolveCount: 2, rejectReasons: [{ category: 'other', at: IN_WINDOW }] }),
+      ], []);
+      expect(e.commandUsageCount).toBe(3);
+    });
+  });
+
+  describe('findingActionRateApprox (proxy)', () => {
+    it('is (agreements + resolves) / surfaced', () => {
+      const e = buildEngagementInsight('7d', WINDOW_END, [
+        disp({ surfaceCount: 10, agreementCount: 2, resolveCount: 3 }),
+      ], []);
+      expect(e.findingActionRateApprox).toBe(0.5); // 5 / 10
+    });
+
+    it('is capped at 1 when a finding carries both a 👍 and a /resolve', () => {
+      const e = buildEngagementInsight('7d', WINDOW_END, [
+        disp({ surfaceCount: 1, agreementCount: 1, resolveCount: 1 }),
+      ], []);
+      expect(e.findingActionRateApprox).toBe(1); // min(1, 2/1)
+    });
+  });
+
+  describe('re-review rate', () => {
+    it('is the share of reviewed PRs with a push after first review', () => {
+      const e = buildEngagementInsight('7d', WINDOW_END, [], [
+        pr({ prNumber: 1, pushesAfterFirstReview: 2 }),
+        pr({ prNumber: 2, pushesAfterFirstReview: 0 }),
+        pr({ prNumber: 3, pushesAfterFirstReview: 1 }),
+        pr({ prNumber: 4, pushesAfterFirstReview: 0 }),
+      ]);
+      expect(e.reviewedPrCount).toBe(4);
+      expect(e.reReviewRate).toBe(0.5); // 2 of 4
+      expect(e.activeInstallation).toBe(true);
+    });
+
+    it('excludes unreviewed PRs and PRs reviewed outside the window', () => {
+      const e = buildEngagementInsight('7d', WINDOW_END, [], [
+        pr({ prNumber: 1, reviewed: false, firstReviewAt: undefined }),
+        pr({ prNumber: 2, firstReviewAt: OUT_OF_WINDOW }),
+        pr({ prNumber: 3, firstReviewAt: IN_WINDOW, pushesAfterFirstReview: 1 }),
+      ]);
+      expect(e.reviewedPrCount).toBe(1);
+      expect(e.reReviewRate).toBe(1); // the one in-window reviewed PR was re-pushed
+    });
+
+    it('reReviewRate is null and activeInstallation false with no reviewed PRs', () => {
+      const e = buildEngagementInsight('7d', WINDOW_END, [], [pr({ reviewed: false, firstReviewAt: undefined })]);
+      expect(e.reReviewRate).toBeNull();
+      expect(e.activeInstallation).toBe(false);
+    });
+  });
+
+  describe('windowing', () => {
+    it('excludes counters from records whose lastSeen is out of window', () => {
+      const e = buildEngagementInsight('7d', WINDOW_END, [
+        disp({ lastSeen: OUT_OF_WINDOW, surfaceCount: 100, agreementCount: 50, resolveCount: 9 }),
+        disp({ lastSeen: IN_WINDOW, surfaceCount: 4, agreementCount: 1 }),
+      ], []);
+      expect(e.totalResolves).toBe(0); // the 9 resolves are out of window
+      expect(e.findingActionRateApprox).toBe(0.25); // 1 / 4 (only in-window record)
+    });
+
+    it('honours the 30d window length', () => {
+      // OUT_OF_WINDOW is 21d before end — inside 30d, outside 7d.
+      const recs = [disp({ lastSeen: OUT_OF_WINDOW, surfaceCount: 4, resolveCount: 2 })];
+      expect(buildEngagementInsight('7d', WINDOW_END, recs, []).totalResolves).toBe(0);
+      expect(buildEngagementInsight('30d', WINDOW_END, recs, []).totalResolves).toBe(2);
+    });
+  });
+});

--- a/packages/core/src/insights/engagement.ts
+++ b/packages/core/src/insights/engagement.ts
@@ -1,0 +1,111 @@
+/**
+ * #195 — aggregate `FindingDispositionRecord` + `PRLifecycleRecord` rows into
+ * the developer-engagement block of an `InstallationFPInsight` for one rolling
+ * window.
+ *
+ * Pure function: takes already-fetched records + a window length, returns the
+ * typed block. Doesn't touch storage; window bounds come in as an ISO string.
+ * Mirrors `buildInsightFromDispositions` (FB-E) and `buildCycleTimeInsight`
+ * (TTM) so the rollup orchestrator computes all three from the same windowEnd.
+ *
+ * Windowing matches the rest of the rollup:
+ *   - disposition counters (agreement / dispute / silentDrop / resolve /
+ *     surface) are summed over records whose `lastSeen` falls in the window —
+ *     same convention `buildInsightFromDispositions` uses for the FP funnel;
+ *   - `/mergewatch reject` commands carry their own `at` timestamp, so they're
+ *     windowed precisely by that, independent of `lastSeen`;
+ *   - PR-lifecycle engagement (reviewed / re-review) windows by `firstReviewAt`
+ *     — the moment MergeWatch reviewed the PR.
+ *
+ * Rates are `number | null`; null means "empty denominator in this window" so
+ * the dashboard can tell "no signal" from a real 0.
+ */
+
+import type { FindingDispositionRecord, PRLifecycleRecord, InstallationFPInsight } from '../types/db.js';
+import { WINDOW_LENGTH_MS } from './rollup.js';
+
+export type EngagementInsight = NonNullable<InstallationFPInsight['engagement']>;
+
+/** A count / denominator → rate, or null when the denominator is 0. */
+function rateOrNull(numerator: number, denominator: number): number | null {
+  return denominator > 0 ? numerator / denominator : null;
+}
+
+/**
+ * Build the engagement block for one window.
+ *
+ * @param dispositionRecords  every disposition row for the installation
+ * @param prLifecycleRecords  every PR-lifecycle row for the installation
+ *                            (empty when no PR-lifecycle store is wired)
+ */
+export function buildEngagementInsight(
+  window: InstallationFPInsight['window'],
+  windowEndIso: string,
+  dispositionRecords: readonly FindingDispositionRecord[],
+  prLifecycleRecords: readonly PRLifecycleRecord[],
+): EngagementInsight {
+  const windowEndMs = new Date(windowEndIso).getTime();
+  const windowStartMs = windowEndMs - WINDOW_LENGTH_MS[window];
+  const inWindow = (iso: string | undefined): boolean => {
+    if (!iso) return false;
+    const t = Date.parse(iso);
+    return !Number.isNaN(t) && t >= windowStartMs && t <= windowEndMs;
+  };
+
+  // ── Disposition-derived signals ──────────────────────────────────────────
+  let surfaced = 0;
+  let agreements = 0;
+  let disputes = 0;
+  let silentDrops = 0;
+  let resolves = 0;
+  let rejectCommands = 0;
+
+  for (const r of dispositionRecords) {
+    // `/mergewatch reject` entries are timestamped — window each one by its own
+    // `at`, so a long-lived record still attributes its rejects to the right
+    // window regardless of where `lastSeen` landed.
+    if (r.rejectReasons) {
+      for (const rr of r.rejectReasons) {
+        if (inWindow(rr.at)) rejectCommands++;
+      }
+    }
+    // Cumulative counters have no per-event timestamp, so attribute the whole
+    // record to the window of its most recent activity — the same convention
+    // the FP-funnel rollup uses.
+    if (!inWindow(r.lastSeen)) continue;
+    surfaced += r.surfaceCount;
+    agreements += r.agreementCount;
+    disputes += r.disputeCount;
+    silentDrops += r.silentDropCount;
+    resolves += r.resolveCount;
+  }
+
+  const actedOn = agreements + disputes + silentDrops;
+  // Proxy capped at 1: a finding can carry both a 👍 and a /resolve, which
+  // would push the raw ratio past 100% — meaningless for a "rate".
+  const actionRateRaw = rateOrNull(agreements + resolves, surfaced);
+  const findingActionRateApprox = actionRateRaw === null ? null : Math.min(1, actionRateRaw);
+
+  // ── PR-lifecycle-derived signals ─────────────────────────────────────────
+  let reviewedPrCount = 0;
+  let reReviewedPrCount = 0;
+  for (const p of prLifecycleRecords) {
+    if (!p.reviewed || !inWindow(p.firstReviewAt)) continue;
+    reviewedPrCount++;
+    if (p.pushesAfterFirstReview > 0) reReviewedPrCount++;
+  }
+
+  const totalResolves = resolves;
+  const totalRejectCommands = rejectCommands;
+
+  return {
+    acceptanceRate: rateOrNull(agreements, actedOn),
+    totalResolves,
+    totalRejectCommands,
+    commandUsageCount: totalResolves + totalRejectCommands,
+    findingActionRateApprox,
+    reReviewRate: rateOrNull(reReviewedPrCount, reviewedPrCount),
+    reviewedPrCount,
+    activeInstallation: reviewedPrCount > 0,
+  };
+}

--- a/packages/core/src/insights/run-rollup.ts
+++ b/packages/core/src/insights/run-rollup.ts
@@ -18,6 +18,7 @@ import type {
 import type { FindingDispositionRecord, InstallationFPInsight, PRLifecycleRecord } from '../types/db.js';
 import { buildInsightFromDispositions } from './rollup.js';
 import { buildCycleTimeInsight } from './cycle-time.js';
+import { buildEngagementInsight } from './engagement.js';
 
 const WINDOWS: InstallationFPInsight['window'][] = ['7d', '30d', '90d'];
 
@@ -112,6 +113,10 @@ export async function runInsightRollup(
         if (stores.prLifecycleStore) {
           insight.cycleTime = buildCycleTimeInsight(window, windowEndIso, prRecords);
         }
+        // #195 — engagement always computes: it only needs the (mandatory)
+        // disposition records; PR-lifecycle records refine the re-review KPIs
+        // when the store is wired and are simply empty otherwise.
+        insight.engagement = buildEngagementInsight(window, windowEndIso, records, prRecords);
         await stores.fpInsightStore.upsert(insight);
         rowsWritten++;
       }

--- a/packages/core/src/types/db.ts
+++ b/packages/core/src/types/db.ts
@@ -697,6 +697,48 @@ export interface InstallationFPInsight {
     /** pushesAfterFirstReview distribution, reviewed merged PRs only. */
     roundTripsBeforeMerge: CycleTimePercentiles | null;
   };
+
+  /**
+   * #195 — developer-engagement block, computed from the same disposition +
+   * PR-lifecycle records in this window. Optional: present only on rollups
+   * generated after this feature shipped. Consumers must handle the undefined
+   * case. Tier-2 satisfaction fields (helpful / NPS) are added by later stages.
+   *
+   * Rates are `number | null` — null distinguishes "no signal in this window"
+   * (empty denominator) from a real `0`, exactly like the cycle-time block.
+   */
+  engagement?: {
+    /**
+     * agreements / (agreements + disputes + silentDrops) — the share of
+     * acted-on findings that were accepted vs disputed/quietly dropped. null
+     * when nothing was acted on in the window.
+     */
+    acceptanceRate: number | null;
+    /** `/resolve` (or `/mergewatch resolve`) command invocations in-window. */
+    totalResolves: number;
+    /** `/mergewatch reject` invocations in-window (rejectReasons[].at). */
+    totalRejectCommands: number;
+    /** totalResolves + totalRejectCommands — overall `/mergewatch` command usage. */
+    commandUsageCount: number;
+    /**
+     * APPROXIMATE finding-action rate: (agreements + resolves) / findings
+     * surfaced, capped at 1. A proxy for "the developer acted on this finding".
+     * The exact signal (cited code actually changed in a later commit) needs
+     * per-commit diff capture and is deferred to a follow-up. null when no
+     * findings surfaced in the window.
+     */
+    findingActionRateApprox: number | null;
+    /**
+     * Of PRs MergeWatch reviewed in-window, the share that got another push
+     * after the first review (devs iterating against feedback). null when no
+     * reviewed PRs in the window.
+     */
+    reReviewRate: number | null;
+    /** PRs MergeWatch reviewed in-window (firstReviewAt in window). */
+    reviewedPrCount: number;
+    /** reviewedPrCount > 0 — this installation's per-window activity signal. */
+    activeInstallation: boolean;
+  };
 }
 
 /** Median / p75 / p90 of a cycle-time sample. */

--- a/packages/storage-dynamo/src/fp-insight-store.ts
+++ b/packages/storage-dynamo/src/fp-insight-store.ts
@@ -55,6 +55,8 @@ export class DynamoFPInsightStore implements IFPInsightStore {
         // TTM (#194) — null (not undefined) when absent: DynamoDB rejects
         // undefined attribute values, and null round-trips back to undefined.
         cycleTime: insight.cycleTime ?? null,
+        // #195 — engagement block; same null-not-undefined discipline.
+        engagement: insight.engagement ?? null,
       },
     }));
   }
@@ -97,5 +99,7 @@ function itemToInsight(it: Record<string, unknown>): InstallationFPInsight {
     topClusters: (it.topClusters as InstallationFPInsight['topClusters']) ?? [],
     // TTM (#194) — absent on pre-Stage-2 rows; null coerces back to undefined.
     ...(it.cycleTime ? { cycleTime: it.cycleTime as InstallationFPInsight['cycleTime'] } : {}),
+    // #195 — absent on pre-engagement rows; null coerces back to undefined.
+    ...(it.engagement ? { engagement: it.engagement as InstallationFPInsight['engagement'] } : {}),
   };
 }

--- a/packages/storage-postgres/drizzle/0011_soft_liz_osborn.sql
+++ b/packages/storage-postgres/drizzle/0011_soft_liz_osborn.sql
@@ -1,0 +1,4 @@
+-- #195 — developer-engagement block on the insight rollup (acceptance /
+-- command-usage / re-review KPIs). Nullable; pre-engagement rows and rollups
+-- run before this stage leave it NULL (→ undefined on the typed shape).
+ALTER TABLE "installation_fp_insights" ADD COLUMN IF NOT EXISTS "engagement" jsonb;

--- a/packages/storage-postgres/drizzle/meta/0011_snapshot.json
+++ b/packages/storage-postgres/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,903 @@
+{
+  "id": "b17528b2-f496-4d1a-9297-df3055ec97a4",
+  "prevId": "b39dbdee-c42a-4fae-bb10-8bcf9931eb17",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_installation_idx": {
+          "name": "api_keys_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.finding_dispositions": {
+      "name": "finding_dispositions",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finding_match_key": {
+          "name": "finding_match_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_count": {
+          "name": "surface_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dispute_count": {
+          "name": "dispute_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verified_count": {
+          "name": "verified_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unverified_count": {
+          "name": "unverified_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "silent_drop_count": {
+          "name": "silent_drop_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "agreement_count": {
+          "name": "agreement_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resolve_count": {
+          "name": "resolve_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_agent": {
+          "name": "top_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sig_tokens": {
+          "name": "sig_tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reject_reasons": {
+          "name": "reject_reasons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "finding_dispositions_installation_idx": {
+          "name": "finding_dispositions_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "finding_dispositions_installation_id_repo_full_name_finding_match_key_pk": {
+          "name": "finding_dispositions_installation_id_repo_full_name_finding_match_key_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name",
+            "finding_match_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installation_fp_insights": {
+      "name": "installation_fp_insights",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window": {
+          "name": "window",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_end": {
+          "name": "window_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_findings_surfaced": {
+          "name": "total_findings_surfaced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_disputes": {
+          "name": "total_disputes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dispute_rate": {
+          "name": "dispute_rate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_silent_drops": {
+          "name": "total_silent_drops",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_agreements": {
+          "name": "total_agreements",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "per_category": {
+          "name": "per_category",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "per_severity": {
+          "name": "per_severity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "per_repo": {
+          "name": "per_repo",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "top_clusters": {
+          "name": "top_clusters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "cycle_time": {
+          "name": "cycle_time",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "engagement": {
+          "name": "engagement",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "installation_fp_insights_installation_id_window_pk": {
+          "name": "installation_fp_insights_installation_id_window_pk",
+          "columns": [
+            "installation_id",
+            "window"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installation_settings": {
+      "name": "installation_settings",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "severity_threshold": {
+          "name": "severity_threshold",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Low'"
+        },
+        "comment_types": {
+          "name": "comment_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"syntax\":true,\"logic\":true,\"style\":true}'::jsonb"
+        },
+        "max_comments": {
+          "name": "max_comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 25
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"prSummary\":true,\"confidenceScore\":true,\"issuesTable\":true,\"diagram\":true}'::jsonb"
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "comment_header": {
+          "name": "comment_header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installations": {
+      "name": "installations",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monitored": {
+          "name": "monitored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "installations_installation_id_repo_full_name_pk": {
+          "name": "installations_installation_id_repo_full_name_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_sessions": {
+      "name": "mcp_sessions",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_billed_at": {
+          "name": "first_billed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_billed_cents": {
+          "name": "max_billed_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iteration": {
+          "name": "iteration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pr_lifecycle": {
+      "name": "pr_lifecycle",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_created_at": {
+          "name": "pr_created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_review_at": {
+          "name": "first_review_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "reviewed": {
+          "name": "reviewed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "skipped": {
+          "name": "skipped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "total_pushes": {
+          "name": "total_pushes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pushes_after_first_review": {
+          "name": "pushes_after_first_review",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pr_lifecycle_installation_idx": {
+          "name": "pr_lifecycle_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "pr_lifecycle_installation_id_repo_full_name_pr_number_pk": {
+          "name": "pr_lifecycle_installation_id_repo_full_name_pr_number_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name",
+            "pr_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number_commit_sha": {
+          "name": "pr_number_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_title": {
+          "name": "pr_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_author": {
+          "name": "pr_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_author_avatar": {
+          "name": "pr_author_avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_branch": {
+          "name": "head_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_severity": {
+          "name": "top_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_text": {
+          "name": "summary_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagram_text": {
+          "name": "diagram_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_score": {
+          "name": "merge_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_score_reason": {
+          "name": "merge_score_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "findings": {
+          "name": "findings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reactions": {
+          "name": "reactions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_used": {
+          "name": "settings_used",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_cost_usd": {
+          "name": "estimated_cost_usd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inline_resolved_keys": {
+          "name": "inline_resolved_keys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "inline_reactions_snapshot": {
+          "name": "inline_reactions_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "reviews_installation_idx": {
+          "name": "reviews_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_pr_idx": {
+          "name": "reviews_pr_idx",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "reviews_repo_full_name_pr_number_commit_sha_pk": {
+          "name": "reviews_repo_full_name_pr_number_commit_sha_pk",
+          "columns": [
+            "repo_full_name",
+            "pr_number_commit_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/storage-postgres/drizzle/meta/_journal.json
+++ b/packages/storage-postgres/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1782001388109,
       "tag": "0010_lying_dracula",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1782005497573,
+      "tag": "0011_soft_liz_osborn",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/storage-postgres/src/fp-insight-store.ts
+++ b/packages/storage-postgres/src/fp-insight-store.ts
@@ -42,6 +42,7 @@ export class PostgresFPInsightStore implements IFPInsightStore {
         perRepo: insight.perRepo as unknown,
         topClusters: insight.topClusters as unknown,
         cycleTime: (insight.cycleTime ?? null) as unknown,
+        engagement: (insight.engagement ?? null) as unknown,
       })
       .onConflictDoUpdate({
         target: [installationFpInsights.installationId, installationFpInsights.window],
@@ -59,6 +60,7 @@ export class PostgresFPInsightStore implements IFPInsightStore {
           perRepo: insight.perRepo as unknown,
           topClusters: insight.topClusters as unknown,
           cycleTime: (insight.cycleTime ?? null) as unknown,
+          engagement: (insight.engagement ?? null) as unknown,
         },
       });
   }
@@ -104,5 +106,7 @@ function rowToInsight(row: Record<string, unknown>): InstallationFPInsight {
     topClusters: (row.topClusters as InstallationFPInsight['topClusters']) ?? [],
     // TTM (#194) — NULL on pre-Stage-2 rows; omit so the field stays undefined.
     ...(row.cycleTime ? { cycleTime: row.cycleTime as InstallationFPInsight['cycleTime'] } : {}),
+    // #195 — NULL on pre-engagement rows; omit so the field stays undefined.
+    ...(row.engagement ? { engagement: row.engagement as InstallationFPInsight['engagement'] } : {}),
   };
 }

--- a/packages/storage-postgres/src/schema.ts
+++ b/packages/storage-postgres/src/schema.ts
@@ -114,6 +114,9 @@ export const installationFpInsights = pgTable('installation_fp_insights', {
   // Nullable: pre-Stage-2 rows and rollups run without a PR-lifecycle store
   // simply leave it NULL, which maps back to `undefined` on the typed shape.
   cycleTime: jsonb('cycle_time'),
+  // #195 — developer-engagement block (acceptance / command-usage / re-review
+  // KPIs). Nullable: pre-engagement rollups leave it NULL → `undefined`.
+  engagement: jsonb('engagement'),
 }, (t) => ({
   pk: primaryKey({ columns: [t.installationId, t.window] }),
 }));


### PR DESCRIPTION
**Stage 2 of 5** of the developer-engagement / NPS feature ([#195](https://github.com/mergewatch/mergewatch.ai/issues/195)). Stacks on **#207** (merged). Plan: `docs/feat/20260620-01-engagement-metrics.plan.md`.

## What this ships
An optional `engagement` block on every `InstallationFPInsight` (7d / 30d / 90d), computed in the nightly rollup from the disposition + PR-lifecycle records it already pages — mirroring the cycle-time (#194) block.

**Tier-1 KPIs**
- `acceptanceRate` — `agreements / (agreements + disputes + silentDrops)`
- `totalResolves` / `totalRejectCommands` / `commandUsageCount` — `/mergewatch` command usage
- `findingActionRateApprox` — `(agreements + resolves) / surfaced`, **capped at 1** (proxy; exact diff-based signal deferred)
- `reReviewRate` — reviewed PRs re-pushed after first review / reviewed PRs
- `reviewedPrCount`, `activeInstallation`

## Design notes
- **Computed unconditionally** — engagement needs only the mandatory disposition store; PR-lifecycle records refine the re-review KPIs when that store is wired, and are simply empty otherwise.
- **Windowing** — disposition counters by `lastSeen` (same as the FP funnel); `/mergewatch reject` by its own `rejectReasons[].at`; reviewed/re-review by `firstReviewAt`.
- **`null` vs `0`** — rates are `null` on an empty denominator so the dashboard tells "no signal" from a real `0`.
- **Both backends at parity** — `engagement` jsonb/attribute with null↔undefined coercion; Postgres column via **idempotent** migration `0011` (`ADD COLUMN IF NOT EXISTS`).

## Verification
- `build` ✅ · `typecheck` ✅ · `test` ✅ (734 core tests, +14 new in `engagement.test.ts`) · `migrations:check` ✅
- Pre-#195 rollup rows (no `engagement`) read back fine — field stays `undefined`.
- E2E: `e2e/RUNBOOK.md` → E2E-59.

## Deferred to later stages
Dashboard Engagement section (stage 3); 👍/👎 footer prompt + NPS survey (stages 4–5). Exact finding-action rate → follow-up ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)