### PR TITLE
feat(insights): hourly rollup (SaaS + self-hosted, configurable)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,3 +50,4 @@ ANTHROPIC_API_KEY=
 # LLM_MODEL=                     # Override default model ID for your provider
 # GITHUB_APP_SLUG=               # GitHub App slug (for install link in dashboard)
 # PORT=3000                      # Server port (default: 3000)
+# INSIGHTS_ROLLUP_INTERVAL_MINUTES=60   # Dashboard insight rollup cadence (default: 60 = hourly; raise to reduce DB load)

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -105,7 +105,7 @@ Globals:
         FP_INSIGHTS_TABLE: !Ref FpInsightsTable
         # TTM (#194): one row per PR. WebhookHandler writes lifecycle transitions
         # (opened/synchronize/closed); ReviewAgent marks reviewed/skipped; the
-        # nightly InsightsRollup reads for cycle-time percentiles.
+        # hourly InsightsRollup reads for cycle-time percentiles.
         PR_LIFECYCLE_TABLE: !Ref PRLifecycleTable
         # #195 Tier 2: helpful votes (ReviewAgent writes 👍/👎 deltas) + NPS
         # responses (dashboard writes). InsightsRollup reads both for the
@@ -387,19 +387,21 @@ Resources:
   # ===========================================================================
   # Lambda: Insights Rollup (FB-E)
   # ===========================================================================
-  # Scheduled nightly to aggregate FindingDispositionRecord rows into
+  # Scheduled hourly to aggregate FindingDispositionRecord rows into
   # InstallationFPInsight rollups (7d / 30d / 90d windows per installation).
-  # Powers the dashboard FB-F..FB-J charts.
+  # Powers the dashboard analytics + accuracy charts.
   #
-  # Cron: 03:00 UTC daily (`cron(0 3 * * ? *)`). Chosen for low traffic
-  # collision with EU/US business hours. Idempotent — re-running the same
-  # window-end overwrites with identical numbers.
+  # Cron: top of every hour (`cron(0 * * * ? *)`). Hourly keeps the
+  # dashboard's cost / cycle-time / engagement blocks within ~1h of fresh,
+  # rather than up to 24h stale. Idempotent — re-running the same
+  # window-end overwrites with identical numbers, so the higher cadence is
+  # safe. (At scale, revisit incremental/active-only rollup — see #218.)
 
   InsightsRollupFunction:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: !Sub 'mergewatch-insights-rollup-${Stage}'
-      Description: Nightly FP insight rollup (FB-E) — aggregates disposition records into per-installation rolling-window insights
+      Description: Hourly FP insight rollup (FB-E) — aggregates disposition records into per-installation rolling-window insights
 
       CodeUri: ../packages/lambda/src/
       Handler: handlers/insights-rollup.handler
@@ -417,13 +419,13 @@ Resources:
       # No Environment block — inherits STAGE / INSTALLATIONS_TABLE /
       # FINDING_DISPOSITIONS_TABLE / FP_INSIGHTS_TABLE from Globals.
 
-      # EventBridge schedule trigger — 03:00 UTC daily.
+      # EventBridge schedule trigger — top of every hour.
       Events:
-        NightlyRollup:
+        HourlyRollup:
           Type: Schedule
           Properties:
-            Schedule: cron(0 3 * * ? *)
-            Description: Nightly insight rollup at 03:00 UTC
+            Schedule: cron(0 * * * ? *)
+            Description: Hourly insight rollup (top of every hour, UTC)
 
     Metadata:
       BuildMethod: esbuild
@@ -666,7 +668,7 @@ Resources:
   # DynamoDB: FindingDispositions (FB-A)
   # ===========================================================================
   # Per-finding cross-PR identity records — one row per distinct
-  # findingMatchKey per repo per installation. Drives the FB-E nightly
+  # findingMatchKey per repo per installation. Drives the FB-E hourly
   # rollup and (via the rollup) every dashboard insight chart.
   #
   # Schema:
@@ -681,7 +683,7 @@ Resources:
   #   - sigTokens              (List<String>) — W10 cluster bag
   #   - rejectReasons          (List<Map>)    — FB-D append-only log
   #
-  # Reads are bounded (FB-E nightly, listByInstallation with Scan + filter);
+  # Reads are bounded (FB-E hourly, listByInstallation with Scan + filter);
   # writes are hot-path (every surfacing/dispute/verification). PAY_PER_REQUEST
   # keeps it cheap.
 
