### PR TITLE
feat(site): frontier-model / no-black-box positioning (repositioning 2/4)

### DIFF
--- a/packages/dashboard/app/about/page.tsx
+++ b/packages/dashboard/app/about/page.tsx
@@ -4,19 +4,19 @@ import { LegalPage } from "@/components/LegalPage";
 export const metadata: Metadata = {
   title: "About",
   description:
-    "MergeWatch is an open-source multi-agent AI code reviewer built by Santthosh. Bring your own model, run in your cloud, or use the hosted SaaS.",
+    "MergeWatch is open-source AI PR review using the model stack you choose — frontier-model review without a closed black-box workflow, priced by reviewed PR instead of developer seat, and free to self-host.",
   alternates: { canonical: "/about" },
 };
 
 export default function AboutPage() {
   return (
-    <LegalPage title="About MergeWatch" lastUpdated="April 13, 2026">
+    <LegalPage title="About MergeWatch" lastUpdated="August 9, 2026">
       <p>
         MergeWatch is an open-source GitHub App that reviews pull requests
         using a multi-agent AI pipeline. It was built to answer a simple
         question: <em>why should the tool that reviews your code cost more as
-        your team grows, run on infrastructure you can&rsquo;t see, and lock you
-        into a model you didn&rsquo;t choose?</em>
+        your team grows, sit inside a closed vendor box you can&rsquo;t
+        inspect, and lock you into a model you didn&rsquo;t choose?</em>
       </p>
 
       <h2>What it does</h2>
@@ -33,10 +33,10 @@ export default function AboutPage() {
       <ul>
         <li>
           <strong>Self-hosted (free, AGPL v3).</strong> One{" "}
-          <code>docker-compose up</code>. Bring your own LLM provider &mdash;
-          Anthropic direct, Amazon Bedrock, any OpenAI-compatible endpoint via
-          LiteLLM (100+ providers), or Ollama for air-gapped environments.
-          Your code never leaves your infrastructure.
+          <code>docker-compose up</code>. Bring your own frontier model &mdash;
+          Claude via Anthropic direct or Amazon Bedrock, GPT-class models and
+          Gemini via LiteLLM (100+ providers), or local models via Ollama for
+          air-gapped environments. Your code never leaves your infrastructure.
         </li>
         <li>
           <strong>Managed SaaS.</strong> Install the GitHub App and go. Runs on

--- a/packages/dashboard/app/layout.tsx
+++ b/packages/dashboard/app/layout.tsx
@@ -6,7 +6,7 @@ import "./globals.css";
 const SITE_URL = "https://mergewatch.ai";
 const SITE_NAME = "MergeWatch";
 const SITE_DESCRIPTION =
-  "AI-powered GitHub App that reviews pull requests with a multi-agent pipeline. Bring your own model, run in your cloud, or use the hosted SaaS.";
+  "Open-source AI PR review using the model stack you choose. Frontier-model review without a closed black-box workflow, priced by reviewed PR instead of developer seat, and free to self-host.";
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),

--- a/packages/dashboard/app/open-source/faqs.ts
+++ b/packages/dashboard/app/open-source/faqs.ts
@@ -1,0 +1,24 @@
+/**
+ * FAQ content for the MergeWatch for Open Source page. Shared between the
+ * visible page (`page.tsx`) and the FAQPage structured data (`layout.tsx`)
+ * so the two never drift. Answers are written as self-contained passages
+ * for AI Overviews / ChatGPT-search extraction.
+ */
+export const ossFaqs: { question: string; answer: string }[] = [
+  {
+    question:
+      "Who qualifies for free MergeWatch access as an open-source project?",
+    answer:
+      "MergeWatch for Open Source is for real, actively maintained open-source projects on public repositories. Approval is manual and lightweight: we look for a genuine project with ongoing pull-request activity, not a placeholder repo. There is no requirement to endorse MergeWatch before you have used it, and maintainers can stop at any time. Heavy usage may move to a bring-your-own-key or sponsorship arrangement so the program stays sustainable, but the starting offer is simply free hosted access in exchange for honest feedback.",
+  },
+  {
+    question: "What does MergeWatch ask for in return?",
+    answer:
+      "Use MergeWatch on your project for real pull requests, and give honest product feedback. If MergeWatch turns out to be useful, we ask for permission to list your project or logo as an early open-source user — but only after you have used it and are satisfied, never before. An optional short quote or case study is a separate, later ask that always requires its own approval. Maintainers are not paid for promotion, and nothing about the program requires a public endorsement.",
+  },
+  {
+    question: "Why is MergeWatch free for open-source maintainers?",
+    answer:
+      "Open-source maintainers are about to face more AI-generated pull requests than anyone else, and much of that code will be produced by capable frontier models used carelessly, cheaply, or adversarially. This is ecosystem defense, not charity: maintainers should not have to protect critical open-source infrastructure with weaker tools than the people flooding them with plausible but risky AI-generated PRs. MergeWatch puts frontier-model review on the maintainer's side — an open, inspectable reviewer that helps spot risk and preserve review quality while keeping human maintainers in control.",
+  },
+];

--- a/packages/dashboard/app/open-source/layout.tsx
+++ b/packages/dashboard/app/open-source/layout.tsx
@@ -1,0 +1,66 @@
+export const dynamic = "force-dynamic";
+
+import { redirect } from "next/navigation";
+import type { Metadata } from "next";
+import { ossFaqs } from "./faqs";
+
+export const metadata: Metadata = {
+  title:
+    "MergeWatch for Open Source — Free frontier-model review for maintainers",
+  description:
+    "Free hosted MergeWatch access for qualifying open-source projects. Maintainers deserve frontier-model review on their side too, as AI-generated PRs get easier to produce and harder to inspect. In exchange we ask for feedback and, if it helps, permission to list your project.",
+  alternates: { canonical: "/open-source" },
+};
+
+function serializeJsonLd(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
+const ossJsonLd = [
+  {
+    "@context": "https://schema.org",
+    "@type": "Offer",
+    name: "MergeWatch for Open Source",
+    price: "0",
+    priceCurrency: "USD",
+    description:
+      "Free hosted MergeWatch access for qualifying open-source projects, in exchange for feedback and optional permission to list the project.",
+    url: "https://mergewatch.ai/open-source",
+    availability: "https://schema.org/InStock",
+    eligibleCustomerType: "https://schema.org/Enduser",
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: ossFaqs.map((faq) => ({
+      "@type": "Question",
+      name: faq.question,
+      acceptedAnswer: { "@type": "Answer", text: faq.answer },
+    })),
+  },
+];
+
+export default function OpenSourceLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  if (process.env.DEPLOYMENT_MODE !== "saas") {
+    redirect("/signin");
+  }
+
+  return (
+    <>
+      {children}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(ossJsonLd) }}
+      />
+    </>
+  );
+}

