### PR TITLE
feat(org-agents): dashboard admin Custom Agents UI + API (#235, PR 3/4)

### DIFF
--- a/packages/core/src/storage/dashboard-types.ts
+++ b/packages/core/src/storage/dashboard-types.ts
@@ -11,7 +11,7 @@
  *   - PostgresDashboardStore (packages/storage-postgres) — self-hosted / Docker
  */
 
-import type { InstallationItem, InstallationSettings, ReviewItem, InstallationFPInsight, NpsResponseRecord } from '../types/db.js';
+import type { InstallationItem, InstallationSettings, ReviewItem, InstallationFPInsight, NpsResponseRecord, OrgCustomAgent } from '../types/db.js';
 
 // ─── Paginated result wrapper ───────────────────────────────────────────────
 
@@ -45,6 +45,12 @@ export interface IDashboardInstallationStore {
 
   /** Save installation-level settings. */
   updateSettings(installationId: string, settings: InstallationSettings): Promise<void>;
+
+  /** #235 — read the installation's org custom agents (sanitized; [] when unset). */
+  getCustomAgents(installationId: string): Promise<OrgCustomAgent[]>;
+
+  /** #235 — replace the installation's org custom agents (full set). */
+  updateCustomAgents(installationId: string, agents: OrgCustomAgent[]): Promise<void>;
 }
 
 // ─── Review store (dashboard operations) ────────────────────────────────────

--- a/packages/dashboard/app/api/custom-agents/route.ts
+++ b/packages/dashboard/app/api/custom-agents/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getDashboardStore } from "@/lib/store";
+import { fetchUserInstallations, checkInstallationAdmin, TokenExpiredError } from "@/lib/github-repos";
+import { sanitizeOrgCustomAgents, ORG_CUSTOM_AGENT_SOFT_CAP } from "@mergewatch/core";
+import { stampAudit } from "@/lib/custom-agents";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * #235 — Org Custom Agents read/write API.
+ *
+ * GET  /api/custom-agents?installation_id=<id>  — any user with access (read-only).
+ * PUT  /api/custom-agents?installation_id=<id>  — org admins only; replaces the
+ *      full set. Server assigns ids for new entries and stamps last-edited
+ *      audit metadata (updatedAt / updatedBy) on created or changed agents.
+ */
+
+export async function GET(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const accessToken = (session as any).accessToken as string | undefined;
+  if (!accessToken) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const installationId = new URL(req.url).searchParams.get("installation_id");
+  if (!installationId) return NextResponse.json({ error: "Missing installation_id" }, { status: 400 });
+
+  let isAdmin = false;
+  try {
+    const installations = await fetchUserInstallations(accessToken);
+    const installation = installations.find((i) => String(i.id) === installationId);
+    if (!installation) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    isAdmin = await checkInstallationAdmin(accessToken, installation);
+  } catch (err) {
+    if (err instanceof TokenExpiredError) {
+      return NextResponse.json({ error: "Token expired" }, { status: 401 });
+    }
+    return NextResponse.json({ error: "GitHub API unavailable, please retry" }, { status: 503 });
+  }
+
+  try {
+    const store = await getDashboardStore();
+    const agents = await store.installations.getCustomAgents(installationId);
+    // `canEdit` lets the client render read-only for non-admins.
+    return NextResponse.json({ agents, canEdit: isAdmin, softCap: ORG_CUSTOM_AGENT_SOFT_CAP });
+  } catch {
+    return NextResponse.json({ agents: [], canEdit: isAdmin, softCap: ORG_CUSTOM_AGENT_SOFT_CAP });
+  }
+}
+
+export async function PUT(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const accessToken = (session as any).accessToken as string | undefined;
+  if (!accessToken) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const installationId = new URL(req.url).searchParams.get("installation_id");
+  if (!installationId) return NextResponse.json({ error: "Missing installation_id" }, { status: 400 });
+
+  // Admin gate.
+  try {
+    const installations = await fetchUserInstallations(accessToken);
+    const installation = installations.find((i) => String(i.id) === installationId);
+    if (!installation) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    const isAdmin = await checkInstallationAdmin(accessToken, installation);
+    if (!isAdmin) return NextResponse.json({ error: "Forbidden — org admins only" }, { status: 403 });
+  } catch (err) {
+    if (err instanceof TokenExpiredError) {
+      return NextResponse.json({ error: "Token expired" }, { status: 401 });
+    }
+    throw err;
+  }
+
+  const body = await req.json().catch(() => null);
+  if (!body || !Array.isArray(body.agents)) {
+    return NextResponse.json({ error: "Missing agents[]" }, { status: 400 });
+  }
+
+  // Sanitize first so malformed entries can't reach storage.
+  const incoming = sanitizeOrgCustomAgents(body.agents);
+  const editor =
+    ((session as any).user?.name as string | undefined) ||
+    ((session as any).githubUserId as string | undefined) ||
+    "unknown";
+  const now = new Date().toISOString();
+
+  try {
+    const store = await getDashboardStore();
+    const existing = await store.installations.getCustomAgents(installationId);
+    const stamped = stampAudit(incoming, existing, editor, now);
+    await store.installations.updateCustomAgents(installationId, stamped);
+    return NextResponse.json({ ok: true, agents: stamped });
+  } catch (err) {
+    console.error("Failed to save custom agents:", err);
+    return NextResponse.json({ error: "Failed to save" }, { status: 500 });
+  }
+}