@@ -719,14 +721,14 @@ Resources:
   # DynamoDB: InstallationFPInsights (FB-E)
   # ===========================================================================
   # Per-installation rolling-window FP insight rollups. Three rows per
-  # installation (7d / 30d / 90d), replaced idempotently by the nightly
+  # installation (7d / 30d / 90d), replaced idempotently by the hourly
   # InsightsRollupFunction. Reads power the dashboard FB-F..FB-J charts.
   #
   # Schema:
   #   PK: installationId (String)
   #   SK: window         (String — '7d' | '30d' | '90d')
   #
-  # Attributes (set on every nightly run):
+  # Attributes (set on every hourly run):
   #   - windowStart / windowEnd / generatedAt (String, ISO 8601)
   #   - totalFindingsSurfaced / totalDisputes / totalSilentDrops /
   #     totalAgreements (Number)
@@ -769,7 +771,7 @@ Resources:
   # DynamoDB: PRLifecycle (TTM / #194)
   # ===========================================================================
   # One row per pull request MergeWatch saw — independent of the per-commit
-  # Reviews table. Drives the nightly cycle-time rollup (time-to-merge,
+  # Reviews table. Drives the hourly cycle-time rollup (time-to-merge,
   # time-from-first-review-to-merge, round-trips).
   #
   # Schema:
@@ -822,7 +824,7 @@ Resources:
   # #195 Tier 2 — explicit-satisfaction signals. Partitioned by installation;
   # SK distinguishes helpful-vote rows (HV#repo#pr) from NPS rows (NPS#userId).
   # ReviewAgent writes helpful-vote deltas; the dashboard writes NPS responses;
-  # the nightly InsightsRollup reads both for the engagement block.
+  # the hourly InsightsRollup reads both for the engagement block.
   SatisfactionTable:
     Type: AWS::DynamoDB::Table
     Properties:
@@ -855,7 +857,7 @@ Resources:
 
   # #193 — per-review LLM cost rows. Partitioned by installation (PK), SK
   # `repo#pr#commit`; ReviewAgent writes one row per completed review and the
-  # nightly InsightsRollup reads them for the engagement insight's cost block.
+  # hourly InsightsRollup reads them for the engagement insight's cost block.
   # TTL (~90d past completion) self-prunes rows past the longest window.
   ReviewCostsTable:
     Type: AWS::DynamoDB::Table