--- a/packages/dashboard/app/open-source/page.tsx
+++ b/packages/dashboard/app/open-source/page.tsx
@@ -1,0 +1,343 @@
+"use client";
+
+import Link from "next/link";
+import { Wordmark } from "@/components/MergeWatchLogo";
+import {
+  Github,
+  ShieldCheck,
+  Eye,
+  HeartHandshake,
+  MessageSquare,
+  Check,
+} from "lucide-react";
+import { ossFaqs } from "./faqs";
+
+/**
+ * Application form for MergeWatch for Open Source.
+ *
+ * TODO(oss-program): replace the placeholder with the real Tally form URL
+ * once it exists (decision Q6 — new Tally form, matching the design-partner
+ * banner pattern). Until then the CTA points at this placeholder.
+ */
+const OSS_APPLY_URL = "https://tally.so/r/PLACEHOLDER";
+
+const GITHUB_REPO = "mergewatch/mergewatch.ai";
+
+/**
+ * MergeWatch for Open Source — program landing page.
+ *
+ * Framed as ecosystem defense, not charity: maintainers face rising volumes
+ * of plausible-but-risky AI-generated PRs and deserve frontier-model review
+ * on their side too. Self-hosted builds never see this page (the layout
+ * redirects to /signin when DEPLOYMENT_MODE !== "saas").
+ */
+export default function OpenSourcePage() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      {/* ─── Nav ───────────────────────────────────────────────────────── */}
+      <nav className="flex items-center justify-between px-6 py-4 md:px-12">
+        <Link href="/">
+          <Wordmark iconSize={20} />
+        </Link>
+        <div className="flex items-center gap-4">
+          <a
+            href="https://docs.mergewatch.ai"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hidden text-sm text-primer-muted transition hover:text-fg-primary sm:inline"
+          >
+            Docs
+          </a>
+          <Link
+            href="/pricing"
+            className="hidden text-sm text-primer-muted transition hover:text-fg-primary sm:inline"
+          >
+            Pricing
+          </Link>
+          <Link
+            href="/open-source"
+            className="hidden text-sm font-medium text-fg-primary sm:inline"
+          >
+            For Open Source
+          </Link>
+          <a
+            href={`https://github.com/${GITHUB_REPO}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hidden text-primer-muted transition hover:text-fg-primary sm:inline"
+            aria-label="GitHub repository"
+          >
+            <Github size={20} />
+          </a>
+          <Link
+            href="/signin"
+            className="inline-flex items-center rounded-lg bg-primer-green px-4 py-2 text-sm font-semibold text-black transition hover:brightness-110"
+          >
+            Get started
+            <ArrowIcon />
+          </Link>
+        </div>
+      </nav>
+
+      <main className="flex-1">
+        {/* ─── Hero ────────────────────────────────────────────────────── */}
+        <section className="flex flex-col items-center px-6 pt-16 pb-14 text-center md:pt-24">
+          <p className="mb-4 text-[11px] font-semibold uppercase tracking-widest text-primer-green">
+            MergeWatch for Open Source
+          </p>
+          <h1 className="mx-auto max-w-3xl text-3xl font-extrabold leading-tight tracking-tight md:text-5xl">
+            Free frontier-model review for{" "}
+            <span className="text-primer-green">open-source maintainers.</span>
+          </h1>
+          <p className="mx-auto mt-6 max-w-2xl text-base leading-relaxed text-primer-muted">
+            If you maintain a real open-source project, we&rsquo;ll give it free
+            hosted MergeWatch access. AI-generated PRs are getting easier to
+            produce and harder to inspect by hand&nbsp;&mdash; maintainers
+            deserve frontier-model review on their side too. In exchange we ask
+            for honest feedback and, if it helps, permission to list your
+            project as an early open-source user.
+          </p>
+          <div className="mt-9 flex w-full max-w-sm flex-col items-center gap-3 sm:w-auto sm:flex-row">
+            <a
+              href={OSS_APPLY_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex w-full items-center justify-center rounded-lg bg-primer-green px-6 py-3 text-sm font-semibold text-black transition hover:brightness-110 sm:w-auto"
+            >
+              Apply for free OSS access
+              <ArrowIcon />
+            </a>
+            <a
+              href={`https://github.com/${GITHUB_REPO}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex w-full items-center justify-center rounded-lg border border-border-default px-6 py-3 text-sm font-semibold text-fg-primary transition hover:bg-surface-card sm:w-auto"
+            >
+              Read the source code
+              <Github className="ml-2 h-4 w-4" />
+            </a>
+          </div>
+          <p className="mt-5 text-xs text-primer-muted">
+            No contract. No seat pricing. No obligation to endorse it if
+            it&rsquo;s not useful.
+          </p>
+        </section>
+
+        {/* ─── Why we're giving this away ──────────────────────────────── */}
+        <section className="border-t border-border-default px-6 py-16 md:py-24">
+          <div className="mx-auto max-w-3xl">
+            <h2 className="text-center text-2xl font-bold md:text-3xl">
+              This is ecosystem defense,{" "}
+              <span className="text-primer-green">not charity.</span>
+            </h2>
+            <div className="mx-auto mt-6 max-w-2xl space-y-4 text-sm leading-relaxed text-primer-muted">
+              <p>
+                Open-source maintainers are about to face more AI-generated code
+                than anyone else, and much of it will be produced by extremely
+                capable frontier models used carelessly, cheaply, or
+                adversarially. Models like Claude Opus and GPT-class systems can
+                generate plausible PRs at a speed maintainers cannot manually
+                match.
+              </p>
+              <p>
+                MergeWatch gives maintainers frontier-model review on their side
+                too: an open, inspectable reviewer that helps protect
+                open-source software from risky model-generated changes.
+                Frontier models are powerful, and in the wrong workflow they can
+                create convincing but dangerous code. MergeWatch helps
+                maintainers spot risk, preserve review quality, and keep human
+                maintainers in control&nbsp;&mdash; without handing the review
+                workflow to a closed black-box vendor.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* ─── The offer / the ask ─────────────────────────────────────── */}
+        <section className="border-t border-border-default px-6 py-16 md:py-24">
+          <div className="mx-auto grid max-w-4xl gap-6 md:grid-cols-2">
+            <div className="rounded-xl border border-border-default bg-surface-card/60 p-6">
+              <div className="mb-3 text-primer-green">
+                <HeartHandshake className="h-5 w-5" />
+              </div>
+              <h3 className="text-lg font-semibold text-primer-green">
+                What you get
+              </h3>
+              <ul className="mt-4 space-y-2.5 text-sm text-primer-muted">
+                <ListItem>
+                  Free access to the managed SaaS for your open-source project
+                </ListItem>
+                <ListItem>Help installing and configuring the GitHub App</ListItem>
+                <ListItem>An optional, lightweight setup call</ListItem>
+                <ListItem>
+                  A direct line to shape review behavior through your feedback
+                </ListItem>
+              </ul>
+            </div>
+            <div className="rounded-xl border border-border-default bg-surface-card/60 p-6">
+              <div className="mb-3 text-primer-blue">
+                <MessageSquare className="h-5 w-5" />
+              </div>
+              <h3 className="text-lg font-semibold text-primer-blue">
+                What we ask
+              </h3>
+              <ul className="mt-4 space-y-2.5 text-sm text-primer-muted">
+                <ListItem>Use MergeWatch on your project for real PRs</ListItem>
+                <ListItem>Give direct, honest product feedback</ListItem>
+                <ListItem>
+                  If it&rsquo;s useful, permission to list your project/logo as
+                  an early user&nbsp;&mdash; only after you&rsquo;re satisfied
+                </ListItem>
+                <ListItem>
+                  Optional, later, and separately approved: a short quote or case
+                  study
+                </ListItem>
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        {/* ─── Eligibility / guardrails ────────────────────────────────── */}
+        <section className="border-t border-border-default px-6 py-16 md:py-24">
+          <div className="mx-auto max-w-3xl">
+            <h2 className="text-center text-2xl font-bold md:text-3xl">
+              How the program works
+            </h2>
+            <div className="mt-10 grid gap-4 sm:grid-cols-2">
+              <GuardrailCard
+                icon={<Eye className="h-4 w-4" />}
+                title="Public repositories only"
+                body="The program is for public, actively maintained open-source projects — not private code."
+              />
+              <GuardrailCard
+                icon={<Check className="h-4 w-4" />}
+                title="Manual approval, fair use"
+                body="Each project is approved by hand with fair-use limits and no SLA. It stays lightweight on both sides."
+              />
+              <GuardrailCard
+                icon={<ShieldCheck className="h-4 w-4" />}
+                title="Logo permission is opt-in"
+                body="We only list your project or logo after you've used MergeWatch and told us it helped. Never before."
+              />
+              <GuardrailCard
+                icon={<HeartHandshake className="h-4 w-4" />}
+                title="Stop anytime"
+                body="No lock-in. Heavy usage may move to bring-your-own-key or sponsorship, but you can leave whenever you like."
+              />
+            </div>
+          </div>
+        </section>
+
+        {/* ─── FAQ ─────────────────────────────────────────────────────── */}
+        <section className="border-t border-border-default px-6 py-16 md:py-24">
+          <div className="mx-auto max-w-3xl">
+            <h2 className="text-center text-2xl font-bold md:text-3xl">
+              Questions maintainers ask
+            </h2>
+            <div className="mt-10 space-y-6">
+              {ossFaqs.map((faq) => (
+                <div
+                  key={faq.question}
+                  className="rounded-xl border border-border-default bg-surface-card/60 p-6"
+                >
+                  <h3 className="text-base font-semibold text-fg-primary">
+                    {faq.question}
+                  </h3>
+                  <p className="mt-3 text-sm leading-relaxed text-primer-muted">
+                    {faq.answer}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ─── CTA ─────────────────────────────────────────────────────── */}
+        <section className="border-t border-border-default px-6 py-16 text-center md:py-24">
+          <h2 className="mx-auto max-w-2xl text-2xl font-bold md:text-3xl">
+            Put frontier-model review on your{" "}
+            <span className="text-primer-green">project&rsquo;s side.</span>
+          </h2>
+          <p className="mx-auto mt-4 max-w-md text-sm text-primer-muted">
+            Tell us about your project. Approval is manual and lightweight.
+          </p>
+          <div className="mt-8 flex justify-center">
+            <a
+              href={OSS_APPLY_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center rounded-lg bg-primer-green px-6 py-3 text-sm font-semibold text-black transition hover:brightness-110"
+            >
+              Apply for free OSS access
+              <ArrowIcon />
+            </a>
+          </div>
+        </section>
+      </main>
+
+      {/* ─── Footer ────────────────────────────────────────────────────── */}
+      <footer className="border-t border-border-default px-6 py-12">
+        <p className="text-center text-xs text-primer-muted">
+          Open source under AGPL-3.0 &copy; {new Date().getFullYear()}{" "}
+          mergewatch.ai &middot;{" "}
+          <Link href="/" className="transition hover:text-fg-primary">
+            Home
+          </Link>{" "}
+          &middot;{" "}
+          <Link href="/pricing" className="transition hover:text-fg-primary">
+            Pricing
+          </Link>
+        </p>
+      </footer>
+    </div>
+  );
+}
+
+/* ─── Inline sub-components ──────────────────────────────────────────────── */
+
+function ListItem({ children }: { children: React.ReactNode }) {
+  return (
+    <li className="flex items-start gap-2">
+      <Check className="mt-0.5 h-4 w-4 shrink-0 text-primer-green" />
+      <span>{children}</span>
+    </li>
+  );
+}
+
+function GuardrailCard({
+  icon,
+  title,
+  body,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  body: string;
+}) {
+  return (
+    <div className="rounded-lg border border-border-default bg-surface-card/40 p-4">
+      <div className="flex items-center gap-2 text-primer-green">
+        {icon}
+        <h3 className="text-sm font-semibold text-fg-primary">{title}</h3>
+      </div>
+      <p className="mt-2 text-sm leading-relaxed text-primer-muted">{body}</p>
+    </div>
+  );
+}
+
+function ArrowIcon() {
+  return (
+    <svg
+      className="ml-2 h-4 w-4"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      viewBox="0 0 24 24"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M13 7l5 5m0 0l-5 5m5-5H6"
+      />
+    </svg>
+  );
+}

--- a/packages/dashboard/app/opengraph-image.tsx
+++ b/packages/dashboard/app/opengraph-image.tsx
@@ -1,7 +1,8 @@
 import { ImageResponse } from "next/og";
 
 export const runtime = "edge";
-export const alt = "MergeWatch — AI-Powered PR Reviews";
+export const alt =
+  "MergeWatch — Frontier-model PR review, without the black box";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
@@ -34,27 +35,27 @@ export default function OpengraphImage() {
         </div>
         <div
           style={{
-            fontSize: 84,
+            fontSize: 76,
             color: "#ffffff",
             fontWeight: 700,
             lineHeight: 1.05,
             letterSpacing: "-0.03em",
-            maxWidth: 1000,
+            maxWidth: 1040,
           }}
         >
-          AI-Powered PR Reviews
+          Frontier-model PR review, without the black box.
         </div>
         <div
           style={{
-            fontSize: 32,
+            fontSize: 30,
             color: "#cbd5e1",
             marginTop: 28,
-            maxWidth: 980,
+            maxWidth: 1000,
             lineHeight: 1.3,
           }}
         >
-          Bring your own model. Run in your cloud. Multi-agent code review for
-          GitHub.
+          Open source · Bring your own model · Pay by PR, not seat · Self-host
+          free.
         </div>
       </div>
     ),

--- a/packages/dashboard/app/page.tsx
+++ b/packages/dashboard/app/page.tsx
@@ -60,6 +60,11 @@ const faqs: { question: string; answer: string }[] = [
     answer:
       "MergeWatch supports four LLM provider backends out of the box. Anthropic (direct Claude API) is the default for self-hosted installs and the fastest way to get started. Amazon Bedrock (IAM-authenticated Claude models) powers the managed SaaS and eliminates the need to manage API keys anywhere in your infrastructure. LiteLLM is an OpenAI-compatible proxy that gives access to 100+ providers including OpenAI, Google Gemini, Azure OpenAI, Groq, Together AI, Mistral, and Fireworks. Ollama supports local models like Llama 3 and Qwen for air-gapped or privacy-sensitive environments and is currently experimental. Self-hosted deployments select a provider via the LLM_PROVIDER environment variable. The ILLMProvider interface in @mergewatch/core is a single method, so contributing a new backend usually takes less than a hundred lines of code.",
   },
+  {
+    question: "Is MergeWatch a closed black box?",
+    answer:
+      "No. MergeWatch is open source under the GNU AGPL v3 license, and the entire review pipeline is inspectable: every agent prompt, the orchestrator that deduplicates and ranks findings, the provider routing, and each comment template live in the public repository at github.com/mergewatch/mergewatch.ai. Closed PR review bots ask you to trust a hosted pipeline you cannot see; MergeWatch lets your security team audit exactly what runs on your code before you install it, and lets your engineers fork or customize it. You also choose the model — Claude, GPT-class models via LiteLLM, Gemini, Amazon Bedrock, or local models via Ollama — so you are not locked into a single vendor's model or infrastructure. Human reviewers always keep final merge authority; MergeWatch surfaces flags, it does not gate your merges on a vendor's judgment.",
+  },
 ];
 
 /**
@@ -153,19 +158,24 @@ export default async function LandingPage() {
         </div>
       </nav>
 
-      {/* ─── 2. Hero — Pain hook + identity ────────────────────────────── */}
+      {/* ─── 2. Hero — Positioning wedge + identity ────────────────────── */}
       <section className="flex flex-col items-center px-6 pt-20 pb-16 text-center md:pt-28 md:pb-24">
