### PR TITLE
test(fp-l): lock the #183 state/check-consistency invariant + document it

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -1942,6 +1942,8 @@ Branch: `fixture/51-no-self-contradiction`. Two-commit sequence:
 
 Pure rendering change — no model calls, no prompt changes, no schema migrations.
 
+**Distinction from a verifier *drop* (#183):** FP-L handles the *demote* case — a critical the verifier kept but couldn't confirm (`verification: 'unverified'`) renders in "Unverified concerns." When the verifier instead **drops** a critical entirely (`keep: false`), it's gone from every surface — and `reconcileMergeScore` then **downgrades the now-stale blocking score** (→ 3 when warnings remain, → 5 when nothing remains) and regenerates the verdict reason, so the verdict prose, the rendered findings, the **review state** (`mergeScoreToReviewEvent`), and the **check conclusion** (`hasCritical`) all agree. Without it, a dropped critical left the state at `CHANGES_REQUESTED` while the check read `success` — the #183 mismatch.
+
 **Setup**
 
 Branch: `fixture/52-unverified-critical-render`. The cleanest repro is to mock the W2 verifier path so a specific critical comes back as `verification: 'unverified'`. Alternatively, exercise the live path on a PR whose critical is shaped like a stale-claim (e.g. a "SQL injection" finding pointed at a Drizzle call site — the verifier cannot confirm against `db.query` and returns `unverified`).
@@ -1955,6 +1957,7 @@ Branch: `fixture/52-unverified-critical-render`. The cleanest repro is to mock t
 - [x] **Empty-case omission:** When there are zero unverified criticals (the all-clean / verified-only path), the "Unverified concerns" sub-section is omitted entirely — no empty headers
 - [x] **W7 score-clamp unchanged:** The formal verdict subtitle still reads *"3/5 — Review recommended. Downgraded to advisory — the PR is not blocked on unverified concerns"* and `mergeScoreToReviewEvent` still returns `COMMENTED`
 - [x] **Back-compat:** A critical with no `verification` field at all (pre-W2 stored record OR a path where W2 didn't run) renders normally in all surfaces — inline, action-table, Critical section
+- [x] **#183 — verifier-dropped criticals stay consistent:** when the verifier drops ALL criticals, `reconcileMergeScore` downgrades the blocking score so the review state is non-blocking (COMMENTED / APPROVE) and matches the `success` check conclusion, and the regenerated reason no longer cites the dropped critical (locked by the `#183 invariant` unit test)
 
 **Failure modes**
 - ❌ Unverified critical still renders as 🔴 inline at the cited line (Layer 1 filter regressed)
@@ -1962,6 +1965,7 @@ Branch: `fixture/52-unverified-critical-render`. The cleanest repro is to mock t
 - ❌ The "Unverified concerns" header renders with `(0)` count when no unverified criticals exist (empty-omission check)
 - ❌ Verified criticals incorrectly land in the Unverified concerns section (the verification check is inverted)
 - ❌ Warnings tagged `verification: 'unverified'` get mis-routed to the Critical Unverified-concerns section (FP-L is explicitly critical-only; warnings retain their existing collapsed surface — see test `does not coerce unverified warnings into the Unverified concerns section`)
+- ❌ **#183** — a verifier-*dropped* critical leaves the review state `CHANGES_REQUESTED` while the check is `success` (the score wasn't reconciled against the post-filter findings)
 
 ---
 

--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { ILLMProvider } from '../llm/types.js';
 import type { CustomAgentDef } from '../config/defaults.js';
+import { mergeScoreToReviewEvent } from '../github/client.js';
 import {
   isValidMermaidDiagram,
   extractDiagramFilePaths,
@@ -2429,6 +2430,30 @@ describe('reconcileMergeScore', () => {
       // needs fixes before merging") must NOT leak into the reconciled
       // reason — that exact phrase is the user-facing bug.
       expect(r.mergeScoreReason).not.toContain('needs fixes before merging');
+    });
+
+    it('#183 invariant — a verifier-dropped-criticals verdict is non-blocking, matching the success check', () => {
+      // The bug: review STATE was REQUEST_CHANGES (from the orchestrator's ≤2
+      // score) while the CHECK was success (zero post-filter criticals). After
+      // reconcile, the score must map to a NON-blocking review event for BOTH
+      // the warnings-remain (→ 3 / COMMENT) and nothing-remains (→ 5 / APPROVE)
+      // paths — so the review state can never contradict the success check.
+      for (const filteredFindings of [[warning()], [] as ReturnType<typeof warning>[]]) {
+        const r = reconcileMergeScore({
+          filteredFindings,
+          previousFindings: undefined,
+          orchestratorScore: 2,
+          orchestratorReason: 'Critical present; needs fixes before merging.',
+          orchestratorCriticalsCount: 1,
+        });
+        const survivingCriticals = filteredFindings.filter((f) => f.severity === 'critical').length;
+        const checkConclusion = survivingCriticals > 0 ? 'failure' : 'success';
+        const reviewEvent = mergeScoreToReviewEvent(r.mergeScore);
+        expect(checkConclusion).toBe('success');
+        expect(reviewEvent).not.toBe('REQUEST_CHANGES'); // never block when the check passes
+        // …and the stale blocking prose must not leak into the verdict.
+        expect(r.mergeScoreReason).not.toContain('needs fixes before merging');
+      }
     });
 
     it('downgrades on orchestratorScore=1 (the strictest blocking tier) the same way', () => {


### PR DESCRIPTION
**Closes #183.**

## TL;DR
#183's mismatch is **already resolved in code** — I traced the full path and verified it rigorously. The gap was a **missing regression test** tying the pieces together, plus undocumented behavior. This PR adds the cross-function invariant test + RUNBOOK notes. **No behavior change** (`reviewer.ts` is untouched).

## Why #183 is already fixed
When the verifier (W2 / FP-G linter interaction) **drops** a critical (`keep:false`), `reconcileMergeScore` reconciles the orchestrator's now-stale blocking score against the post-filter findings:
- **warnings remain** → downgrade to **3** (COMMENT), regenerated reason: *"N critical dropped by verification — M warnings remain… not blocked"*.
- **nothing remains** → the `noActionItems` return gives **5** (APPROVE), *"No issues found"*.

The `orchestratorCriticalsCount` it keys on is the **pre-filter** count (`reviewer.ts:2340`), so the clamp actually fires. Both runtimes derive the review state from `mergeScoreToReviewEvent(reconciledScore)` and the check from the post-filter `criticalCount` — so verdict prose, rendered findings, **review state**, and **check conclusion** all agree. The old mismatch (state `CHANGES_REQUESTED`, check `success`) can't occur.

*(I initially tried to also "acknowledge dropped criticals" in the nothing-remains case, but two existing tests showed the maintainer deliberately returns a clean `5`/"No issues found" there — the FP-reduction philosophy of not re-surfacing a dropped finding. Reverted; `reviewer.ts` unchanged.)*

## What this PR adds
- **`#183 invariant` unit test** — over **both** paths (`[warning()]` and `[]`), asserts the reconciled score maps to a **non-blocking** review event whenever the check is `success`, and the stale blocking prose doesn't leak. No existing test made this cross-function (`reconcileMergeScore` → `mergeScoreToReviewEvent` → check) assertion.
- **RUNBOOK E2E-52** — distinguishes a verifier **demote** (renders in "Unverified concerns") from a verifier **drop** (score reconciled → state matches check), with a Pass item + failure mode for the #183 invariant.

`build` + `typecheck` + full `test` 20/20 (core **772**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)