--- a/packages/dashboard/app/api/custom-agents/route.ts
+++ b/packages/dashboard/app/api/custom-agents/route.ts
@@ -69,7 +69,10 @@ export async function PUT(req: NextRequest) {
     if (err instanceof TokenExpiredError) {
       return NextResponse.json({ error: "Token expired" }, { status: 401 });
     }
-    throw err;
+    // GitHub API/network failure during the admin check — log for diagnostics
+    // and surface a 503 (rather than an opaque unhandled 500).
+    console.error("[custom-agents] admin check failed:", err);
+    return NextResponse.json({ error: "GitHub API unavailable, please retry" }, { status: 503 });
   }
 
   const body = await req.json().catch(() => null);

--- a/packages/dashboard/app/dashboard/settings/custom-agents/page.tsx
+++ b/packages/dashboard/app/dashboard/settings/custom-agents/page.tsx
@@ -1,0 +1,62 @@
+export const dynamic = "force-dynamic";
+
+import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import {
+  fetchUserInstallations,
+  fetchInstallationRepos,
+  checkInstallationAdmin,
+  TokenExpiredError,
+} from "@/lib/github-repos";
+import CustomAgentsManager from "@/components/CustomAgentsManager";
+
+interface Props {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}
+
+/**
+ * /dashboard/settings/custom-agents (#235) — org admins define custom review
+ * agents enforced across the org's repos. Members see a read-only view.
+ */
+export default async function CustomAgentsPage({ searchParams }: Props) {
+  const session = await getServerSession(authOptions);
+  if (!session) redirect("/");
+  const accessToken = (session as any).accessToken as string | undefined;
+  if (!accessToken) redirect("/");
+
+  const params = await searchParams;
+  let installations;
+  try {
+    installations = await fetchUserInstallations(accessToken);
+  } catch (err) {
+    if (err instanceof TokenExpiredError) redirect("/signout");
+    throw err;
+  }
+  if (installations.length === 0) redirect("/onboarding");
+
+  const orgParam = typeof params.org === "string" ? params.org : undefined;
+  const activeInstallation = orgParam
+    ? installations.find((i) => String(i.id) === orgParam) ?? installations[0]
+    : installations[0];
+
+  const isAdmin = await checkInstallationAdmin(accessToken, activeInstallation);
+
+  // Repo list powers the "selected repos" scope picker. Best-effort — the page
+  // still works (all-repos scope) if the repo fetch fails.
+  let repoNames: string[] = [];
+  try {
+    const { repos } = await fetchInstallationRepos(accessToken, activeInstallation.id);
+    repoNames = repos.map((r) => r.repoFullName).sort();
+  } catch {
+    repoNames = [];
+  }
+
+  return (
+    <CustomAgentsManager
+      installationId={String(activeInstallation.id)}
+      isAdmin={isAdmin}
+      repos={repoNames}
+    />
+  );
+}