+        <p className="mb-4 text-[11px] font-semibold uppercase tracking-widest text-primer-green">
+          Open source &middot; Bring your own model
+        </p>
+
         <h1 className="max-w-3xl text-4xl font-extrabold leading-tight tracking-tight md:text-6xl">
-          The <span className="text-primer-purple">diff</span>{" "}
-          <span className="text-primer-green">is too long.</span>{" "}
-          <span className="text-primer-blue">It always is.</span>
+          <span className="text-fg-primary">Frontier-model PR review,</span>{" "}
+          <span className="text-primer-green">without the black box.</span>
         </h1>
 
         <p className="mt-6 max-w-2xl text-lg leading-relaxed text-primer-muted">
-          MergeWatch runs specialized AI agents on every pull
-          request&nbsp;&mdash; before your reviewer opens the diff. Security
-          issues, logic bugs, style violations, and architectural risks surface
-          as inline comments. Add your own custom agents for anything else.{" "}
+          MergeWatch reviews every pull request with the model stack you
+          choose&nbsp;&mdash; Claude, GPT-class models via LiteLLM, Gemini,
+          Amazon Bedrock, or local models via Ollama. The review pipeline is
+          open and inspectable, not a closed vendor box. Use the hosted SaaS and
+          pay by PR, not by seat&nbsp;&mdash; or self-host the open-source
+          version free and pay only your own model tokens.{" "}
           <strong className="text-fg-primary">
             Your reviewer makes the final call.
           </strong>
