### PR TITLE
feat(dashboard): move Impact (cost/cycle-time/engagement) to Analytics

### DIFF
--- a/packages/dashboard/components/AnalyticsClient.tsx
+++ b/packages/dashboard/components/AnalyticsClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useMemo, useRef } from "react";
 import { ChevronDown, Search, X } from "lucide-react";
+import ImpactPanel from "./insights/ImpactPanel";
 import {
   LineChart,
   Line,
@@ -820,6 +821,11 @@ export default function AnalyticsClient({ installationId }: AnalyticsClientProps
             </ResponsiveContainer>
           </ChartCard>
         )}
+      </div>
+
+      {/* Impact (value / ROI) — cost, cycle-time, engagement from the hourly rollup. */}
+      <div className="mt-8 border-t border-border-default pt-8">
+        <ImpactPanel installationId={installationId} />
       </div>
     </div>
   );

--- a/packages/dashboard/components/InsightsClient.tsx
+++ b/packages/dashboard/components/InsightsClient.tsx
@@ -38,9 +38,7 @@ import {
   BarChart, Bar, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend, Cell,
 } from "recharts";
 import { ChevronDown, ChevronUp, Copy, Check } from "lucide-react";
-import NpsPrompt from "./NpsPrompt";
 import type { CategoryBucket, ClusterRow, Insight } from "./insights/types";
-import { CostSection, CycleTimeSection, EngagementSection } from "./insights/ImpactSections";
 
 // ─── Types ────────────────────────────────────────────────────────────────
 
@@ -204,42 +202,21 @@ export default function InsightsClient({ installationId }: InsightsClientProps) 
     );
   }
 
-  // TTM (#194) — cycle-time can have data even when no findings were ever
-  // surfaced (a repo with merges but a clean review history), so it must NOT
-  // be gated behind `totalFindingsSurfaced`. We show the page when EITHER
-  // signal has data, and gate each section independently below.
-  const cyc = active?.cycleTime;
-  const hasCycleData = !!cyc && (cyc.mergedCount > 0 || cyc.closedUnmergedCount > 0 || cyc.openCount > 0);
+  // The cost / cycle-time / engagement ("Impact") blocks now live on the
+  // Analytics page; this surface is false-positive feedback only, so it's gated
+  // on `totalFindingsSurfaced`.
   const hasFpData = (active?.totalFindingsSurfaced ?? 0) > 0;
-  // #195 — engagement can carry signal (command usage, re-review) even with no
-  // findings surfaced, so it's gated independently like cycle-time.
-  const eng = active?.engagement;
-  const hasEngagementData = !!eng && (
-    eng.commandUsageCount > 0 ||
-    eng.reviewedPrCount > 0 ||
-    eng.acceptanceRate !== null ||
-    eng.findingActionRateApprox !== null ||
-    // Tier 2 — satisfaction can carry signal independently of Tier 1.
-    (eng.helpfulUp ?? 0) > 0 ||
-    (eng.helpfulDown ?? 0) > 0 ||
-    (eng.npsResponses ?? 0) > 0
-  );
-  // #193 — cost is gated independently: a window can have spend even with no
-  // findings (all-clear reviews still cost tokens).
-  const cost = active?.cost;
-  const hasCostData = !!cost && cost.reviewCount > 0;
 