--- a/packages/dashboard/components/CustomAgentsManager.tsx
+++ b/packages/dashboard/components/CustomAgentsManager.tsx
@@ -1,0 +1,344 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Plus, Trash2, AlertTriangle } from "lucide-react";
+import type { OrgCustomAgent } from "@mergewatch/core";
+
+interface Props {
+  installationId: string;
+  isAdmin: boolean;
+  repos: string[];
+}
+
+type Draft = OrgCustomAgent;
+
+function blankAgent(): Draft {
+  return {
+    id: "",
+    name: "",
+    prompt: "",
+    severityDefault: "warning",
+    enforcement: "advisory",
+    enabled: true,
+    scope: { mode: "all" },
+    updatedAt: "",
+    updatedBy: "",
+  };
+}
+
+export default function CustomAgentsManager({ installationId, isAdmin, repos }: Props) {
+  const [agents, setAgents] = useState<Draft[]>([]);
+  const [softCap, setSoftCap] = useState(10);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      try {
+        const res = await fetch(`/api/custom-agents?installation_id=${installationId}`);
+        if (res.status === 401) { window.location.href = "/signout"; return; }
+        if (!res.ok) throw new Error("Failed to load custom agents");
+        const json = await res.json();
+        if (!cancelled) {
+          setAgents(json.agents ?? []);
+          setSoftCap(json.softCap ?? 10);
+        }
+      } catch (e: any) {
+        if (!cancelled) setError(e.message ?? "Failed to load");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [installationId]);
+
+  const enabledCount = useMemo(() => agents.filter((a) => a.enabled).length, [agents]);
+  const overCap = enabledCount > softCap;
+
+  function update(i: number, patch: Partial<Draft>) {
+    setAgents((prev) => prev.map((a, idx) => (idx === i ? { ...a, ...patch } : a)));
+    setSavedAt(null);
+  }
+
+  function addAgent() {
+    setAgents((prev) => [...prev, blankAgent()]);
+    setSavedAt(null);
+  }
+
+  function removeAgent(i: number) {
+    setAgents((prev) => prev.filter((_, idx) => idx !== i));
+    setSavedAt(null);
+  }
+
+  async function save() {
+    setSaving(true);
+    setError(null);
+    try {
+      // Drop entries missing a name/prompt before saving (the API sanitizes too).
+      const payload = agents.filter((a) => a.name.trim() && a.prompt.trim());
+      const res = await fetch(`/api/custom-agents?installation_id=${installationId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agents: payload }),
+      });
+      if (res.status === 401) { window.location.href = "/signout"; return; }
+      if (res.status === 403) throw new Error("Only org admins can edit custom agents.");
+      if (!res.ok) throw new Error((await res.json().catch(() => ({})))?.error ?? "Failed to save");
+      const json = await res.json();
+      setAgents(json.agents ?? payload);
+      setSavedAt(new Date().toLocaleTimeString());
+    } catch (e: any) {
+      setError(e.message ?? "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="px-4 py-6 sm:px-8">
+        <div className="h-6 w-48 animate-pulse rounded bg-surface-subtle" />
+        <div className="mt-4 h-40 animate-pulse rounded-lg bg-surface-subtle" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-4 py-6 sm:px-8">
+      <header className="mb-4">
+        <h1 className="text-xl font-bold text-fg-primary">Custom Agents</h1>
+        <p className="mt-1 text-sm text-fg-secondary">
+          Org-wide review agents enforced across your repositories. Each runs in
+          addition to the built-in agents and any repo&apos;s <code>.mergewatch.yml</code>.
+          {" "}Set an agent to <strong>blocking</strong> to fail the check run and request
+          changes when it flags a critical issue.
+        </p>
+      </header>
+
+      {!isAdmin && (
+        <div className="mb-4 rounded-md border border-border-default bg-surface-subtle p-3 text-sm text-fg-secondary">
+          You have read-only access. Only organization admins can add or edit custom agents.
+        </div>
+      )}
+
+      {error && (
+        <div className="mb-4 rounded-md border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-500">
+          {error}
+        </div>
+      )}
+
+      {overCap && (
+        <div className="mb-4 flex items-start gap-2 rounded-md border border-yellow-500/40 bg-yellow-500/10 p-3 text-sm text-fg-secondary">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-yellow-500" />
+          <span>
+            {enabledCount} agents enabled — above the recommended {softCap}. Each agent adds an
+            LLM call per review, increasing latency and cost.
+          </span>
+        </div>
+      )}
+
+      <div className="space-y-4">
+        {agents.length === 0 && (
+          <div className="rounded-lg border border-border-default bg-surface-card p-8 text-center text-sm text-fg-secondary">
+            No custom agents yet.{isAdmin ? " Add one to enforce an org-wide review standard." : ""}
+          </div>
+        )}
+
+        {agents.map((a, i) => (
+          <AgentCard
+            key={a.id || `new-${i}`}
+            agent={a}
+            repos={repos}
+            disabled={!isAdmin}
+            onChange={(patch) => update(i, patch)}
+            onRemove={() => removeAgent(i)}
+          />
+        ))}
+      </div>
+
+      {isAdmin && (
+        <div className="mt-4 flex items-center gap-3">
+          <button
+            type="button"
+            onClick={addAgent}
+            className="inline-flex items-center gap-1.5 rounded-md border border-border-default bg-surface-card px-3 py-1.5 text-sm text-fg-primary transition hover:bg-hover"
+          >
+            <Plus className="h-4 w-4" /> Add agent
+          </button>
+          <button
+            type="button"
+            onClick={save}
+            disabled={saving}
+            className="rounded-md bg-accent-emphasis px-4 py-1.5 text-sm font-medium text-white transition hover:opacity-90 disabled:opacity-50"
+          >
+            {saving ? "Saving…" : "Save changes"}
+          </button>
+          {savedAt && <span className="text-xs text-fg-tertiary">Saved at {savedAt}</span>}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AgentCard({
+  agent,
+  repos,
+  disabled,
+  onChange,
+  onRemove,
+}: {
+  agent: Draft;
+  repos: string[];
+  disabled: boolean;
+  onChange: (patch: Partial<Draft>) => void;
+  onRemove: () => void;
+}) {
+  const [repoFilter, setRepoFilter] = useState("");
+  const inputCls =
+    "rounded-md border border-border-default bg-surface-card px-2 py-1.5 text-sm text-fg-primary focus:border-accent-emphasis focus:outline-none focus:ring-1 focus:ring-accent-emphasis disabled:opacity-60";
+
+  const selectedRepos = agent.scope.mode === "selected" ? agent.scope.repos : [];
+  const filteredRepos = repoFilter
+    ? repos.filter((r) => r.toLowerCase().includes(repoFilter.toLowerCase()))
+    : repos;
+
+  function toggleRepo(repo: string) {
+    const set = new Set(selectedRepos);
+    if (set.has(repo)) set.delete(repo); else set.add(repo);
+    onChange({ scope: { mode: "selected", repos: Array.from(set) } });
+  }
+
+  return (
+    <div className="rounded-lg border border-border-default bg-surface-card p-4 sm:p-5">
+      <div className="flex items-start justify-between gap-3">
+        <input
+          className={`${inputCls} flex-1 font-medium`}
+          placeholder="Agent name (e.g. No console.log)"
+          value={agent.name}
+          disabled={disabled}
+          onChange={(e) => onChange({ name: e.target.value })}
+        />
+        {!disabled && (
+          <button type="button" onClick={onRemove} className="p-1.5 text-fg-tertiary transition hover:text-red-500" aria-label="Remove agent">
+            <Trash2 className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+
+      <textarea
+        className={`${inputCls} mt-3 w-full`}
+        rows={3}
+        placeholder="Prompt — what should this agent look for?"
+        value={agent.prompt}
+        disabled={disabled}
+        onChange={(e) => onChange({ prompt: e.target.value })}
+      />
+
+      <div className="mt-3 flex flex-wrap items-center gap-4">
+        <label className="flex items-center gap-1.5 text-sm text-fg-secondary">
+          Severity
+          <select className={inputCls} value={agent.severityDefault} disabled={disabled}
+            onChange={(e) => onChange({ severityDefault: e.target.value as Draft["severityDefault"] })}>
+            <option value="info">Info</option>
+            <option value="warning">Warning</option>
+            <option value="critical">Critical</option>
+          </select>
+        </label>
+
+        <label className="flex items-center gap-1.5 text-sm text-fg-secondary">
+          Enforcement
+          <select className={inputCls} value={agent.enforcement} disabled={disabled}
+            onChange={(e) => onChange({ enforcement: e.target.value as Draft["enforcement"] })}>
+            <option value="advisory">Advisory</option>
+            <option value="blocking">Blocking</option>
+          </select>
+        </label>
+
+        <label className="flex items-center gap-1.5 text-sm text-fg-secondary">
+          <input type="checkbox" checked={agent.enabled} disabled={disabled}
+            onChange={(e) => onChange({ enabled: e.target.checked })} />
+          Enabled
+        </label>
+      </div>
+
+      {/* Scope */}
+      <div className="mt-3">
+        <p className="mb-1 text-xs font-medium uppercase tracking-wider text-fg-tertiary">Applies to</p>
+        <div className="flex gap-4 text-sm text-fg-secondary">
+          <label className="flex items-center gap-1.5">
+            <input type="radio" checked={agent.scope.mode === "all"} disabled={disabled}
+              onChange={() => onChange({ scope: { mode: "all" } })} />
+            All repositories
+          </label>
+          <label className="flex items-center gap-1.5">
+            <input type="radio" checked={agent.scope.mode === "selected"} disabled={disabled}
+              onChange={() => onChange({ scope: { mode: "selected", repos: selectedRepos } })} />
+            Selected repositories
+          </label>
+        </div>
+        {agent.scope.mode === "selected" && (
+          <div className="mt-2 rounded-md border border-border-default p-2">
+            <input className={`${inputCls} mb-2 w-full`} placeholder="Filter repositories…"
+              value={repoFilter} disabled={disabled} onChange={(e) => setRepoFilter(e.target.value)} />
+            <div className="max-h-40 overflow-y-auto">
+              {filteredRepos.length === 0 && <p className="px-1 py-2 text-xs text-fg-tertiary">No repositories.</p>}
+              {filteredRepos.map((r) => (
+                <label key={r} className="flex items-center gap-1.5 px-1 py-0.5 text-sm text-fg-primary">
+                  <input type="checkbox" checked={selectedRepos.includes(r)} disabled={disabled}
+                    onChange={() => toggleRepo(r)} />
+                  {r}
+                </label>
+              ))}
+            </div>
+            <p className="mt-1 text-xs text-fg-tertiary">{selectedRepos.length} selected</p>
+          </div>
+        )}
+      </div>
+
+      {/* Targeting */}
+      <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <label className="text-sm text-fg-secondary">
+          <span className="mb-1 block text-xs font-medium uppercase tracking-wider text-fg-tertiary">Path globs (optional)</span>
+          <input className={`${inputCls} w-full`} placeholder="src/api/**, **/*.ts" disabled={disabled}
+            value={(agent.targeting?.pathGlobs ?? []).join(", ")}
+            onChange={(e) => onChange({ targeting: mergeTargeting(agent, "pathGlobs", e.target.value) })} />
+        </label>
+        <label className="text-sm text-fg-secondary">
+          <span className="mb-1 block text-xs font-medium uppercase tracking-wider text-fg-tertiary">Languages (optional)</span>
+          <input className={`${inputCls} w-full`} placeholder="typescript, go" disabled={disabled}
+            value={(agent.targeting?.languages ?? []).join(", ")}
+            onChange={(e) => onChange({ targeting: mergeTargeting(agent, "languages", e.target.value) })} />
+        </label>
+      </div>
+
+      {agent.updatedBy && (
+        <p className="mt-3 text-xs text-fg-tertiary">
+          Last edited by {agent.updatedBy}
+          {agent.updatedAt ? ` · ${new Date(agent.updatedAt).toLocaleString()}` : ""}
+        </p>
+      )}
+    </div>
+  );
+}
+
+/** Parse a comma-separated list into a targeting field; omit targeting when both empty. */
+function mergeTargeting(
+  agent: Draft,
+  field: "pathGlobs" | "languages",
+  raw: string,
+): Draft["targeting"] {
+  const list = raw.split(",").map((s) => s.trim()).filter(Boolean);
+  const next = {
+    pathGlobs: field === "pathGlobs" ? list : agent.targeting?.pathGlobs ?? [],
+    languages: field === "languages" ? list : agent.targeting?.languages ?? [],
+  };
+  if (next.pathGlobs.length === 0 && next.languages.length === 0) return undefined;
+  return {
+    ...(next.pathGlobs.length ? { pathGlobs: next.pathGlobs } : {}),
+    ...(next.languages.length ? { languages: next.languages } : {}),
+  };
+}

--- a/packages/dashboard/components/SettingsTabs.tsx
+++ b/packages/dashboard/components/SettingsTabs.tsx
@@ -5,6 +5,7 @@ import { usePathname, useSearchParams } from "next/navigation";
 
 const tabs = [
   { label: "General", href: "/dashboard/settings" },
+  { label: "Custom Agents", href: "/dashboard/settings/custom-agents" },
   { label: "API Keys", href: "/dashboard/settings/api-keys" },
 ];
 

--- a/packages/dashboard/lib/custom-agents.test.ts
+++ b/packages/dashboard/lib/custom-agents.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { stampAudit, contentKey } from "./custom-agents";
+import type { OrgCustomAgent } from "@mergewatch/core";
+
+function agent(over: Partial<OrgCustomAgent> = {}): OrgCustomAgent {
+  return {
+    id: "a1",
+    name: "No console.log",
+    prompt: "Flag console.log.",
+    severityDefault: "warning",
+    enforcement: "advisory",
+    enabled: true,
+    scope: { mode: "all" },
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    updatedBy: "alice",
+    ...over,
+  };
+}
+
+const NOW = "2026-06-25T12:00:00.000Z";
+
+describe("stampAudit", () => {
+  it("assigns ids to new agents and stamps the editor", () => {
+    let n = 0;
+    const out = stampAudit([agent({ id: "" })], [], "bob", NOW, () => `gen-${++n}`);
+    expect(out[0].id).toBe("gen-1");
+    expect(out[0].updatedAt).toBe(NOW);
+    expect(out[0].updatedBy).toBe("bob");
+  });
+
+  it("preserves prior audit metadata for an unchanged agent", () => {
+    const existing = [agent()];
+    const out = stampAudit([agent()], existing, "bob", NOW);
+    expect(out[0].updatedBy).toBe("alice"); // unchanged → keep original editor
+    expect(out[0].updatedAt).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  it("re-stamps an agent whose content changed", () => {
+    const existing = [agent()];
+    const out = stampAudit([agent({ prompt: "Flag console.error too." })], existing, "bob", NOW);
+    expect(out[0].updatedBy).toBe("bob");
+    expect(out[0].updatedAt).toBe(NOW);
+  });
+
+  it("treats a scope change as an edit", () => {
+    const existing = [agent()];
+    const out = stampAudit(
+      [agent({ scope: { mode: "selected", repos: ["o/a"] } })],
+      existing,
+      "bob",
+      NOW,
+    );
+    expect(out[0].updatedBy).toBe("bob");
+  });
+});
+
+describe("contentKey", () => {
+  it("is stable across audit-only differences", () => {
+    expect(contentKey(agent({ updatedBy: "x", updatedAt: "y" }))).toBe(
+      contentKey(agent({ updatedBy: "z", updatedAt: "w" })),
+    );
+  });
+  it("differs when a meaningful field changes", () => {
+    expect(contentKey(agent())).not.toBe(contentKey(agent({ enforcement: "blocking" })));
+  });
+});

--- a/packages/dashboard/lib/custom-agents.ts
+++ b/packages/dashboard/lib/custom-agents.ts
@@ -1,0 +1,43 @@
+/**
+ * #235 — pure helpers for the Org Custom Agents API. Kept dependency-free so
+ * the audit-stamping logic is unit-testable without mocking the route.
+ */
+
+import type { OrgCustomAgent } from "@mergewatch/core";
+
+/** Stable fields that, when changed, count as an "edit" for audit purposes. */
+export function contentKey(a: OrgCustomAgent): string {
+  return JSON.stringify({
+    name: a.name,
+    prompt: a.prompt,
+    severityDefault: a.severityDefault,
+    enforcement: a.enforcement,
+    enabled: a.enabled,
+    scope: a.scope,
+    targeting: a.targeting ?? null,
+  });
+}
+
+/**
+ * Assign ids to new agents and stamp `updatedAt` / `updatedBy` on created or
+ * changed agents; preserve prior audit metadata for unchanged agents — so
+ * "last edited by" reflects the actual last editor of THAT agent, not whoever
+ * saved the set. `genId` is injectable for deterministic tests.
+ */
+export function stampAudit(
+  incoming: OrgCustomAgent[],
+  existing: OrgCustomAgent[],
+  editor: string,
+  now: string,
+  genId: () => string = () => globalThis.crypto.randomUUID(),
+): OrgCustomAgent[] {
+  const byId = new Map(existing.map((a) => [a.id, a]));
+  return incoming.map((a) => {
+    const id = a.id || genId();
+    const prior = byId.get(id);
+    const changed = !prior || contentKey(prior) !== contentKey(a);
+    return changed
+      ? { ...a, id, updatedAt: now, updatedBy: editor }
+      : { ...a, id, updatedAt: prior.updatedAt, updatedBy: prior.updatedBy };
+  });
+}

--- a/packages/storage-dynamo/src/dashboard-store.ts
+++ b/packages/storage-dynamo/src/dashboard-store.ts
@@ -8,6 +8,7 @@
 import {
   DynamoDBDocumentClient,
   GetCommand,
+  PutCommand,
   QueryCommand,
   UpdateCommand,
 } from '@aws-sdk/lib-dynamodb';
@@ -21,8 +22,9 @@ import type {
   InstallationItem,
   InstallationSettings,
   ReviewItem,
+  OrgCustomAgent,
 } from '@mergewatch/core';
-import { DEFAULT_INSTALLATION_SETTINGS as DEFAULTS } from '@mergewatch/core';
+import { DEFAULT_INSTALLATION_SETTINGS as DEFAULTS, sanitizeOrgCustomAgents } from '@mergewatch/core';
 
 // ─── Installation store ─────────────────────────────────────────────────────
 
@@ -76,6 +78,34 @@ class DynamoDashboardInstallationStore implements IDashboardInstallationStore {
         ExpressionAttributeValues: {
           ':settings': settings,
           ':now': new Date().toISOString(),
+        },
+      }),
+    );
+  }
+
+  async getCustomAgents(installationId: string): Promise<OrgCustomAgent[]> {
+    try {
+      const result = await this.client.send(
+        new GetCommand({
+          TableName: this.tableName,
+          Key: { installationId, repoFullName: '#AGENTS' },
+        }),
+      );
+      return sanitizeOrgCustomAgents(result.Item?.agents);
+    } catch {
+      return [];
+    }
+  }
+
+  async updateCustomAgents(installationId: string, agents: OrgCustomAgent[]): Promise<void> {
+    await this.client.send(
+      new PutCommand({
+        TableName: this.tableName,
+        Item: {
+          installationId,
+          repoFullName: '#AGENTS',
+          agents: sanitizeOrgCustomAgents(agents),
+          updatedAt: new Date().toISOString(),
         },
       }),
     );

--- a/packages/storage-dynamo/src/dashboard-store.ts
+++ b/packages/storage-dynamo/src/dashboard-store.ts
@@ -92,7 +92,8 @@ class DynamoDashboardInstallationStore implements IDashboardInstallationStore {
         }),
       );
       return sanitizeOrgCustomAgents(result.Item?.agents);
-    } catch {
+    } catch (err) {
+      console.error('[dashboard-store] getCustomAgents failed:', err);
       return [];
     }
   }

--- a/packages/storage-postgres/src/dashboard-store.ts
+++ b/packages/storage-postgres/src/dashboard-store.ts
@@ -20,8 +20,9 @@ import type {
   InstallationSettings,
   ReviewItem,
   ReviewStatus,
+  OrgCustomAgent,
 } from '@mergewatch/core';
-import { DEFAULT_INSTALLATION_SETTINGS as DEFAULTS } from '@mergewatch/core';
+import { DEFAULT_INSTALLATION_SETTINGS as DEFAULTS, sanitizeOrgCustomAgents } from '@mergewatch/core';
 import { installations, installationSettings, reviews } from './schema.js';
 
 // ─── Helper: map a Drizzle row to ReviewItem ────────────────────────────────
@@ -118,6 +119,27 @@ class PostgresDashboardInstallationStore implements IDashboardInstallationStore 
           customInstructions: settings.customInstructions,
           commentHeader: settings.commentHeader,
         },
+      });
+  }
+
+  async getCustomAgents(installationId: string): Promise<OrgCustomAgent[]> {
+    const rows = await this.db
+      .select({ customAgents: installationSettings.customAgents })
+      .from(installationSettings)
+      .where(eq(installationSettings.installationId, installationId))
+      .limit(1);
+    if (rows.length === 0) return [];
+    return sanitizeOrgCustomAgents(rows[0].customAgents);
+  }
+
+  async updateCustomAgents(installationId: string, agents: OrgCustomAgent[]): Promise<void> {
+    const sanitized = sanitizeOrgCustomAgents(agents);
+    await this.db
+      .insert(installationSettings)
+      .values({ installationId, customAgents: sanitized as any })
+      .onConflictDoUpdate({
+        target: installationSettings.installationId,
+        set: { customAgents: sanitized as any },
       });
   }
 


### PR DESCRIPTION
**Part of #235** — PR 3 of 4 (dashboard admin UI + API). Builds on PR1 store (#236) + PR2 enforcement (#237).

> Note: this work was briefly committed to `main` by mistake (cf29dae) and immediately reverted (3eba234); this PR re-applies it through the proper review flow.

## What's here
- **store:** `IDashboardInstallationStore` gains `getCustomAgents` / `updateCustomAgents`, implemented for DynamoDB (`#AGENTS` row) and Postgres (`custom_agents` column), reusing the PR1 row/column + `sanitizeOrgCustomAgents` logic.
- **API — `/api/custom-agents`:** `GET` (any user with installation access; returns `canEdit` + `softCap`) and `PUT` (**org admins only** via `checkInstallationAdmin`). Server sanitizes, assigns ids to new agents, and stamps last-edited audit metadata only on created/changed agents (`lib/custom-agents` `stampAudit`).
- **UI — Settings → Custom Agents** (admin-only edit; members read-only): per-agent name, prompt, severity, **advisory/blocking**, enabled, **repo scope** (all or a filterable selected-repos allowlist), **path-glob + language targeting**, and last-edited-by/when. **Soft-cap warning** past the recommended limit. New "Custom Agents" settings tab.

## Tests
- `stampAudit` + `contentKey`: id assignment, stamp-on-change, preserve-on-unchanged, scope-change-as-edit, audit-only stability.
- Dashboard store methods are byte-identical to the PR1-tested installation stores; the genuinely-new logic (audit stamping, sanitization) is unit-tested. (The dashboard-store classes are internal/non-exported and the factory builds a real client, so testing them in isolation would need a test-only export — deliberately avoided.)
- `build` + `typecheck` + `test` green workspace-wide.

## Next
- PR4: docs + RUNBOOK (`Closes #235`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)