### PR TITLE
docs(org-agents): README + RUNBOOK for Org Custom Agents (#235, PR 4/4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ The review pipeline runs parallel specialized agents (security, bug, style, summ
 
 ### Data Layer
 **SaaS (DynamoDB):** Two tables defined in `infra/template.yaml`:
-- **mergewatch-installations** — PK: `installationId`, SK: `repoFullName` (or `#SETTINGS` for installation-level settings)
+- **mergewatch-installations** — PK: `installationId`, SK: `repoFullName` (or `#SETTINGS` for installation-level settings, `#AGENTS` for org custom agents)
 - **mergewatch-reviews** — PK: `repoFullName`, SK: `prNumberCommitSha` (format: `42#abc123`). 90-day TTL.
 
 **Self-hosted (Postgres):** Drizzle ORM schema in `packages/storage-postgres/src/schema.ts`:
@@ -128,6 +128,7 @@ Types in `packages/core/src/types/db.ts`, GitHub payload types in `packages/core
 - Comment upsert: finds existing bot comment via HTML marker, DynamoDB lookup, or GitHub API scan
 - Smart skip: `shouldSkipPR()` in `packages/core/src/skip-logic.ts` detects docs-only/lock-file PRs to avoid unnecessary LLM costs
 - Installation settings stored as sentinel row with SK `#SETTINGS` in the installations table
+- Org custom agents (#235): dashboard-defined, stored as the `#AGENTS` sentinel row (DynamoDB) / `installation_settings.custom_agents` jsonb (Postgres); selected by repo scope + path/language targeting, run in union with repo `.mergewatch.yml` `customAgents` (org wins), and a `blocking` agent's critical finding fails the check + requests changes. Logic in `packages/core/src/org-agents.ts`
 - SaaS: Zero API keys — Lambda uses IAM instance profiles for Bedrock; GitHub credentials in SSM
 - Self-hosted: LLM provider configurable via `LLM_PROVIDER` env var (anthropic, bedrock, litellm, ollama)
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,17 @@ LLM_MODEL_OUTPUT_PRICE_PER_1M=25   # USD per 1M output tokens
 
 Both must be set (a partial/invalid value is ignored with a warning). Use `0`/`0` for a local model to record a real `$0`. A per-repo `.mergewatch.yml` `pricing:` entry for the same model **overrides** the env price.
 
+## Org Custom Agents
+
+Beyond the per-repo `customAgents` in `.mergewatch.yml`, **organization admins** can define custom review agents from the dashboard (**Settings → Custom Agents**) and have them enforced across the org's repositories. Each org agent has:
+
+- **Prompt + severity** — what it looks for and the default severity of its findings.
+- **Repo scope** — applies to **all repositories** or a **selected allowlist**.
+- **Targeting (optional)** — only run when the PR changes files matching given **path globs** and/or **languages**.
+- **Enforcement** — **advisory** (surfaces findings only) or **blocking** (a *critical* finding fails the check run **and** requests changes, regardless of the overall merge score).
+
+Org agents run **in addition to** each repo's own `.mergewatch.yml` `customAgents` — on a name collision, the org agent wins (repos can add agents, not remove org ones). Only org admins can create or edit them; other members see a read-only view. Each agent adds an LLM call per review, so the dashboard warns past a recommended count. Available on both SaaS and self-hosted.
+
 ## Interacting via comments
 
 | Comment | What happens |

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -194,6 +194,7 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-65](#e2e-65-analytics-tabbed-view--accuracy-folded-in-227) | `/dashboard/analytics` is a tabbed view (Overview · Cost & Impact · Findings · Activity · Accuracy); active tab in `?tab=` (shareable, `?org=` preserved); `/dashboard/accuracy` redirects to `?tab=accuracy`; Accuracy nav item removed; filter bar scoped to data tabs (#227) | 2m | 30s | #227 |
 | [E2E-66](#e2e-66-self-hosted-cost-shows-when-the-model-is-priced-231) | Self-hosted LLM cost: current-gen Anthropic IDs priced out of the box; `.mergewatch.yml` `pricing:` override now parsed (was dropped); unpriced model → one-time server warn + dashboard "set pricing" hint (not silent $0); `0`/`0` records a real $0 (#231) | 3m | 30s | #231 |
 | [E2E-67](#e2e-67-global-env-pricing-for-the-llm_model-233) | Self-hosted global pricing: `LLM_MODEL_INPUT_PRICE_PER_1M` / `LLM_MODEL_OUTPUT_PRICE_PER_1M` price whatever `LLM_MODEL` is set to (e.g. a Bedrock inference-profile ARN) for full reviews **and** inline replies — no per-repo config; per-repo `pricing:` wins; `0`/`0` = real $0; partial/invalid → one-time warn (#233) | 3m | 30s | #233 |
+| [E2E-68](#e2e-68-org-custom-agents-235) | Org admins define custom review agents in the dashboard (Settings → Custom Agents), scoped to all/selected repos with optional path/language targeting; advisory vs blocking (blocking critical → REQUEST_CHANGES + failing check); union with repo `.mergewatch.yml` (org wins on name clash); admin-only edit, members read-only; both backends (#235) | 3m | 60s | #235 |
 
 ---
 
@@ -2409,6 +2410,37 @@ The env price becomes a `customPricing` entry keyed to the `LLM_MODEL` value, ap
 - ❌ Inline replies stay unpriced while full reviews are priced.
 - ❌ Env price wins over a per-repo `pricing:` for the same model.
 - ❌ A partial/invalid value reads as $0 with no warning, or the warn spams every review.
+
+---
+
+### E2E-68: Org Custom Agents (#235)
+
+**Status:** ✅ SHIPPED.
+
+**Behavior:** Org admins define custom review agents in the dashboard (**Settings → Custom Agents**) that are enforced across the org's repos — promoting the per-repo `.mergewatch.yml` `customAgents` concept to the installation level. Each agent has a prompt + default severity, a **repo scope** (all repos or a selected allowlist), optional **path-glob / language targeting**, and an **enforcement** mode (advisory or blocking). Stored per installation (DynamoDB `#AGENTS` sentinel row / Postgres `installation_settings.custom_agents` jsonb). At review time the runtime selects enabled agents that are in-scope and match targeting, runs them in **union** with the repo's `.mergewatch.yml` `customAgents` (org wins on a name collision), and — for a **blocking** agent — a **critical** finding forces `REQUEST_CHANGES` + a failing check run regardless of the merge score (`Blocked by org agent: <name>`). Only org admins can edit (members read-only); each agent's last-editor/timestamp is recorded. A soft cap warns past ~10 active agents. Authors can still triage a blocking finding, but it's recorded (disposition store + a `[org-agents]` log).
+
+**How to run.** As an org admin, on an installation with ≥1 repo.
+1. **Create (admin):** Settings → Custom Agents → Add agent. Name `no-todo`, prompt "Flag any new TODO comment", severity `critical`, enforcement **blocking**, scope **All repositories**. Save. Reload as a non-admin member → fields are read-only.
+2. **Advisory run:** set the agent to **advisory**, open a PR that adds a `// TODO`. The review surfaces a finding from `no-todo`; the check still passes / score is normal.
+3. **Blocking run:** set it to **blocking**, push another `// TODO`. The summary review is **REQUEST_CHANGES**, the MergeWatch check run is **failure** titled `Blocked by org agent: no-todo`.
+4. **Scope:** switch the agent to **Selected repositories** and pick only repo B. Open a PR in repo A → the agent does NOT run; in repo B → it does.
+5. **Targeting:** add path glob `src/**`. A PR touching only `docs/**` does NOT trigger it; one touching `src/**` does.
+6. **Union + precedence:** define a repo `.mergewatch.yml` `customAgents` entry with the SAME name as an org agent → only the org definition runs (org wins).
+7. **Both backends:** repeat on a self-hosted (Postgres) instance — same behavior.
+
+**Pass:**
+- [ ] Admins can CRUD org agents; members are read-only; the API rejects non-admin writes (403).
+- [ ] In-scope + targeting-matching agents run, in union with repo `customAgents` (org wins on name clash).
+- [ ] Advisory agent only surfaces findings; blocking agent's critical → REQUEST_CHANGES + failing check (`Blocked by org agent: …`) regardless of score.
+- [ ] Repo scope (all/selected) and path/language targeting gate execution correctly.
+- [ ] Last-edited-by/when recorded; soft-cap warning past the limit.
+- [ ] Identical behavior on DynamoDB (SaaS) and Postgres (self-hosted).
+
+**Fail signals:**
+- ❌ A non-admin can edit org agents (write succeeds).
+- ❌ A blocking critical finding still APPROVES / passes the check.
+- ❌ An out-of-scope or non-matching-targeting agent runs anyway.
+- ❌ A repo `.mergewatch.yml` agent shadows/disables an org agent of the same name.
 
 ---
 


### PR DESCRIPTION
**Closes #235** — PR 4 of 4 (docs), completing the Org Custom Agents stack (PR1 #236 · PR2 #237 · PR3 #238).

## What's here (docs only)
- **README** — new "Org Custom Agents" section: repo scope (all/selected), path/language targeting, advisory vs blocking enforcement, union-with-`.mergewatch.yml` precedence (org wins), admin-only management, soft cap, both backends.
- **e2e/RUNBOOK.md** — **E2E-68** scenario: admin CRUD + non-admin read-only, advisory vs blocking gate (REQUEST_CHANGES + failing check), repo scope, path/language targeting, union precedence, both backends.
- **CLAUDE.md** — documents the `#AGENTS` sentinel row / `custom_agents` column and the enforcement model.

## The full feature (across the stack)
Org admins define custom review agents in the dashboard (Settings → Custom Agents), scoped to all or selected repos with optional path/language targeting, advisory or blocking. They run in union with repo `.mergewatch.yml` `customAgents` (org wins on name clash); a blocking agent's critical finding forces REQUEST_CHANGES + a failing check run. Admin-only management, recorded triage, soft cap, last-edited audit — on both DynamoDB (SaaS) and Postgres (self-hosted).

All acceptance criteria from #235 are satisfied across PRs 1–4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)