### PR TITLE
fix(fb-d): reject acks via comment edit, not a reply (no extra Review) (#190)

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -166,7 +166,7 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-37](#e2e-37-fb-a--findingdispositionrecord-storage--writers) | FindingDispositionRecord rows are written on every surfacing, W3 dispute, FP-F inline-resolve (FB-A) | 2m | 60s | FB-A |
 | [E2E-38](#e2e-38-fb-b--quiet-drop-derived-counter) | Quiet-drop (finding gone without code change) increments `silentDropCount` on the matching record (FB-B) | 2m | 60s | FB-B |
 | [E2E-39](#e2e-39-fb-c--inline-comment--reactions--disputes) | 👎 / 🤔 on a bot inline comment increments `disputeCount`; 👍 / ❤️ / 🚀 increments `agreementCount` (FB-C) | 2m | 60s | FB-C |
-| [E2E-40](#e2e-40-fb-d--mergewatch-reject-slash-command) | `/mergewatch reject <category> [reason]` on an inline thread persists a categorised rejection + posts a confirming bot reply (FB-D) | 3m | 90s | FB-D |
+| [E2E-40](#e2e-40-fb-d--mergewatch-reject-slash-command) | `/mergewatch reject <category> [reason]` on an inline thread persists a categorised rejection + confirms by editing the finding comment (footer), creating NO extra bot Review event (FB-D, #190) | 3m | 90s | FB-D |
 | [E2E-41](#e2e-41-fb-e--hourly-installationfpinsight-rollup) | Hourly scheduled job produces InstallationFPInsight rollups for 7d / 30d / 90d windows per installation (FB-E) | 3m | 90s | FB-E |
 | [E2E-42](#e2e-42-fb-f--dashboard-fp-funnel-chart) | Org dashboard renders the FP funnel: unsignaled + agreed + silently-dropped + disputed segments per window (FB-F) | 2m | 60s | FB-F |
 | [E2E-43](#e2e-43-fb-g--dispute-rate-by-agent-bar-chart) | Org dashboard renders dispute-rate by agent category as a horizontal bar chart with severity colouring (FB-G) | 2m | 60s | FB-G |
@@ -1600,21 +1600,22 @@ Branch: `fixture/39-inline-reactions`. A PR with at least one inline-comment-eli
 
 **Status:** ✅ SHIPPED. See [`docs/false-positive-feedback-plan.md` → FB-D](./../docs/false-positive-feedback-plan.md#fb-d--mergewatch-reject-slash-command--shipped).
 
-**Behavior (intended, once FB-D ships):** new inline-thread intent parser alongside `detectResolveIntent`. Recognises `/mergewatch reject <category> [optional reason]` where category is one of: `already-handled`, `out-of-scope`, `wrong-target`, `style-disagreement`, `other`. Increments `disputeCount` AND appends `{ category, text?, at }` to `rejectReasons[]` on the `FindingDispositionRecord`. Bot posts a confirming reply (`Got it — recording as <category>. This pattern won't be re-raised on similar code unless conditions change.`). Thread is NOT auto-resolved (different from `/resolve` — rejection is for *finding-level FP signal*, resolution is for *thread-level closure*).
+**Behavior (intended, once FB-D ships):** new inline-thread intent parser alongside `detectResolveIntent`. Recognises `/mergewatch reject <category> [optional reason]` where category is one of: `already-handled`, `out-of-scope`, `wrong-target`, `style-disagreement`, `other`. Increments `disputeCount` AND appends `{ category, text?, at }` to `rejectReasons[]` on the `FindingDispositionRecord`. Bot confirms by **editing the finding comment in place** — appending a `> ✅ Marked rejected (<category>)` footer with a hidden `<!-- mergewatch-rejected -->` sentinel — **rather than posting a thread reply**. (A reply is auto-wrapped by GitHub into a standalone empty COMMENTED Review, which pollutes the PR's review timeline / W6 — #190; editing avoids it.) The sentinel makes the reject **idempotent**: a re-delivered webhook, or a repeat reject on an already-rejected finding, is a no-op. Thread is NOT auto-resolved (different from `/resolve` — rejection is for *finding-level FP signal*, resolution is for *thread-level closure*).
 
 **Setup**
 
 Branch: `fixture/40-mergewatch-reject`. PR with an inline finding:
 1. Reply `/mergewatch reject style-disagreement we use snake_case for python here` on the thread.
 2. Confirm the `FindingDispositionRecord` has `disputeCount = 1` and `rejectReasons[0] = { category: 'style-disagreement', text: 'we use snake_case for python here', at: <iso> }`.
-3. Confirm the bot posts a structured confirmation reply.
+3. Confirm the bot appends a `✅ Marked rejected` footer to the finding comment — and that **no new bot Review event** appears on the PR (only the user's own reply may be auto-wrapped by GitHub into a COMMENTED review).
 4. Confirm the thread is NOT auto-resolved on GitHub.
 
 **Expected outcomes**
 
 - [ ] Recognised categories: `already-handled`, `out-of-scope`, `wrong-target`, `style-disagreement`, `other`
-- [ ] Unrecognised category (`/mergewatch reject typo-here foo`) → silently coerced to `{ category: 'other', text: 'typo-here foo' }`; bot's confirming reply says "recording as `other`". No request for re-entry (preserve the signal).
-- [ ] Multiple `/mergewatch reject` replies on the same thread append to `rejectReasons[]` (don't overwrite)
+- [ ] Unrecognised category (`/mergewatch reject typo-here foo`) → silently coerced to `{ category: 'other', text: 'typo-here foo' }`; the appended footer says "Marked **rejected** (`other`)" and lists the recognised categories. No request for re-entry (preserve the signal).
+- [ ] The reject is **idempotent** — a re-delivered webhook, or a repeat `/mergewatch reject` on an already-rejected finding, is a no-op (the first rejection stands), guarded by the `<!-- mergewatch-rejected -->` sentinel. (Changed in #190: previously multiple replies appended to `rejectReasons[]`; the first rejection is now sticky.)
+- [ ] **No extra bot COMMENTED Review event** is created by the reject — preserves the W6 single-authoritative-Review invariant ([E2E-28](#e2e-28-w6-single-authoritative-review-comment--no-duplicate-verdict-body)).
 - [ ] Top-level `## mergewatch triage` continues to function (FB-D is an inline-thread addition, not a replacement)
 - [ ] The GitHub thread is NOT auto-resolved by `/reject` — `/resolve` and `/reject` are orthogonal verbs
 
@@ -1622,6 +1623,8 @@ Branch: `fixture/40-mergewatch-reject`. PR with an inline finding:
 - ❌ `/mergewatch reject` is matched in prose ("here's how I'd reject this differently") — pattern must be standalone-line or slash-command form
 - ❌ The thread is auto-resolved (signal collected; closure is human-driven)
 - ❌ Unrecognised category writes nothing (must coerce to `other` and preserve the original token in `text`)
+- ❌ The reject ack posts a thread reply that GitHub wraps into a standalone COMMENTED Review (the #190 regression — must edit the finding comment in place, not reply)
+- ❌ A re-delivered webhook double-records the rejection (sentinel must short-circuit the second run)
 
 ---
 

--- a/packages/core/src/agents/inline-reply.test.ts
+++ b/packages/core/src/agents/inline-reply.test.ts
@@ -389,6 +389,7 @@ describe('parseRejectIntent (FB-D)', () => {
 interface MockOctokitCalls {
   listReviewComments: ReturnType<typeof vi.fn>;
   createReplyForReviewComment: ReturnType<typeof vi.fn>;
+  updateReviewComment: ReturnType<typeof vi.fn>;
   createForPullRequestReviewComment: ReturnType<typeof vi.fn>;
   deleteForPullRequestComment: ReturnType<typeof vi.fn>;
   graphql: ReturnType<typeof vi.fn>;
@@ -406,6 +407,7 @@ function makeOctokitMock(comments: Array<{
   const calls: MockOctokitCalls = {
     listReviewComments: vi.fn(async () => ({ data: comments })),
     createReplyForReviewComment: vi.fn(async () => ({ data: { id: 99999 } })),
+    updateReviewComment: vi.fn(async () => ({ data: {} })),
     createForPullRequestReviewComment: vi.fn(async () => ({ data: { id: 777 } })),
     deleteForPullRequestComment: vi.fn(async () => ({})),
     graphql: vi.fn(async () => ({
@@ -422,6 +424,7 @@ function makeOctokitMock(comments: Array<{
     pulls: {
       listReviewComments: calls.listReviewComments,
       createReplyForReviewComment: calls.createReplyForReviewComment,
+      updateReviewComment: calls.updateReviewComment,
     },
     reactions: {
       createForPullRequestReviewComment: calls.createForPullRequestReviewComment,
@@ -720,10 +723,18 @@ describe('handleInlineReply', () => {
     ]);
     // Zero LLM cost on the fast path.
     expect(llm.calls).toHaveLength(0);
-    // Bot posts a confirming reply with the category name.
-    expect(calls.createReplyForReviewComment).toHaveBeenCalled();
-    const replyArg = (calls.createReplyForReviewComment as any).mock.calls[0][0];
-    expect(replyArg.body).toContain('already-handled');
+    // Bot confirms by EDITING the finding comment (append a footer), NOT a
+    // thread reply — a reply is auto-wrapped into a spurious COMMENTED Review
+    // (#190). The original body is preserved and the category + sentinel added.
+    expect(calls.createReplyForReviewComment).not.toHaveBeenCalled();
+    expect(calls.updateReviewComment).toHaveBeenCalledTimes(1);
+    const editArg = (calls.updateReviewComment as any).mock.calls[0][0];
+    expect(editArg.comment_id).toBe(100);
+    expect(editArg.body).toContain(inlineRoot.body);
+    expect(editArg.body).toContain('already-handled');
+    expect(editArg.body).toContain('Marked **rejected**');
+    expect(editArg.body).toContain('<!-- mergewatch-rejected -->');
+    expect(result.botCommentId).toBe(100);
     // Does NOT auto-resolve the thread (orthogonal verbs).
     expect(calls.graphql).not.toHaveBeenCalled();
   });
@@ -748,9 +759,34 @@ describe('handleInlineReply', () => {
     expect(result.action).toBe('rejected');
     expect(result.rejectCategory).toBe('other');
     expect(result.rejectText).toBe('typo-cat foo');
-    const replyArg = (calls.createReplyForReviewComment as any).mock.calls[0][0];
-    expect(replyArg.body).toContain('other');
-    expect(replyArg.body).toMatch(/known reject category/i);
+    expect(calls.createReplyForReviewComment).not.toHaveBeenCalled();
+    const editArg = (calls.updateReviewComment as any).mock.calls[0][0];
+    expect(editArg.body).toContain('other');
+    expect(editArg.body).toMatch(/known reject category/i);
+  });
+
+  it('FB-D — re-delivery on an already-rejected finding is an idempotent no-op', async () => {
+    const inlineRoot = {
+      id: 100,
+      body: "<!-- mergewatch-inline -->\n**🔴 Some title**\n\nDesc.\n\n<!-- mergewatch-rejected -->\n---\n> ✅ Marked **rejected** (`style-disagreement`) — won't re-raise.",
+      user: { login: 'mergewatch[bot]', type: 'Bot' as const },
+      created_at: '2026-04-01T00:00:00Z',
+      path: 'src/a.ts',
+    };
+    const { octokit, calls } = makeOctokitMock([
+      inlineRoot,
+      { id: 101, body: '/mergewatch reject style-disagreement', user: { login: 'santthosh', type: 'User' as const }, in_reply_to_id: 100, created_at: '2026-04-01T01:00:00Z' },
+    ]);
+    const llm = makeLLM('unused');
+    const result = await handleInlineReply(
+      { owner: 'o', repo: 'r', prNumber: 1, replyCommentId: 101 },
+      { octokit, llm, lightModelId: 'light' },
+    );
+    // Sentinel already present → skip without re-editing or re-recording.
+    expect(result.action).toBe('skipped');
+    expect(result.reason).toMatch(/already marked rejected/i);
+    expect(calls.updateReviewComment).not.toHaveBeenCalled();
+    expect(calls.createReplyForReviewComment).not.toHaveBeenCalled();
   });
 
   it('FB-D — resolve takes precedence when both `/resolve` and `/mergewatch reject` appear in the same reply', async () => {

--- a/packages/core/src/agents/inline-reply.ts
+++ b/packages/core/src/agents/inline-reply.ts
@@ -30,6 +30,7 @@ import {
   addReviewCommentReaction,
   removeReviewCommentReaction,
   replyToReviewComment,
+  editInlineReviewComment,
   fetchReviewCommentThread,
   resolveReviewThread,
   findReviewThreadIdForComment,
@@ -433,6 +434,14 @@ ${formatThreadTranscript(opts.thread)}`;
  * MergeWatch-authored thread. Returns a result describing what action was
  * taken so callers can track costs and log telemetry.
  */
+/**
+ * Hidden sentinel appended to a finding comment when it's rejected via
+ * `/mergewatch reject`. Lets us (a) confirm the rejection visually and
+ * (b) detect a prior rejection so a re-delivered webhook doesn't
+ * double-append the footer or double-record the disposition.
+ */
+const REJECT_FOOTER_SENTINEL = '<!-- mergewatch-rejected -->';
+
 export async function handleInlineReply(
   ctx: InlineReplyContext,
   deps: InlineReplyDeps,
@@ -504,20 +513,28 @@ export async function handleInlineReply(
     // signal; closure stays a human decision.
     const rejectIntent = parseRejectIntent(lastComment.body);
     if (rejectIntent) {
+      // Idempotency / dedup: we no longer post a bot reply (which used to move
+      // the thread tip and short-circuit re-runs), so a re-delivered webhook
+      // would re-enter this branch. The sentinel on the finding comment is the
+      // guard against double-appending the footer or double-recording the
+      // disposition.
+      if (root.body.includes(REJECT_FOOTER_SENTINEL)) {
+        return { action: 'skipped', reason: 'finding already marked rejected', inputTokens: 0, outputTokens: 0, estimatedCostUsd: 0 };
+      }
       const rejectedFindingKeys = deriveResolvedFindingKeys(root);
-      // Confirming reply: short, structured, mentions both the category
-      // we persisted AND (when coerced) the original token so the user
-      // can see what happened.
-      const confirmation = rejectIntent.coerced
-        ? `Got it — your reply didn't match a known reject category, so I'm recording this as \`other\`. Recognised categories: \`already-handled\`, \`out-of-scope\`, \`wrong-target\`, \`style-disagreement\`, \`other\`.`
-        : `Got it — recording as \`${rejectIntent.category}\`. This finding's pattern won't be re-raised on similar code unless conditions change.`;
-      const botCommentId = await replyToReviewComment(
-        deps.octokit, ctx.owner, ctx.repo, ctx.prNumber, root.id, confirmation,
-      );
+      // Confirm by EDITING the finding comment (append a footer) rather than
+      // posting a thread reply: a reply is auto-wrapped by GitHub into a
+      // standalone COMMENTED Review event (#190 — pollutes the PR's review
+      // timeline / W6). The footer names the persisted category AND, when
+      // coerced, explains the fallback so the user sees what happened.
+      const footer = rejectIntent.coerced
+        ? `\n\n${REJECT_FOOTER_SENTINEL}\n---\n> ✅ Marked **rejected** (\`other\`) — your reply didn't match a known reject category. Recognised: \`already-handled\`, \`out-of-scope\`, \`wrong-target\`, \`style-disagreement\`, \`other\`. Won't re-raise on similar code unless conditions change.`
+        : `\n\n${REJECT_FOOTER_SENTINEL}\n---\n> ✅ Marked **rejected** (\`${rejectIntent.category}\`) — won't re-raise on similar code unless conditions change.`;
+      await editInlineReviewComment(deps.octokit, ctx.owner, ctx.repo, root.id, `${root.body}${footer}`);
       return {
         action: 'rejected',
         reason: 'explicit /mergewatch reject',
-        botCommentId,
+        botCommentId: root.id,
         rejectedFindingKeys: rejectedFindingKeys.length > 0 ? rejectedFindingKeys : undefined,
         rejectCategory: rejectIntent.category,
         rejectText: rejectIntent.text,

--- a/packages/core/src/github/client.ts
+++ b/packages/core/src/github/client.ts
@@ -689,6 +689,32 @@ export async function replyToReviewComment(
 }
 
 /**
+ * Edit an existing inline (review) comment in place — used to append a status
+ * footer to a finding comment.
+ *
+ * Unlike {@link replyToReviewComment}, this does NOT create a new pull request
+ * Review: a thread reply is auto-wrapped by GitHub into a standalone COMMENTED
+ * Review event, which pollutes the PR's review timeline (the W6 single-review
+ * concern in #190). Editing the comment keeps the timeline clean. The caller
+ * passes the FULL new body (the inline comment already carries its own marker,
+ * so we do not prepend one here).
+ */
+export async function editInlineReviewComment(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  commentId: number,
+  body: string,
+): Promise<void> {
+  await octokit.pulls.updateReviewComment({
+    owner,
+    repo,
+    comment_id: commentId,
+    body,
+  });
+}
+
+/**
  * Add an "eyes" reaction to an inline review comment to signal MergeWatch is
  * processing the reply. Returns the reaction ID so callers can remove it
  * after the reply is posted.


### PR DESCRIPTION
**Closes #190.**

## Root cause (verified, not the filed hypothesis)
The issue guessed the handler "fires twice." It doesn't. I pulled the actual reviews on the fixture PR (`santthosh/mergewatch-fixtures#119`):

```
03:56:06  CHANGES_REQUESTED  by mergewatch[bot]   (the real verdict)
04:20:15  COMMENTED (empty)  by santthosh-mb      ← GitHub auto-wrapping the USER's /mergewatch reject reply
04:20:19  COMMENTED (empty)  by mergewatch[bot]   ← GitHub auto-wrapping the BOT's "Got it…" ack reply
```

The bot's COMMENTED review wraps exactly its ack reply (confirmed via the review's `comments` → `in_reply_to`). So the bot emits **one** extra review — its ack reply — which GitHub auto-wraps. (The user's reply wrapper is unavoidable.) FP-F's `/resolve` avoids this only because it posts **no** bot reply.

## Fix
FB-D's reject now **confirms by editing the finding comment in place** (appends a `> ✅ Marked rejected (<category>)` footer) instead of posting a thread reply — so GitHub creates no standalone bot Review. New helper `editInlineReviewComment` (`pulls.updateReviewComment`). Editing is re-trigger-safe: the webhook guard only handles `action === 'created'`, skips bots, and requires `in_reply_to_id` (the root finding comment has none).

## Idempotency (important subtlety)
Removing the bot reply also removed the old **tip-based re-delivery dedup** (the bot reply used to move the thread tip, so re-runs hit "reply not at tip"). A hidden `<!-- mergewatch-rejected -->` sentinel replaces it: a re-delivered webhook — or a repeat reject on an already-rejected finding — short-circuits to `action: 'skipped'` **before** re-editing or re-recording. Both runtime wrappers already gate disposition recording on `action === 'rejected'`, so no double-write.

**Behavior change (documented):** the first rejection is now **sticky** — previously multiple `/mergewatch reject` replies appended to `rejectReasons[]`. Re-rejecting a finding that's already suppressed is an edge case; "rejected once, stays rejected" is the cleaner semantic. Flagged in RUNBOOK E2E-40.

## Scope
The LLM **conversational** reply path is unchanged — those are genuine dialogue turns where a review-comment thread is appropriate; #190 is specifically the slash-command ack.

## Tests / docs
- `inline-reply.test.ts`: FB-D tests now assert the edit (not a reply) + body/sentinel/category preserved; **new idempotency test** (sentinel present → `skipped`, no re-edit/re-record).
- RUNBOOK **E2E-40** rewritten (edit mechanism, no-extra-Review, idempotency) + **E2E-28/W6** cross-reference + failure modes.
- `pnpm build` + `typecheck` (20/20) + full `test` (20/20, core 763) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)