--- a/packages/server/src/insights-cron.test.ts
+++ b/packages/server/src/insights-cron.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// runInsightRollup is the only @mergewatch/core symbol insights-cron calls at
+// runtime; stub it so the scheduler tests don't touch real stores.
+vi.mock('@mergewatch/core', () => ({
+  runInsightRollup: vi.fn().mockResolvedValue({
+    installationsProcessed: 0,
+    rowsWritten: 0,
+    installationsFailed: [],
+    elapsedMs: 1,
+  }),
+}));
+
+import { resolveRollupIntervalMs, startInsightsCron } from './insights-cron.js';
+import { runInsightRollup } from '@mergewatch/core';
+
+const HOUR_MS = 60 * 60 * 1000;
+const STARTUP_DELAY_MS = 60 * 1000;
+
+describe('resolveRollupIntervalMs', () => {
+  it('defaults to hourly when unset', () => {
+    expect(resolveRollupIntervalMs(undefined)).toBe(HOUR_MS);
+  });
+
+  it('honors a valid positive interval (minutes → ms)', () => {
+    expect(resolveRollupIntervalMs('30')).toBe(30 * 60 * 1000);
+    expect(resolveRollupIntervalMs('120')).toBe(120 * 60 * 1000);
+    expect(resolveRollupIntervalMs('1')).toBe(60 * 1000);
+  });
+
+  it('falls back to hourly for non-numeric values', () => {
+    expect(resolveRollupIntervalMs('abc')).toBe(HOUR_MS);
+    expect(resolveRollupIntervalMs('')).toBe(HOUR_MS);
+  });
+
+  it('falls back to hourly for non-positive values', () => {
+    expect(resolveRollupIntervalMs('0')).toBe(HOUR_MS);
+    expect(resolveRollupIntervalMs('-15')).toBe(HOUR_MS);
+  });
+
+  it('reads from process.env.INSIGHTS_ROLLUP_INTERVAL_MINUTES by default', () => {
+    const prev = process.env.INSIGHTS_ROLLUP_INTERVAL_MINUTES;
+    process.env.INSIGHTS_ROLLUP_INTERVAL_MINUTES = '5';
+    try {
+      expect(resolveRollupIntervalMs()).toBe(5 * 60 * 1000);
+    } finally {
+      if (prev === undefined) delete process.env.INSIGHTS_ROLLUP_INTERVAL_MINUTES;
+      else process.env.INSIGHTS_ROLLUP_INTERVAL_MINUTES = prev;
+    }
+  });
+});
+
+describe('startInsightsCron', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete process.env.INSIGHTS_ROLLUP_INTERVAL_MINUTES;
+  });
+
+  it('runs once after the startup delay, then on each configured interval, and stops cleanly', async () => {
+    process.env.INSIGHTS_ROLLUP_INTERVAL_MINUTES = '30';
+    const handle = startInsightsCron({} as never);
+
+    // Nothing fires before the startup delay elapses.
+    expect(runInsightRollup).toHaveBeenCalledTimes(0);
+
+    await vi.advanceTimersByTimeAsync(STARTUP_DELAY_MS);
+    expect(runInsightRollup).toHaveBeenCalledTimes(1);
+
+    // Then once per configured interval (30 min).
+    await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
+    expect(runInsightRollup).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
+    expect(runInsightRollup).toHaveBeenCalledTimes(3);
+
+    // After stop(), no further runs.
+    handle.stop();
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+    expect(runInsightRollup).toHaveBeenCalledTimes(3);
+  });
+
+  it('defaults to an hourly interval when the env var is unset', async () => {
+    const handle = startInsightsCron({} as never);
+
+    await vi.advanceTimersByTimeAsync(STARTUP_DELAY_MS);
+    expect(runInsightRollup).toHaveBeenCalledTimes(1);
+
+    // No fire before a full hour has passed...
+    await vi.advanceTimersByTimeAsync(59 * 60 * 1000);
+    expect(runInsightRollup).toHaveBeenCalledTimes(1);
+    // ...and exactly one more at the hour mark.
+    await vi.advanceTimersByTimeAsync(1 * 60 * 1000);
+    expect(runInsightRollup).toHaveBeenCalledTimes(2);
+
+    handle.stop();
+  });
+});

--- a/packages/server/src/insights-cron.ts
+++ b/packages/server/src/insights-cron.ts
@@ -2,11 +2,16 @@
  * FB-E — self-hosted insight rollup scheduler.
  *
  * Lightweight `setInterval`-based runner rather than a real cron library:
- * the job is once-a-day, idempotent, and we don't need precise wall-clock
- * timing. The first run fires `STARTUP_DELAY_MS` after server startup (to
- * avoid colliding with DB-migration work); subsequent runs at 24h
- * intervals from there. Operators who want precise 03:00 UTC scheduling
- * can run the server as a Docker job triggered by an external cron.
+ * the job is idempotent and we don't need precise wall-clock timing. The
+ * first run fires `STARTUP_DELAY_MS` after server startup (to avoid
+ * colliding with DB-migration work); subsequent runs at a fixed interval
+ * from there.
+ *
+ * Cadence defaults to hourly, matching the SaaS EventBridge schedule, so the
+ * dashboard's cost / cycle-time / engagement blocks stay within ~1h of fresh
+ * rather than up to 24h stale. Operators can tune it via
+ * INSIGHTS_ROLLUP_INTERVAL_MINUTES (raise it to reduce DB load, or run the
+ * server as a one-shot Docker job behind an external cron with a large value).
  */
 
 import { runInsightRollup } from '@mergewatch/core';
@@ -19,10 +24,25 @@ import type {
   IReviewCostStore,
 } from '@mergewatch/core';
 
-const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+/** Default rollup cadence when INSIGHTS_ROLLUP_INTERVAL_MINUTES is unset or
+ *  invalid. Hourly, matching the SaaS EventBridge schedule. */
+const DEFAULT_INTERVAL_MINUTES = 60;
 /** Wait 60s after startup before the first run so migrations / warm-up
  *  paths complete first. */
 const STARTUP_DELAY_MS = 60 * 1000;