-  if (insights.length === 0 || !active || (!hasFpData && !hasCycleData && !hasEngagementData && !hasCostData)) {
+  if (insights.length === 0 || !active || !hasFpData) {
     return (
       <div className="rounded-lg border border-border-default bg-surface-card p-6">
         <h2 className="text-base font-semibold text-text-primary">No insights yet</h2>
         <p className="mt-2 text-sm text-text-secondary">
           MergeWatch starts collecting per-finding feedback (👍 / 👎 reactions,
-          inline-thread resolves, <code>/mergewatch reject</code> commands) and
-          PR cycle-time from the moment the GitHub App is installed. The nightly
-          rollup aggregates that data. Once a few reviews have run — and PRs
-          start merging — you&apos;ll see cycle-time, funnel, and dispute-rate
-          charts here.
+          inline-thread resolves, <code>/mergewatch reject</code> commands) from
+          the moment the GitHub App is installed. The hourly rollup aggregates
+          that data. Once a few reviews have run, you&apos;ll see the false-positive
+          funnel and dispute-rate charts here.
         </p>
       </div>
     );
@@ -274,20 +251,6 @@ export default function InsightsClient({ installationId }: InsightsClientProps) 
           last rolled-up {new Date(active.generatedAt).toLocaleString()}
         </span>
       </div>
-
-      {/* ─── TTM (#194): Cycle time (time-to-merge) ──────────────────── */}
-      {hasCycleData && cyc && <CycleTimeSection cycleTime={cyc} window={activeWindow} />}
-
-      {/* ─── #195: Developer engagement ──────────────────────────────── */}
-      {hasEngagementData && eng && (
-        <EngagementSection engagement={eng} insights={insights} window={activeWindow} />
-      )}
-
-      {/* ─── #193: LLM cost ──────────────────────────────────────────── */}
-      {hasCostData && cost && <CostSection cost={cost} insights={insights} window={activeWindow} />}
-
-      {/* ─── #195 Phase 5: throttled NPS survey prompt ───────────────── */}
-      <NpsPrompt installationId={installationId} />
 
       {/* ─── FB-F..FB-J: FP-feedback sections (only when findings exist) ── */}
       {hasFpData && (

--- a/packages/dashboard/components/insights/ImpactPanel.tsx
+++ b/packages/dashboard/components/insights/ImpactPanel.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+/**
+ * Impact panel — the "is MergeWatch worth it?" value view, rendered on the
+ * Analytics page. Self-contained: fetches `/api/insights` (the hourly rollup),
+ * owns a 7d/30d/90d window selector, and renders the cycle-time, engagement,
+ * and LLM-cost sections for the active window.
+ *
+ * Backend-agnostic — reads through `/api/insights`, which resolves to the
+ * Dynamo (SaaS) or Postgres (self-hosted) dashboard store via DEPLOYMENT_MODE,
+ * so this works identically in both runtimes.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import type { Insight } from "./types";
+import { CostSection, CycleTimeSection, EngagementSection } from "./ImpactSections";
+import NpsPrompt from "../NpsPrompt";
+
+function pickWindow(insights: Insight[], window: "7d" | "30d" | "90d"): Insight | undefined {
+  return insights.find((i) => i.window === window);
+}
+
+export default function ImpactPanel({ installationId }: { installationId: string }) {
+  const [insights, setInsights] = useState<Insight[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [activeWindow, setActiveWindow] = useState<"7d" | "30d" | "90d">("30d");
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await fetch(`/api/insights?installation_id=${encodeURIComponent(installationId)}`);
+        if (!r.ok) {
+          // 503 = upstream-degraded; the API returns an `error` string we can
+          // surface verbatim for an actionable message.
+          let upstreamMessage: string | undefined;
+          try {
+            const body = (await r.json()) as { error?: string };
+            upstreamMessage = body.error;
+          } catch { /* not JSON; fall through to generic */ }
+          throw new Error(
+            r.status === 503 && upstreamMessage ? upstreamMessage : `HTTP ${r.status}`,
+          );
+        }
+        const data = (await r.json()) as { insights?: Insight[] };
+        if (!cancelled) setInsights(data.insights ?? []);
+      } catch (e) {
+        if (!cancelled) setError((e as Error).message);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [installationId]);
+
+  const active = useMemo(
+    () => (insights ? pickWindow(insights, activeWindow) : undefined),
+    [insights, activeWindow],
+  );
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-border-default bg-surface-card p-6">
+        <div className="text-sm text-text-error">Failed to load impact metrics: {error}</div>
+      </div>
+    );
+  }
+
+  if (!insights) {
+    return (
+      <div className="animate-pulse rounded-lg border border-border-default bg-surface-card p-6">
+        <div className="h-4 w-40 rounded bg-border-default" />
+        <div className="mt-4 h-48 rounded bg-border-default" />
+      </div>
+    );
+  }
+
+  // Each block is gated independently — a window can have spend or cycle-time
+  // with no findings (all-clear reviews still cost tokens / merge PRs).
+  const cyc = active?.cycleTime;
+  const hasCycleData = !!cyc && (cyc.mergedCount > 0 || cyc.closedUnmergedCount > 0 || cyc.openCount > 0);
+  const eng = active?.engagement;
+  const hasEngagementData = !!eng && (
+    eng.commandUsageCount > 0 ||
+    eng.reviewedPrCount > 0 ||
+    eng.acceptanceRate !== null ||
+    eng.findingActionRateApprox !== null ||
+    (eng.helpfulUp ?? 0) > 0 ||
+    (eng.helpfulDown ?? 0) > 0 ||
+    (eng.npsResponses ?? 0) > 0
+  );
+  const cost = active?.cost;
+  const hasCostData = !!cost && cost.reviewCount > 0;
+  const hasAnyImpact = hasCycleData || hasEngagementData || hasCostData;
+
+  return (
+    <section className="space-y-6">
+      <div>
+        <h2 className="text-base font-semibold text-text-primary">Impact</h2>
+        <p className="mt-0.5 text-xs text-text-secondary">
+          Is MergeWatch worth it? — cycle time, spend, and developer engagement. Updated hourly.
+        </p>
+      </div>
+
+      {/* Window selector — the rollup's three fixed windows. */}
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-text-secondary">Window:</span>
+        {(["7d", "30d", "90d"] as const).map((w) => (
+          <button
+            key={w}
+            onClick={() => setActiveWindow(w)}
+            className={`rounded-md border px-3 py-1 text-xs font-medium transition-colors ${
+              activeWindow === w
+                ? "border-accent-default bg-accent-subtle text-accent-default"
+                : "border-border-default bg-surface-card text-text-secondary hover:border-border-default-hover"
+            }`}
+          >
+            {w}
+          </button>
+        ))}
+        {active && (
+          <span className="ml-auto text-xs text-text-secondary">
+            last rolled-up {new Date(active.generatedAt).toLocaleString()}
+          </span>
+        )}
+      </div>
+
+      {!hasAnyImpact ? (
+        <div className="rounded-lg border border-border-default bg-surface-card p-6">
+          <p className="text-sm text-text-secondary">
+            No impact metrics for this window yet. Cycle time, spend, and engagement
+            appear once reviews run and PRs start merging — the hourly rollup
+            aggregates them.
+          </p>
+        </div>
+      ) : (
+        <>
+          {hasCycleData && cyc && <CycleTimeSection cycleTime={cyc} window={activeWindow} />}
+          {hasEngagementData && eng && (
+            <EngagementSection engagement={eng} insights={insights} window={activeWindow} />
+          )}
+          {hasCostData && cost && <CostSection cost={cost} insights={insights} window={activeWindow} />}
+          <NpsPrompt installationId={installationId} />
+        </>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
**Part of #218** — Phase 3 of 5. Option B (B1): the value/ROI metrics move to the leader-facing **Analytics** page; the false-positive surface keeps only FP content.

## What
- **New `insights/ImpactPanel.tsx`** — self-contained: fetches `/api/insights` (the hourly rollup), owns a 7d/30d/90d window selector, and renders the **Cost / Cycle-time / Engagement** sections + the NPS prompt, with loading / error / zero states. Header: *"Impact — Is MergeWatch worth it? … Updated hourly."*
- **`AnalyticsClient`** renders `<ImpactPanel>` below the Activity charts (reviews, findings, severity, categories) — Analytics is now **Activity + Impact**.
- **`InsightsClient`** (the FP surface) no longer renders those three sections or the NPS prompt; its page-show gate is now **FP-only** and the zero-state copy is trimmed to the false-positive funnel + dispute-rate.

## Self-hosted parity
`ImpactPanel` reads through `/api/insights`, which resolves to the Dynamo (SaaS) or Postgres (self-hosted) dashboard store via `DEPLOYMENT_MODE` — no backend-specific code. Same contract as before.

## Notes
- The three sections are the **same components** extracted in #220 — identical rendering, just hosted on Analytics now.
- Full rename of the FP page (FP Insights → **Accuracy**, route + jargon) is the next PR (Phase 4); this PR leaves the route/nav untouched to keep the diff focused on relocating Impact.

## Verification
`next build` exit 0 (type-validation incl.), `pnpm typecheck` 20/20, full `pnpm test` 20/20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)