### PR TITLE
feat(insights): surface LLM cost in nightly rollup, insights API, and dashboard (#193)

### DIFF
--- a/docs/pending/cost-analytics.md
+++ b/docs/pending/cost-analytics.md
@@ -1,0 +1,72 @@
+# LLM cost analytics
+
+**Status:** 🚧 In review
+**Issue:** [#193](https://github.com/mergewatch/mergewatch.ai/issues/193)
+
+Surface **LLM cost** as a first-class metric — aggregated in the nightly insights rollup, returned by `/api/insights`, and rendered on `/dashboard/insights`. The per-review capture (tokens + estimated USD on `ReviewItem`, cost in the PR comment's "Review details" drawer) already shipped; this closes the aggregation + visualization gap.
+
+## Architecture
+
+```
+capture (per review)              aggregation (nightly)        surface
+──────────────────────            ─────────────────────        ───────────────
+review completes  ─► ReviewCostRecord ─► buildCostInsight() ─► InstallationFPInsight
+  inputTokens          (IReviewCostStore   (insights/cost.ts)     .cost ─► /api/insights
+  outputTokens          row per review,                           └► CostSection
+  estimatedCostUsd      installation-keyed)                          (InsightsClient.tsx)
+  findingCount
+  model
+```
+
+The issue noted cost lives on `ReviewItem` (repo-partitioned), so the rollup — which fans out per installation — can't read it cheaply. We took the **denormalize** option: write one `ReviewCostRecord` per completed review into an installation-partitioned store, then page those rows in the rollup exactly like the disposition / PR-lifecycle / satisfaction records. One extra best-effort write per review; O(1) per-installation read at rollup time.
+
+## `cost` block shape
+
+```ts
+cost?: {
+  totalCostUsd: number;          // sum over PRICED reviews in-window
+  totalInputTokens: number;      // sum over ALL reviews (tokens known regardless of pricing)
+  totalOutputTokens: number;
+  reviewCount: number;           // priced + unpriced
+  pricedReviewCount: number;     // model matched the pricing table
+  unpricedReviewCount: number;   // unknown-model reviews — excluded from money totals
+  avgCostPerReview: number | null;   // totalCostUsd / pricedReviewCount
+  findingCount: number;          // findings across priced reviews
+  avgCostPerFinding: number | null;  // totalCostUsd / findingCount
+  perRepo: Record<string, { costUsd: number; reviewCount: number }>;
+};
+```
+
+Optional-by-block: pre-feature rollups (and rollups run without a cost store) have no `cost`; consumers handle `undefined`. Averages are `null` (not `0`) when their denominator is empty — the dashboard tells "no spend data" from a real `$0`.
+
+## What changed
+
+**Capture**
+- `ReviewCostRecord` type (`packages/core/src/types/db.ts`) + `IReviewCostStore` (`recordCost` / `listByInstallation`, `storage/types.ts`).
+- `DynamoReviewCostStore` (`mergewatch-review-costs`, PK=installation, SK=`repo#pr#commit`, 90d TTL) and `PostgresReviewCostStore` (`review_costs`, `cost_usd` as text → no float drift), both idempotent per review. Migration `0013_clean_xorn.sql` (`CREATE TABLE IF NOT EXISTS` + `ADD COLUMN IF NOT EXISTS`).
+- Both runtimes (`review-processor.ts`, lambda `review-agent.ts`) call `recordCost` at completion — best-effort; unknown-model cost (`null`) is recorded as **unpriced**, never coerced to `0`.
+
+**Aggregation**
+- New pure module `packages/core/src/insights/cost.ts` — `buildCostInsight(window, windowEndIso, costRecords)`, windowed by `completedAt`, exported from `@mergewatch/core` with `CostInsight`.
+- `runInsightRollup` pages cost rows from the optional `costStore` and assigns `insight.cost` only when wired; persisted in both fp-insight stores (`cost` jsonb / attribute, null↔undefined coercion).
+
+**Surface**
+- `/api/insights` passes the `cost` block through (it returns the full `InstallationFPInsight` — no route change).
+- `CostSection` on `/dashboard/insights`: StatCards (**Total spend**, **Avg cost / review**, **Cost / finding**, **Reviews** with an unpriced count), a **Spend by repo** breakdown, and a **spend-over-time** bar across 7d / 30d / 90d. Gated independently (a window can have spend with zero findings).
+
+## Edge cases
+
+- **Unknown model** → `estimatedCostUsd` null → recorded unpriced; excluded from money totals + the cost-per-finding denominator; surfaced as "N unpriced". Tokens still summed (they're known).
+- **Re-reviews** accrue cost: identity is per (installation, repo, PR, commit), so a re-review on a new commit is a distinct row; a retried review of the same commit overwrites idempotently.
+- Averages `null` on empty denominators; `cost` absent on pre-feature rollups.
+
+## Tests
+
+- `cost.test.ts` — aggregation, per-repo bucketing, windowing (7d vs 30d, out-of-window exclusion), and the full null-pricing path (unpriced excluded from money, included in tokens; all-unpriced → null averages; zero-finding → null cost-per-finding).
+- `review-cost-store.test.ts` (both backends) — key/SK construction, null-cost round-trip, idempotent upsert, pagination cursor, best-effort swallow.
+- `run-rollup.test.ts` — cost block attached when wired (aggregates across pages, counts unpriced), omitted otherwise.
+- Dashboard `CostSection` covered by the production build (tsc + ESLint) and the RUNBOOK E2E, consistent with the rest of the dashboard.
+
+> **Deploy note (SaaS):** the Amplify SSR role's DynamoDB inline policy already covers `mergewatch-*`, so the new `mergewatch-review-costs-*` table is in scope. No dashboard env var is needed — the cost block rides the existing `/api/insights` read.
+
+**E2E:** [E2E-63](../e2e/RUNBOOK.md#e2e-63-cost--llm-spend-rollup--dashboard-193).

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -189,6 +189,7 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-60](#e2e-60-engagement--dashboard-section-engagement-metrics-stage-3) | `/dashboard/insights` Developer engagement section: StatCards (acceptance, approx action, command usage, re-review) + cross-window trend line; relaxed zero-state gate; `null` renders `—`; trend gaps on null windows (engagement) | 2m | 30s | #209 |
 | [E2E-61](#e2e-61-engagement--helpful-footer-prompt-engagement-metrics-stage-4) | Summary comment renders "Was this review helpful? 👍 / 👎"; reacting on the comment records a snapshot-delta into the satisfaction store; nightly rollup fills `helpful*`; dashboard shows Helpful rate; both backends (engagement, tier 2) | 3m | 30s | #210 |
 | [E2E-62](#e2e-62-engagement--dashboard-nps-survey-engagement-metrics-stage-5) | `/dashboard/insights` NPS prompt shown to eligible admin (0–10), throttled to once / 90d per `githubUserId`; response recorded; rollup computes NPS = %promoters − %detractors; dashboard renders NPS StatCard (engagement, tier 2) | 3m | 30s | #210 |
+| [E2E-63](#e2e-63-cost--llm-spend-rollup--dashboard-193) | Each review writes a `ReviewCostRecord`; nightly rollup aggregates a `cost` block (total spend, avg cost/review, cost/finding, per-repo); `/api/insights` returns it; dashboard LLM cost section renders; unknown-model reviews counted as "unpriced", excluded from money; both backends (cost) | 3m | 30s | #212 |
 
 ---
 
@@ -2248,6 +2249,28 @@ Branch: `fixture/60-engagement-dashboard`. Use the E2E-59 installation (an `enga
 - ❌ The prompt re-appears for an admin who already responded within 90 days.
 - ❌ NPS counts passives (7–8) as promoters or detractors.
 - ❌ The route records a response without verifying installation access.
+
+---
+
+### E2E-63: Cost — LLM spend rollup + dashboard (#193)
+
+**Status:** ✅ SHIPPED (#212). See [`docs/pending/cost-analytics.md`](./../docs/pending/cost-analytics.md).
+
+**Behavior:** On every completed review the handler writes a `ReviewCostRecord` (tokens, estimated USD, finding count, model) into the cost store, keyed per (installation, repo, PR, commit). The nightly rollup aggregates a `cost` block onto each `InstallationFPInsight` (7d / 30d / 90d): **total spend** (priced reviews), **avg cost / review**, **cost / finding**, token totals, a **per-repo** spend bucket, and a **priced / unpriced** review split. Reviews on a model not in the pricing table are recorded with `costUsd: null`, counted as **unpriced**, and excluded from the money totals (but their tokens still count). `/api/insights` returns the block unchanged; `/dashboard/insights` renders an **LLM cost** section (StatCards + spend-by-repo + spend-over-time bar). Works on both backends (`mergewatch-review-costs` DynamoDB table / `review_costs` Postgres table).
+
+**How to run.** Branch: `fixture/63-cost`. Trigger a few reviews (ideally across two repos, and one re-review on a new commit). Inspect the cost store (`<repo>#<pr>#<commit>` items / `review_costs` rows). Trigger the nightly rollup (EventBridge → `insights-rollup` Lambda on SaaS, or the self-hosted cron) and open `/dashboard/insights`.
+
+**Pass:**
+- [ ] Each completed review produces one `ReviewCostRecord`; a re-review on a new commit adds a distinct row.
+- [ ] The rollup's `cost` block shows total spend, avg cost/review, cost/finding, and a per-repo breakdown matching the recorded reviews.
+- [ ] The dashboard LLM cost section renders the StatCards, spend-by-repo list, and spend-over-time bar; `null` averages show `—`.
+- [ ] A review on an unknown/unpriced model is counted in `reviewCount` and surfaced as "N unpriced", but excluded from `totalCostUsd` and the averages.
+- [ ] A pre-#193 rollup row (no `cost`) renders the page unchanged; an installation with no cost store provisioned reviews normally.
+
+**Fail signals:**
+- ❌ An unpriced review drags `totalCostUsd` / averages toward 0 (must be excluded, not coerced to 0).
+- ❌ A re-review on the same commit double-counts (must overwrite idempotently).
+- ❌ A cost-store write error blocks the review.
 
 ---
 

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -111,6 +111,9 @@ Globals:
         # responses (dashboard writes). InsightsRollup reads both for the
         # engagement block's helpful-rate + NPS fields.
         SATISFACTION_TABLE: !Ref SatisfactionTable
+        # #193: per-review cost rows. ReviewAgent writes one row per completed
+        # review; InsightsRollup reads them for the engagement insight's cost block.
+        REVIEW_COSTS_TABLE: !Ref ReviewCostsTable
 
         # SSM parameter paths for GitHub App credentials.
         # The Lambda functions read these at runtime via the AWS SDK.
@@ -850,6 +853,44 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
 
+  # #193 — per-review LLM cost rows. Partitioned by installation (PK), SK
+  # `repo#pr#commit`; ReviewAgent writes one row per completed review and the
+  # nightly InsightsRollup reads them for the engagement insight's cost block.
+  # TTL (~90d past completion) self-prunes rows past the longest window.
+  ReviewCostsTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub 'mergewatch-review-costs-${Stage}'
+      BillingMode: PAY_PER_REQUEST
+
+      KeySchema:
+        - AttributeName: pk
+          KeyType: HASH
+        - AttributeName: sk
+          KeyType: RANGE
+
+      AttributeDefinitions:
+        - AttributeName: pk
+          AttributeType: S
+        - AttributeName: sk
+          AttributeType: S
+
+      TimeToLiveSpecification:
+        AttributeName: ttl
+        Enabled: true
+
+      SSESpecification:
+        SSEEnabled: true
+
+      Tags:
+        - Key: Project
+          Value: MergeWatch
+        - Key: Stage
+          Value: !Ref Stage
+
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+
   # ===========================================================================
   # IAM Role: Lambda Execution Role
   # ===========================================================================
@@ -928,6 +969,7 @@ Resources:
                   - !GetAtt FpInsightsTable.Arn
                   - !GetAtt PRLifecycleTable.Arn
                   - !GetAtt SatisfactionTable.Arn
+                  - !GetAtt ReviewCostsTable.Arn
                   # Index ARNs (for future GSIs)
                   - !Sub '${InstallationsTable.Arn}/index/*'
                   - !Sub '${ReviewsTable.Arn}/index/*'
@@ -937,6 +979,7 @@ Resources:
                   - !Sub '${FpInsightsTable.Arn}/index/*'
                   - !Sub '${PRLifecycleTable.Arn}/index/*'
                   - !Sub '${SatisfactionTable.Arn}/index/*'
+                  - !Sub '${ReviewCostsTable.Arn}/index/*'
 
         # --- SSM Parameter Store ---
         # Read-only access to GitHub credentials stored in SSM.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ export type {
   IFPInsightStore,
   IPRLifecycleStore,
   ISatisfactionStore,
+  IReviewCostStore,
   PRLifecycleOpenInput,
   PRLifecycleCloseInput,
   FindingDispositionAttribution,
@@ -176,6 +177,10 @@ export type { CycleTimeInsight } from './insights/cycle-time.js';
 export { buildEngagementInsight } from './insights/engagement.js';
 export type { EngagementInsight, SatisfactionRecords } from './insights/engagement.js';
 
+// ─── Cost rollup (#193) ────────────────────────────────────────────────────
+export { buildCostInsight } from './insights/cost.js';
+export type { CostInsight } from './insights/cost.js';
+
 // ─── Satisfaction writer (#195 Tier 2 / Phase 4) ───────────────────────────
 export {
   recordSummaryHelpfulVotes,
@@ -274,6 +279,7 @@ export type {
   PRLifecycleRecord,
   HelpfulVoteRecord,
   NpsResponseRecord,
+  ReviewCostRecord,
 } from './types/db.js';
 
 export { DEFAULT_INSTALLATION_SETTINGS } from './types/db.js';

--- a/packages/core/src/insights/cost.test.ts
+++ b/packages/core/src/insights/cost.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { buildCostInsight } from './cost.js';
+import type { ReviewCostRecord } from '../types/db.js';
+
+// 7d window ends here; "in window" means completedAt ≥ 2026-05-15.
+const WINDOW_END = '2026-05-22T00:00:00.000Z';
+const IN_WINDOW = '2026-05-20T00:00:00.000Z'; // 2d before end
+const OUT_OF_WINDOW = '2026-05-01T00:00:00.000Z'; // 21d before end (outside 7d)
+
+function cost(over: Partial<ReviewCostRecord> = {}): ReviewCostRecord {
+  return {
+    installationId: '42',
+    repoFullName: 'org/repo',
+    prNumber: 1,
+    commitSha: 'abc1234',
+    completedAt: IN_WINDOW,
+    inputTokens: 0,
+    outputTokens: 0,
+    costUsd: 0,
+    findingCount: 0,
+    ...over,
+  };
+}
+
+describe('buildCostInsight (#193)', () => {
+  describe('empty / windowing', () => {
+    it('returns zeros and null averages with no records', () => {
+      expect(buildCostInsight('7d', WINDOW_END, [])).toEqual({
+        totalCostUsd: 0,
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        reviewCount: 0,
+        pricedReviewCount: 0,
+        unpricedReviewCount: 0,
+        avgCostPerReview: null,
+        findingCount: 0,
+        avgCostPerFinding: null,
+        perRepo: {},
+      });
+    });
+
+    it('excludes records whose completedAt is out of window', () => {
+      const c = buildCostInsight('7d', WINDOW_END, [
+        cost({ completedAt: OUT_OF_WINDOW, costUsd: 9.99, inputTokens: 1000 }),
+        cost({ completedAt: IN_WINDOW, costUsd: 1, inputTokens: 10, findingCount: 2 }),
+      ]);
+      expect(c.reviewCount).toBe(1);
+      expect(c.totalCostUsd).toBe(1);
+      expect(c.totalInputTokens).toBe(10);
+    });
+
+    it('honours the 30d window length', () => {
+      const recs = [cost({ completedAt: OUT_OF_WINDOW, costUsd: 2 })];
+      expect(buildCostInsight('7d', WINDOW_END, recs).totalCostUsd).toBe(0);
+      expect(buildCostInsight('30d', WINDOW_END, recs).totalCostUsd).toBe(2);
+    });
+  });
+
+  describe('aggregation', () => {
+    it('sums cost + tokens and averages over priced reviews', () => {
+      const c = buildCostInsight('7d', WINDOW_END, [
+        cost({ commitSha: 'a', costUsd: 1.5, inputTokens: 100, outputTokens: 20, findingCount: 3 }),
+        cost({ commitSha: 'b', costUsd: 0.5, inputTokens: 50, outputTokens: 10, findingCount: 1 }),
+      ]);
+      expect(c.totalCostUsd).toBe(2);
+      expect(c.totalInputTokens).toBe(150);
+      expect(c.totalOutputTokens).toBe(30);
+      expect(c.reviewCount).toBe(2);
+      expect(c.pricedReviewCount).toBe(2);
+      expect(c.avgCostPerReview).toBe(1); // 2 / 2
+      expect(c.findingCount).toBe(4);
+      expect(c.avgCostPerFinding).toBe(0.5); // 2 / 4
+    });
+
+    it('buckets spend per repo', () => {
+      const c = buildCostInsight('7d', WINDOW_END, [
+        cost({ repoFullName: 'org/a', commitSha: 'a', costUsd: 2 }),
+        cost({ repoFullName: 'org/a', commitSha: 'b', costUsd: 1 }),
+        cost({ repoFullName: 'org/b', commitSha: 'c', costUsd: 4 }),
+      ]);
+      expect(c.perRepo).toEqual({
+        'org/a': { costUsd: 3, reviewCount: 2 },
+        'org/b': { costUsd: 4, reviewCount: 1 },
+      });
+    });
+  });
+
+  describe('null-pricing path (unknown model)', () => {
+    it('counts unpriced reviews separately and excludes them from money totals', () => {
+      const c = buildCostInsight('7d', WINDOW_END, [
+        cost({ commitSha: 'a', costUsd: 2, inputTokens: 100, findingCount: 2 }),
+        cost({ commitSha: 'b', costUsd: null, inputTokens: 80, findingCount: 5 }), // unpriced
+      ]);
+      expect(c.reviewCount).toBe(2);
+      expect(c.pricedReviewCount).toBe(1);
+      expect(c.unpricedReviewCount).toBe(1);
+      // Money totals + finding denominator ignore the unpriced review...
+      expect(c.totalCostUsd).toBe(2);
+      expect(c.findingCount).toBe(2);
+      expect(c.avgCostPerReview).toBe(2); // 2 / 1 priced
+      expect(c.avgCostPerFinding).toBe(1); // 2 / 2 priced-review findings
+      // ...but tokens are summed across ALL reviews (tokens are known regardless).
+      expect(c.totalInputTokens).toBe(180);
+      // The unpriced review still contributes to its repo's reviewCount, not cost.
+      expect(c.perRepo['org/repo']).toEqual({ costUsd: 2, reviewCount: 2 });
+    });
+
+    it('averages are null when every in-window review is unpriced', () => {
+      const c = buildCostInsight('7d', WINDOW_END, [
+        cost({ commitSha: 'a', costUsd: null, findingCount: 3 }),
+      ]);
+      expect(c.pricedReviewCount).toBe(0);
+      expect(c.unpricedReviewCount).toBe(1);
+      expect(c.totalCostUsd).toBe(0);
+      expect(c.avgCostPerReview).toBeNull();
+      expect(c.avgCostPerFinding).toBeNull();
+    });
+
+    it('avgCostPerFinding is null when priced reviews surfaced zero findings', () => {
+      const c = buildCostInsight('7d', WINDOW_END, [
+        cost({ costUsd: 1.25, findingCount: 0 }),
+      ]);
+      expect(c.totalCostUsd).toBe(1.25);
+      expect(c.avgCostPerReview).toBe(1.25);
+      expect(c.avgCostPerFinding).toBeNull();
+    });
+  });
+});

--- a/packages/core/src/insights/cost.ts
+++ b/packages/core/src/insights/cost.ts
@@ -1,0 +1,92 @@
+/**
+ * #193 — aggregate `ReviewCostRecord` rows into the LLM-cost block of an
+ * `InstallationFPInsight` for one rolling window.
+ *
+ * Pure function: takes already-fetched cost records + a window length, returns
+ * the typed block. Doesn't touch storage; window bounds come in as an ISO
+ * string. Mirrors `buildCycleTimeInsight` / `buildEngagementInsight` so the
+ * rollup orchestrator computes every block from the same windowEnd.
+ *
+ * Windowing: each review is attributed to the window of its `completedAt`.
+ *
+ * Pricing discipline: cost is summed over PRICED reviews only (`costUsd != null`
+ * — the model matched the pricing table). Unpriced reviews (unknown model) are
+ * counted separately and excluded from the money totals so a mis-priced model
+ * can't silently pull the average toward 0. Token sums include every review
+ * (tokens are known regardless of pricing). Averages are `number | null`; null
+ * means "empty denominator" so the dashboard can tell "no spend data" from a
+ * real `$0`.
+ */
+
+import type { ReviewCostRecord, InstallationFPInsight } from '../types/db.js';
+import { WINDOW_LENGTH_MS } from './rollup.js';
+
+export type CostInsight = NonNullable<InstallationFPInsight['cost']>;
+
+/** A money/count → average, or null when the denominator is 0. */
+function avgOrNull(total: number, denominator: number): number | null {
+  return denominator > 0 ? total / denominator : null;
+}
+
+/**
+ * Build the cost block for one window.
+ *
+ * @param costRecords  every review-cost row for the installation (empty when no
+ *                     review-cost store is wired)
+ */
+export function buildCostInsight(
+  window: InstallationFPInsight['window'],
+  windowEndIso: string,
+  costRecords: readonly ReviewCostRecord[],
+): CostInsight {
+  const windowEndMs = new Date(windowEndIso).getTime();
+  const windowStartMs = windowEndMs - WINDOW_LENGTH_MS[window];
+  const inWindow = (iso: string | undefined): boolean => {
+    if (!iso) return false;
+    const t = Date.parse(iso);
+    return !Number.isNaN(t) && t >= windowStartMs && t <= windowEndMs;
+  };
+
+  let totalCostUsd = 0;
+  let totalInputTokens = 0;
+  let totalOutputTokens = 0;
+  let reviewCount = 0;
+  let pricedReviewCount = 0;
+  let unpricedReviewCount = 0;
+  let findingCount = 0;
+  const perRepo: Record<string, { costUsd: number; reviewCount: number }> = {};
+
+  for (const r of costRecords) {
+    if (!inWindow(r.completedAt)) continue;
+    reviewCount++;
+    // Tokens are known regardless of whether the model was priced.
+    totalInputTokens += r.inputTokens;
+    totalOutputTokens += r.outputTokens;
+
+    const repoBucket = (perRepo[r.repoFullName] ??= { costUsd: 0, reviewCount: 0 });
+    repoBucket.reviewCount++;
+
+    if (r.costUsd == null) {
+      // Unknown-model review — counted, but excluded from money totals.
+      unpricedReviewCount++;
+      continue;
+    }
+    pricedReviewCount++;
+    totalCostUsd += r.costUsd;
+    findingCount += r.findingCount;
+    repoBucket.costUsd += r.costUsd;
+  }
+
+  return {
+    totalCostUsd,
+    totalInputTokens,
+    totalOutputTokens,
+    reviewCount,
+    pricedReviewCount,
+    unpricedReviewCount,
+    avgCostPerReview: avgOrNull(totalCostUsd, pricedReviewCount),
+    findingCount,
+    avgCostPerFinding: avgOrNull(totalCostUsd, findingCount),
+    perRepo,
+  };
+}

--- a/packages/core/src/insights/run-rollup.test.ts
+++ b/packages/core/src/insights/run-rollup.test.ts
@@ -257,4 +257,42 @@ describe('runInsightRollup — cycle-time block', () => {
     // Both pages' merged PRs counted into each window.
     expect(stores.upserts[0].cycleTime?.mergedCount).toBe(2);
   });
+
+  // ── #193 — cost block wiring ──────────────────────────────────────────────
+
+  it('attaches a cost block when the costStore is wired', async () => {
+    const stores = makeStores({ installationIds: ['42'], recordsByInstallation: { '42': [] } });
+    const withCost: RollupStores & { upserts: InstallationFPInsight[] } = {
+      ...stores,
+      costStore: {
+        listByInstallation: async (_id: string, opts?: { cursor?: string }) => {
+          if (!opts?.cursor) return { items: [
+            { installationId: '42', repoFullName: 'org/repo', prNumber: 1, commitSha: 'a', completedAt: '2026-05-21T00:00:00.000Z', inputTokens: 100, outputTokens: 20, costUsd: 2, findingCount: 4 },
+          ], nextCursor: 'p2' };
+          return { items: [
+            { installationId: '42', repoFullName: 'org/repo', prNumber: 2, commitSha: 'b', completedAt: '2026-05-21T00:00:00.000Z', inputTokens: 50, outputTokens: 10, costUsd: null, findingCount: 1 },
+          ] };
+        },
+      },
+    };
+    await runInsightRollup(withCost, WINDOW_END);
+    for (const u of stores.upserts) {
+      expect(u.cost).toBeDefined();
+    }
+    // Both pages aggregated; the null-cost review is counted but unpriced.
+    const c7 = stores.upserts.find((u) => u.window === '7d')!.cost!;
+    expect(c7.reviewCount).toBe(2);
+    expect(c7.pricedReviewCount).toBe(1);
+    expect(c7.unpricedReviewCount).toBe(1);
+    expect(c7.totalCostUsd).toBe(2);
+    expect(c7.avgCostPerFinding).toBe(0.5); // 2 / 4
+  });
+
+  it('omits the cost block when no costStore is wired (back-compat)', async () => {
+    const stores = makeStores({ installationIds: ['42'], recordsByInstallation: { '42': [] } });
+    await runInsightRollup(stores, WINDOW_END);
+    for (const u of stores.upserts) {
+      expect(u.cost).toBeUndefined();
+    }
+  });
 });

--- a/packages/core/src/insights/run-rollup.ts
+++ b/packages/core/src/insights/run-rollup.ts
@@ -15,6 +15,7 @@ import type {
   IInstallationStore,
   IPRLifecycleStore,
   ISatisfactionStore,
+  IReviewCostStore,
 } from '../storage/types.js';
 import type {
   FindingDispositionRecord,
@@ -22,10 +23,12 @@ import type {
   PRLifecycleRecord,
   HelpfulVoteRecord,
   NpsResponseRecord,
+  ReviewCostRecord,
 } from '../types/db.js';
 import { buildInsightFromDispositions } from './rollup.js';
 import { buildCycleTimeInsight } from './cycle-time.js';
 import { buildEngagementInsight } from './engagement.js';
+import { buildCostInsight } from './cost.js';
 
 const WINDOWS: InstallationFPInsight['window'][] = ['7d', '30d', '90d'];
 
@@ -48,6 +51,12 @@ export interface RollupStores {
    * 1–3.
    */
   satisfactionStore?: Pick<ISatisfactionStore, 'listHelpfulVotes' | 'listNpsResponses'>;
+  /**
+   * #193 — optional. When wired, each insight row gains a `cost` block built
+   * from this installation's per-review cost records. When absent the rollup
+   * behaves exactly as before and `cost` stays undefined.
+   */
+  costStore?: Pick<IReviewCostStore, 'listByInstallation'>;
 }
 
 export interface RollupRunResult {
@@ -143,6 +152,18 @@ export async function runInsightRollup(
         } while (npsCursor);
       }
 
+      // #193 — page per-review cost rows when the cost store is wired. Same
+      // cursor discipline; left empty otherwise so `cost` stays undefined.
+      const costRecords: ReviewCostRecord[] = [];
+      if (stores.costStore) {
+        let costCursor: string | undefined;
+        do {
+          const page = await stores.costStore.listByInstallation(installationId, { limit: 1000, cursor: costCursor });
+          costRecords.push(...page.items);
+          costCursor = page.nextCursor;
+        } while (costCursor);
+      }
+
       for (const window of WINDOWS) {
         const insight = buildInsightFromDispositions(installationId, window, windowEndIso, records);
         if (stores.prLifecycleStore) {
@@ -156,6 +177,10 @@ export async function runInsightRollup(
           helpfulVotes,
           npsResponses,
         });
+        // #193 — cost block computes only when the cost store is wired.
+        if (stores.costStore) {
+          insight.cost = buildCostInsight(window, windowEndIso, costRecords);
+        }
         await stores.fpInsightStore.upsert(insight);
         rowsWritten++;
       }

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -14,6 +14,7 @@ import type {
   PRLifecycleRecord,
   HelpfulVoteRecord,
   NpsResponseRecord,
+  ReviewCostRecord,
 } from '../types/db.js';
 
 export interface IInstallationStore {
@@ -306,4 +307,32 @@ export interface ISatisfactionStore {
     installationId: string,
     opts?: { limit?: number; cursor?: string },
   ): Promise<{ items: NpsResponseRecord[]; nextCursor?: string }>;
+}
+
+// ─── #193 — per-review LLM cost store ──────────────────────────────────────
+
+/**
+ * Persists one `ReviewCostRecord` per completed review so the nightly rollup
+ * can aggregate spend per installation without scanning the repo-partitioned
+ * reviews table. Writes are best-effort (swallow-and-log in the
+ * implementations) — a cost write must never block a review. Optional
+ * throughout: a deployment that hasn't provisioned the table simply records no
+ * cost rows and the `cost` insight block stays undefined.
+ */
+export interface IReviewCostStore {
+  /**
+   * Record one completed review's cost. Idempotent per (installation, repo, PR,
+   * commit): re-running the same review overwrites the row with identical
+   * figures rather than double-counting.
+   */
+  recordCost(record: ReviewCostRecord): Promise<void>;
+
+  /**
+   * Page through all cost rows for an installation. Used by the nightly cost
+   * rollup. Optional limit + cursor pagination (cap ~1000/page).
+   */
+  listByInstallation(
+    installationId: string,
+    opts?: { limit?: number; cursor?: string },
+  ): Promise<{ items: ReviewCostRecord[]; nextCursor?: string }>;
 }

--- a/packages/core/src/types/db.ts
+++ b/packages/core/src/types/db.ts
@@ -774,6 +774,41 @@ export interface InstallationFPInsight {
      */
     npsScore: number | null;
   };
+
+  /**
+   * #193 — LLM cost block, aggregated from per-review `ReviewCostRecord` rows
+   * in the same window. Optional: present only on rollups generated after this
+   * feature shipped AND when a review-cost store is wired into the rollup.
+   * Consumers must handle the undefined case.
+   *
+   * A review is windowed by its `completedAt`. Cost is summed over PRICED
+   * reviews only (a known model→pricing match); unpriced reviews (unknown
+   * model) are counted separately and excluded from the money totals so a
+   * mis-priced model can't silently drag the average to 0. Averages are
+   * `number | null` — null when their denominator is empty, exactly like the
+   * cycle-time and engagement blocks.
+   */
+  cost?: {
+    /** Sum of estimated USD across priced reviews in-window. */
+    totalCostUsd: number;
+    /** Sum of input / output tokens across ALL reviews in-window (tokens are known even when the model is unpriced). */
+    totalInputTokens: number;
+    totalOutputTokens: number;
+    /** Every review completed in-window (priced + unpriced). */
+    reviewCount: number;
+    /** Reviews with a known cost (model matched the pricing table). */
+    pricedReviewCount: number;
+    /** Reviews whose model wasn't in the pricing table — surfaced as "N unpriced", excluded from money totals. */
+    unpricedReviewCount: number;
+    /** totalCostUsd / pricedReviewCount. null when no priced reviews in-window. */
+    avgCostPerReview: number | null;
+    /** Findings surfaced across priced reviews in-window — the cost-per-finding denominator. */
+    findingCount: number;
+    /** totalCostUsd / findingCount. null when no findings on priced reviews in-window. */
+    avgCostPerFinding: number | null;
+    /** Per-repo spend bucket — which repos drive cost. Keyed by repoFullName. */
+    perRepo: Record<string, { costUsd: number; reviewCount: number }>;
+  };
 }
 
 /** Median / p75 / p90 of a cycle-time sample. */
@@ -817,6 +852,39 @@ export interface NpsResponseRecord {
   score: number;
   /** ISO 8601 — when the response was recorded. */
   respondedAt: string;
+}
+
+// ─── #193 — per-review LLM cost record ──────────────────────────────────────
+
+/**
+ * One row per completed review, denormalizing the cost/token figures off the
+ * `ReviewItem` so the nightly rollup can aggregate spend per installation
+ * without scanning the (repo-partitioned) reviews table. Written best-effort
+ * at review completion; the cost rollup windows these rows by `completedAt`.
+ *
+ * Identity is per-review (installation + repo + PR + commit), so a re-review of
+ * the same PR on a new commit is a distinct row — re-reviews accrue cost.
+ */
+export interface ReviewCostRecord {
+  installationId: string;
+  repoFullName: string;
+  prNumber: number;
+  /** Head commit SHA the review ran against — distinguishes re-reviews of the same PR. */
+  commitSha: string;
+  /** ISO 8601 — review completion time; the rollup's windowing anchor. */
+  completedAt: string;
+  inputTokens: number;
+  outputTokens: number;
+  /**
+   * Estimated USD for this review, or null when the model wasn't in the pricing
+   * table (unknown-model review). null is excluded from cost aggregates and
+   * surfaced separately as an "unpriced" count — never coerced to 0.
+   */
+  costUsd: number | null;
+  /** Findings surfaced by this review — the cost-per-finding denominator. */
+  findingCount: number;
+  /** Model id the review ran on (for debugging / future per-model breakdowns). */
+  model?: string;
 }
 
 /**

--- a/packages/dashboard/components/InsightsClient.tsx
+++ b/packages/dashboard/components/InsightsClient.tsx
@@ -96,6 +96,20 @@ interface Engagement {
   npsScore?: number | null;
 }
 
+/** #193 — LLM-cost block. Optional for pre-cost rollups. */
+interface Cost {
+  totalCostUsd: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  reviewCount: number;
+  pricedReviewCount: number;
+  unpricedReviewCount: number;
+  avgCostPerReview: number | null;
+  findingCount: number;
+  avgCostPerFinding: number | null;
+  perRepo: Record<string, { costUsd: number; reviewCount: number }>;
+}
+
 interface Insight {
   installationId: string;
   window: "7d" | "30d" | "90d";
@@ -116,6 +130,8 @@ interface Insight {
   cycleTime?: CycleTime;
   /** #195 — present only on rollups generated after the engagement stage shipped. */
   engagement?: Engagement;
+  /** #193 — present only on rollups generated after the cost stage shipped. */
+  cost?: Cost;
 }
 
 interface InsightsClientProps {
@@ -156,6 +172,17 @@ function fmtHours(h: number | null | undefined): string {
 function fmtPct(r: number | null | undefined): string {
   if (r == null) return "—";
   return `${Math.round(r * 100)}%`;
+}
+
+/**
+ * #193 — format a USD amount. Sub-dollar values (a per-finding cost is often a
+ * few cents) keep more precision; dollar+ values round to cents. `null` → `—`.
+ */
+function fmtUsd(n: number | null | undefined): string {
+  if (n == null) return "—";
+  if (n === 0) return "$0";
+  if (Math.abs(n) < 1) return `$${n.toFixed(n < 0.01 ? 4 : 3)}`;
+  return `$${n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 }
 
 function pickWindow(insights: Insight[], window: "7d" | "30d" | "90d"): Insight | undefined {
@@ -323,8 +350,12 @@ export default function InsightsClient({ installationId }: InsightsClientProps) 
     (eng.helpfulDown ?? 0) > 0 ||
     (eng.npsResponses ?? 0) > 0
   );
+  // #193 — cost is gated independently: a window can have spend even with no
+  // findings (all-clear reviews still cost tokens).
+  const cost = active?.cost;
+  const hasCostData = !!cost && cost.reviewCount > 0;
 
-  if (insights.length === 0 || !active || (!hasFpData && !hasCycleData && !hasEngagementData)) {
+  if (insights.length === 0 || !active || (!hasFpData && !hasCycleData && !hasEngagementData && !hasCostData)) {
     return (
       <div className="rounded-lg border border-border-default bg-surface-card p-6">
         <h2 className="text-base font-semibold text-text-primary">No insights yet</h2>
@@ -377,6 +408,9 @@ export default function InsightsClient({ installationId }: InsightsClientProps) 
       {hasEngagementData && eng && (
         <EngagementSection engagement={eng} insights={insights} window={activeWindow} />
       )}
+
+      {/* ─── #193: LLM cost ──────────────────────────────────────────── */}
+      {hasCostData && cost && <CostSection cost={cost} insights={insights} window={activeWindow} />}
 
       {/* ─── #195 Phase 5: throttled NPS survey prompt ───────────────── */}
       <NpsPrompt installationId={installationId} />
@@ -1020,6 +1054,128 @@ function EngagementSection({
                   connectNulls={false}
                 />
               </LineChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+// ─── #193 — LLM cost ──────────────────────────────────────────────────────
+
+const COST_COLOUR = "#f59e0b"; // amber — spend
+
+interface CostPoint {
+  window: "7d" | "30d" | "90d";
+  spend: number;
+}
+
+/** Total spend across the three windows (for the trend bars). */
+function buildCostPoints(insights: Insight[]): CostPoint[] {
+  const order: CostPoint["window"][] = ["7d", "30d", "90d"];
+  return order
+    .map((w) => insights.find((i) => i.window === w))
+    .filter((i): i is Insight => Boolean(i?.cost))
+    .map((i) => ({ window: i.window, spend: i.cost!.totalCostUsd }));
+}
+
+/** Top repos by spend (descending), for the per-repo breakdown. */
+function topRepoSpend(cost: Cost, limit = 5): Array<{ repo: string; costUsd: number; reviewCount: number }> {
+  return Object.entries(cost.perRepo)
+    .map(([repo, v]) => ({ repo, costUsd: v.costUsd, reviewCount: v.reviewCount }))
+    .filter((r) => r.costUsd > 0)
+    .sort((a, b) => b.costUsd - a.costUsd)
+    .slice(0, limit);
+}
+
+/**
+ * LLM-cost section. Headline spend KPIs (total spend, avg cost / review, cost /
+ * finding) for the active window, a per-repo spend breakdown, and a spend-over-
+ * time bar across 7d / 30d / 90d. Unpriced (unknown-model) reviews are surfaced
+ * explicitly and excluded from the money figures.
+ */
+function CostSection({
+  cost,
+  insights,
+  window,
+}: {
+  cost: Cost;
+  insights: Insight[];
+  window: string;
+}) {
+  const c = cost;
+  const points = buildCostPoints(insights);
+  const hasTrend = points.length > 1 && points.some((p) => p.spend > 0);
+  const repos = topRepoSpend(c);
+  const totalTokens = c.totalInputTokens + c.totalOutputTokens;
+
+  return (
+    <section className="rounded-lg border border-border-default bg-surface-card p-4 sm:p-5">
+      <header className="mb-4">
+        <h2 className="text-sm font-semibold text-text-primary">LLM cost — {window}</h2>
+        <p className="mt-1 text-xs text-text-secondary">
+          Estimated spend on review LLM calls. Costs are estimates from the
+          provider pricing table; reviews on an unpriced model are counted but
+          excluded from the dollar figures.
+        </p>
+      </header>
+
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <StatCard
+          label="Total spend"
+          value={fmtUsd(c.totalCostUsd)}
+          subtext={`${totalTokens.toLocaleString()} tokens`}
+        />
+        <StatCard
+          label="Avg cost / review"
+          value={fmtUsd(c.avgCostPerReview)}
+          subtext={`${c.pricedReviewCount.toLocaleString()} priced review${c.pricedReviewCount === 1 ? "" : "s"}`}
+        />
+        <StatCard
+          label="Cost / finding"
+          value={fmtUsd(c.avgCostPerFinding)}
+          subtext={`${c.findingCount.toLocaleString()} finding${c.findingCount === 1 ? "" : "s"}`}
+        />
+        <StatCard
+          label="Reviews"
+          value={c.reviewCount.toLocaleString()}
+          subtext={c.unpricedReviewCount > 0 ? `${c.unpricedReviewCount.toLocaleString()} unpriced` : "all priced"}
+        />
+      </div>
+
+      {repos.length > 0 && (
+        <div className="mt-5">
+          <h3 className="mb-2 text-xs font-semibold text-text-primary">Spend by repo</h3>
+          <ul className="space-y-1">
+            {repos.map((r) => (
+              <li key={r.repo} className="flex items-center justify-between text-xs">
+                <span className="truncate text-text-secondary">{r.repo}</span>
+                <span className="ml-3 shrink-0 tabular-nums text-text-primary">
+                  {fmtUsd(r.costUsd)} <span className="text-text-secondary">· {r.reviewCount.toLocaleString()} review{r.reviewCount === 1 ? "" : "s"}</span>
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {hasTrend && (
+        <div className="mt-5">
+          <h3 className="mb-1 text-xs font-semibold text-text-primary">Spend — across 7d / 30d / 90d</h3>
+          <p className="mb-3 text-[11px] text-text-secondary">
+            Cumulative spend over each widening window. The 90d bar includes the
+            30d and 7d spend.
+          </p>
+          <div className="h-56">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={points} margin={{ left: 8, right: 16, top: 8, bottom: 8 }}>
+                <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
+                <XAxis dataKey="window" fontSize={11} />
+                <YAxis tickFormatter={(v) => fmtUsd(v)} fontSize={11} width={56} />
+                <Tooltip formatter={(value: number) => [fmtUsd(value), "Spend"]} />
+                <Bar dataKey="spend" fill={COST_COLOUR} radius={[4, 4, 0, 0]} />
+              </BarChart>
             </ResponsiveContainer>
           </div>
         </div>

--- a/packages/lambda/src/handlers/insights-rollup.ts
+++ b/packages/lambda/src/handlers/insights-rollup.ts
@@ -30,10 +30,12 @@ import {
   DynamoFPInsightStore,
   DynamoPRLifecycleStore,
   DynamoSatisfactionStore,
+  DynamoReviewCostStore,
   DEFAULT_FINDING_DISPOSITIONS_TABLE,
   DEFAULT_FP_INSIGHTS_TABLE,
   DEFAULT_PR_LIFECYCLE_TABLE,
   DEFAULT_SATISFACTION_TABLE,
+  DEFAULT_REVIEW_COSTS_TABLE,
 } from '@mergewatch/storage-dynamo';
 
 const dynamodb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
@@ -43,6 +45,7 @@ const FINDING_DISPOSITIONS_TABLE = process.env.FINDING_DISPOSITIONS_TABLE ?? DEF
 const FP_INSIGHTS_TABLE = process.env.FP_INSIGHTS_TABLE ?? DEFAULT_FP_INSIGHTS_TABLE;
 const PR_LIFECYCLE_TABLE = process.env.PR_LIFECYCLE_TABLE ?? DEFAULT_PR_LIFECYCLE_TABLE;
 const SATISFACTION_TABLE = process.env.SATISFACTION_TABLE ?? DEFAULT_SATISFACTION_TABLE;
+const REVIEW_COSTS_TABLE = process.env.REVIEW_COSTS_TABLE ?? DEFAULT_REVIEW_COSTS_TABLE;
 
 const installationStore = new DynamoInstallationStore(dynamodb, INSTALLATIONS_TABLE);
 const dispositionStore = new DynamoFindingDispositionStore(dynamodb, FINDING_DISPOSITIONS_TABLE);
@@ -51,6 +54,8 @@ const fpInsightStore = new DynamoFPInsightStore(dynamodb, FP_INSIGHTS_TABLE);
 const prLifecycleStore = new DynamoPRLifecycleStore(dynamodb, PR_LIFECYCLE_TABLE);
 // #195 Tier 2 — feeds the helpful-rate + NPS fields of each engagement block.
 const satisfactionStore = new DynamoSatisfactionStore(dynamodb, SATISFACTION_TABLE);
+// #193 — feeds the cost block of each insight row.
+const costStore = new DynamoReviewCostStore(dynamodb, REVIEW_COSTS_TABLE);
 
 export async function handler(): Promise<{ statusCode: number; body: string }> {
   console.log('[fb-e] insights rollup starting');
@@ -60,6 +65,7 @@ export async function handler(): Promise<{ statusCode: number; body: string }> {
     fpInsightStore,
     prLifecycleStore,
     satisfactionStore,
+    costStore,
   });
   console.log(
     '[fb-e] rollup complete — processed=%d, rows=%d, failed=[%s], elapsed=%dms, windowEnd=%s',

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -77,6 +77,8 @@ import {
   DEFAULT_PR_LIFECYCLE_TABLE,
   DynamoSatisfactionStore,
   DEFAULT_SATISFACTION_TABLE,
+  DynamoReviewCostStore,
+  DEFAULT_REVIEW_COSTS_TABLE,
 } from '@mergewatch/storage-dynamo';
 import { BedrockLLMProvider, SUPPORTED_MODELS } from '@mergewatch/llm-bedrock';
 import { isSaas, billingCheck, recordReview, postBlockedCheckRun, ensureBillingIssue, updateBillingFields, getStripe } from '@mergewatch/billing';
@@ -92,6 +94,7 @@ const FINDING_DISPOSITIONS_TABLE = process.env.FINDING_DISPOSITIONS_TABLE ?? DEF
 const FP_INSIGHTS_TABLE = process.env.FP_INSIGHTS_TABLE ?? DEFAULT_FP_INSIGHTS_TABLE;
 const PR_LIFECYCLE_TABLE = process.env.PR_LIFECYCLE_TABLE ?? DEFAULT_PR_LIFECYCLE_TABLE;
 const SATISFACTION_TABLE = process.env.SATISFACTION_TABLE ?? DEFAULT_SATISFACTION_TABLE;
+const REVIEW_COSTS_TABLE = process.env.REVIEW_COSTS_TABLE ?? DEFAULT_REVIEW_COSTS_TABLE;
 const DEFAULT_BEDROCK_MODEL_ID = process.env.DEFAULT_BEDROCK_MODEL_ID ?? 'us.anthropic.claude-sonnet-4-20250514-v1:0';
 const DASHBOARD_BASE_URL = process.env.DASHBOARD_BASE_URL ?? 'https://mergewatch.ai';
 
@@ -111,6 +114,9 @@ const prLifecycleStore = new DynamoPRLifecycleStore(dynamodb, PR_LIFECYCLE_TABLE
 // #195 Phase 4 — captures summary 👍/👎 helpful votes into the engagement
 // rollup. Best-effort; swallows if the table isn't provisioned yet.
 const satisfactionStore = new DynamoSatisfactionStore(dynamodb, SATISFACTION_TABLE);
+// #193 — denormalizes per-review cost for the nightly cost rollup. Best-effort;
+// swallows if the table isn't provisioned yet.
+const costStore = new DynamoReviewCostStore(dynamodb, REVIEW_COSTS_TABLE);
 const llm = new BedrockLLMProvider();
 const authProvider = new SSMGitHubAuthProvider();
 
@@ -929,6 +935,21 @@ export async function handler(
     // TTM (#194) — anchor the first-review timestamp (set-once) for the
     // time-from-first-review-to-merge metric.
     await prLifecycleStore.markReviewed(String(installationId), repoFullName, prNumber, completedAt);
+
+    // #193 — denormalize this review's cost for the nightly cost rollup.
+    // Best-effort; unknown-model cost (null) is recorded as unpriced, not 0.
+    await costStore.recordCost({
+      installationId: String(installationId),
+      repoFullName,
+      prNumber,
+      commitSha: headSha,
+      completedAt,
+      inputTokens: result.inputTokens ?? 0,
+      outputTokens: result.outputTokens ?? 0,
+      costUsd: result.estimatedCostUsd ?? null,
+      findingCount: result.findings.length,
+      model: modelName,
+    });
 
     // ── Record billing (SaaS only) ────
     // Retry once on failure. If both attempts fail, log as ERROR (not warn)

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -11,6 +11,7 @@ import {
   PostgresFPInsightStore,
   PostgresPRLifecycleStore,
   PostgresSatisfactionStore,
+  PostgresReviewCostStore,
   runMigrations,
 } from '@mergewatch/storage-postgres';
 import { EnvGitHubAuthProvider } from './github-auth-env.js';
@@ -71,6 +72,7 @@ async function main() {
   const fpInsightStore = new PostgresFPInsightStore(db);
   const prLifecycleStore = new PostgresPRLifecycleStore(db);
   const satisfactionStore = new PostgresSatisfactionStore(db);
+  const costStore = new PostgresReviewCostStore(db);
   const authProvider = new EnvGitHubAuthProvider(githubAppId, githubPrivateKey);
   const llm = createLLMProvider();
 
@@ -78,7 +80,7 @@ async function main() {
   // (60s after init to let migrations complete) and every 24h after.
   // Errors are caught + logged inside; the cron handle is kept for
   // future graceful-shutdown support.
-  startInsightsCron({ installationStore, dispositionStore, fpInsightStore, prLifecycleStore, satisfactionStore });
+  startInsightsCron({ installationStore, dispositionStore, fpInsightStore, prLifecycleStore, satisfactionStore, costStore });
 
   // Express app
   const app = express();
@@ -128,6 +130,7 @@ async function main() {
     fpInsightStore,
     prLifecycleStore,
     satisfactionStore,
+    costStore,
     authProvider,
     llm,
     dashboardBaseUrl,

--- a/packages/server/src/insights-cron.ts
+++ b/packages/server/src/insights-cron.ts
@@ -16,6 +16,7 @@ import type {
   IInstallationStore,
   IPRLifecycleStore,
   ISatisfactionStore,
+  IReviewCostStore,
 } from '@mergewatch/core';
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
@@ -31,6 +32,8 @@ export interface InsightsCronStores {
   prLifecycleStore?: IPRLifecycleStore;
   /** #195 Tier 2 — feeds the helpful-rate + NPS fields of each engagement block. */
   satisfactionStore?: ISatisfactionStore;
+  /** #193 — feeds the cost block of each insight row. */
+  costStore?: IReviewCostStore;
 }
 
 export interface InsightsCronHandle {

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -234,7 +234,7 @@ async function handleInlineReplyJob(
 
 export async function processReviewJob(
   job: ReviewJobPayload,
-  deps: Pick<WebhookDeps, 'installationStore' | 'reviewStore' | 'dispositionStore' | 'fpInsightStore' | 'prLifecycleStore' | 'satisfactionStore' | 'authProvider' | 'llm' | 'dashboardBaseUrl'>,
+  deps: Pick<WebhookDeps, 'installationStore' | 'reviewStore' | 'dispositionStore' | 'fpInsightStore' | 'prLifecycleStore' | 'satisfactionStore' | 'costStore' | 'authProvider' | 'llm' | 'dashboardBaseUrl'>,
 ): Promise<void> {
   const { installationId, owner, repo, prNumber, mode } = job;
   const instId = String(installationId);
@@ -797,6 +797,25 @@ export async function processReviewJob(
     // TTM (#194) — anchor the first-review timestamp (set-once) for the
     // time-from-first-review-to-merge metric. Later re-reviews don't move it.
     await deps.prLifecycleStore?.markReviewed(instId, repoFullName, prNumber, new Date().toISOString());
+
+    // #193 — denormalize this review's cost so the nightly rollup can aggregate
+    // spend per installation without scanning the reviews table. Best-effort;
+    // `estimatedCostUsd` undefined/null (unknown model) is recorded as a null
+    // (unpriced) cost, never coerced to 0. The store swallows on failure.
+    if (deps.costStore && installationId != null) {
+      await deps.costStore.recordCost({
+        installationId: String(installationId),
+        repoFullName,
+        prNumber,
+        commitSha: headSha,
+        completedAt: new Date().toISOString(),
+        inputTokens: result.inputTokens ?? 0,
+        outputTokens: result.outputTokens ?? 0,
+        costUsd: result.estimatedCostUsd ?? null,
+        findingCount: result.findings.length,
+        model: config.model,
+      });
+    }
 
     // Create structured check run (matches Lambda pattern)
     const hasCritical = criticalCount > 0;

--- a/packages/server/src/webhook-handler.ts
+++ b/packages/server/src/webhook-handler.ts
@@ -1,6 +1,6 @@
 import { createHmac, timingSafeEqual } from 'crypto';
 import type { Request, Response } from 'express';
-import type { IInstallationStore, IReviewStore, IFindingDispositionStore, IFPInsightStore, IPRLifecycleStore, ISatisfactionStore, IGitHubAuthProvider, ILLMProvider, AgentReviewConfig } from '@mergewatch/core';
+import type { IInstallationStore, IReviewStore, IFindingDispositionStore, IFPInsightStore, IPRLifecycleStore, ISatisfactionStore, IReviewCostStore, IGitHubAuthProvider, ILLMProvider, AgentReviewConfig } from '@mergewatch/core';
 import type { ReviewJobPayload, ReviewMode, PullRequestEvent, IssueCommentEvent, PullRequestReviewCommentEvent, InstallationEvent, CheckRunEvent } from '@mergewatch/core';
 import { REVIEW_TRIGGERING_ACTIONS, COMMENT_LOOKUP_ACTIONS, MERGEWATCH_CHECK_RUN_NAME, findExistingBotComment, classifyPrSource, fetchRepoConfig, mergeConfig, isBotActor } from '@mergewatch/core';
 import { processReviewJob } from './review-processor.js';
@@ -29,6 +29,11 @@ export interface WebhookDeps {
    * summary 👍/👎 helpful-vote capture is a no-op and the review runs unchanged.
    */
   satisfactionStore?: ISatisfactionStore;
+  /**
+   * #193 — optional review-cost store. Best-effort: when unset, per-review cost
+   * isn't recorded and the `cost` insight block stays absent.
+   */
+  costStore?: IReviewCostStore;
   authProvider: IGitHubAuthProvider;
   llm: ILLMProvider;
   dashboardBaseUrl: string;

--- a/packages/storage-dynamo/src/fp-insight-store.ts
+++ b/packages/storage-dynamo/src/fp-insight-store.ts
@@ -57,6 +57,8 @@ export class DynamoFPInsightStore implements IFPInsightStore {
         cycleTime: insight.cycleTime ?? null,
         // #195 — engagement block; same null-not-undefined discipline.
         engagement: insight.engagement ?? null,
+        // #193 — cost block; same null-not-undefined discipline.
+        cost: insight.cost ?? null,
       },
     }));
   }
@@ -101,5 +103,7 @@ function itemToInsight(it: Record<string, unknown>): InstallationFPInsight {
     ...(it.cycleTime ? { cycleTime: it.cycleTime as InstallationFPInsight['cycleTime'] } : {}),
     // #195 — absent on pre-engagement rows; null coerces back to undefined.
     ...(it.engagement ? { engagement: it.engagement as InstallationFPInsight['engagement'] } : {}),
+    // #193 — absent on pre-cost rows; null coerces back to undefined.
+    ...(it.cost ? { cost: it.cost as InstallationFPInsight['cost'] } : {}),
   };
 }

--- a/packages/storage-dynamo/src/index.ts
+++ b/packages/storage-dynamo/src/index.ts
@@ -24,3 +24,7 @@ export {
   DynamoSatisfactionStore,
   DEFAULT_SATISFACTION_TABLE,
 } from './satisfaction-store.js';
+export {
+  DynamoReviewCostStore,
+  DEFAULT_REVIEW_COSTS_TABLE,
+} from './review-cost-store.js';

--- a/packages/storage-dynamo/src/review-cost-store.test.ts
+++ b/packages/storage-dynamo/src/review-cost-store.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PutCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { DynamoReviewCostStore } from './review-cost-store.js';
+import type { ReviewCostRecord } from '@mergewatch/core';
+
+const TABLE = 'test-review-costs';
+
+function makeClient(response: unknown = {}) {
+  return { send: vi.fn().mockResolvedValue(response) } as any;
+}
+
+function lastCmd(client: any) {
+  const calls = client.send.mock.calls;
+  return calls[calls.length - 1][0];
+}
+
+function rec(over: Partial<ReviewCostRecord> = {}): ReviewCostRecord {
+  return {
+    installationId: '42',
+    repoFullName: 'octo/repo',
+    prNumber: 7,
+    commitSha: 'abc1234',
+    completedAt: '2026-05-20T00:00:00.000Z',
+    inputTokens: 100,
+    outputTokens: 20,
+    costUsd: 1.5,
+    findingCount: 3,
+    model: 'claude-sonnet-4',
+    ...over,
+  };
+}
+
+describe('DynamoReviewCostStore', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('writes one row per (repo, pr, commit) under the installation partition', async () => {
+    const client = makeClient();
+    const store = new DynamoReviewCostStore(client, TABLE);
+    await store.recordCost(rec());
+    const cmd = lastCmd(client);
+    expect(cmd).toBeInstanceOf(PutCommand);
+    expect(cmd.input.Item).toMatchObject({
+      pk: '42',
+      sk: 'octo/repo#7#abc1234',
+      costUsd: 1.5,
+      findingCount: 3,
+      model: 'claude-sonnet-4',
+    });
+    // TTL is set for self-pruning.
+    expect(typeof cmd.input.Item.ttl).toBe('number');
+  });
+
+  it('persists null cost (unpriced) rather than dropping the attribute', async () => {
+    const client = makeClient();
+    const store = new DynamoReviewCostStore(client, TABLE);
+    await store.recordCost(rec({ costUsd: null }));
+    expect(lastCmd(client).input.Item.costUsd).toBeNull();
+  });
+
+  it('swallows write failures (best-effort)', async () => {
+    const client = { send: vi.fn().mockRejectedValue(new Error('throttled')) } as any;
+    const store = new DynamoReviewCostStore(client, TABLE);
+    await expect(store.recordCost(rec())).resolves.toBeUndefined();
+  });
+
+  it('lists rows for an installation and round-trips null cost', async () => {
+    const client = makeClient({
+      Items: [
+        { pk: '42', installationId: '42', repoFullName: 'octo/repo', prNumber: 7, commitSha: 'abc', completedAt: 'iso', inputTokens: 100, outputTokens: 20, costUsd: 1.5, findingCount: 3, model: 'm' },
+        { pk: '42', installationId: '42', repoFullName: 'octo/repo', prNumber: 8, commitSha: 'def', completedAt: 'iso', inputTokens: 50, outputTokens: 5, costUsd: null, findingCount: 0 },
+      ],
+    });
+    const store = new DynamoReviewCostStore(client, TABLE);
+    const { items } = await store.listByInstallation('42');
+    expect(lastCmd(client)).toBeInstanceOf(QueryCommand);
+    expect(lastCmd(client).input.ExpressionAttributeValues).toMatchObject({ ':pk': '42' });
+    expect(items[0].costUsd).toBe(1.5);
+    expect(items[1].costUsd).toBeNull(); // unpriced survives the round trip
+    expect(items[0].model).toBe('m');
+  });
+
+  it('threads the pagination cursor', async () => {
+    const client = makeClient({ Items: [], LastEvaluatedKey: { pk: '42', sk: 'x' } });
+    const store = new DynamoReviewCostStore(client, TABLE);
+    const { nextCursor } = await store.listByInstallation('42');
+    expect(nextCursor).toBe(JSON.stringify({ pk: '42', sk: 'x' }));
+  });
+});

--- a/packages/storage-dynamo/src/review-cost-store.ts
+++ b/packages/storage-dynamo/src/review-cost-store.ts
@@ -1,0 +1,109 @@
+/**
+ * DynamoDB implementation of `IReviewCostStore` (#193).
+ *
+ * Table shape (created in infra/template.yaml):
+ *   PK: installationId
+ *   SK: `${repoFullName}#${prNumber}#${commitSha}`  — one row per review run
+ *
+ * Per-installation partition so the nightly cost rollup reads with a single
+ * Query (no Scan), and one row per (repo, PR, commit) so a re-review on a new
+ * commit accrues cost while a retried review of the same commit overwrites
+ * idempotently. Rows carry a TTL ~90 days past completion — long enough for the
+ * 90d window — so the table self-prunes.
+ *
+ * Best-effort writes: `recordCost` swallows-and-logs so a cost write can never
+ * block the review pipeline.
+ */
+
+import {
+  DynamoDBDocumentClient,
+  PutCommand,
+  QueryCommand,
+} from '@aws-sdk/lib-dynamodb';
+import type { IReviewCostStore, ReviewCostRecord } from '@mergewatch/core';
+
+export const DEFAULT_REVIEW_COSTS_TABLE = 'mergewatch-review-costs';
+
+/** Retain rows ~90 days past completion — long enough for the 90d window. */
+const TTL_DAYS = 90;
+
+function sk(repoFullName: string, prNumber: number, commitSha: string): string {
+  return `${repoFullName}#${prNumber}#${commitSha}`;
+}
+
+/** Unix epoch seconds, TTL_DAYS past the given ISO timestamp. */
+function ttlFrom(iso: string): number {
+  const ms = Date.parse(iso);
+  const base = Number.isNaN(ms) ? Date.now() : ms;
+  return Math.floor(base / 1000) + TTL_DAYS * 24 * 60 * 60;
+}
+
+export class DynamoReviewCostStore implements IReviewCostStore {
+  constructor(
+    private readonly client: DynamoDBDocumentClient,
+    private readonly tableName: string = DEFAULT_REVIEW_COSTS_TABLE,
+  ) {}
+
+  async recordCost(record: ReviewCostRecord): Promise<void> {
+    try {
+      await this.client.send(new PutCommand({
+        TableName: this.tableName,
+        Item: {
+          pk: record.installationId,
+          sk: sk(record.repoFullName, record.prNumber, record.commitSha),
+          installationId: record.installationId,
+          repoFullName: record.repoFullName,
+          prNumber: record.prNumber,
+          commitSha: record.commitSha,
+          completedAt: record.completedAt,
+          inputTokens: record.inputTokens,
+          outputTokens: record.outputTokens,
+          // DynamoDB rejects `undefined`; persist null so the unpriced signal
+          // round-trips. `removeUndefinedValues` isn't enabled on every client.
+          costUsd: record.costUsd ?? null,
+          findingCount: record.findingCount,
+          ...(record.model ? { model: record.model } : {}),
+          ttl: ttlFrom(record.completedAt),
+        },
+      }));
+    } catch (err) {
+      console.warn('[fb-cost] recordCost failed (%s/%s#%d):', record.installationId, record.repoFullName, record.prNumber, err);
+    }
+  }
+
+  async listByInstallation(
+    installationId: string,
+    opts?: { limit?: number; cursor?: string },
+  ): Promise<{ items: ReviewCostRecord[]; nextCursor?: string }> {
+    const limit = Math.min(opts?.limit ?? 1000, 1000);
+    const resp = await this.client.send(new QueryCommand({
+      TableName: this.tableName,
+      KeyConditionExpression: 'pk = :pk',
+      ExpressionAttributeValues: { ':pk': installationId },
+      Limit: limit,
+      ...(opts?.cursor ? { ExclusiveStartKey: JSON.parse(opts.cursor) } : {}),
+    }));
+    const items = (resp.Items ?? []).map(itemToRecord);
+    return resp.LastEvaluatedKey
+      ? { items, nextCursor: JSON.stringify(resp.LastEvaluatedKey) }
+      : { items };
+  }
+}
+
+function itemToRecord(it: Record<string, unknown>): ReviewCostRecord {
+  const r: ReviewCostRecord = {
+    installationId: String(it.installationId ?? it.pk ?? ''),
+    repoFullName: String(it.repoFullName ?? ''),
+    prNumber: Number(it.prNumber ?? 0),
+    commitSha: String(it.commitSha ?? ''),
+    completedAt: String(it.completedAt ?? ''),
+    inputTokens: Number(it.inputTokens ?? 0),
+    outputTokens: Number(it.outputTokens ?? 0),
+    // null (unpriced) must survive the round-trip — only coerce a genuine
+    // number; leave null/absent as null.
+    costUsd: it.costUsd == null ? null : Number(it.costUsd),
+    findingCount: Number(it.findingCount ?? 0),
+  };
+  if (it.model) r.model = String(it.model);
+  return r;
+}

--- a/packages/storage-dynamo/src/review-cost-store.ts
+++ b/packages/storage-dynamo/src/review-cost-store.ts
@@ -67,7 +67,10 @@ export class DynamoReviewCostStore implements IReviewCostStore {
         },
       }));
     } catch (err) {
-      console.warn('[fb-cost] recordCost failed (%s/%s#%d):', record.installationId, record.repoFullName, record.prNumber, err);
+      // Best-effort: don't interpolate installation / repo / PR identifiers —
+      // cost-tracking patterns are business-sensitive in centralized logs. The
+      // error carries enough (table, stack) to diagnose a write failure.
+      console.warn('[fb-cost] recordCost failed for a review:', err);
     }
   }
 

--- a/packages/storage-postgres/drizzle/0013_clean_xorn.sql
+++ b/packages/storage-postgres/drizzle/0013_clean_xorn.sql
@@ -1,0 +1,21 @@
+-- #193 — per-review cost denormalization (one row per completed review) so the
+-- nightly rollup can aggregate spend per installation. IF NOT EXISTS so the
+-- self-hosted startup migration is idempotent.
+CREATE TABLE IF NOT EXISTS "review_costs" (
+	"installation_id" text NOT NULL,
+	"repo_full_name" text NOT NULL,
+	"pr_number" integer NOT NULL,
+	"commit_sha" text NOT NULL,
+	"completed_at" text NOT NULL,
+	"input_tokens" integer DEFAULT 0 NOT NULL,
+	"output_tokens" integer DEFAULT 0 NOT NULL,
+	"cost_usd" text,
+	"finding_count" integer DEFAULT 0 NOT NULL,
+	"model" text,
+	CONSTRAINT "review_costs_installation_id_repo_full_name_pr_number_commit_sha_pk" PRIMARY KEY("installation_id","repo_full_name","pr_number","commit_sha")
+);
+--> statement-breakpoint
+-- #193 — LLM-cost block on the insight rollup. Nullable; pre-cost rows and
+-- rollups run without a cost store leave it NULL (→ undefined on the typed shape).
+ALTER TABLE "installation_fp_insights" ADD COLUMN IF NOT EXISTS "cost" jsonb;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "review_costs_installation_idx" ON "review_costs" USING btree ("installation_id");

--- a/packages/storage-postgres/drizzle/meta/0013_snapshot.json
+++ b/packages/storage-postgres/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,1148 @@
+{
+  "id": "1c4b6d79-88fb-45cd-a984-c719429efe03",
+  "prevId": "c4c36d6d-549b-44b3-acf9-c8aace2b8185",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_installation_idx": {
+          "name": "api_keys_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.finding_dispositions": {
+      "name": "finding_dispositions",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finding_match_key": {
+          "name": "finding_match_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_count": {
+          "name": "surface_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dispute_count": {
+          "name": "dispute_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verified_count": {
+          "name": "verified_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unverified_count": {
+          "name": "unverified_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "silent_drop_count": {
+          "name": "silent_drop_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "agreement_count": {
+          "name": "agreement_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resolve_count": {
+          "name": "resolve_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_agent": {
+          "name": "top_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sig_tokens": {
+          "name": "sig_tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reject_reasons": {
+          "name": "reject_reasons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "finding_dispositions_installation_idx": {
+          "name": "finding_dispositions_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "finding_dispositions_installation_id_repo_full_name_finding_match_key_pk": {
+          "name": "finding_dispositions_installation_id_repo_full_name_finding_match_key_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name",
+            "finding_match_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.helpful_votes": {
+      "name": "helpful_votes",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "up": {
+          "name": "up",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "down": {
+          "name": "down",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_vote_at": {
+          "name": "last_vote_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "helpful_votes_installation_idx": {
+          "name": "helpful_votes_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "helpful_votes_installation_id_repo_full_name_pr_number_pk": {
+          "name": "helpful_votes_installation_id_repo_full_name_pr_number_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name",
+            "pr_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installation_fp_insights": {
+      "name": "installation_fp_insights",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window": {
+          "name": "window",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_end": {
+          "name": "window_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_findings_surfaced": {
+          "name": "total_findings_surfaced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_disputes": {
+          "name": "total_disputes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dispute_rate": {
+          "name": "dispute_rate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_silent_drops": {
+          "name": "total_silent_drops",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_agreements": {
+          "name": "total_agreements",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "per_category": {
+          "name": "per_category",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "per_severity": {
+          "name": "per_severity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "per_repo": {
+          "name": "per_repo",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "top_clusters": {
+          "name": "top_clusters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "cycle_time": {
+          "name": "cycle_time",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "engagement": {
+          "name": "engagement",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "installation_fp_insights_installation_id_window_pk": {
+          "name": "installation_fp_insights_installation_id_window_pk",
+          "columns": [
+            "installation_id",
+            "window"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installation_settings": {
+      "name": "installation_settings",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "severity_threshold": {
+          "name": "severity_threshold",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Low'"
+        },
+        "comment_types": {
+          "name": "comment_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"syntax\":true,\"logic\":true,\"style\":true}'::jsonb"
+        },
+        "max_comments": {
+          "name": "max_comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 25
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"prSummary\":true,\"confidenceScore\":true,\"issuesTable\":true,\"diagram\":true}'::jsonb"
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "comment_header": {
+          "name": "comment_header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installations": {
+      "name": "installations",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monitored": {
+          "name": "monitored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "installations_installation_id_repo_full_name_pk": {
+          "name": "installations_installation_id_repo_full_name_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_sessions": {
+      "name": "mcp_sessions",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_billed_at": {
+          "name": "first_billed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_billed_cents": {
+          "name": "max_billed_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iteration": {
+          "name": "iteration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nps_responses": {
+      "name": "nps_responses",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_user_id": {
+          "name": "github_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nps_responses_installation_idx": {
+          "name": "nps_responses_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "nps_responses_installation_id_github_user_id_pk": {
+          "name": "nps_responses_installation_id_github_user_id_pk",
+          "columns": [
+            "installation_id",
+            "github_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pr_lifecycle": {
+      "name": "pr_lifecycle",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_created_at": {
+          "name": "pr_created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_review_at": {
+          "name": "first_review_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "reviewed": {
+          "name": "reviewed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "skipped": {
+          "name": "skipped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "total_pushes": {
+          "name": "total_pushes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pushes_after_first_review": {
+          "name": "pushes_after_first_review",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pr_lifecycle_installation_idx": {
+          "name": "pr_lifecycle_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "pr_lifecycle_installation_id_repo_full_name_pr_number_pk": {
+          "name": "pr_lifecycle_installation_id_repo_full_name_pr_number_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name",
+            "pr_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_costs": {
+      "name": "review_costs",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "review_costs_installation_idx": {
+          "name": "review_costs_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "review_costs_installation_id_repo_full_name_pr_number_commit_sha_pk": {
+          "name": "review_costs_installation_id_repo_full_name_pr_number_commit_sha_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name",
+            "pr_number",
+            "commit_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number_commit_sha": {
+          "name": "pr_number_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_title": {
+          "name": "pr_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_author": {
+          "name": "pr_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_author_avatar": {
+          "name": "pr_author_avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_branch": {
+          "name": "head_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_severity": {
+          "name": "top_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_text": {
+          "name": "summary_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagram_text": {
+          "name": "diagram_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_score": {
+          "name": "merge_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_score_reason": {
+          "name": "merge_score_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "findings": {
+          "name": "findings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reactions": {
+          "name": "reactions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_used": {
+          "name": "settings_used",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_cost_usd": {
+          "name": "estimated_cost_usd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inline_resolved_keys": {
+          "name": "inline_resolved_keys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "inline_reactions_snapshot": {
+          "name": "inline_reactions_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "reviews_installation_idx": {
+          "name": "reviews_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_pr_idx": {
+          "name": "reviews_pr_idx",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "reviews_repo_full_name_pr_number_commit_sha_pk": {
+          "name": "reviews_repo_full_name_pr_number_commit_sha_pk",
+          "columns": [
+            "repo_full_name",
+            "pr_number_commit_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/storage-postgres/drizzle/meta/_journal.json
+++ b/packages/storage-postgres/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1782259686791,
       "tag": "0012_lean_star_brand",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1782276863027,
+      "tag": "0013_clean_xorn",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/storage-postgres/src/fp-insight-store.ts
+++ b/packages/storage-postgres/src/fp-insight-store.ts
@@ -43,6 +43,7 @@ export class PostgresFPInsightStore implements IFPInsightStore {
         topClusters: insight.topClusters as unknown,
         cycleTime: (insight.cycleTime ?? null) as unknown,
         engagement: (insight.engagement ?? null) as unknown,
+        cost: (insight.cost ?? null) as unknown,
       })
       .onConflictDoUpdate({
         target: [installationFpInsights.installationId, installationFpInsights.window],
@@ -61,6 +62,7 @@ export class PostgresFPInsightStore implements IFPInsightStore {
           topClusters: insight.topClusters as unknown,
           cycleTime: (insight.cycleTime ?? null) as unknown,
           engagement: (insight.engagement ?? null) as unknown,
+          cost: (insight.cost ?? null) as unknown,
         },
       });
   }
@@ -108,5 +110,7 @@ function rowToInsight(row: Record<string, unknown>): InstallationFPInsight {
     ...(row.cycleTime ? { cycleTime: row.cycleTime as InstallationFPInsight['cycleTime'] } : {}),
     // #195 — NULL on pre-engagement rows; omit so the field stays undefined.
     ...(row.engagement ? { engagement: row.engagement as InstallationFPInsight['engagement'] } : {}),
+    // #193 — NULL on pre-cost rows; omit so the field stays undefined.
+    ...(row.cost ? { cost: row.cost as InstallationFPInsight['cost'] } : {}),
   };
 }

--- a/packages/storage-postgres/src/index.ts
+++ b/packages/storage-postgres/src/index.ts
@@ -4,10 +4,11 @@ export { PostgresFindingDispositionStore } from './finding-disposition-store.js'
 export { PostgresFPInsightStore } from './fp-insight-store.js';
 export { PostgresPRLifecycleStore } from './pr-lifecycle-store.js';
 export { PostgresSatisfactionStore } from './satisfaction-store.js';
+export { PostgresReviewCostStore } from './review-cost-store.js';
 export {
   installations, installationSettings, reviews, apiKeys, mcpSessions,
   findingDispositions, installationFpInsights, prLifecycle,
-  helpfulVotes, npsResponses,
+  helpfulVotes, npsResponses, reviewCosts,
 } from './schema.js';
 export { runMigrations } from './migrate.js';
 export { createPostgresDashboardStore } from './dashboard-store.js';

--- a/packages/storage-postgres/src/review-cost-store.test.ts
+++ b/packages/storage-postgres/src/review-cost-store.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PostgresReviewCostStore } from './review-cost-store';
+import { reviewCosts } from './schema';
+import type { ReviewCostRecord } from '@mergewatch/core';
+
+/** Drizzle chain mock (mirrors api-key-store.test). */
+function chain(result: any) {
+  const p: any = {
+    select: vi.fn(() => p),
+    from: vi.fn(() => p),
+    where: vi.fn(() => p),
+    limit: vi.fn(() => Promise.resolve(result)),
+    insert: vi.fn(() => p),
+    values: vi.fn(() => p),
+    onConflictDoUpdate: vi.fn(() => Promise.resolve(result)),
+    then: (resolve: any) => Promise.resolve(result).then(resolve),
+  };
+  return p;
+}
+
+function rec(over: Partial<ReviewCostRecord> = {}): ReviewCostRecord {
+  return {
+    installationId: '42',
+    repoFullName: 'octo/repo',
+    prNumber: 7,
+    commitSha: 'abc1234',
+    completedAt: 'iso',
+    inputTokens: 100,
+    outputTokens: 20,
+    costUsd: 1.5,
+    findingCount: 3,
+    model: 'm',
+    ...over,
+  };
+}
+
+describe('PostgresReviewCostStore', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('upserts cost as text on conflict (idempotent per review)', async () => {
+    const db: any = chain(undefined);
+    const store = new PostgresReviewCostStore(db);
+    await store.recordCost(rec());
+    expect(db.insert).toHaveBeenCalledWith(reviewCosts);
+    // cost stored as text to avoid float drift.
+    expect(db.values).toHaveBeenCalledWith(expect.objectContaining({ costUsd: '1.5', findingCount: 3 }));
+    expect(db.onConflictDoUpdate).toHaveBeenCalled();
+  });
+
+  it('stores null cost for an unpriced review', async () => {
+    const db: any = chain(undefined);
+    const store = new PostgresReviewCostStore(db);
+    await store.recordCost(rec({ costUsd: null }));
+    expect(db.values).toHaveBeenCalledWith(expect.objectContaining({ costUsd: null }));
+  });
+
+  it('hydrates rows and round-trips null cost as null', async () => {
+    const db: any = chain([
+      { installationId: '42', repoFullName: 'octo/repo', prNumber: 7, commitSha: 'a', completedAt: 'iso', inputTokens: 100, outputTokens: 20, costUsd: '1.5', findingCount: 3, model: 'm' },
+      { installationId: '42', repoFullName: 'octo/repo', prNumber: 8, commitSha: 'b', completedAt: 'iso', inputTokens: 50, outputTokens: 5, costUsd: null, findingCount: 0, model: null },
+    ]);
+    const store = new PostgresReviewCostStore(db);
+    const { items } = await store.listByInstallation('42');
+    expect(items[0].costUsd).toBe(1.5);
+    expect(items[1].costUsd).toBeNull();
+    expect(items[0].model).toBe('m');
+    expect(items[1].model).toBeUndefined();
+  });
+});

--- a/packages/storage-postgres/src/review-cost-store.ts
+++ b/packages/storage-postgres/src/review-cost-store.ts
@@ -1,0 +1,81 @@
+/**
+ * Postgres implementation of `IReviewCostStore` (#193).
+ *
+ * One row per (installation, repo, PR, commit). `recordCost` upserts so a
+ * retried review of the same commit overwrites idempotently rather than
+ * double-counting. `cost_usd` is stored as text (mirrors `dispute_rate`) to
+ * avoid float drift; null marks an unpriced (unknown-model) review.
+ *
+ * Best-effort writes: `recordCost` swallows-and-logs so a cost write can never
+ * block the review pipeline.
+ */
+
+import { eq } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import type { IReviewCostStore, ReviewCostRecord } from '@mergewatch/core';
+import { reviewCosts } from './schema.js';
+
+export class PostgresReviewCostStore implements IReviewCostStore {
+  constructor(private db: PostgresJsDatabase) {}
+
+  async recordCost(record: ReviewCostRecord): Promise<void> {
+    try {
+      const costUsd = record.costUsd == null ? null : String(record.costUsd);
+      await this.db
+        .insert(reviewCosts)
+        .values({
+          installationId: record.installationId,
+          repoFullName: record.repoFullName,
+          prNumber: record.prNumber,
+          commitSha: record.commitSha,
+          completedAt: record.completedAt,
+          inputTokens: record.inputTokens,
+          outputTokens: record.outputTokens,
+          costUsd,
+          findingCount: record.findingCount,
+          model: record.model ?? null,
+        })
+        .onConflictDoUpdate({
+          target: [reviewCosts.installationId, reviewCosts.repoFullName, reviewCosts.prNumber, reviewCosts.commitSha],
+          set: {
+            completedAt: record.completedAt,
+            inputTokens: record.inputTokens,
+            outputTokens: record.outputTokens,
+            costUsd,
+            findingCount: record.findingCount,
+            model: record.model ?? null,
+          },
+        });
+    } catch (err) {
+      console.warn('[fb-cost] recordCost failed (%s/%s#%d):', record.installationId, record.repoFullName, record.prNumber, err);
+    }
+  }
+
+  async listByInstallation(
+    installationId: string,
+    opts?: { limit?: number; cursor?: string },
+  ): Promise<{ items: ReviewCostRecord[]; nextCursor?: string }> {
+    const limit = Math.min(opts?.limit ?? 1000, 1000);
+    const rows = await this.db
+      .select()
+      .from(reviewCosts)
+      .where(eq(reviewCosts.installationId, installationId))
+      .limit(limit);
+    const items: ReviewCostRecord[] = rows.map((r) => {
+      const rec: ReviewCostRecord = {
+        installationId: r.installationId,
+        repoFullName: r.repoFullName,
+        prNumber: r.prNumber,
+        commitSha: r.commitSha,
+        completedAt: r.completedAt,
+        inputTokens: r.inputTokens,
+        outputTokens: r.outputTokens,
+        costUsd: r.costUsd == null ? null : Number(r.costUsd),
+        findingCount: r.findingCount,
+      };
+      if (r.model) rec.model = r.model;
+      return rec;
+    });
+    return { items };
+  }
+}

--- a/packages/storage-postgres/src/review-cost-store.ts
+++ b/packages/storage-postgres/src/review-cost-store.ts
@@ -47,7 +47,10 @@ export class PostgresReviewCostStore implements IReviewCostStore {
           },
         });
     } catch (err) {
-      console.warn('[fb-cost] recordCost failed (%s/%s#%d):', record.installationId, record.repoFullName, record.prNumber, err);
+      // Best-effort: don't interpolate installation / repo / PR identifiers —
+      // cost-tracking patterns are business-sensitive in centralized logs. The
+      // error carries enough (stack) to diagnose a write failure.
+      console.warn('[fb-cost] recordCost failed for a review:', err);
     }
   }
 

--- a/packages/storage-postgres/src/schema.ts
+++ b/packages/storage-postgres/src/schema.ts
@@ -117,6 +117,10 @@ export const installationFpInsights = pgTable('installation_fp_insights', {
   // #195 — developer-engagement block (acceptance / command-usage / re-review
   // KPIs). Nullable: pre-engagement rollups leave it NULL → `undefined`.
   engagement: jsonb('engagement'),
+  // #193 — LLM-cost block (spend / cost-per-review / cost-per-finding).
+  // Nullable: pre-cost rollups (or rollups run without a cost store) leave it
+  // NULL → `undefined`.
+  cost: jsonb('cost'),
 }, (t) => ({
   pk: primaryKey({ columns: [t.installationId, t.window] }),
 }));
@@ -200,4 +204,25 @@ export const npsResponses = pgTable('nps_responses', {
 }, (t) => ({
   pk: primaryKey({ columns: [t.installationId, t.githubUserId] }),
   installationIdx: index('nps_responses_installation_idx').on(t.installationId),
+}));
+
+// #193 — one row per completed review denormalizing its cost/token figures so
+// the nightly rollup can aggregate spend per installation. See ReviewCostRecord
+// in @mergewatch/core. `cost_usd` is nullable — null marks an unpriced
+// (unknown-model) review, excluded from money totals.
+export const reviewCosts = pgTable('review_costs', {
+  installationId: text('installation_id').notNull(),
+  repoFullName: text('repo_full_name').notNull(),
+  prNumber: integer('pr_number').notNull(),
+  commitSha: text('commit_sha').notNull(),
+  completedAt: text('completed_at').notNull(),
+  inputTokens: integer('input_tokens').notNull().default(0),
+  outputTokens: integer('output_tokens').notNull().default(0),
+  // Stored as text to avoid float precision drift (mirrors dispute_rate); null = unpriced.
+  costUsd: text('cost_usd'),
+  findingCount: integer('finding_count').notNull().default(0),
+  model: text('model'),
+}, (t) => ({
+  pk: primaryKey({ columns: [t.installationId, t.repoFullName, t.prNumber, t.commitSha] }),
+  installationIdx: index('review_costs_installation_idx').on(t.installationId),
 }));


### PR DESCRIPTION
Closes #193. Surfaces **LLM cost** as a first-class metric — aggregated in the nightly insights rollup, returned by `/api/insights`, and rendered on `/dashboard/insights`. The per-review capture (tokens + estimated USD on `ReviewItem`, cost in the PR-comment "Review details" drawer) already shipped; this closes the three gaps the issue lists.

## Approach
Cost lives on `ReviewItem` (repo-partitioned), so the per-installation rollup can't read it cheaply. Took the issue's **denormalize** option: write one installation-keyed `ReviewCostRecord` per completed review, then page those rows in the rollup exactly like the disposition / PR-lifecycle / satisfaction records. One extra best-effort write per review; O(1) per-installation read at rollup time.

## Gap 1 — rollup aggregation
- `ReviewCostRecord` + `IReviewCostStore` (`recordCost` / `listByInstallation`).
- `DynamoReviewCostStore` (`mergewatch-review-costs`, PK=installation, SK=`repo#pr#commit`, 90d TTL) + `PostgresReviewCostStore` (`review_costs`, `cost_usd` as text → no float drift). Idempotent per review. Migration `0013` (idempotent `CREATE TABLE IF NOT EXISTS` + `ADD COLUMN IF NOT EXISTS`).
- Both runtimes call `recordCost` at completion (best-effort). **Unknown-model cost (`null`) is recorded as unpriced, never coerced to `0`.**
- New pure `buildCostInsight` (`insights/cost.ts`), windowed by `completedAt` → `cost` block: `totalCostUsd` (priced only), token totals (all reviews), `reviewCount`, priced/unpriced split, `avgCostPerReview`, `findingCount`, `avgCostPerFinding`, `perRepo`. Wired into `runInsightRollup`; persisted in both fp-insight stores.

## Gap 2 — insights API
`/api/insights` returns the `cost` block unchanged (it already returns the full `InstallationFPInsight`) — no route change.

## Gap 3 — dashboard
`CostSection` on `/dashboard/insights`: StatCards (**Total spend**, **Avg cost / review**, **Cost / finding**, **Reviews** + unpriced count), a **Spend by repo** breakdown, and a **spend-over-time** bar across 7d / 30d / 90d. Gated independently (spend can exist with zero findings).

## Acceptance criteria
- [x] Rollup computes cost aggregates per window, persisted in `InstallationFPInsight` (both backends)
- [x] `/api/insights` returns cost fields
- [x] Dashboard shows total spend, cost-per-review, cost-per-finding, and a spend trend
- [x] Works for DynamoDB (SaaS) and Postgres (self-hosted)
- [x] Unknown-model reviews (null cost) excluded from aggregates, surfaced as "N unpriced"
- [x] Tests cover the rollup cost math and the null-pricing path

## Tests
- `cost.test.ts` — aggregation, per-repo bucketing, windowing, full null-pricing path (unpriced excluded from money / included in tokens; all-unpriced → null averages; zero-finding → null cost-per-finding).
- `review-cost-store.test.ts` (both backends) — key construction, null-cost round-trip, idempotent upsert, pagination.
- `run-rollup.test.ts` — cost block attached when wired (aggregates across pages, counts unpriced), omitted otherwise.
- Full `pnpm build` + `pnpm typecheck` (20 tasks) + suites green (904 tests); `drizzle-kit check` passes.

## Back-compat
`cost` is optional-by-block — absent on pre-feature rollups and when no cost store is wired; averages are `null` (not `0`) on empty denominators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)