+
+/**
+ * Resolve the rollup interval (ms) from INSIGHTS_ROLLUP_INTERVAL_MINUTES,
+ * falling back to the hourly default for unset / non-numeric / non-positive
+ * values. Exported for unit testing.
+ */
+export function resolveRollupIntervalMs(
+  raw = process.env.INSIGHTS_ROLLUP_INTERVAL_MINUTES,
+): number {
+  const minutes = Number(raw);
+  const safe = Number.isFinite(minutes) && minutes > 0 ? minutes : DEFAULT_INTERVAL_MINUTES;
+  return safe * 60 * 1000;
+}
 
 export interface InsightsCronStores {
   installationStore: IInstallationStore;
@@ -44,7 +64,8 @@ export interface InsightsCronHandle {
 /**
  * Start the self-hosted insights rollup scheduler. Returns a handle so
  * tests + graceful-shutdown paths can stop it. Runs the rollup once at
- * startup (delayed by STARTUP_DELAY_MS) and then every 24 hours.
+ * startup (delayed by STARTUP_DELAY_MS) and then every
+ * INSIGHTS_ROLLUP_INTERVAL_MINUTES (default hourly).
  *
  * Errors inside the rollup are caught by `runInsightRollup` and surfaced
  * via the per-installation failure list — this scheduler also wraps the
@@ -55,10 +76,12 @@ export function startInsightsCron(stores: InsightsCronStores): InsightsCronHandl
   let stopped = false;
   let intervalHandle: ReturnType<typeof setInterval> | undefined;
 
+  const intervalMs = resolveRollupIntervalMs();
+
   const runOnce = async () => {
     if (stopped) return;
     try {
-      console.log('[fb-e cron] starting nightly insights rollup');
+      console.log('[fb-e cron] starting insights rollup (every %d min)', intervalMs / 60000);
       const result = await runInsightRollup(stores);
       console.log(
         '[fb-e cron] rollup complete — processed=%d, rows=%d, failed=[%s], elapsed=%dms',
@@ -76,7 +99,7 @@ export function startInsightsCron(stores: InsightsCronStores): InsightsCronHandl
   const firstRunTimer = setTimeout(() => {
     if (stopped) return;
     void runOnce();
-    intervalHandle = setInterval(() => void runOnce(), ONE_DAY_MS);
+    intervalHandle = setInterval(() => void runOnce(), intervalMs);
   }, STARTUP_DELAY_MS);
 
   return {


### PR DESCRIPTION
**Part of #218** — Phase 1 of 5 (the quick freshness win).

## Problem
The insight rollup ran **nightly**, so the dashboard's cost / cycle-time / engagement blocks were up to **24h stale** — exactly the lag we hit validating #193 today.

## Change — hourly in both runtimes
- **SaaS** (`infra/template.yaml`): `InsightsRollupFunction` EventBridge schedule `cron(0 3 * * ? *)` → **`cron(0 * * * ? *)`** (top of every hour). All "nightly / 03:00 UTC" comments + descriptions updated.
- **Self-hosted** (`packages/server/src/insights-cron.ts`): the hard-coded `ONE_DAY_MS` is now **configurable** via `INSIGHTS_ROLLUP_INTERVAL_MINUTES` (default **60** = hourly). Unset / non-numeric / non-positive values fall back to hourly. Startup delay preserved; log/doc strings updated.
- `.env.example` documents the new knob.

## Safety
The rollup is **idempotent** (re-running a window-end upserts identical numbers), so the higher cadence can't double-count. At scale, an incremental/active-only rollup is noted as a follow-up in #218 (hourly full-rollup is ~1.7s for 9 installations today).

## Tests
New `insights-cron.test.ts`:
- `resolveRollupIntervalMs` — default (hourly), valid minutes→ms, non-numeric/empty → hourly, non-positive → hourly, reads `process.env` by default.
- `startInsightsCron` (fake timers) — fires once after the startup delay, then once per configured interval, defaults to hourly when unset, and `stop()` halts further runs.

`pnpm build` + `typecheck` + full `test` green (server 91/91 incl. 7 new; 20/20 suites). SAM template parses (CFN-aware), schedule confirmed `cron(0 * * * ? *)`.

## Self-hosted parity
Both halves of the cadence change ship together — no SaaS-only behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)