### PR TITLE
fix(fp-f): embed code fingerprint in inline comments so /resolve survives title reword (#182)

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -1442,9 +1442,9 @@ export function parseChunks(raw: unknown[]): unknown[] {
 
 **Status:** ✅ SHIPPED. See [`docs/false-positive-reduction-plan.md` → FP-F](./../docs/false-positive-reduction-plan.md#fp-f--inline-reply-resolve-memory--disputedkeys--shipped).
 
-**Behavior:** when a human posts an inline-thread reply matching `detectResolveIntent` (*"resolved"* / *"please resolve"* / *"mergewatch resolve"* / *"/resolve"*), `handleInlineReply` recovers the finding's stable identity keys from the thread root (file `path` from the GitHub review-comment object + title parsed via `extractInlineCommentTitle` → `findingMatchKeys`) and returns them in the result. The server / lambda handlers append the keys to the latest review record's new `inlineResolvedKeys` field (dedup, cap 500). The next full review unions `prevComplete.inlineResolvedKeys` with the live-computed W3 `disputedKeys` and feeds the union into both FP-B's previousFindings pre-filter and the downstream W3 `partitionDisputed` suppression. Same identity scheme (W9 union-matching) as W3 itself.
+**Behavior:** when a human posts an inline-thread reply matching `detectResolveIntent` (*"resolved"* / *"please resolve"* / *"mergewatch resolve"* / *"/resolve"*), `handleInlineReply` recovers the finding's stable identity keys from the thread root: the file `path`, the title (`extractInlineCommentTitle`), AND — **#182** — the W9 **code fingerprint** that the review pipeline embeds in every inline comment as a hidden base64 `<!-- mw-fp:… -->` marker (`extractInlineCommentFingerprint`). Because the fingerprint key (`file::F::<code>`) is recovered **directly** from the comment, suppression survives the LLM rewording the finding's title between review rounds — it no longer depends on the title key matching the prior-review findings lookup. (Pre-#182 comments have no marker → title-key only, and the `enrichResolvedFindingKeys` fallback still recovers the fingerprint from `latestReview.findings`.) The server / lambda handlers append the keys to the latest review record's `inlineResolvedKeys` field (dedup, cap 500). The next full review unions `prevComplete.inlineResolvedKeys` with the live-computed W3 `disputedKeys` and feeds the union into both FP-B's previousFindings pre-filter and the downstream W3 `partitionDisputed` suppression. Same identity scheme (W9 union-matching) as W3 itself.
 
-Fail-safe: if the root inline comment is missing `path` (pre-FP-F comment shape) or the title can't be parsed (`**🔴 …**` format absent), the keys derivation returns `[]` and resolution proceeds normally — pre-FP-F behavior is preserved.
+Fail-safe: if the root inline comment is missing `path`, or BOTH the title (`**🔴 …**`) and the fingerprint marker are absent, the keys derivation returns `[]` and resolution proceeds normally — pre-FP-F behavior is preserved. Because suppression is code-anchored via the fingerprint, a later commit that **changes** the cited code (new fingerprint) correctly re-raises the finding.
 
 **Setup**
 
@@ -1463,7 +1463,7 @@ Branch: `fixture/35-inline-resolve`. Two-commit sequence:
 - [x] **Regression check**: a non-resolve reply (just discussion) does NOT persist any keys
 
 **Failure modes**
-- ❌ The resolved finding re-appears on the next review under a slightly different framing (FP-F's stable-key persistence missed the framing change — likely a W9 fingerprint coverage gap surfaced via this path)
+- ❌ The resolved finding re-appears on the next review under a slightly different framing on **unchanged** code (#182 — the embedded `mw-fp:` fingerprint should anchor suppression through a title reword; a recurrence means the fingerprint marker wasn't embedded/recovered, or the cited line has no derivable fingerprint)
 - ❌ An unrelated finding gets suppressed (the resolve key was over-broad)
 - ❌ The Postgres `inline_resolved_keys` column is missing — migrations didn't run (self-hosted) or the deploy SAM template is stale (SaaS); resolve still works but the union is a no-op
 

--- a/packages/core/src/agents/inline-reply.test.ts
+++ b/packages/core/src/agents/inline-reply.test.ts
@@ -11,6 +11,8 @@ import {
   REJECT_CATEGORIES,
   MAX_BOT_REPLIES,
 } from './inline-reply.js';
+import { buildInlineComments } from '../github/client.js';
+import { findingMatchKeys } from '../review-delta.js';
 import type { IReviewStore } from '../storage/types.js';
 import type { ReviewItem } from '../types/db.js';
 
@@ -512,6 +514,56 @@ describe('handleInlineReply', () => {
     // Eyes reaction added + removed
     expect(calls.createForPullRequestReviewComment).toHaveBeenCalled();
     expect(calls.deleteForPullRequestComment).toHaveBeenCalled();
+  });
+
+  it('FP-F (#182) — resolve recovers the embedded fingerprint key directly, surviving title rewording', async () => {
+    // Build a real inline comment from a critical finding (with a W9
+    // fingerprint), exactly as the review pipeline does — the round-trip
+    // through buildInlineComments → extractInlineCommentFingerprint is the
+    // crux of #182.
+    const finding = {
+      file: 'src/admin.ts',
+      line: 8,
+      severity: 'critical' as const,
+      title: 'Unauthenticated admin endpoint exposes sensitive data',
+      description: 'Anyone can call this.',
+      suggestion: '',
+      // Code text with chars that would break a raw HTML comment (`--`, `>`).
+      fingerprint: "app.get('/admin', (req, res) => res.json(getAllUsers()))",
+    };
+    const [inline] = buildInlineComments([finding], ['src/admin.ts'], new Map([['src/admin.ts', new Set([8])]]));
+    const root = {
+      id: 100,
+      body: inline.body,
+      user: { login: 'mergewatch[bot]', type: 'Bot' as const },
+      created_at: '2026-04-01T00:00:00Z',
+      path: 'src/admin.ts',
+    };
+    const { octokit } = makeOctokitMock([
+      root,
+      { id: 101, body: 'resolved', user: { login: 'santthosh', type: 'User' as const }, in_reply_to_id: 100, created_at: '2026-04-01T01:00:00Z' },
+    ]);
+    const llm = makeLLM('unused');
+    const result = await handleInlineReply(
+      { owner: 'o', repo: 'r', prNumber: 1, replyCommentId: 101 },
+      { octokit, llm, lightModelId: 'light' },
+    );
+    expect(result.action).toBe('resolved');
+    // Both the title key AND the stable fingerprint key are derived directly
+    // from the comment — no dependency on the prior-review findings lookup.
+    expect(result.resolvedFindingKeys).toContain('src/admin.ts::T::Unauthenticated admin endpoint exposes sensitive data');
+    expect(result.resolvedFindingKeys).toContain(`src/admin.ts::F::${finding.fingerprint}`);
+    // #182: next round, the LLM rewords the title but the code is unchanged
+    // (same fingerprint) — the finding still matches the resolved set via the
+    // fingerprint key, so it is suppressed rather than re-emitted.
+    const rewordedNextRound = {
+      file: 'src/admin.ts',
+      line: 8,
+      title: 'Unauthenticated admin endpoint exposes sensitive USER data',
+      fingerprint: finding.fingerprint,
+    };
+    const stillSuppressed = findingMatchKeys(rewordedNextRound).some((k) => result.resolvedFindingKeys!.includes(k));
+    expect(stillSuppressed).toBe(true);
   });
 
   it('calls the LLM and posts a threaded reply on normal replies', async () => {

--- a/packages/core/src/agents/inline-reply.ts
+++ b/packages/core/src/agents/inline-reply.ts
@@ -36,6 +36,7 @@ import {
   findReviewThreadIdForComment,
   INLINE_BOT_COMMENT_MARKER,
   extractInlineCommentTitle,
+  extractInlineCommentFingerprint,
   type ReviewThreadComment,
 } from '../github/client.js';
 import { findingMatchKeys, type FindingLike } from '../review-delta.js';
@@ -240,12 +241,18 @@ export interface InlineReplyResult {
 function deriveResolvedFindingKeys(root: ReviewThreadComment): string[] {
   if (!root.path) return [];
   const title = extractInlineCommentTitle(root.body);
-  if (!title) return [];
-  // `findingMatchKeys` reads only `file`, `title`, and `fingerprint`. The
-  // `line: 0` placeholder satisfies the FindingLike shape without affecting
-  // the emitted keys — the title key is `file::T::title`, which is exactly
-  // what we want here (no fingerprint is recoverable from the comment body).
-  return findingMatchKeys({ file: root.path, line: 0, title });
+  // FP-F (#182) — recover the W9 fingerprint embedded in the comment so the
+  // stable `file::F::<fingerprint>` key is derived DIRECTLY. This survives the
+  // LLM rewording the finding title between review rounds without depending on
+  // the prior-review findings lookup (which itself carries the drifted title).
+  // Pre-#182 comments carry no marker → title-only key, and the caller's
+  // `enrichResolvedFindingKeys` fallback still tries to recover the fingerprint.
+  const fingerprint = extractInlineCommentFingerprint(root.body);
+  if (!title && !fingerprint) return [];
+  // `findingMatchKeys` is the single source of truth for key shape. Drop the
+  // degenerate empty-title key when the title couldn't be parsed.
+  return findingMatchKeys({ file: root.path, line: 0, title, fingerprint: fingerprint || undefined })
+    .filter((k) => k !== `${root.path}::T::`);
 }
 
 /**

--- a/packages/core/src/github/client.test.ts
+++ b/packages/core/src/github/client.test.ts
@@ -3,6 +3,7 @@ import {
   mergeScoreToReviewEvent,
   buildInlineComments,
   extractInlineCommentTitle,
+  extractInlineCommentFingerprint,
   BOT_COMMENT_MARKER,
   parseRepoConfigYaml,
   addPRReaction,
@@ -61,6 +62,34 @@ describe('buildInlineComments', () => {
     expect(result[0].path).toBe('src/app.ts');
     expect(result[0].line).toBe(10);
     expect(result[0].side).toBe('RIGHT');
+  });
+
+  it('FP-F (#182) — embeds a base64 fingerprint marker that round-trips through extractInlineCommentFingerprint', () => {
+    // Code text with chars that would break a raw HTML comment (`--`, `>`).
+    const fp = "app.get('/admin', (req,res) => res.json(db.query('--x'))) // a-->b";
+    const findings = [
+      { file: 'src/app.ts', line: 10, severity: 'critical' as const, title: 'T', description: 'd', suggestion: '', fingerprint: fp },
+    ];
+    const [c] = buildInlineComments(findings, changedFiles);
+    expect(c.body).toMatch(/<!-- mw-fp:[A-Za-z0-9+/=]+ -->/);
+    // The marker survives the dangerous chars and decodes back exactly.
+    expect(extractInlineCommentFingerprint(c.body)).toBe(fp);
+    // The visible title still extracts cleanly alongside the hidden marker.
+    expect(extractInlineCommentTitle(c.body)).toBe('T');
+  });
+
+  it('FP-F (#182) — omits the fingerprint marker when the finding has none', () => {
+    const findings = [
+      { file: 'src/app.ts', line: 10, severity: 'critical' as const, title: 'T', description: 'd', suggestion: '' },
+    ];
+    const [c] = buildInlineComments(findings, changedFiles);
+    expect(c.body).not.toContain('mw-fp:');
+    expect(extractInlineCommentFingerprint(c.body)).toBe('');
+  });
+
+  it('extractInlineCommentFingerprint returns empty for absent / malformed markers', () => {
+    expect(extractInlineCommentFingerprint('no marker here')).toBe('');
+    expect(extractInlineCommentFingerprint('<!-- mw-fp:!!! not base64 !!! -->')).toBe('');
   });
 
   it('excludes non-critical findings (warning)', () => {

--- a/packages/core/src/github/client.ts
+++ b/packages/core/src/github/client.ts
@@ -461,6 +461,12 @@ interface InlineCommentCandidate {
   description: string;
   suggestion: string;
   /**
+   * FP-F (#182) — W9 code fingerprint. Embedded (base64) in the inline comment
+   * so a later `/resolve` can recover the stable fingerprint key directly, even
+   * after the LLM rewords the finding title across review rounds.
+   */
+  fingerprint?: string;
+  /**
    * FP-L — W2 verification verdict. When `'unverified'` the finding is dropped
    * from the inline-comment surface entirely (it still appears in the top-level
    * review comment under "Unverified concerns"). Absent → treated as a pre-W2
@@ -506,7 +512,7 @@ export function buildInlineComments(
       path: f.file,
       line: f.line,
       side: 'RIGHT',
-      body: `${INLINE_BOT_COMMENT_MARKER}\n**🔴 ${f.title}**\n\n${f.description}${f.suggestion ? `\n\n> **Suggestion:** ${f.suggestion}` : ''}`,
+      body: `${INLINE_BOT_COMMENT_MARKER}\n**🔴 ${f.title}**\n\n${f.description}${f.suggestion ? `\n\n> **Suggestion:** ${f.suggestion}` : ''}${f.fingerprint ? `\n\n<!-- mw-fp:${encodeInlineFingerprint(f.fingerprint)} -->` : ''}`,
     }));
 }
 
@@ -518,6 +524,31 @@ const INLINE_TITLE_REGEX = /\*\*🔴 (.+?)\*\*/;
  */
 export function extractInlineCommentTitle(body: string): string {
   return body.match(INLINE_TITLE_REGEX)?.[1] ?? '';
+}
+
+// FP-F (#182) — hidden fingerprint marker embedded in inline comments. The
+// fingerprint is the finding's (whitespace-collapsed) code line, which can
+// contain `--`/`>` and would break a raw HTML comment, so it's base64-encoded.
+const INLINE_FP_REGEX = /<!-- mw-fp:([A-Za-z0-9+/=]+) -->/;
+
+function encodeInlineFingerprint(fingerprint: string): string {
+  return Buffer.from(fingerprint, 'utf-8').toString('base64');
+}
+
+/**
+ * Recover a finding's code fingerprint from its inline comment body, or `''`
+ * when absent (pre-#182 comments) or malformed. Lets `/resolve` build the
+ * stable `file::F::<fingerprint>` key directly off the comment — so suppression
+ * survives the LLM rewording the title between review rounds.
+ */
+export function extractInlineCommentFingerprint(body: string): string {
+  const b64 = body.match(INLINE_FP_REGEX)?.[1];
+  if (!b64) return '';
+  try {
+    return Buffer.from(b64, 'base64').toString('utf-8');
+  } catch {
+    return '';
+  }
 }
 
 /**

--- a/packages/core/src/github/client.ts
+++ b/packages/core/src/github/client.ts
@@ -546,7 +546,12 @@ export function extractInlineCommentFingerprint(body: string): string {
   if (!b64) return '';
   try {
     return Buffer.from(b64, 'base64').toString('utf-8');
-  } catch {
+  } catch (err) {
+    // Near-unreachable (the regex already constrained b64 to the base64
+    // alphabet), but if a marker is ever truncated/corrupted we log rather than
+    // swallow silently, then fall back to the title key — FP-F is best-effort,
+    // so a missing fingerprint just means the worst case is a re-raise.
+    console.warn('[fp-f] failed to decode inline fingerprint marker — falling back to title key:', err);
     return '';
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -124,6 +124,7 @@ export {
   dismissStaleReviews,
   buildInlineComments,
   extractInlineCommentTitle,
+  extractInlineCommentFingerprint,
   fetchRepoConfig,
   parseRepoConfigYaml,
 } from './github/client.js';


### PR DESCRIPTION
**Closes #182.**

## Root cause
FP-F derives the resolved finding's keys from the inline comment, but it only had the **title key** (`file::T::title`) directly. To get the stable **fingerprint key** it relied on `enrichResolvedFindingKeys` joining the comment's title against `latestReview.findings`.

That join breaks exactly in #182's scenario: the LLM **rewords the finding title** between rounds (the issue's "exposes sensitive data" → "exposes sensitive **user** data"). The comment carries the *original* title; `latestReview.findings` carries the *drifted* one; they don't match; no fingerprint is enriched; and the title-only key fails to suppress the reworded finding on the next review. A prior fix (#185) added the enrichment but couldn't cover this title-drift case.

## Fix — recover the fingerprint *directly* from the comment
The review pipeline now **embeds each finding's W9 fingerprint in its inline comment** as a hidden marker:
```
<!-- mw-fp:<base64(fingerprint)> -->
```
base64 because `fingerprintFromCode` returns the raw (whitespace-collapsed) **code line**, which can contain `--`/`>` and would break an HTML comment. On `/resolve`, `deriveResolvedFindingKeys` recovers **both** the title key and `file::F::<fingerprint>` straight from the comment — **no dependency on the prior-findings lookup** — so suppression is code-anchored and survives any title rewording. Code that genuinely **changes** yields a new fingerprint and correctly re-raises.

**Back-compat:** pre-#182 comments have no marker → title-key only, and the existing `enrichResolvedFindingKeys` fallback still recovers the fingerprint from `latestReview.findings`.

## Changes
- `client.ts`: `InlineCommentCandidate.fingerprint?`; embed `mw-fp` marker in `buildInlineComments`; new `extractInlineCommentFingerprint` (+ exported).
- `inline-reply.ts`: `deriveResolvedFindingKeys` extracts + uses the fingerprint (drops the degenerate empty-title key).

## Tests
- `client.test`: marker embeds + round-trips through `extractInlineCommentFingerprint` **with dangerous chars** (`--`, `>`); omitted when no fingerprint; malformed/absent → `''`.
- `inline-reply.test`: **end-to-end** — build a real inline comment via `buildInlineComments`, `/resolve` it, assert both keys recovered, and that a **reworded same-code finding still matches** the resolved set (the #182 regression locked in).
- `pnpm build` + `typecheck` + full `test` 20/20 (core 767). RUNBOOK E2E-35 updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)