### PR TITLE
feat(cost): price self-hosted models so per-PR + dashboard cost show (#231)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,8 @@ ANTHROPIC_API_KEY=
 
 # ── Optional ─────────────────────────────────────────────────────────────────
 # LLM_MODEL=                     # Override default model ID for your provider
+#                                # To show LLM cost for a non-Anthropic / custom model, add a
+#                                # `pricing:` block in .mergewatch.yml (USD per 1M tokens) — see README.
 # GITHUB_APP_SLUG=               # GitHub App slug (for install link in dashboard)
 # PORT=3000                      # Server port (default: 3000)
 # INSIGHTS_ROLLUP_INTERVAL_MINUTES=60   # Dashboard insight rollup cadence (default: 60 = hourly; raise to reduce DB load)

--- a/.mergewatch.yml
+++ b/.mergewatch.yml
@@ -49,3 +49,12 @@ minSeverity: info
 
 # Maximum findings posted per review.
 maxFindings: 25
+
+# LLM cost pricing overrides (USD per 1M tokens). The Anthropic models
+# MergeWatch ships with are priced out of the box; add an entry for any other
+# model (Ollama, LiteLLM, a newer alias) so per-PR + dashboard cost show real
+# spend instead of "unpriced". Use 0/0 for a local model to record a real $0.
+# pricing:
+#   gpt-4o:
+#     inputPer1M: 2.5
+#     outputPer1M: 10

--- a/README.md
+++ b/README.md
@@ -172,6 +172,15 @@ excludePatterns:
 tone: collaborative
 
 maxFindings: 25
+
+# LLM cost pricing (USD per 1M tokens). MergeWatch prices the Anthropic models
+# it ships with out of the box; add an entry here for any other model — Ollama,
+# LiteLLM, a newer alias — so per-PR and dashboard cost show real spend instead
+# of "unpriced". Use 0/0 for a local model to record a real $0.
+pricing:
+  gpt-4o:
+    inputPer1M: 2.5
+    outputPer1M: 10
 ```
 
 Settings can also be managed from the dashboard (per-installation).

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -192,6 +192,7 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-63](#e2e-63-cost--llm-spend-rollup--dashboard-193) | Each review writes a `ReviewCostRecord`; hourly rollup aggregates a `cost` block (total spend, avg cost/review, cost/finding, per-repo); `/api/insights` returns it; dashboard LLM cost section renders; unknown-model reviews counted as "unpriced", excluded from money; both backends (cost) | 3m | 30s | #212 |
 | [E2E-64](#e2e-64-dashboard-restructure--analytics-value--accuracy-correctness-hourly-rollup-218) | Dashboard split by intent: Analytics = Activity + Impact (cost/cycle/engagement); FP Insights renamed Accuracy at `/dashboard/accuracy` (old `/dashboard/insights` 308-redirects, query preserved); rollup hourly both runtimes; both backends (#218) | 3m | 30s | #218 |
 | [E2E-65](#e2e-65-analytics-tabbed-view--accuracy-folded-in-227) | `/dashboard/analytics` is a tabbed view (Overview · Cost & Impact · Findings · Activity · Accuracy); active tab in `?tab=` (shareable, `?org=` preserved); `/dashboard/accuracy` redirects to `?tab=accuracy`; Accuracy nav item removed; filter bar scoped to data tabs (#227) | 2m | 30s | #227 |
+| [E2E-66](#e2e-66-self-hosted-cost-shows-when-the-model-is-priced-231) | Self-hosted LLM cost: current-gen Anthropic IDs priced out of the box; `.mergewatch.yml` `pricing:` override now parsed (was dropped); unpriced model → one-time server warn + dashboard "set pricing" hint (not silent $0); `0`/`0` records a real $0 (#231) | 3m | 30s | #231 |
 
 ---
 
@@ -2340,6 +2341,36 @@ Branch: `fixture/60-engagement-dashboard`. Use the E2E-59 installation (an `enga
 - ❌ Switching tabs reloads the server page / loses `?org=` / doesn't update the URL.
 - ❌ `/dashboard/accuracy` 404s or the Accuracy tab is blank.
 - ❌ The date filter bar shows on the Cost or Accuracy tab (double window selectors).
+
+---
+
+### E2E-66: Self-hosted cost shows when the model is priced (#231)
+
+**Status:** ✅ SHIPPED.
+
+**Behavior:** On self-hosted, per-PR cost (the "Est. cost" line in the review comment) and the dashboard **Cost & Impact** block now populate whenever the model is priced. There is **no deployment-mode suppression** — cost was previously blank only because the model wasn't in the pricing table. Three things change:
+1. `DEFAULT_PRICING` (`packages/core/src/llm/pricing.ts`) gains the current-gen Anthropic IDs (Sonnet 4.6, Opus 4.8) by both Bedrock and direct ID, so direct-Anthropic self-hosters get cost with zero config. Unknown models still return `null`.
+2. The `.mergewatch.yml` **`pricing:`** override (model ID → `inputPer1M`/`outputPer1M` USD per 1M tokens) is now **parsed** (`parseRepoConfigYaml`). It was silently dropped before. Malformed/negative entries are skipped; `0`/`0` records a real **priced $0** (for a local model), distinct from an unpriced unknown model.
+3. When a review runs on an unpriced model, the server logs a one-time (per-model) `[cost] No pricing for model(s) …` warn pointing at the override, and the dashboard Cost section shows an actionable "set a `pricing:` override" hint instead of a silent $0.
+
+**How to run.** Self-hosted server with Postgres + cost rollup data.
+1. **Priced default** — set `model:` to a priced Anthropic ID (e.g. `claude-sonnet-4-6`). Run a review → the PR comment "Review details" drawer shows an `Est. cost` line; after the hourly rollup, `/dashboard/analytics?tab=cost` shows non-zero Total spend.
+2. **Override** — set `model:` to an unpriced model (e.g. an Ollama/LiteLLM ID) and add a matching `pricing:` block in `.mergewatch.yml`. Re-review → cost appears in both places.
+3. **Local $0** — set `pricing:` to `0`/`0` for the local model → "Reviews" shows "all priced", Total spend `$0.00` (not "unpriced").
+4. **Unpriced hint** — remove the `pricing:` entry → server logs the one-time `[cost]` warn; the dashboard Cost section shows the "this model isn't priced" hint with the `.mergewatch.yml` snippet.
+
+**Pass:**
+- [ ] Priced model → `Est. cost` in the PR comment **and** non-zero dashboard Total spend.
+- [ ] `.mergewatch.yml` `pricing:` override is applied (cost appears for an otherwise-unknown model); malformed entries ignored.
+- [ ] `0`/`0` model counts as priced ($0), not unpriced.
+- [ ] All-unpriced window → dashboard shows the actionable `pricing:` hint (not a silent $0); server logs the one-time warn.
+- [ ] SaaS/Bedrock cost unchanged; rollup still excludes unpriced reviews from money.
+
+**Fail signals:**
+- ❌ Cost still blank on a priced/overridden model.
+- ❌ `pricing:` in `.mergewatch.yml` has no effect (still dropped).
+- ❌ A `0`/`0` model is reported as "unpriced".
+- ❌ The unpriced warn spams every review instead of once per model.
 
 ---
 

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -2042,6 +2042,13 @@ function appendStalenessNote(reason: string, droppedCount: number): string {
 }
 
 /**
+ * #231 — model IDs we've already warned about being unpriced, so a long-lived
+ * self-hosted process logs the "set a pricing override" hint once per model
+ * instead of on every review.
+ */
+const WARNED_UNPRICED_MODELS = new Set<string>();
+
+/**
  * Execute the full multi-agent review pipeline.
  * All independent agents run in parallel; the orchestrator runs after they complete.
  */
@@ -2341,6 +2348,24 @@ export async function runReviewPipeline(
     orchestratorWarningsCount,
   });
 