@@ -190,13 +200,27 @@ export default async function LandingPage() {
           </a>
         </div>
 
-        <p className="mt-6 max-w-lg text-xs text-primer-muted">
-          AGPL v3&nbsp;&mdash; the whole codebase, not just the parts
-          we&rsquo;re comfortable showing you.
-        </p>
+        <div className="mt-8 flex max-w-3xl flex-wrap items-center justify-center gap-x-3 gap-y-2 text-xs font-medium text-primer-muted">
+          {[
+            "AGPL v3 open source",
+            "Bring your own model",
+            "Pay by PR, not seat",
+            "Self-host free forever",
+            "Human reviewer makes the final call",
+          ].map((claim, i) => (
+            <span key={claim} className="flex items-center gap-3">
+              {i > 0 && (
+                <span className="text-border-default" aria-hidden="true">
+                  &middot;
+                </span>
+              )}
+              <span className="whitespace-nowrap">{claim}</span>
+            </span>
+          ))}
+        </div>
 
-        <p className="mt-3 text-[11px] uppercase tracking-widest text-primer-muted">
-          v1.0 &middot; Updated April 2026 &middot; Actively maintained
+        <p className="mt-6 text-[11px] uppercase tracking-widest text-primer-muted">
+          v1.0 &middot; Updated August 2026 &middot; Actively maintained
         </p>
       </section>
 
@@ -310,6 +334,43 @@ export default async function LandingPage() {
           </code>{" "}
           with a name and a prompt.
         </p>
+      </section>
+
+      {/* ─── 4.6 No Black Box — Control & Transparency ─────────────────── */}
+      <section className="border-t border-border-default px-6 py-16 md:py-24">
+        <h2 className="text-center text-2xl font-bold md:text-4xl">
+          Your model. Your infrastructure.{" "}
+          <span className="text-primer-green">Your review workflow.</span>
+        </h2>
+
+        <p className="mx-auto mt-4 max-w-2xl text-center text-sm leading-relaxed text-primer-muted">
+          Closed PR review bots ask you to trust their pipeline. MergeWatch lets
+          you inspect and control all of it&nbsp;&mdash; prompts, agents,
+          provider routing, deployment, and data path.
+        </p>
+
+        <div className="mx-auto mt-12 grid max-w-5xl gap-6 md:grid-cols-3">
+          <PillarCard title="Model choice, not lock-in" accent="text-primer-blue">
+            Route to frontier models through Anthropic, GPT-class models via
+            LiteLLM, Gemini, or Amazon Bedrock&nbsp;&mdash; or run local models
+            via Ollama for air-gapped environments. Swap providers with an env
+            var; nothing hard-codes you to one vendor.
+          </PillarCard>
+          <PillarCard
+            title="An inspectable pipeline, not a black box"
+            accent="text-primer-purple"
+          >
+            Every agent prompt, the orchestrator, and each comment template ship
+            in the open under AGPL v3. Your security team can read exactly what
+            runs on your code before a single PR is reviewed.
+          </PillarCard>
+          <PillarCard title="Your data path stays yours" accent="text-primer-green">
+            Self-host and your diffs never leave your network. MergeWatch the
+            company has zero access to code, diffs, or review results in a
+            self-hosted deployment&nbsp;&mdash; the reviewer works for you, not
+            the other way around.
+          </PillarCard>
+        </div>
       </section>
 
       {/* ─── 4.5 Frequently Asked ──────────────────────────────────────── */}

--- a/packages/dashboard/app/page.tsx
+++ b/packages/dashboard/app/page.tsx
@@ -65,6 +65,11 @@ const faqs: { question: string; answer: string }[] = [
     answer:
       "No. MergeWatch is open source under the GNU AGPL v3 license, and the entire review pipeline is inspectable: every agent prompt, the orchestrator that deduplicates and ranks findings, the provider routing, and each comment template live in the public repository at github.com/mergewatch/mergewatch.ai. Closed PR review bots ask you to trust a hosted pipeline you cannot see; MergeWatch lets your security team audit exactly what runs on your code before you install it, and lets your engineers fork or customize it. You also choose the model — Claude, GPT-class models via LiteLLM, Gemini, Amazon Bedrock, or local models via Ollama — so you are not locked into a single vendor's model or infrastructure. Human reviewers always keep final merge authority; MergeWatch surfaces flags, it does not gate your merges on a vendor's judgment.",
   },
+  {
+    question: "Do you offer free access for open-source maintainers?",
+    answer:
+      "Yes. MergeWatch for Open Source gives qualifying open-source projects free hosted access to the managed SaaS, because maintainers are about to face rising volumes of plausible-but-risky AI-generated pull requests and deserve frontier-model review on their side too. The program is for real, actively maintained public repositories, is approved manually with fair-use limits, and carries no SLA. In exchange we ask for honest product feedback and, only if MergeWatch proves useful, permission to list your project or logo as an early open-source user — never before you have used it. Maintainers are not paid for promotion and can stop at any time. You can apply at mergewatch.ai/open-source.",
+  },
 ];
 
 /**
@@ -138,6 +143,12 @@ export default async function LandingPage() {
             className="hidden text-sm text-primer-muted transition hover:text-fg-primary sm:inline"
           >
             Pricing
+          </Link>
+          <Link
+            href="/open-source"
+            className="hidden text-sm text-primer-muted transition hover:text-fg-primary sm:inline"
+          >
+            For Open Source
           </Link>
           <a
             href="https://github.com/mergewatch/mergewatch.ai"
@@ -632,6 +643,32 @@ export default async function LandingPage() {
         </div>
       </section>
 
+      {/* ─── 7.5 Open Source Program ───────────────────────────────────── */}
+      <section className="border-t border-border-default px-6 py-16 md:py-24">
+        <div className="mx-auto max-w-3xl rounded-2xl border border-primer-green/30 bg-primer-green/[0.04] p-8 text-center md:p-12">
+          <p className="text-[11px] font-semibold uppercase tracking-widest text-primer-green">
+            MergeWatch for Open Source
+          </p>
+          <h2 className="mx-auto mt-3 max-w-2xl text-2xl font-bold md:text-3xl">
+            Free frontier-model review for open-source maintainers.
+          </h2>
+          <p className="mx-auto mt-4 max-w-xl text-sm leading-relaxed text-primer-muted">
+            Maintain a real open-source project? We&rsquo;ll give it free hosted
+            access. AI-generated PRs are getting easier to produce and harder to
+            inspect by hand&nbsp;&mdash; maintainers deserve frontier-model
+            review on their side too. In exchange we ask for feedback and, if it
+            helps, permission to list your project.
+          </p>
+          <Link
+            href="/open-source"
+            className="mt-8 inline-flex items-center rounded-lg bg-primer-green px-6 py-3 text-sm font-semibold text-black transition hover:brightness-110"
+          >
+            Apply for free OSS access
+            <ArrowIcon />
+          </Link>
+        </div>
+      </section>
+
       {/* ─── 8. Final CTA — Loss Aversion Close ───────────────────────── */}
       <section className="border-t border-border-default px-6 py-16 text-center md:py-24">
         <h2 className="mx-auto max-w-3xl text-2xl font-bold md:text-4xl">
