### PR TITLE
fix(fb-c): sweep inline reactions on PR close so end-of-PR reactions count (#189)

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -1574,23 +1574,27 @@ Branch: `fixture/38-quiet-drop`. A PR with a finding that the orchestrator's con
 
 Reaction *removal* is a no-op (signal stays monotonic). Anonymous: we count, we don't store reactor identity.
 
+**Capture timing (#189):** GitHub does NOT emit a webhook for reactions, so MergeWatch **polls** them — folding a single `listReviewComments` call (the per-comment `reactions` summary) into the post-pipeline path and counting only the positive delta vs the snapshot persisted on the prior review. Because a reaction is usually added *after* the final review (people react when they read it), an in-review poll alone would miss it — so a final sweep **also runs on the terminal `closed` event** (`sweepInlineReactionsOnClose`, both runtimes). Net: a reaction is captured on the **next review of the PR OR when the PR closes**, whichever comes first.
+
 **Setup**
 
 Branch: `fixture/39-inline-reactions`. A PR with at least one inline-comment-eligible finding:
 1. Confirm `FindingDispositionRecord` row exists post-review with `disputeCount = 0`, `agreementCount = 0`.
-2. Add 👎 to the inline bot comment → confirm `disputeCount = 1`.
-3. Add 🚀 → confirm `agreementCount = 1`.
-4. Remove the 👎 → confirm `disputeCount` stays at 1 (monotonic).
+2. Add 👎 to the inline bot comment, then **trigger a poll** — push a commit (re-review) or **close the PR** — and confirm `disputeCount = 1`.
+3. Add 🚀, trigger another poll → confirm `agreementCount = 1`.
+4. Remove the 👎 before the next poll → after a poll, confirm `disputeCount` stays at 1 (monotonic).
 
 **Expected outcomes**
 
 - [ ] 👎 / 🤔 ↔ `disputeCount` mapping fires per-reaction
 - [ ] 👍 / ❤️ / 🚀 ↔ `agreementCount` mapping fires per-reaction
+- [ ] **#189** — a reaction added *after the final review* is still captured when the PR is **closed** (the close-sweep), not silently lost
 - [ ] Reactions on the TOP-level bot comment continue to populate `ReviewItem.reactions` separately (back-compat)
 - [ ] Reactions added by `mergewatch[bot]` itself are ignored (no self-counting)
 
 **Failure modes**
 - ❌ Reaction removal decrements the counter (must be monotonic)
+- ❌ **#189** — a reaction added after the last review never increments because no poll ever ran (must be captured by the close-sweep)
 - ❌ Reactions on a CopilotAI / dependabot inline comment get attributed to a MergeWatch finding (must filter by `INLINE_BOT_COMMENT_MARKER`)
 - ❌ Bot's own reactions count (loop)
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -163,6 +163,7 @@ export {
   detectQuietDrops,
   recordQuietDrops,
   pollAndRecordInlineReactions,
+  sweepInlineReactionsOnClose,
 } from './insights/disposition-writer.js';
 
 // ─── Insight rollup (FB-E) ─────────────────────────────────────────────────

--- a/packages/core/src/insights/disposition-writer.test.ts
+++ b/packages/core/src/insights/disposition-writer.test.ts
@@ -6,8 +6,9 @@ import {
   detectQuietDrops,
   recordQuietDrops,
   pollAndRecordInlineReactions,
+  sweepInlineReactionsOnClose,
 } from './disposition-writer.js';
-import type { IFindingDispositionStore } from '../storage/types.js';
+import type { IFindingDispositionStore, IReviewStore } from '../storage/types.js';
 import type { OrchestratedFinding, PreviousFinding } from '../agents/reviewer.js';
 import type { Octokit } from '@octokit/rest';
 
@@ -477,5 +478,68 @@ describe('pollAndRecordInlineReactions (FB-C)', () => {
     expect(store.calls.incrementDispute).toHaveLength(0);
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
+  });
+});
+
+// ─── sweepInlineReactionsOnClose (FB-C #189) ────────────────────────────────
+
+describe('sweepInlineReactionsOnClose (FB-C #189)', () => {
+  const inlineBody = '<!-- mergewatch-inline -->\n**🔴 Missing try/catch around fetch**\n\nDesc.';
+  const expectedKey = 'src/worker.ts::T::Missing try/catch around fetch';
+
+  function makeReviewStore(latest: Partial<{ prNumberCommitSha: string; status: string; inlineReactionsSnapshot: Record<string, Record<string, number>> }> | null) {
+    const updates: Array<{ key: string; status: string; extra: Record<string, unknown> }> = [];
+    const store = {
+      async queryByPR() { return latest ? [latest] : []; },
+      async updateStatus(_repo: string, key: string, status: string, extra: Record<string, unknown>) {
+        updates.push({ key, status, extra });
+      },
+      async upsert() { /* unused */ },
+    } as unknown as IReviewStore;
+    return { store, updates };
+  }
+
+  it('counts reactions added since the last review and persists the refreshed snapshot', async () => {
+    const store = makeMockStore();
+    const octokit = makeReactionOctokit([
+      { id: 100, body: inlineBody, path: 'src/worker.ts', user: { type: 'Bot' }, reactions: { rocket: 1 } },
+    ]);
+    // Latest review's snapshot had no reactions on comment 100 → delta rocket:1.
+    const rs = makeReviewStore({ prNumberCommitSha: '1#abc', status: 'complete', inlineReactionsSnapshot: { '100': {} } });
+    await sweepInlineReactionsOnClose({
+      octokit, owner: 'o', repo: 'r', prNumber: 1,
+      reviewStore: rs.store, dispositionStore: store, installationId: 42, repoFullName: 'org/repo',
+    });
+    expect(store.calls.incrementAgreement.filter((c) => c[2] === expectedKey)).toHaveLength(1);
+    // Refreshed snapshot is persisted back onto the latest review.
+    expect(rs.updates).toHaveLength(1);
+    expect((rs.updates[0].extra.inlineReactionsSnapshot as Record<string, Record<string, number>>)['100'].rocket).toBe(1);
+  });
+
+  it('still captures reactions when there is no prior review (first-ever poll)', async () => {
+    const store = makeMockStore();
+    const octokit = makeReactionOctokit([
+      { id: 100, body: inlineBody, path: 'src/worker.ts', user: { type: 'Bot' }, reactions: { '-1': 1 } },
+    ]);
+    const rs = makeReviewStore(null); // queryByPR → []
+    await sweepInlineReactionsOnClose({
+      octokit, owner: 'o', repo: 'r', prNumber: 1,
+      reviewStore: rs.store, dispositionStore: store, installationId: 42, repoFullName: 'org/repo',
+    });
+    expect(store.calls.incrementDispute.filter((c) => c[2] === expectedKey)).toHaveLength(1);
+    expect(rs.updates).toHaveLength(0); // nothing to persist onto
+  });
+
+  it('no-ops (no API call) when no disposition store is wired', async () => {
+    const octokit = makeReactionOctokit([
+      { id: 100, body: inlineBody, path: 'src/worker.ts', user: { type: 'Bot' }, reactions: { rocket: 1 } },
+    ]);
+    const rs = makeReviewStore({ prNumberCommitSha: '1#abc', status: 'complete' });
+    await sweepInlineReactionsOnClose({
+      octokit, owner: 'o', repo: 'r', prNumber: 1,
+      reviewStore: rs.store, dispositionStore: undefined, installationId: 42, repoFullName: 'org/repo',
+    });
+    expect(octokit.pulls.listReviewComments as unknown as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+    expect(rs.updates).toHaveLength(0);
   });
 });

--- a/packages/core/src/insights/disposition-writer.test.ts
+++ b/packages/core/src/insights/disposition-writer.test.ts
@@ -487,10 +487,12 @@ describe('sweepInlineReactionsOnClose (FB-C #189)', () => {
   const inlineBody = '<!-- mergewatch-inline -->\n**🔴 Missing try/catch around fetch**\n\nDesc.';
   const expectedKey = 'src/worker.ts::T::Missing try/catch around fetch';
 
-  function makeReviewStore(latest: Partial<{ prNumberCommitSha: string; status: string; inlineReactionsSnapshot: Record<string, Record<string, number>> }> | null) {
+  type ReviewLike = Partial<{ prNumberCommitSha: string; status: string; inlineReactionsSnapshot: Record<string, Record<string, number>> }>;
+  function makeReviewStore(reviews: ReviewLike | ReviewLike[] | null) {
+    const list = reviews == null ? [] : Array.isArray(reviews) ? reviews : [reviews];
     const updates: Array<{ key: string; status: string; extra: Record<string, unknown> }> = [];
     const store = {
-      async queryByPR() { return latest ? [latest] : []; },
+      async queryByPR() { return list; },
       async updateStatus(_repo: string, key: string, status: string, extra: Record<string, unknown>) {
         updates.push({ key, status, extra });
       },
@@ -541,5 +543,25 @@ describe('sweepInlineReactionsOnClose (FB-C #189)', () => {
     });
     expect(octokit.pulls.listReviewComments as unknown as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
     expect(rs.updates).toHaveLength(0);
+  });
+
+  it('merges ALL prior snapshots (max per type) so it cannot double-count regardless of queryByPR order (#189 review)', async () => {
+    const store = makeMockStore();
+    const octokit = makeReactionOctokit([
+      { id: 100, body: inlineBody, path: 'src/worker.ts', user: { type: 'Bot' }, reactions: { rocket: 2 } },
+    ]);
+    // queryByPR sorts by commitSha (NOT time). Review B's poll already counted
+    // 🚀:1 (its snapshot), but the stale review A (returned first) has {100:{}}.
+    // Merging both → baseline rocket:1, so only the NEW 🚀 (2−1) is counted.
+    const reviewA = { prNumberCommitSha: '1#aaa', status: 'complete', inlineReactionsSnapshot: { '100': {} } };
+    const reviewB = { prNumberCommitSha: '1#bbb', status: 'complete', inlineReactionsSnapshot: { '100': { rocket: 1 } } };
+    const rs = makeReviewStore([reviewA, reviewB]);
+    await sweepInlineReactionsOnClose({
+      octokit, owner: 'o', repo: 'r', prNumber: 1,
+      reviewStore: rs.store, dispositionStore: store, installationId: 42, repoFullName: 'org/repo',
+    });
+    // Only ONE new agreement (delta 2−1), NOT two — the merge prevents the
+    // double-count a naive `.find(complete)` on the stale review A would cause.
+    expect(store.calls.incrementAgreement.filter((c) => c[2] === expectedKey)).toHaveLength(1);
   });
 });

--- a/packages/core/src/insights/disposition-writer.ts
+++ b/packages/core/src/insights/disposition-writer.ts
@@ -13,7 +13,7 @@
  * "event". Callers should not loop the same event with the same key set.
  */
 
-import type { IFindingDispositionStore } from '../storage/types.js';
+import type { IFindingDispositionStore, IReviewStore } from '../storage/types.js';
 import type { OrchestratedFinding, PreviousFinding } from '../agents/reviewer.js';
 import { findingMatchKeys, fingerprintFromCode } from '../review-delta.js';
 import { extractSignificantTokens } from '../finding-clustering.js';
@@ -364,6 +364,52 @@ export async function pollAndRecordInlineReactions(
   }
 
   return newSnapshot;
+}
+
+/**
+ * FB-C (#189) — final inline-reaction sweep when a PR closes / merges.
+ *
+ * GitHub does NOT emit a webhook for reactions, and `pollAndRecordInlineReactions`
+ * only runs *during a review*. A reaction added after the last review — the
+ * common case, since people react when they read the review — would otherwise
+ * never be counted. On the terminal `closed` event we do one last poll, seeded
+ * by the latest review's snapshot so only reactions added since the last poll
+ * are counted, and persist the refreshed snapshot (so a rare re-open + re-close
+ * can't double-count). Best-effort; never throws.
+ */
+export async function sweepInlineReactionsOnClose(opts: {
+  octokit: Octokit;
+  owner: string;
+  repo: string;
+  prNumber: number;
+  reviewStore: IReviewStore;
+  dispositionStore: IFindingDispositionStore | undefined;
+  installationId: string | number | undefined;
+  repoFullName: string;
+}): Promise<void> {
+  const { octokit, owner, repo, prNumber, reviewStore, dispositionStore, installationId, repoFullName } = opts;
+  if (!dispositionStore || installationId == null) return;
+  try {
+    const prevReviews = await reviewStore.queryByPR(repoFullName, `${prNumber}#`, 5).catch(() => []);
+    const latest = prevReviews.find((r) => r.status === 'complete');
+    const updated = await pollAndRecordInlineReactions(
+      octokit, owner, repo, prNumber,
+      latest?.inlineReactionsSnapshot,
+      dispositionStore, installationId, repoFullName,
+    );
+    // Persist the refreshed snapshot onto the latest review so a (rare)
+    // re-open → react → re-close sequence doesn't re-count earlier reactions.
+    if (latest && Object.keys(updated).length > 0) {
+      await reviewStore.updateStatus(
+        repoFullName,
+        latest.prNumberCommitSha as string,
+        latest.status,
+        { inlineReactionsSnapshot: updated },
+      ).catch(() => {});
+    }
+  } catch (err) {
+    console.warn('[fb-c] reaction sweep on close failed for %s#%d:', repoFullName, prNumber, err);
+  }
 }
 
 // Re-exported so external callers don't need to dip into review-delta.js

--- a/packages/core/src/insights/disposition-writer.ts
+++ b/packages/core/src/insights/disposition-writer.ts
@@ -390,26 +390,58 @@ export async function sweepInlineReactionsOnClose(opts: {
   const { octokit, owner, repo, prNumber, reviewStore, dispositionStore, installationId, repoFullName } = opts;
   if (!dispositionStore || installationId == null) return;
   try {
-    const prevReviews = await reviewStore.queryByPR(repoFullName, `${prNumber}#`, 5).catch(() => []);
-    const latest = prevReviews.find((r) => r.status === 'complete');
+    // queryByPR is keyed on `${prNumber}#${commitSha}`; the `#` delimiter makes
+    // the `${prNumber}#` prefix unambiguous (PR 1 cannot match PR 12's `12#…`).
+    const prevReviews = await reviewStore.queryByPR(repoFullName, `${prNumber}#`, 10).catch(() => []);
+    const completes = prevReviews.filter((r) => r.status === 'complete');
+    // Baseline = the MAX reaction count per (comment, type) across EVERY prior
+    // review's snapshot. Counters are monotonic, so the merged view is exactly
+    // what's already been counted by an in-review poll. Merging (rather than
+    // picking "the latest" review) is what makes this correct: queryByPR sorts
+    // by commitSha, NOT by time, so a single `.find(complete)` could return a
+    // stale snapshot and double-count. The merge is order-independent.
+    const baseline = mergeReactionSnapshots(completes.map((r) => r.inlineReactionsSnapshot));
     const updated = await pollAndRecordInlineReactions(
       octokit, owner, repo, prNumber,
-      latest?.inlineReactionsSnapshot,
+      baseline,
       dispositionStore, installationId, repoFullName,
     );
-    // Persist the refreshed snapshot onto the latest review so a (rare)
-    // re-open → react → re-close sequence doesn't re-count earlier reactions.
-    if (latest && Object.keys(updated).length > 0) {
+    // Persist the refreshed snapshot onto a complete review so a later sweep
+    // (rare re-open → react → re-close) folds it into the merged baseline. Any
+    // complete review works — the merge picks it up regardless of order.
+    const target = completes[0];
+    if (target && Object.keys(updated).length > 0) {
       await reviewStore.updateStatus(
         repoFullName,
-        latest.prNumberCommitSha as string,
-        latest.status,
+        target.prNumberCommitSha as string,
+        target.status,
         { inlineReactionsSnapshot: updated },
       ).catch(() => {});
     }
   } catch (err) {
     console.warn('[fb-c] reaction sweep on close failed for %s#%d:', repoFullName, prNumber, err);
   }
+}
+
+/**
+ * Merge inline-reaction snapshots, taking the MAX count per (commentId, type).
+ * Reaction counters are monotonic, so the max across all prior reviews is
+ * everything already counted — the correct baseline for a close-time delta.
+ */
+function mergeReactionSnapshots(
+  snapshots: Array<Record<string, Record<string, number>> | undefined>,
+): Record<string, Record<string, number>> {
+  const merged: Record<string, Record<string, number>> = {};
+  for (const snap of snapshots) {
+    if (!snap) continue;
+    for (const [commentId, counts] of Object.entries(snap)) {
+      const into = (merged[commentId] ??= {});
+      for (const [type, n] of Object.entries(counts)) {
+        if (n > (into[type] ?? 0)) into[type] = n;
+      }
+    }
+  }
+  return merged;
 }
 
 // Re-exported so external callers don't need to dip into review-delta.js

--- a/packages/lambda/src/handlers/webhook.ts
+++ b/packages/lambda/src/handlers/webhook.ts
@@ -23,6 +23,7 @@ import {
   fetchRepoConfig,
   mergeConfig,
   isBotActor,
+  sweepInlineReactionsOnClose,
 } from '@mergewatch/core';
 import type {
   PullRequestEvent,
@@ -34,7 +35,10 @@ import type {
   ReviewJobPayload,
   AgentReviewConfig,
 } from '@mergewatch/core';
-import { DynamoPRLifecycleStore, DEFAULT_PR_LIFECYCLE_TABLE } from '@mergewatch/storage-dynamo';
+import {
+  DynamoPRLifecycleStore, DEFAULT_PR_LIFECYCLE_TABLE,
+  DynamoReviewStore, DynamoFindingDispositionStore, DEFAULT_FINDING_DISPOSITIONS_TABLE,
+} from '@mergewatch/storage-dynamo';
 import { SSMGitHubAuthProvider, getWebhookSecret } from '../github-auth-ssm.js';
 
 // ---------------------------------------------------------------------------
@@ -49,6 +53,13 @@ const authProvider = new SSMGitHubAuthProvider();
 // transitions directly (no review needed); ReviewAgent marks reviewed/skipped.
 const PR_LIFECYCLE_TABLE = process.env.PR_LIFECYCLE_TABLE ?? DEFAULT_PR_LIFECYCLE_TABLE;
 const prLifecycleStore = new DynamoPRLifecycleStore(dynamodb, PR_LIFECYCLE_TABLE);
+
+// FB-C (#189) — review + disposition stores for the close-time reaction sweep.
+const reviewStore = new DynamoReviewStore(dynamodb, process.env.REVIEWS_TABLE ?? 'mergewatch-reviews');
+const dispositionStore = new DynamoFindingDispositionStore(
+  dynamodb,
+  process.env.FINDING_DISPOSITIONS_TABLE ?? DEFAULT_FINDING_DISPOSITIONS_TABLE,
+);
 
 // ---------------------------------------------------------------------------
 // Signature verification
@@ -201,6 +212,27 @@ async function handlePullRequestEvent(
   // Record lifecycle for every relevant action (incl. `closed`) before the
   // review gate — merges/closes terminate the lifecycle without a review.
   await recordPrLifecycle(event, installationId);
+
+  // FB-C (#189) — reactions don't emit webhooks and the in-review poll can't see
+  // a reaction added after the final review (the common case). On the terminal
+  // `closed` event, sweep once so end-of-PR 👍/👎 aren't lost.
+  if (action === 'closed') {
+    try {
+      const octokit = await authProvider.getInstallationOctokit(installationId);
+      await sweepInlineReactionsOnClose({
+        octokit,
+        owner: repository.owner.login,
+        repo: repository.name,
+        prNumber: pr.number,
+        reviewStore,
+        dispositionStore,
+        installationId: String(installationId),
+        repoFullName: repository.full_name,
+      });
+    } catch (err) {
+      console.warn('[fb-c] close reaction sweep failed to start:', err);
+    }
+  }
 
   if (!(REVIEW_TRIGGERING_ACTIONS as readonly string[]).includes(action)) return;
 

--- a/packages/server/src/webhook-handler.ts
+++ b/packages/server/src/webhook-handler.ts
@@ -2,7 +2,7 @@ import { createHmac, timingSafeEqual } from 'crypto';
 import type { Request, Response } from 'express';
 import type { IInstallationStore, IReviewStore, IFindingDispositionStore, IFPInsightStore, IPRLifecycleStore, ISatisfactionStore, IReviewCostStore, IGitHubAuthProvider, ILLMProvider, AgentReviewConfig } from '@mergewatch/core';
 import type { ReviewJobPayload, ReviewMode, PullRequestEvent, IssueCommentEvent, PullRequestReviewCommentEvent, InstallationEvent, CheckRunEvent } from '@mergewatch/core';
-import { REVIEW_TRIGGERING_ACTIONS, COMMENT_LOOKUP_ACTIONS, MERGEWATCH_CHECK_RUN_NAME, findExistingBotComment, classifyPrSource, fetchRepoConfig, mergeConfig, isBotActor } from '@mergewatch/core';
+import { REVIEW_TRIGGERING_ACTIONS, COMMENT_LOOKUP_ACTIONS, MERGEWATCH_CHECK_RUN_NAME, findExistingBotComment, classifyPrSource, fetchRepoConfig, mergeConfig, isBotActor, sweepInlineReactionsOnClose } from '@mergewatch/core';
 import { processReviewJob } from './review-processor.js';
 
 export interface WebhookDeps {
@@ -137,6 +137,27 @@ async function handlePullRequest(payload: PullRequestEvent, deps: WebhookDeps) {
   // Record lifecycle for every relevant action (incl. `closed`) before the
   // review gate — merges/closes terminate the lifecycle without a review.
   await recordPrLifecycle(payload, deps);
+
+  // FB-C (#189) — reactions don't emit webhooks and the in-review poll can't see
+  // a reaction added after the final review (the common case). On the terminal
+  // `closed` event, sweep once so end-of-PR 👍/👎 aren't lost.
+  if (action === 'closed') {
+    try {
+      const octokit = await deps.authProvider.getInstallationOctokit(installation.id);
+      await sweepInlineReactionsOnClose({
+        octokit,
+        owner: repository.owner.login,
+        repo: repository.name,
+        prNumber: pull_request.number,
+        reviewStore: deps.reviewStore,
+        dispositionStore: deps.dispositionStore,
+        installationId: String(installation.id),
+        repoFullName: repository.full_name,
+      });
+    } catch (err) {
+      console.warn('[fb-c] close reaction sweep failed to start:', err);
+    }
+  }
 
   if (!(REVIEW_TRIGGERING_ACTIONS as readonly string[]).includes(action)) return;
 


### PR DESCRIPTION
**Closes #189.**

## Root cause (verified, not the filed hypotheses)
FB-C *is* implemented and wired, and `listReviewComments` *does* return the `reactions` summary. The real gap is the **trigger**: `pollAndRecordInlineReactions` only runs **during a review**, and GitHub emits **no webhook for reactions** — so a reaction added after the *final* review is never polled.

Ground truth on `santthosh/mergewatch-fixtures#118`:
```
bot inline comment 3308330603 → reactions: { rocket: 1 }   (still there)
#118 reviews: ONE review at 03:56  — the 🚀 was added ~04:20, AFTER it
```
No review ran after the reaction → it was never counted (`agreementCount: 0`). That's the common case: people react *when they read the review*.

## Fix
Capture reactions one final time on the terminal `pull_request` **`closed`** event (which we already handle for TTM lifecycle). New core helper **`sweepInlineReactionsOnClose`**:
- loads the latest review's reaction snapshot,
- runs the **same** poll (so only reactions added *since the last poll* are counted — no double-count with in-review polls),
- persists the refreshed snapshot so a rare *re-open → react → re-close* can't re-count.

Wired into **both** runtimes' close handlers — lambda `webhook.ts` (module review/disposition stores + `authProvider` octokit) and server `webhook-handler.ts` (`deps.reviewStore` / `deps.dispositionStore` / `deps.authProvider`). Best-effort; never blocks the close path. Net: a reaction is captured on the **next review OR when the PR closes**, whichever comes first.

## Tests
`disposition-writer.test`: sweep counts reactions added since the last review **and persists the refreshed snapshot**; captures on a first-ever poll (no prior review); no-ops (no API call) without a disposition store. RUNBOOK **E2E-39** now documents the poll/close-sweep capture timing + the #189 failure mode. `build`+`typecheck`+`test` 20/20 (core **770**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)