### PR TITLE
feat(dashboard): developer-engagement section on /insights (#195, stage 3)

### DIFF
--- a/docs/feat/20260620-01-engagement-metrics.plan.md
+++ b/docs/feat/20260620-01-engagement-metrics.plan.md
@@ -82,7 +82,7 @@ All fields optional-by-block: pre-feature rollups have no `engagement`; consumer
 - **RUNBOOK:** E2E-59 — nightly rollup attaches an `engagement` block (acceptance rate, command usage, re-review rate, approx action rate, reviewed-PR count) over each window; empty/low-volume installation yields `null` rates not crashes.
 - **Tests:** KPI math (acceptance/action/re-review rates, command counts, windowing), empty + single-record edge cases, back-compat when `satisfactionStore` absent.
 
-### Phase 3 — Engagement dashboard section (Tier 1 surfaced) — [x] (in review)
+### Phase 3 — Engagement dashboard section (Tier 1 surfaced) — [x] PR #209 (MergeWatch 5/5, 0 findings)
 - **Goal:** render the Tier 1 engagement metrics. Depends on Phase 2.
 - **Files:** `packages/dashboard/components/InsightsClient.tsx` — `EngagementSection` (StatCards: acceptance rate, command usage, re-review rate, approx action rate; trend across windows where useful), render after `CycleTimeSection`, relax zero-state gate (L281) to include `hasEngagementData`. No API route change.
 - **RUNBOOK:** E2E-60 — `/dashboard/insights` Engagement section: StatCards render; `null` rates show `—`; the action-rate card is labeled "approx."

--- a/docs/feat/20260620-01-engagement-metrics.plan.md
+++ b/docs/feat/20260620-01-engagement-metrics.plan.md
@@ -82,7 +82,7 @@ All fields optional-by-block: pre-feature rollups have no `engagement`; consumer
 - **RUNBOOK:** E2E-59 — nightly rollup attaches an `engagement` block (acceptance rate, command usage, re-review rate, approx action rate, reviewed-PR count) over each window; empty/low-volume installation yields `null` rates not crashes.
 - **Tests:** KPI math (acceptance/action/re-review rates, command counts, windowing), empty + single-record edge cases, back-compat when `satisfactionStore` absent.
 
-### Phase 3 — Engagement dashboard section (Tier 1 surfaced) — [ ]
+### Phase 3 — Engagement dashboard section (Tier 1 surfaced) — [x] (in review)
 - **Goal:** render the Tier 1 engagement metrics. Depends on Phase 2.
 - **Files:** `packages/dashboard/components/InsightsClient.tsx` — `EngagementSection` (StatCards: acceptance rate, command usage, re-review rate, approx action rate; trend across windows where useful), render after `CycleTimeSection`, relax zero-state gate (L281) to include `hasEngagementData`. No API route change.
 - **RUNBOOK:** E2E-60 — `/dashboard/insights` Engagement section: StatCards render; `null` rates show `—`; the action-rate card is labeled "approx."

--- a/docs/pending/engagement-metrics.md
+++ b/docs/pending/engagement-metrics.md
@@ -122,7 +122,26 @@ engagement?: {
 
 **E2E:** [E2E-59](../../e2e/RUNBOOK.md#e2e-59-engagement--tier-1-rollup-engagement-metrics-stage-2).
 
-## Stage 3 — Engagement dashboard section — _planned_
+## Stage 3 — Engagement dashboard section
+
+Surfaces the Tier-1 KPIs on `/dashboard/insights`.
+
+**What changed** (`packages/dashboard/components/InsightsClient.tsx`)
+
+- New `EngagementSection` (mirrors `CycleTimeSection`), rendered below Cycle time and above the FP funnel. Four StatCards — **Acceptance rate**, **Action rate (approx)**, **Command usage** (`N resolve · N reject`), **Re-review rate** (`N PRs reviewed`) — plus a cross-window acceptance/action **trend line** across 7d / 30d / 90d (mirrors the FB-I severity detector).
+- `Engagement` type + `engagement?` on the `Insight` shape; `fmtPct` helper (0..1 → whole-percent, `null`/`undefined` → `—`).
+- Zero-state gate relaxed: the page renders when **any** of FP-feedback, cycle-time, or engagement has data (`hasEngagementData`), each section gated independently.
+- No API change — `/api/insights` already returns the `engagement` block from the fp-insight store.
+
+**Edge cases**
+
+- `null` rates render `—`, never `0%` (empty denominator ≠ a real 0).
+- The trend line uses `connectNulls={false}` so a window with no signal shows a gap, not an interpolated line.
+- A pre-#195 rollup row (no `engagement`) renders the page unchanged.
+
+**Verification:** dashboard `tsc --noEmit` + Next production build (runs ESLint) — consistent with how the TTM cycle-time section (#199) shipped; the dashboard has no unit-test harness, so behavior is covered by the RUNBOOK E2E.
+
+**E2E:** [E2E-60](../../e2e/RUNBOOK.md#e2e-60-engagement--dashboard-section-engagement-metrics-stage-3).
 
 ## Stage 4 — Tier 2 footer 👍/👎 helpful prompt — _planned_
 

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -186,6 +186,7 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-57](#e2e-57-ttm--dashboard-cycle-time-section-time-to-merge-stage-3) | `/dashboard/insights` Cycle time section: StatCards + reviewed-vs-unreviewed bar chart; relaxed zero-state gate; `null` percentile renders `—` (TTM) | 2m | 30s | #199 |
 | [E2E-58](#e2e-58-engagement--resolve-capture-engagement-metrics-stage-1) | `/resolve` on an inline thread increments a new `resolveCount` on the `FindingDispositionRecord` (positive engagement signal) alongside the existing `disputeCount`; defaults to 0 with no backfill; both backends (engagement) | 2m | 30s | #207 |
 | [E2E-59](#e2e-59-engagement--tier-1-rollup-engagement-metrics-stage-2) | Nightly rollup attaches an `engagement` block (acceptance rate, command usage, approx finding-action rate, re-review rate, reviewed-PR count) per window; `null` rates for empty denominators; rejects windowed by `at`; both backends (engagement) | 3m | 90s | #208 |
+| [E2E-60](#e2e-60-engagement--dashboard-section-engagement-metrics-stage-3) | `/dashboard/insights` Developer engagement section: StatCards (acceptance, approx action, command usage, re-review) + cross-window trend line; relaxed zero-state gate; `null` renders `—`; trend gaps on null windows (engagement) | 2m | 30s | #TBD |
 
 ---
 
@@ -2172,6 +2173,35 @@ Branch: `fixture/59-engagement-rollup`. Use an installation with disposition + P
 - ❌ Rejects windowed by `lastSeen` instead of `rejectReasons[].at` (drops in-window rejects on long-lived records).
 - ❌ `findingActionRateApprox` exceeds 1 (uncapped proxy).
 - ❌ The `engagement` jsonb migration is non-idempotent (no `ADD COLUMN IF NOT EXISTS`).
+
+---
+
+### E2E-60: Engagement — dashboard section (engagement metrics, stage 3)
+
+**Status:** ✅ SHIPPED (#TBD). See [`docs/pending/engagement-metrics.md` → Stage 3](./../docs/pending/engagement-metrics.md#stage-3--engagement-dashboard-section).
+
+**Behavior:** `/dashboard/insights` renders a **Developer engagement** section (below Cycle time, above the FP funnel): four StatCards — Acceptance rate, Action rate (approx), Command usage (`N resolve · N reject`), Re-review rate (`N PRs reviewed`) — plus a cross-window acceptance/action trend line (7d / 30d / 90d). A `null` rate renders `—`, never `0%`. The action-rate card is labeled "approx". The zero-state gate is relaxed so the page shows when **any** of FP-feedback, cycle-time, or engagement has data, each section gated independently. No new API route — `/api/insights` already returns the `engagement` block.
+
+**Setup**
+
+Branch: `fixture/60-engagement-dashboard`. Use the E2E-59 installation (an `engagement` block on its rollup rows). Open `/dashboard/insights?org=<installationId>` and switch the 7d / 30d / 90d window selector.
+
+**Expected outcomes**
+
+- [ ] The Developer engagement section renders below Cycle time with correct StatCard values for the active window.
+- [ ] `null` rates render `—` (e.g. acceptance with nothing acted on), never `0%`.
+- [ ] The Action rate card reads "approx" in its label/subtext.
+- [ ] Command usage shows `N resolve · N reject` matching the rollup counts.
+- [ ] The trend line plots acceptance + action across the windows; a window with no signal shows a gap (no connected line through null).
+- [ ] Switching the window selector updates the StatCard numbers.
+- [ ] An installation with engagement signal but **zero findings surfaced** still shows this section (relaxed gate); a fresh install with none of FP/cycle/engagement shows "No insights yet".
+- [ ] An older rollup row without an `engagement` block renders the page unchanged (no engagement section).
+
+**Failure modes**
+- ❌ A `null` rate renders as `0%` (an empty install looks like a 0%-acceptance install).
+- ❌ The trend line connects across a null window (`connectNulls` regression), implying data that isn't there.
+- ❌ The section throws on a pre-#195 rollup with no `engagement` (must be optional).
+- ❌ The action-rate card drops the "approx" label (misrepresents the proxy as exact).
 
 ---
 

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -186,7 +186,7 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-57](#e2e-57-ttm--dashboard-cycle-time-section-time-to-merge-stage-3) | `/dashboard/insights` Cycle time section: StatCards + reviewed-vs-unreviewed bar chart; relaxed zero-state gate; `null` percentile renders `—` (TTM) | 2m | 30s | #199 |
 | [E2E-58](#e2e-58-engagement--resolve-capture-engagement-metrics-stage-1) | `/resolve` on an inline thread increments a new `resolveCount` on the `FindingDispositionRecord` (positive engagement signal) alongside the existing `disputeCount`; defaults to 0 with no backfill; both backends (engagement) | 2m | 30s | #207 |
 | [E2E-59](#e2e-59-engagement--tier-1-rollup-engagement-metrics-stage-2) | Nightly rollup attaches an `engagement` block (acceptance rate, command usage, approx finding-action rate, re-review rate, reviewed-PR count) per window; `null` rates for empty denominators; rejects windowed by `at`; both backends (engagement) | 3m | 90s | #208 |
-| [E2E-60](#e2e-60-engagement--dashboard-section-engagement-metrics-stage-3) | `/dashboard/insights` Developer engagement section: StatCards (acceptance, approx action, command usage, re-review) + cross-window trend line; relaxed zero-state gate; `null` renders `—`; trend gaps on null windows (engagement) | 2m | 30s | #TBD |
+| [E2E-60](#e2e-60-engagement--dashboard-section-engagement-metrics-stage-3) | `/dashboard/insights` Developer engagement section: StatCards (acceptance, approx action, command usage, re-review) + cross-window trend line; relaxed zero-state gate; `null` renders `—`; trend gaps on null windows (engagement) | 2m | 30s | #209 |
 
 ---
 
@@ -2178,7 +2178,7 @@ Branch: `fixture/59-engagement-rollup`. Use an installation with disposition + P
 
 ### E2E-60: Engagement — dashboard section (engagement metrics, stage 3)
 
-**Status:** ✅ SHIPPED (#TBD). See [`docs/pending/engagement-metrics.md` → Stage 3](./../docs/pending/engagement-metrics.md#stage-3--engagement-dashboard-section).
+**Status:** ✅ SHIPPED (#209). See [`docs/pending/engagement-metrics.md` → Stage 3](./../docs/pending/engagement-metrics.md#stage-3--engagement-dashboard-section).
 
 **Behavior:** `/dashboard/insights` renders a **Developer engagement** section (below Cycle time, above the FP funnel): four StatCards — Acceptance rate, Action rate (approx), Command usage (`N resolve · N reject`), Re-review rate (`N PRs reviewed`) — plus a cross-window acceptance/action trend line (7d / 30d / 90d). A `null` rate renders `—`, never `0%`. The action-rate card is labeled "approx". The zero-state gate is relaxed so the page shows when **any** of FP-feedback, cycle-time, or engagement has data, each section gated independently. No new API route — `/api/insights` already returns the `engagement` block.
 

--- a/packages/dashboard/components/InsightsClient.tsx
+++ b/packages/dashboard/components/InsightsClient.tsx
@@ -10,6 +10,10 @@
  *     (median / p75 / p90), time-from-first-review-to-merge, round-trips,
  *     and a reviewed-vs-unreviewed comparison ("did MergeWatch make us
  *     faster?"). Computed from the `cycleTime` block on each insight row.
+ *   - **#195** — developer-engagement section: Tier-1 behavioral KPIs
+ *     (acceptance rate, approx finding-action rate, `/mergewatch` command
+ *     usage, re-review rate) plus a cross-window acceptance/action trend.
+ *     Computed from the `engagement` block on each insight row.
  *   - **FB-F** — FP funnel (stacked bar): unsignaled / agreed / silent-
  *     dropped / disputed counts per window. Single chart that answers
  *     "is the review noise increasing or decreasing for us?".
@@ -71,6 +75,18 @@ interface CycleTime {
   roundTripsBeforeMerge: Percentiles | null;
 }
 
+/** #195 — developer-engagement block (Tier 1). Optional for pre-engagement rollups. */
+interface Engagement {
+  acceptanceRate: number | null;
+  totalResolves: number;
+  totalRejectCommands: number;
+  commandUsageCount: number;
+  findingActionRateApprox: number | null;
+  reReviewRate: number | null;
+  reviewedPrCount: number;
+  activeInstallation: boolean;
+}
+
 interface Insight {
   installationId: string;
   window: "7d" | "30d" | "90d";
@@ -89,6 +105,8 @@ interface Insight {
   topClusters: ClusterRow[];
   /** TTM (#194) — present only on rollups generated after Stage 2 shipped. */
   cycleTime?: CycleTime;
+  /** #195 — present only on rollups generated after the engagement stage shipped. */
+  engagement?: Engagement;
 }
 
 interface InsightsClientProps {
@@ -123,6 +141,12 @@ function fmtHours(h: number | null | undefined): string {
   if (h < 1) return `${Math.round(h * 60)}m`;
   if (h < 48) return `${h.toFixed(1)}h`;
   return `${(h / 24).toFixed(1)}d`;
+}
+
+/** Format a 0..1 rate as a whole-number percentage; null/undefined → em-dash. */
+function fmtPct(r: number | null | undefined): string {
+  if (r == null) return "—";
+  return `${Math.round(r * 100)}%`;
 }
 
 function pickWindow(insights: Insight[], window: "7d" | "30d" | "90d"): Insight | undefined {
@@ -277,8 +301,17 @@ export default function InsightsClient({ installationId }: InsightsClientProps) 
   const cyc = active?.cycleTime;
   const hasCycleData = !!cyc && (cyc.mergedCount > 0 || cyc.closedUnmergedCount > 0 || cyc.openCount > 0);
   const hasFpData = (active?.totalFindingsSurfaced ?? 0) > 0;
+  // #195 — engagement can carry signal (command usage, re-review) even with no
+  // findings surfaced, so it's gated independently like cycle-time.
+  const eng = active?.engagement;
+  const hasEngagementData = !!eng && (
+    eng.commandUsageCount > 0 ||
+    eng.reviewedPrCount > 0 ||
+    eng.acceptanceRate !== null ||
+    eng.findingActionRateApprox !== null
+  );
 
-  if (insights.length === 0 || !active || (!hasFpData && !hasCycleData)) {
+  if (insights.length === 0 || !active || (!hasFpData && !hasCycleData && !hasEngagementData)) {
     return (
       <div className="rounded-lg border border-border-default bg-surface-card p-6">
         <h2 className="text-base font-semibold text-text-primary">No insights yet</h2>
@@ -326,6 +359,11 @@ export default function InsightsClient({ installationId }: InsightsClientProps) 
 
       {/* ─── TTM (#194): Cycle time (time-to-merge) ──────────────────── */}
       {hasCycleData && cyc && <CycleTimeSection cycleTime={cyc} window={activeWindow} />}
+
+      {/* ─── #195: Developer engagement ──────────────────────────────── */}
+      {hasEngagementData && eng && (
+        <EngagementSection engagement={eng} insights={insights} window={activeWindow} />
+      )}
 
       {/* ─── FB-F..FB-J: FP-feedback sections (only when findings exist) ── */}
       {hasFpData && (
@@ -804,6 +842,144 @@ function CycleTimeSection({ cycleTime, window }: { cycleTime: CycleTime; window:
             </div>
           )}
         </>
+      )}
+    </section>
+  );
+}
+
+// ─── #195 — developer-engagement section ───────────────────────────────────
+
+// Engagement trend palette.
+const ENGAGEMENT_COLOURS = {
+  acceptance: "#10b981", // emerald — accepted vs disputed/dropped
+  action: "#6366f1",     // indigo — acted-on (approx)
+};
+
+interface EngagementPoint {
+  window: "7d" | "30d" | "90d";
+  acceptance: number | null; // 0..1, null = no signal in window
+  action: number | null;     // 0..1
+}
+
+/** Acceptance + approx action rate across the three windows (for the trend line). */
+function buildEngagementPoints(insights: Insight[]): EngagementPoint[] {
+  const order: EngagementPoint["window"][] = ["7d", "30d", "90d"];
+  return order
+    .map((w) => insights.find((i) => i.window === w))
+    .filter((i): i is Insight => Boolean(i))
+    .map((i) => ({
+      window: i.window,
+      acceptance: i.engagement?.acceptanceRate ?? null,
+      action: i.engagement?.findingActionRateApprox ?? null,
+    }));
+}
+
+/**
+ * Developer-engagement section. Headline Tier-1 KPIs (acceptance rate, approx
+ * finding-action rate, `/mergewatch` command usage, re-review rate) for the
+ * active window, plus a cross-window trend line for the two finding-level
+ * rates — "are developers acting on and accepting reviews, and is it holding
+ * over time?". null rates render as an em-dash, never a misleading 0%.
+ */
+function EngagementSection({
+  engagement,
+  insights,
+  window,
+}: {
+  engagement: Engagement;
+  insights: Insight[];
+  window: string;
+}) {
+  const e = engagement;
+  const points = buildEngagementPoints(insights);
+  // Only plot the trend when at least one window carries a finding-level rate;
+  // an all-null line is noise, not signal.
+  const hasTrend = points.some((p) => p.acceptance !== null || p.action !== null);
+
+  return (
+    <section className="rounded-lg border border-border-default bg-surface-card p-4 sm:p-5">
+      <header className="mb-4">
+        <h2 className="text-sm font-semibold text-text-primary">Developer engagement — {window}</h2>
+        <p className="mt-1 text-xs text-text-secondary">
+          Whether developers find reviews useful — behavioral signals, not surveys.
+          Acceptance weighs 👍 against 👎 / quiet drops; action rate is an{" "}
+          <em>approximation</em> ((agreements + resolves) / findings, capped at 100%) —
+          the exact &ldquo;cited code changed&rdquo; signal is a planned follow-up.
+        </p>
+      </header>
+
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <StatCard
+          label="Acceptance rate"
+          value={fmtPct(e.acceptanceRate)}
+          subtext="👍 vs 👎 / quiet drops"
+        />
+        <StatCard
+          label="Action rate (approx)"
+          value={fmtPct(e.findingActionRateApprox)}
+          subtext="findings acted on"
+        />
+        <StatCard
+          label="Command usage"
+          value={e.commandUsageCount.toLocaleString()}
+          subtext={`${e.totalResolves.toLocaleString()} resolve · ${e.totalRejectCommands.toLocaleString()} reject`}
+        />
+        <StatCard
+          label="Re-review rate"
+          value={fmtPct(e.reReviewRate)}
+          subtext={`${e.reviewedPrCount.toLocaleString()} PRs reviewed`}
+        />
+      </div>
+
+      {hasTrend && (
+        <div className="mt-5">
+          <h3 className="mb-1 text-xs font-semibold text-text-primary">
+            Acceptance &amp; action rate — across 7d / 30d / 90d
+          </h3>
+          <p className="mb-3 text-[11px] text-text-secondary">
+            Rates holding or rising across widening windows suggest reviews stay
+            useful as more history accrues. A gap means no signal in that window.
+          </p>
+          <div className="h-56">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={points} margin={{ left: 8, right: 16, top: 8, bottom: 8 }}>
+                <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
+                <XAxis dataKey="window" fontSize={11} />
+                <YAxis
+                  domain={[0, 1]}
+                  tickFormatter={(v) => `${Math.round(v * 100)}%`}
+                  fontSize={11}
+                  width={40}
+                />
+                <Tooltip
+                  formatter={(value: number, name: string) => [
+                    fmtPct(value),
+                    name === "acceptance" ? "Acceptance" : "Action (approx)",
+                  ]}
+                />
+                <Legend
+                  formatter={(value) => (value === "acceptance" ? "Acceptance" : "Action (approx)")}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="acceptance"
+                  stroke={ENGAGEMENT_COLOURS.acceptance}
+                  strokeWidth={2}
+                  dot={{ r: 4 }}
+                  connectNulls={false}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="action"
+                  stroke={ENGAGEMENT_COLOURS.action}
+                  strokeWidth={2}
+                  dot={{ r: 4 }}
+                  connectNulls={false}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
       )}
     </section>
   );


### PR DESCRIPTION
**Stage 3 of 5** of the developer-engagement / NPS feature ([#195](https://github.com/mergewatch/mergewatch.ai/issues/195)). Stacks on **#208** (merged). Plan: `docs/feat/20260620-01-engagement-metrics.plan.md`.

## What this ships
A **Developer engagement** section on `/dashboard/insights`, surfacing the Tier-1 KPIs from the rollup's `engagement` block — rendered below Cycle time, above the FP funnel.

- **Four StatCards** — Acceptance rate · Action rate (approx) · Command usage (`N resolve · N reject`) · Re-review rate (`N PRs reviewed`).
- **Cross-window trend line** — acceptance + approx action rate across 7d / 30d / 90d (mirrors the FB-I severity detector).
- `Engagement` type + `engagement?` on the `Insight` shape; `fmtPct` helper.
- **Zero-state gate relaxed** — the page renders when **any** of FP-feedback, cycle-time, or engagement has data (`hasEngagementData`), each section gated independently.

## Design notes
- `null` rates render `—`, never `0%` — an empty denominator isn't a real 0.
- The trend uses `connectNulls={false}` so a window with no signal shows a gap, not an interpolated line.
- The action-rate card is labeled **approx** so the proxy isn't read as the exact "code changed" signal.
- **No `/api/insights` change** — the route already returns the `engagement` block.

## Verification
- Dashboard `tsc --noEmit` ✅ · Next production build ✅ (runs ESLint, clean) · repo `typecheck` ✅
- The dashboard package has no unit-test harness — same as when the TTM cycle-time section shipped (#199); behavior is covered by the RUNBOOK E2E.
- E2E: `e2e/RUNBOOK.md` → E2E-60.

## Deferred to later stages
👍/👎 footer prompt (stage 4) + dashboard NPS survey (stage 5). Exact finding-action rate → follow-up ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)