+  // #231 — when a model isn't priced, cost shows as "unpriced" everywhere (PR
+  // comment + dashboard). Warn once per model so self-hosted operators know to
+  // add a `pricing:` override in .mergewatch.yml. Skipped when all models are
+  // priced (including a deliberate $0 local model).
+  const estimatedCostUsd = accumulator.estimateTotalCost(customPricing);
+  if (estimatedCostUsd === null) {
+    const newlyUnpriced = accumulator
+      .unpricedModels(customPricing)
+      .filter((m) => !WARNED_UNPRICED_MODELS.has(m));
+    if (newlyUnpriced.length > 0) {
+      newlyUnpriced.forEach((m) => WARNED_UNPRICED_MODELS.add(m));
+      console.warn(
+        `[cost] No pricing for model(s) ${newlyUnpriced.join(', ')} — review cost will show as "unpriced". ` +
+        `Add a "pricing:" entry (USD per 1M tokens) for this model in .mergewatch.yml to surface spend.`,
+      );
+    }
+  }
+
   return {
     summary,
     findings: filteredFindings,
@@ -2354,7 +2379,7 @@ export async function runReviewPipeline(
     enabledAgentCount,
     inputTokens: accumulator.totalInputTokens,
     outputTokens: accumulator.totalOutputTokens,
-    estimatedCostUsd: accumulator.estimateTotalCost(customPricing),
+    estimatedCostUsd,
     conventionsUsed: !!(conventions && conventions.trim()),
     deltaCaption,
   };

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -2044,9 +2044,12 @@ function appendStalenessNote(reason: string, droppedCount: number): string {
 /**
  * #231 — model IDs we've already warned about being unpriced, so a long-lived
  * self-hosted process logs the "set a pricing override" hint once per model
- * instead of on every review.
+ * instead of on every review. Bounded so a stream of distinct IDs (versioned
+ * names, typos) can't grow it without limit — on overflow we clear and let the
+ * warnings re-emit, which is harmless.
  */
 const WARNED_UNPRICED_MODELS = new Set<string>();
+const MAX_WARNED_UNPRICED_MODELS = 100;
 
 /**
  * Execute the full multi-agent review pipeline.
@@ -2358,6 +2361,9 @@ export async function runReviewPipeline(
       .unpricedModels(customPricing)
       .filter((m) => !WARNED_UNPRICED_MODELS.has(m));
     if (newlyUnpriced.length > 0) {
+      if (WARNED_UNPRICED_MODELS.size + newlyUnpriced.length > MAX_WARNED_UNPRICED_MODELS) {
+        WARNED_UNPRICED_MODELS.clear();
+      }
       newlyUnpriced.forEach((m) => WARNED_UNPRICED_MODELS.add(m));
       console.warn(
         `[cost] No pricing for model(s) ${newlyUnpriced.join(', ')} — review cost will show as "unpriced". ` +

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -2361,7 +2361,9 @@ export async function runReviewPipeline(
       .unpricedModels(customPricing)
       .filter((m) => !WARNED_UNPRICED_MODELS.has(m));
     if (newlyUnpriced.length > 0) {
-      if (WARNED_UNPRICED_MODELS.size + newlyUnpriced.length > MAX_WARNED_UNPRICED_MODELS) {
+      // Bound the Set before adding (per-review unpriced count is tiny, so this
+      // keeps it at ~MAX). On overflow we clear and let warnings re-emit later.
+      if (WARNED_UNPRICED_MODELS.size >= MAX_WARNED_UNPRICED_MODELS) {
         WARNED_UNPRICED_MODELS.clear();
       }
       newlyUnpriced.forEach((m) => WARNED_UNPRICED_MODELS.add(m));

--- a/packages/core/src/github/client.test.ts
+++ b/packages/core/src/github/client.test.ts
@@ -317,6 +317,25 @@ pricing:
     expect(parseRepoConfigYaml('pricing:\n  - foo')?.pricing).toBeUndefined();
   });
 
+  it('skips prototype-pollution keys in pricing (#231)', () => {
+    const yaml = `
+pricing:
+  __proto__:
+    inputPer1M: 1
+    outputPer1M: 2
+  constructor:
+    inputPer1M: 1
+    outputPer1M: 2
+  safe-model:
+    inputPer1M: 3
+    outputPer1M: 4
+`;
+    const result = parseRepoConfigYaml(yaml);
+    expect(result?.pricing).toEqual({ 'safe-model': { inputPer1M: 3, outputPer1M: 4 } });
+    // The prototype is not polluted.
+    expect(({} as Record<string, unknown>).inputPer1M).toBeUndefined();
+  });
+
   it('parses agents as boolean object', () => {
     const yaml = `
 agents:

--- a/packages/core/src/github/client.test.ts
+++ b/packages/core/src/github/client.test.ts
@@ -273,6 +273,50 @@ describe('parseRepoConfigYaml', () => {
     expect(result?.model).toBeUndefined();
   });
 
+  it('parses a valid pricing override (#231)', () => {
+    const yaml = `
+pricing:
+  gpt-4o:
+    inputPer1M: 2.5
+    outputPer1M: 10
+`;
+    const result = parseRepoConfigYaml(yaml);
+    expect(result?.pricing).toEqual({ 'gpt-4o': { inputPer1M: 2.5, outputPer1M: 10 } });
+  });
+
+  it('accepts 0/0 pricing (priced $0 for a local model) (#231)', () => {
+    const yaml = `
+pricing:
+  llama3:
+    inputPer1M: 0
+    outputPer1M: 0
+`;
+    const result = parseRepoConfigYaml(yaml);
+    expect(result?.pricing).toEqual({ llama3: { inputPer1M: 0, outputPer1M: 0 } });
+  });
+
+  it('skips malformed pricing entries but keeps valid ones (#231)', () => {
+    const yaml = `
+pricing:
+  good-model:
+    inputPer1M: 1
+    outputPer1M: 2
+  missing-output:
+    inputPer1M: 1
+  negative:
+    inputPer1M: -1
+    outputPer1M: 2
+  not-an-object: "nope"
+`;
+    const result = parseRepoConfigYaml(yaml);
+    expect(result?.pricing).toEqual({ 'good-model': { inputPer1M: 1, outputPer1M: 2 } });
+  });
+
+  it('leaves pricing undefined when all entries are invalid or it is an array (#231)', () => {
+    expect(parseRepoConfigYaml('pricing:\n  bad:\n    inputPer1M: "x"\n    outputPer1M: 2')?.pricing).toBeUndefined();
+    expect(parseRepoConfigYaml('pricing:\n  - foo')?.pricing).toBeUndefined();
+  });
+
   it('parses agents as boolean object', () => {
     const yaml = `
 agents:

--- a/packages/core/src/github/client.ts
+++ b/packages/core/src/github/client.ts
@@ -896,6 +896,8 @@ export function parseRepoConfigYaml(content: string): Partial<MergeWatchConfig> 
     if (parsed.pricing && typeof parsed.pricing === 'object' && !Array.isArray(parsed.pricing)) {
       const pricing: Record<string, { inputPer1M: number; outputPer1M: number }> = {};
       for (const [modelId, raw] of Object.entries(parsed.pricing as Record<string, unknown>)) {
+        // Skip prototype-pollution keys — never treat them as model IDs.
+        if (modelId === '__proto__' || modelId === 'constructor' || modelId === 'prototype') continue;
         if (!raw || typeof raw !== 'object') continue;
         const p = raw as Record<string, unknown>;
         if (

--- a/packages/core/src/github/client.ts
+++ b/packages/core/src/github/client.ts
@@ -887,6 +887,26 @@ export function parseRepoConfigYaml(content: string): Partial<MergeWatchConfig> 
     if (typeof parsed.model === 'string') config.model = parsed.model;
     if (typeof parsed.lightModel === 'string') config.lightModel = parsed.lightModel;
     if (typeof parsed.maxTokensPerAgent === 'number') config.maxTokensPerAgent = parsed.maxTokensPerAgent;
+
+    // Custom LLM pricing overrides (model ID -> USD per 1M tokens). Lets
+    // self-hosted operators price any model — Ollama, LiteLLM, a newer alias —
+    // so per-PR + dashboard cost show. Each entry needs numeric, non-negative
+    // inputPer1M / outputPer1M; malformed entries are skipped. `0`/`0` records a
+    // real $0 (priced), distinct from an unpriced (unknown) model.
+    if (parsed.pricing && typeof parsed.pricing === 'object' && !Array.isArray(parsed.pricing)) {
+      const pricing: Record<string, { inputPer1M: number; outputPer1M: number }> = {};
+      for (const [modelId, raw] of Object.entries(parsed.pricing as Record<string, unknown>)) {
+        if (!raw || typeof raw !== 'object') continue;
+        const p = raw as Record<string, unknown>;
+        if (
+          typeof p.inputPer1M === 'number' && Number.isFinite(p.inputPer1M) && p.inputPer1M >= 0 &&
+          typeof p.outputPer1M === 'number' && Number.isFinite(p.outputPer1M) && p.outputPer1M >= 0
+        ) {
+          pricing[modelId] = { inputPer1M: p.inputPer1M, outputPer1M: p.outputPer1M };
+        }
+      }
+      if (Object.keys(pricing).length > 0) config.pricing = pricing;
+    }
     if (typeof parsed.minSeverity === 'string' && ['info', 'warning', 'critical'].includes(parsed.minSeverity)) {
       config.minSeverity = parsed.minSeverity as 'info' | 'warning' | 'critical';
     }

--- a/packages/core/src/llm/pricing.test.ts
+++ b/packages/core/src/llm/pricing.test.ts
@@ -28,6 +28,18 @@ describe('estimateCost', () => {
     expect(cost).toBeCloseTo(0.0175, 6);
   });
 
+  it('prices current-gen Sonnet 4.6 (Bedrock + direct) at $3/$15 per 1M', () => {
+    // (1_000_000/1M)*3 + (1_000_000/1M)*15 = 18
+    expect(estimateCost('us.anthropic.claude-sonnet-4-6', 1_000_000, 1_000_000)).toBeCloseTo(18, 6);
+    expect(estimateCost('claude-sonnet-4-6', 1_000_000, 1_000_000)).toBeCloseTo(18, 6);
+  });
+
+  it('prices current-gen Opus 4.8 (Bedrock + direct) at $5/$25 per 1M', () => {
+    // (1_000_000/1M)*5 + (1_000_000/1M)*25 = 30
+    expect(estimateCost('us.anthropic.claude-opus-4-8-v1', 1_000_000, 1_000_000)).toBeCloseTo(30, 6);
+    expect(estimateCost('claude-opus-4-8', 1_000_000, 1_000_000)).toBeCloseTo(30, 6);
+  });
+
   it('the retired claude-3-5-sonnet is no longer priced (returns null)', () => {
     expect(estimateCost('us.anthropic.claude-3-5-sonnet-20241022-v2:0', 100, 100)).toBeNull();
     expect(estimateCost('claude-3-5-sonnet-20241022', 100, 100)).toBeNull();

--- a/packages/core/src/llm/pricing.ts
+++ b/packages/core/src/llm/pricing.ts
@@ -10,18 +10,29 @@ interface ModelPricing {
   outputPer1M: number;
 }
 
-/** Default pricing for known models (USD per 1M tokens). */
+/**
+ * Default pricing for known models (USD per 1M tokens). Covers the Anthropic
+ * models MergeWatch ships/recommends, by both Bedrock and direct-Anthropic ID.
+ * Self-hosted operators on any other model (Ollama, LiteLLM, a newer alias)
+ * should set a `pricing:` override in `.mergewatch.yml`; unknown models return
+ * null (counted but excluded from spend). Tiers: Opus $5/$25, legacy Opus
+ * $15/$75, Sonnet $3/$15, Haiku $0.80/$4 per 1M.
+ */
 export const DEFAULT_PRICING: Record<string, ModelPricing> = {
   // Bedrock Anthropic model IDs
+  'us.anthropic.claude-opus-4-8-v1': { inputPer1M: 5, outputPer1M: 25 },
   'us.anthropic.claude-opus-4-6-v1': { inputPer1M: 5, outputPer1M: 25 },
   'us.anthropic.claude-opus-4-20250514-v1:0': { inputPer1M: 15, outputPer1M: 75 },
+  'us.anthropic.claude-sonnet-4-6': { inputPer1M: 3, outputPer1M: 15 },
   'us.anthropic.claude-sonnet-4-20250514-v1:0': { inputPer1M: 3, outputPer1M: 15 },
   'us.anthropic.claude-haiku-4-5-20251001-v1:0': { inputPer1M: 0.80, outputPer1M: 4 },
   'us.anthropic.claude-3-5-haiku-20241022-v1:0': { inputPer1M: 0.80, outputPer1M: 4 },
 
   // Direct Anthropic model IDs
+  'claude-opus-4-8': { inputPer1M: 5, outputPer1M: 25 },
   'claude-opus-4-6': { inputPer1M: 5, outputPer1M: 25 },
   'claude-opus-4-20250514': { inputPer1M: 15, outputPer1M: 75 },
+  'claude-sonnet-4-6': { inputPer1M: 3, outputPer1M: 15 },
   'claude-sonnet-4-20250514': { inputPer1M: 3, outputPer1M: 15 },
   'claude-haiku-4-5-20251001': { inputPer1M: 0.80, outputPer1M: 4 },
   'claude-3-5-haiku-20241022': { inputPer1M: 0.80, outputPer1M: 4 },

--- a/packages/core/src/llm/token-accumulator.test.ts
+++ b/packages/core/src/llm/token-accumulator.test.ts
@@ -61,6 +61,28 @@ describe('TokenAccumulator', () => {
     });
     expect(cost).toBe(6);
   });
+
+  it('unpricedModels() is empty when every model is priced (#231)', () => {
+    const acc = new TokenAccumulator();
+    acc.add('claude-sonnet-4-20250514', { inputTokens: 10, outputTokens: 5 });
+    expect(acc.unpricedModels()).toEqual([]);
+  });
+
+  it('unpricedModels() lists models with no known pricing (#231)', () => {
+    const acc = new TokenAccumulator();
+    acc.add('claude-sonnet-4-20250514', { inputTokens: 10, outputTokens: 5 }); // priced
+    acc.add('llama3-local', { inputTokens: 10, outputTokens: 5 }); // unknown
+    expect(acc.unpricedModels()).toEqual(['llama3-local']);
+  });
+
+  it('unpricedModels() respects custom pricing, incl. a 0/0 priced model (#231)', () => {
+    const acc = new TokenAccumulator();
+    acc.add('llama3-local', { inputTokens: 10, outputTokens: 5 });
+    // Unpriced without an override...
+    expect(acc.unpricedModels()).toEqual(['llama3-local']);
+    // ...but a 0/0 override makes it priced ($0), not unpriced.
+    expect(acc.unpricedModels({ 'llama3-local': { inputPer1M: 0, outputPer1M: 0 } })).toEqual([]);
+  });
 });
 
 describe('TrackingLLMProvider', () => {

--- a/packages/core/src/llm/token-accumulator.ts
+++ b/packages/core/src/llm/token-accumulator.ts
@@ -55,6 +55,20 @@ export class TokenAccumulator {
     }
     return total;
   }
+
+  /**
+   * Model IDs used during this review that have no known pricing (after
+   * applying any custom overrides). Empty when every model is priced. Lets the
+   * caller surface an actionable "set a `pricing:` override" hint instead of a
+   * silent unpriced cost. A `0`/`0` priced model is NOT unpriced.
+   */
+  unpricedModels(customPricing?: Record<string, { inputPer1M: number; outputPer1M: number }>): string[] {
+    const unpriced: string[] = [];
+    for (const modelId of this.usage.keys()) {
+      if (estimateCost(modelId, 0, 0, customPricing) === null) unpriced.push(modelId);
+    }
+    return unpriced;
+  }
 }
 
 /**

--- a/packages/dashboard/components/insights/ImpactSections.tsx
+++ b/packages/dashboard/components/insights/ImpactSections.tsx
@@ -17,6 +17,7 @@ import {
 } from "recharts";
 import type { Cost, CycleTime, Engagement, Insight, Percentiles } from "./types";
 import { fmtHours, fmtPct, fmtUsd } from "./format";
+import { isAllUnpriced } from "@/lib/cost-insight";
 
 /** Small headline metric card matching the dashboard StatCard pattern. */
 function StatCard({ label, value, subtext }: { label: string; value: string; subtext?: string }) {
@@ -389,6 +390,19 @@ export function CostSection({
           subtext={c.unpricedReviewCount > 0 ? `${c.unpricedReviewCount.toLocaleString()} unpriced` : "all priced"}
         />
       </div>
+
+      {isAllUnpriced(c) && (
+        <div className="mt-4 rounded-md border border-border-default bg-surface-subtle p-3 text-xs text-text-secondary">
+          <p className="font-medium text-text-primary">No spend shown — this model isn&apos;t priced.</p>
+          <p className="mt-1">
+            Every review in this window ran on a model with no known pricing, so
+            spend reads $0. Add a <code className="px-1">pricing:</code> entry (USD
+            per 1M tokens) for your model in <code className="px-1">.mergewatch.yml</code> to
+            surface cost — use <code className="px-1">0</code>/<code className="px-1">0</code> for a
+            local model to record a real $0.
+          </p>
+        </div>
+      )}
 
       {repos.length > 0 && (
         <div className="mt-5">

--- a/packages/dashboard/lib/cost-insight.test.ts
+++ b/packages/dashboard/lib/cost-insight.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { isAllUnpriced } from "./cost-insight";
+
+describe("isAllUnpriced", () => {
+  it("is true when there are unpriced reviews and no priced ones", () => {
+    expect(isAllUnpriced({ pricedReviewCount: 0, unpricedReviewCount: 3 })).toBe(true);
+  });
+
+  it("is false when at least one review is priced", () => {
+    expect(isAllUnpriced({ pricedReviewCount: 1, unpricedReviewCount: 3 })).toBe(false);
+    expect(isAllUnpriced({ pricedReviewCount: 5, unpricedReviewCount: 0 })).toBe(false);
+  });
+
+  it("is false for an empty window (no reviews at all)", () => {
+    expect(isAllUnpriced({ pricedReviewCount: 0, unpricedReviewCount: 0 })).toBe(false);
+  });
+});

--- a/packages/dashboard/lib/cost-insight.ts
+++ b/packages/dashboard/lib/cost-insight.ts
@@ -1,0 +1,20 @@
+/**
+ * Pure helpers for the LLM-cost (Impact) surface. Kept dependency-free so the
+ * logic is unit-testable without React.
+ */
+
+/** Minimal shape needed to classify a window's cost data. */
+interface CostCounts {
+  pricedReviewCount: number;
+  unpricedReviewCount: number;
+}
+
+/**
+ * True when a window has reviews but **none** were priced — i.e. every review
+ * ran on a model with no known pricing, so all the money figures are $0. The
+ * dashboard uses this to show an actionable "set a `pricing:` override" hint
+ * instead of a silent $0. A window with zero reviews is not "all unpriced".
+ */
+export function isAllUnpriced(cost: CostCounts): boolean {
+  return cost.unpricedReviewCount > 0 && cost.pricedReviewCount === 0;
+}


### PR DESCRIPTION
## Summary

Closes #231. On self-hosted, the per-PR "Est. cost" line and the dashboard **Cost & Impact** block were blank — **not** because of a deployment-mode gate (both runtimes emit cost identically), but because `estimateCost()` returns `null` for any model outside the pricing table, which zeroes the comment line *and* the dashboard money figures. This fixes the pricing path end to end.

## Changes

- **`pricing.ts`** — add current-gen Anthropic IDs (**Sonnet 4.6**, **Opus 4.8**) by both Bedrock and direct ID, so direct-Anthropic self-hosters get cost with zero config. Unknown models still return `null` (counted, excluded from spend).
- **`parseRepoConfigYaml`** — actually **parse + validate** the `.mergewatch.yml` **`pricing:`** override (model → `inputPer1M`/`outputPer1M`). It was *silently dropped* before, so the documented knob never worked. Malformed/negative entries are skipped; `0`/`0` records a real **priced $0** for a local model (distinct from "unpriced").
- **`TokenAccumulator.unpricedModels()` + reviewer warn** — one-time (per-model, per-process) `[cost] No pricing for model(s) …` warn pointing to the override, so self-hosted operators know why cost is missing.
- **Dashboard `CostSection`** — actionable "set a `pricing:` override" hint when every in-window review is unpriced, instead of a silent $0. Pure `isAllUnpriced` predicate, unit-tested.
- **Docs** — `README`, `.mergewatch.yml`, `.env.example` `pricing:` examples (incl. the `0`/`0` local convention); RUNBOOK **E2E-66**.

## Acceptance criteria (from #231)
- [x] Priced model (default or `.mergewatch.yml` override) → per-PR "Est. cost" **and** non-zero dashboard cost
- [x] `DEFAULT_PRICING` covers current direct-Anthropic IDs; unknown models still `null`
- [x] `pricing:` override documented for self-hosted (incl. `0/0` convention) — **and now actually parsed**
- [x] All-unpriced window → dashboard actionable hint (not silent $0); server warn
- [x] No SaaS/Bedrock regression; rollup still excludes unpriced from money

## Tests
Unit tests for every branch: new pricing IDs, YAML `pricing:` parse (valid / `0,0` / malformed / array), `unpricedModels()` incl. `0/0`, and the `isAllUnpriced` predicate. `build` + `typecheck` + `test` green workspace-wide. No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)