### PR TITLE
fix(docker): publish images to ghcr.io/mergewatch namespace

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,9 +36,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - image: ghcr.io/santthosh/mergewatch
+          - image: ghcr.io/mergewatch/mergewatch
             dockerfile: Dockerfile
-          - image: ghcr.io/santthosh/mergewatch-dashboard
+          - image: ghcr.io/mergewatch/mergewatch-dashboard
             dockerfile: Dockerfile.dashboard
 
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ ARG VERSION
 LABEL org.opencontainers.image.title="MergeWatch"
 LABEL org.opencontainers.image.description="AI-powered GitHub PR review server"
 LABEL org.opencontainers.image.version="${VERSION}"
-LABEL org.opencontainers.image.source="https://github.com/santthosh/mergewatch.ai"
+LABEL org.opencontainers.image.source="https://github.com/mergewatch/mergewatch.ai"
 LABEL org.opencontainers.image.licenses="AGPL-3.0"
 
 RUN npm install -g pnpm@10.23.0

--- a/Dockerfile.dashboard
+++ b/Dockerfile.dashboard
@@ -34,7 +34,7 @@ ARG VERSION
 LABEL org.opencontainers.image.title="MergeWatch Dashboard"
 LABEL org.opencontainers.image.description="Next.js dashboard for MergeWatch"
 LABEL org.opencontainers.image.version="${VERSION}"
-LABEL org.opencontainers.image.source="https://github.com/santthosh/mergewatch.ai"
+LABEL org.opencontainers.image.source="https://github.com/mergewatch/mergewatch.ai"
 LABEL org.opencontainers.image.licenses="AGPL-3.0"
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Dashboard at **http://localhost:3001**. Sign in with GitHub and install the app 
 
 | Service | Port | Image |
 |---------|------|-------|
-| **mergewatch** (server) | 3000 | `ghcr.io/santthosh/mergewatch:0.1.0` |
-| **dashboard** (Next.js) | 3001 | `ghcr.io/santthosh/mergewatch-dashboard:0.1.0` |
+| **mergewatch** (server) | 3000 | `ghcr.io/mergewatch/mergewatch:0.1.0` |
+| **dashboard** (Next.js) | 3001 | `ghcr.io/mergewatch/mergewatch-dashboard:0.1.0` |
 | **db** (PostgreSQL 16) | 5432 | `postgres:16-alpine` |
 
 Pre-built images are published to GHCR on pushes to `main` that change relevant source files, and on every GitHub Release. Upgrade with `docker compose pull && docker compose up -d`.
@@ -265,7 +265,7 @@ gh release create v0.2.0 --generate-notes
 
 ### Docker image tags
 
-Images are published to `ghcr.io/santthosh/mergewatch` and `ghcr.io/santthosh/mergewatch-dashboard`:
+Images are published to `ghcr.io/mergewatch/mergewatch` and `ghcr.io/mergewatch/mergewatch-dashboard`:
 
 | Tag | When |
 |-----|------|

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   mergewatch:
-    image: ghcr.io/santthosh/mergewatch:0.1.0
+    image: ghcr.io/mergewatch/mergewatch:0.1.0
     build: .
     restart: unless-stopped
     environment:
@@ -35,7 +35,7 @@ services:
       start_period: 30s
 
   dashboard:
-    image: ghcr.io/santthosh/mergewatch-dashboard:0.1.0
+    image: ghcr.io/mergewatch/mergewatch-dashboard:0.1.0
     build:
       context: .
       dockerfile: Dockerfile.dashboard

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -571,7 +571,7 @@ Self-hosted MergeWatch runs on any platform that can run a Docker container.
 
 | Platform | How |
 |----------|-----|
-| **Google Cloud Run** | `gcloud run deploy --image ghcr.io/santthosh/mergewatch` (scales to zero) |
+| **Google Cloud Run** | `gcloud run deploy --image ghcr.io/mergewatch/mergewatch` (scales to zero) |
 | **GCP GKE / Compute Engine** | Docker or Kubernetes |
 | **Azure Container Apps / AKS** | Managed containers or Kubernetes |
 | **AWS ECS / Fargate / EC2** | Docker on AWS |

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -107,8 +107,8 @@ fi
 COMPOSE_FILE="$REPO_ROOT/docker-compose.yml"
 if [ -f "$COMPOSE_FILE" ]; then
   sed \
-    -e "s|ghcr.io/santthosh/mergewatch:[^ ]*|ghcr.io/santthosh/mergewatch:${VERSION}|" \
-    -e "s|ghcr.io/santthosh/mergewatch-dashboard:[^ ]*|ghcr.io/santthosh/mergewatch-dashboard:${VERSION}|" \
+    -e "s|ghcr.io/mergewatch/mergewatch:[^ ]*|ghcr.io/mergewatch/mergewatch:${VERSION}|" \
+    -e "s|ghcr.io/mergewatch/mergewatch-dashboard:[^ ]*|ghcr.io/mergewatch/mergewatch-dashboard:${VERSION}|" \
     "$COMPOSE_FILE" > "$COMPOSE_FILE.tmp" \
     && mv "$COMPOSE_FILE.tmp" "$COMPOSE_FILE"
   echo "  Updated docker-compose.yml image tags"
@@ -178,7 +178,7 @@ echo "  2. Create the GitHub Release:"
 echo "     gh release create ${TAG} --generate-notes"
 echo ""
 echo "  3. This will trigger:"
-echo "     - Docker images: ghcr.io/santthosh/mergewatch:${VERSION}"
-echo "     - Docker images: ghcr.io/santthosh/mergewatch-dashboard:${VERSION}"
+echo "     - Docker images: ghcr.io/mergewatch/mergewatch:${VERSION}"
+echo "     - Docker images: ghcr.io/mergewatch/mergewatch-dashboard:${VERSION}"
 echo "     - SAM deploy to dev (auto), prod (manual approval)"
 echo ""


### PR DESCRIPTION
## Problem
The **Publish Docker Images** workflow has failed on every push to `main` (#209–#214). Build succeeds; the **push fails**:
```
failed to push ghcr.io/santthosh/mergewatch:latest: denied:
permission_denied: The requested installation does not exist.
```

## Root cause
Same repo-transfer fallout as the deploy/OIDC and Amplify fixes: the repo moved **`santthosh` → `mergewatch` org**, but the workflow still pushed to `ghcr.io/santthosh/*`. The job's `GITHUB_TOKEN` is scoped to the **mergewatch** org and has no write access to the `santthosh` package namespace → denied.

## Fix
Repoint the published image namespace to **`ghcr.io/mergewatch/*`** and keep all directly-related references consistent:
- `.github/workflows/docker-publish.yml` — matrix images → `ghcr.io/mergewatch/mergewatch` + `…-dashboard` *(the actual fix)*
- `docker-compose.yml` — image tags
- `Dockerfile` / `Dockerfile.dashboard` — `org.opencontainers.image.source` label → mergewatch repo
- `README.md` docker section + `docs/architecture.md` Cloud Run example
- `scripts/release.sh` — it rewrites compose image tags on release (would otherwise revert this)

`git grep ghcr.io/santthosh` is now empty; `yaml.safe_load` parses the workflow clean.

## Out of scope (follow-up)
README badges / clone URLs still point at `github.com/santthosh/...` (work via redirect). That's a broader repo-URL cleanup, separate from this Docker-publish fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)