### PR TITLE
feat(model): default review model Sonnet 4 → Opus 4.6 (closes #197)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -142,7 +142,7 @@ jobs:
           sam deploy \
             --stack-name mergewatch-dev \
             --region "$AWS_REGION" \
-            --parameter-overrides "Stage=dev DeploymentMode=${{ vars.DEPLOYMENT_MODE || 'self-hosted' }} DefaultBedrockModelId=us.anthropic.claude-sonnet-4-20250514-v1:0 DashboardBaseUrl=${{ vars.DASHBOARD_BASE_URL || 'https://mergewatch.ai' }}" \
+            --parameter-overrides "Stage=dev DeploymentMode=${{ vars.DEPLOYMENT_MODE || 'self-hosted' }} DefaultBedrockModelId=us.anthropic.claude-opus-4-6-v1 DashboardBaseUrl=${{ vars.DASHBOARD_BASE_URL || 'https://mergewatch.ai' }}" \
             --capabilities CAPABILITY_NAMED_IAM \
             --resolve-s3 \
             --no-confirm-changeset \

--- a/.mergewatch.yml
+++ b/.mergewatch.yml
@@ -4,7 +4,7 @@
 # All fields are optional; omitted fields use sensible defaults.
 
 # Primary model for review agents (Bedrock model ID).
-model: anthropic.claude-sonnet-4-20250514
+model: us.anthropic.claude-opus-4-6-v1
 
 # Built-in review agents — toggle each on/off.
 agents:

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -52,7 +52,7 @@ Parameters:
   # via the modelId field in the mergewatch-installations table.
   DefaultBedrockModelId:
     Type: String
-    Default: us.anthropic.claude-sonnet-4-20250514-v1:0
+    Default: us.anthropic.claude-opus-4-6-v1
     Description: Default Amazon Bedrock model ID for PR reviews
 
   # Deployment mode: 'saas' enables billing enforcement, 'self-hosted' disables it.

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -183,7 +183,7 @@ export interface MergeWatchConfig {
 }
 
 export const DEFAULT_CONFIG: MergeWatchConfig = {
-  model: 'us.anthropic.claude-sonnet-4-20250514-v1:0',
+  model: 'us.anthropic.claude-opus-4-6-v1',
   lightModel: 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
   maxTokensPerAgent: 4096,
   agents: {

--- a/packages/core/src/llm/pricing.test.ts
+++ b/packages/core/src/llm/pricing.test.ts
@@ -21,6 +21,18 @@ describe('estimateCost', () => {
     expect(cost).toBeCloseTo(0.105, 6);
   });
 
+  it('prices the Opus 4.6 default (Bedrock) at $5/$25 per 1M', () => {
+    // us.anthropic.claude-opus-4-6-v1: input $5/1M, output $25/1M
+    const cost = estimateCost('us.anthropic.claude-opus-4-6-v1', 1000, 500);
+    // (1000 / 1_000_000) * 5 + (500 / 1_000_000) * 25 = 0.005 + 0.0125 = 0.0175
+    expect(cost).toBeCloseTo(0.0175, 6);
+  });
+
+  it('the retired claude-3-5-sonnet is no longer priced (returns null)', () => {
+    expect(estimateCost('us.anthropic.claude-3-5-sonnet-20241022-v2:0', 100, 100)).toBeNull();
+    expect(estimateCost('claude-3-5-sonnet-20241022', 100, 100)).toBeNull();
+  });
+
   it('returns null for an unknown model', () => {
     expect(estimateCost('gpt-4o', 100, 100)).toBeNull();
   });

--- a/packages/core/src/llm/pricing.ts
+++ b/packages/core/src/llm/pricing.ts
@@ -13,17 +13,17 @@ interface ModelPricing {
 /** Default pricing for known models (USD per 1M tokens). */
 export const DEFAULT_PRICING: Record<string, ModelPricing> = {
   // Bedrock Anthropic model IDs
+  'us.anthropic.claude-opus-4-6-v1': { inputPer1M: 5, outputPer1M: 25 },
   'us.anthropic.claude-opus-4-20250514-v1:0': { inputPer1M: 15, outputPer1M: 75 },
   'us.anthropic.claude-sonnet-4-20250514-v1:0': { inputPer1M: 3, outputPer1M: 15 },
   'us.anthropic.claude-haiku-4-5-20251001-v1:0': { inputPer1M: 0.80, outputPer1M: 4 },
-  'us.anthropic.claude-3-5-sonnet-20241022-v2:0': { inputPer1M: 3, outputPer1M: 15 },
   'us.anthropic.claude-3-5-haiku-20241022-v1:0': { inputPer1M: 0.80, outputPer1M: 4 },
 
   // Direct Anthropic model IDs
+  'claude-opus-4-6': { inputPer1M: 5, outputPer1M: 25 },
   'claude-opus-4-20250514': { inputPer1M: 15, outputPer1M: 75 },
   'claude-sonnet-4-20250514': { inputPer1M: 3, outputPer1M: 15 },
   'claude-haiku-4-5-20251001': { inputPer1M: 0.80, outputPer1M: 4 },
-  'claude-3-5-sonnet-20241022': { inputPer1M: 3, outputPer1M: 15 },
   'claude-3-5-haiku-20241022': { inputPer1M: 0.80, outputPer1M: 4 },
 };
 

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -95,7 +95,7 @@ const FP_INSIGHTS_TABLE = process.env.FP_INSIGHTS_TABLE ?? DEFAULT_FP_INSIGHTS_T
 const PR_LIFECYCLE_TABLE = process.env.PR_LIFECYCLE_TABLE ?? DEFAULT_PR_LIFECYCLE_TABLE;
 const SATISFACTION_TABLE = process.env.SATISFACTION_TABLE ?? DEFAULT_SATISFACTION_TABLE;
 const REVIEW_COSTS_TABLE = process.env.REVIEW_COSTS_TABLE ?? DEFAULT_REVIEW_COSTS_TABLE;
-const DEFAULT_BEDROCK_MODEL_ID = process.env.DEFAULT_BEDROCK_MODEL_ID ?? 'us.anthropic.claude-sonnet-4-20250514-v1:0';
+const DEFAULT_BEDROCK_MODEL_ID = process.env.DEFAULT_BEDROCK_MODEL_ID ?? 'us.anthropic.claude-opus-4-6-v1';
 const DASHBOARD_BASE_URL = process.env.DASHBOARD_BASE_URL ?? 'https://mergewatch.ai';
 
 const installationStore = new DynamoInstallationStore(dynamodb, INSTALLATIONS_TABLE);

--- a/packages/llm-bedrock/src/bedrock-provider.test.ts
+++ b/packages/llm-bedrock/src/bedrock-provider.test.ts
@@ -89,7 +89,7 @@ describe('BedrockLLMProvider', () => {
     }));
 
     const provider = new BedrockLLMProvider();
-    const result = await provider.invoke('us.anthropic.claude-3-5-sonnet-20241022-v2:0', 'prompt');
+    const result = await provider.invoke('us.anthropic.claude-opus-4-6-v1', 'prompt');
 
     expect(result.text).toBe('Review result');
     expect(result.usage).toEqual({ inputTokens: 100, outputTokens: 50 });
@@ -134,9 +134,9 @@ describe('BedrockLLMProvider', () => {
   });
 
   it('has correct SUPPORTED_MODELS mapping', () => {
+    expect(SUPPORTED_MODELS['claude-opus-4.6']).toBe('us.anthropic.claude-opus-4-6-v1');
     expect(SUPPORTED_MODELS['claude-sonnet-4']).toBe('us.anthropic.claude-sonnet-4-20250514-v1:0');
     expect(SUPPORTED_MODELS['claude-haiku-4.5']).toBe('us.anthropic.claude-haiku-4-5-20251001-v1:0');
-    expect(SUPPORTED_MODELS['claude-3.5-sonnet']).toBe('us.anthropic.claude-3-5-sonnet-20241022-v2:0');
     expect(SUPPORTED_MODELS['amazon-titan-text']).toBe('amazon.titan-text-express-v1');
   });
 

--- a/packages/llm-bedrock/src/bedrock-provider.ts
+++ b/packages/llm-bedrock/src/bedrock-provider.ts
@@ -20,9 +20,9 @@ import type { ILLMProvider, LLMInvokeResult, LLMSamplingConfig, TokenUsage } fro
 
 // ─── Supported model IDs ───────────────────────────────────────────────────
 export const SUPPORTED_MODELS = {
+  'claude-opus-4.6': 'us.anthropic.claude-opus-4-6-v1',
   'claude-sonnet-4': 'us.anthropic.claude-sonnet-4-20250514-v1:0',
   'claude-haiku-4.5': 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
-  'claude-3.5-sonnet': 'us.anthropic.claude-3-5-sonnet-20241022-v2:0',
   'amazon-titan-text': 'amazon.titan-text-express-v1',
 } as const;
 


### PR DESCRIPTION
Closes #197. Migrates the default review model off the **retiring** Bedrock Sonnet 4 snapshot to **Opus 4.6**.

## Why now
The current default `us.anthropic.claude-sonnet-4-20250514-v1:0` is a `20250514` snapshot on the Bedrock retirement clock (**EOL 2026-06-15, already passed**). This is a forced migration.

## Why Opus 4.6 (not 4.8 yet)
Opus 4.8's Bedrock entitlement is stuck in-account (control plane `AVAILABLE`, but `Converse` returns `AccessDenied` — a Marketplace provisioning issue). **Opus 4.6 is enabled and invocable now**, **same price as 4.8 ($5 in / $25 out per 1M, 1M context)**, and per the gate-3 audit it's a **clean drop-in**: I verified live that the provider's exact native `InvokeModel` body **with `temperature: 0` is accepted (HTTP 200)** by Opus 4.6. (4.7/4.8 remove sampling params and would 400 — see fast-follow.)

## Changes
- **`SUPPORTED_MODELS`**: add `claude-opus-4.6` → `us.anthropic.claude-opus-4-6-v1`; drop the retired `claude-3.5-sonnet` alias.
- **`pricing.ts`**: add Opus 4.6 = **$5/$25** (Bedrock + direct IDs); drop the retired `claude-3-5-sonnet-20241022` rows.
- **Default flipped across all sync points**: `defaults.ts`, `infra/template.yaml` (`DefaultBedrockModelId`), `deploy.yml` dev override, lambda `DEFAULT_BEDROCK_MODEL_ID` fallback, and `.mergewatch.yml`. **`lightModel` stays Haiku 4.5** (already current).
- **Tests**: `SUPPORTED_MODELS` mapping, Opus 4.6 pricing ($5/$25), and the retired 3.5-sonnet now returns `null` (unpriced).

## Verification
Full `pnpm build` + `pnpm typecheck` (20/20) + `pnpm test` (20/20 suites) green. The provider request shape is unchanged (Opus 4.6 accepts `temperature`), so no pipeline behavior change beyond the model swap.

## Acceptance criteria (#197)
- [x] Bedrock model access for the chosen Opus ID confirmed enabled (Opus 4.6, verified live)
- [x] Opus alias added to `SUPPORTED_MODELS` (+ provider test updated)
- [x] Default updated consistently across `defaults.ts`, `infra/template.yaml`, lambda fallback, and the deploy workflow
- [x] `lightModel` decision applied (kept Haiku 4.5)
- [x] Pricing row exists for the chosen Opus ID
- [x] Per-repo `.mergewatch.yml` updated; per-repo + dashboard override still let users pick another model (regression-safe — SUPPORTED_MODELS/pricing unchanged for those paths)
- [ ] *Deferred:* end-to-end test review on Opus runs after deploy (validate post-merge in dev)

## Opus 4.8 fast-follow
Once 4.8's entitlement clears: bump `…opus-4-6-v1` → `…opus-4-8` **and** add a `modelRejectsSamplingParams()` gate in `buildAnthropicBody` (4.7/4.8 reject `temperature`/`top_p`/`top_k` with 400). ~15 lines + test updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)