### PR TITLE
ci: deploy prod on merge to main, gated by approval

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,8 @@
 # =============================================================================
 #
 # Pipeline:
-#   push to main → build & test → deploy to dev → (optional) deploy to prod
+#   push to main → build & test → deploy to dev → deploy to prod (manual approval gate)
+#   (prod also deployable on-demand via workflow_dispatch with deploy_prod=true)
 #
 # Required GitHub Secrets:
 #   AWS_ROLE_ARN           — IAM role ARN for OIDC (e.g. arn:aws:iam::123456789012:role/mergewatch-github-deploy)
@@ -166,14 +167,16 @@ jobs:
   # =========================================================================
   # Stage 3: Deploy to Production (requires manual approval)
   # =========================================================================
-  # This job uses the "production" GitHub environment which should have
-  # "Required reviewers" enabled in Settings > Environments > production.
-  # The pipeline pauses here until an authorized reviewer approves.
+  # Runs after a successful dev deploy on every push to main, AND on a manual
+  # workflow_dispatch with deploy_prod=true. Either way it pauses at the
+  # "production" GitHub environment, which has "Required reviewers" enabled
+  # (Settings > Environments > production) — nothing reaches prod until an
+  # authorized reviewer approves.
   deploy-prod:
     name: Deploy to Production
     runs-on: ubuntu-latest
     needs: deploy-dev
-    if: github.event.inputs.deploy_prod == 'true'
+    if: github.event_name == 'push' || github.event.inputs.deploy_prod == 'true'
     environment: production
 
     steps:


### PR DESCRIPTION
## What
Make the prod deploy run automatically after a successful dev deploy on **every push to `main`**, instead of only via manual `workflow_dispatch`.

```diff
  deploy-prod:
    needs: deploy-dev
-   if: github.event.inputs.deploy_prod == 'true'
+   if: github.event_name == 'push' || github.event.inputs.deploy_prod == 'true'
    environment: production
```

## Why
Previously, merging to `main` deployed **dev** and **skipped prod entirely** — so prod silently fell behind `main` until someone remembered to run a manual prod dispatch (which is exactly how the cost/engagement/cycle-time backend ended up un-deployed in prod). Now every merge queues a prod deploy.

## Safety
This is **not** an unguarded prod deploy. The `production` GitHub environment has a **Required-reviewers** rule (`santthosh`), verified via the API:
```
production: protection_rules = [{ type: required_reviewers, reviewers: [santthosh] }]
```
So on each merge the pipeline is: build → dev (auto) → **prod *pending your approval*** — nothing reaches prod until you approve at the gate. On-demand `workflow_dispatch` with `deploy_prod=true` still works unchanged.

Workflow-only change; `python yaml.safe_load` parses clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)