@@ -687,6 +724,14 @@ export default async function LandingPage() {
                   className="transition hover:text-fg-primary"
                 >
                   Pricing
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/open-source"
+                  className="transition hover:text-fg-primary"
+                >
+                  For Open Source
                 </Link>
               </li>
               <li>

--- a/packages/dashboard/app/pricing/layout.tsx
+++ b/packages/dashboard/app/pricing/layout.tsx
@@ -6,7 +6,7 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Pricing — Pay for what you review",
   description:
-    "No per-seat fees. First 5 reviews free. Self-host for free or use the managed SaaS with prepaid credits based on actual LLM cost.",
+    "No per-seat fees. First 5 reviews free every month. Self-host for free or use the managed SaaS with prepaid credits based on actual LLM cost.",
   alternates: { canonical: "/pricing" },
 };
 

--- a/packages/dashboard/app/pricing/page.tsx
+++ b/packages/dashboard/app/pricing/page.tsx
@@ -41,6 +41,12 @@ export default function PricingPage() {
           >
             Pricing
           </Link>
+          <Link
+            href="/open-source"
+            className="hidden text-sm text-primer-muted transition hover:text-fg-primary sm:inline"
+          >
+            For Open Source
+          </Link>
           <a
             href="https://github.com/mergewatch/mergewatch.ai"
             target="_blank"
@@ -70,10 +76,12 @@ export default function PricingPage() {
             </span>
           </h1>
           <p className="mx-auto mt-6 max-w-xl text-sm leading-relaxed text-primer-muted">
-            No seats. No per-user fees. No contracts. You pay based on the
-            actual LLM cost of each review&nbsp;&mdash; and your first{" "}
+            Code review cost should track review activity, not headcount. No
+            seats. No per-user fees. No contracts. You pay based on the actual
+            LLM cost of each review&nbsp;&mdash; and your first{" "}
             <strong className="text-fg-primary">{FREE_REVIEWS} reviews</strong>{" "}
-            each month are free, no credit card required.
+            each month are free, no credit card required. Prefer to self-host?
+            It&rsquo;s free, and you pay only your own model tokens.
           </p>
         </section>
 
@@ -358,9 +366,12 @@ export default function PricingPage() {
                 PRs over file limits are skipped and never billed.
               </FaqItem>
               <FaqItem question="What LLM does the SaaS version use?">
-                Claude via Amazon Bedrock. We use the best available Sonnet
-                model at the time of your review. Pricing reflects current
-                Bedrock on-demand rates.
+                The hosted SaaS runs frontier Claude models via Amazon Bedrock
+                with IAM auth&nbsp;&mdash; no API keys to manage. We use the best
+                available Sonnet model at the time of your review, and pricing
+                reflects current Bedrock on-demand rates. Self-hosting? You
+                choose the provider&nbsp;&mdash; Claude, GPT-class models via
+                LiteLLM, Gemini, Bedrock, or local models via Ollama.
               </FaqItem>
               <FaqItem question="Why not just show a price-per-PR table?">
                 Because it would be misleading. Your cost depends on diff size,
@@ -432,6 +443,14 @@ export default function PricingPage() {
                 </Link>
               </li>
               <li>
+                <Link
+                  href="/open-source"
+                  className="transition hover:text-fg-primary"
+                >
+                  For Open Source
+                </Link>
+              </li>
+              <li>
                 <a
                   href="https://docs.mergewatch.ai/self-hosting/overview"
                   target="_blank"
@@ -446,6 +465,14 @@ export default function PricingPage() {
           <div>
             <h4 className="font-semibold text-fg-primary">Company</h4>
             <ul className="mt-3 space-y-2 text-primer-muted">
+              <li>
+                <Link
+                  href="/about"
+                  className="transition hover:text-fg-primary"
+                >
+                  About
+                </Link>
+              </li>
               <li>
                 <a
                   href="https://github.com/mergewatch/mergewatch.ai"

--- a/packages/dashboard/app/signin/page.tsx
+++ b/packages/dashboard/app/signin/page.tsx
@@ -32,7 +32,7 @@ export default async function SignInPage() {
             Sign in to mergewatch<span className="opacity-55">.ai</span>
           </h1>
           <p className="mt-2 text-center text-sm text-primer-muted">
-            AI-powered PR reviews — your models, your cloud.
+            Frontier-model PR review — your model, your workflow, priced by PR.
           </p>
 
           {/* Card */}

--- a/packages/dashboard/app/sitemap.ts
+++ b/packages/dashboard/app/sitemap.ts
@@ -18,6 +18,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.9,
     },
     {
+      url: `${SITE_URL}/open-source`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
       url: `${SITE_URL}/about`,
       lastModified: now,
       changeFrequency: "monthly",


### PR DESCRIPTION
**PR 2/4 of the site repositioning** — see `docs/feat/20260809-01-repositioning-site.plan.md`.

⚠️ **Stacked on #243** (base = `repositioning/pr1-consistency`). Review/merge #243 first.

Leads the marketing surfaces with the new wedge: frontier-model review, no closed black box, pay-by-PR, self-host free.

## Homepage (`app/page.tsx`)
- **Hero H1** → "Frontier-model PR review, without the black box." with an "Open source · Bring your own model" eyebrow and a model-choice subhead. The diff-length hook is retired from the H1 (per decision Q1).
- **Trust strip** → 5 claims: AGPL v3 open source · Bring your own model · Pay by PR, not seat · Self-host free forever · Human reviewer makes the final call.
- **New section** "Your model. Your infrastructure. Your review workflow." — three cards on model choice, inspectable pipeline (AGPL v3), and data-path control.
- **New FAQ** "Is MergeWatch a closed black box?" — rendered visibly and in the FAQPage JSON-LD.

## Other surfaces
- `layout.tsx` — global meta `description` → positioning line (D3). **`<title>` unchanged** (Q2, preserve SERP equity).
- `opengraph-image.tsx` — headline/subhead/alt → new positioning.
- `signin/page.tsx` — subhead → "Frontier-model PR review — your model, your workflow, priced by PR."
- `about/page.tsx` — opening framed around the closed-box problem; provider list reframed as frontier models; meta description + date updated.
- Freshness stamps bumped April 2026 → August 2026.

## Deferred to PR 4/4
The "Do you offer free access for open-source maintainers?" FAQ and the OSS nav/section link land with the `/open-source` route so this PR ships no dead links.

## Verification
- `tsc --noEmit` (dashboard): pass · `vitest run`: 19/19 pass
- Rendered live (`DEPLOYMENT_MODE=saas`): `/` → 200, new H1 / section / trust strip / black-box FAQ present; old hero gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)