### PR TITLE
feat(open-source): MergeWatch for Open Source program page (repositioning 4/4)

### DIFF
--- a/packages/dashboard/app/open-source/faqs.ts
+++ b/packages/dashboard/app/open-source/faqs.ts
@@ -1,0 +1,24 @@
+/**
+ * FAQ content for the MergeWatch for Open Source page. Shared between the
+ * visible page (`page.tsx`) and the FAQPage structured data (`layout.tsx`)
+ * so the two never drift. Answers are written as self-contained passages
+ * for AI Overviews / ChatGPT-search extraction.
+ */
+export const ossFaqs: { question: string; answer: string }[] = [
+  {
+    question:
+      "Who qualifies for free MergeWatch access as an open-source project?",
+    answer:
+      "MergeWatch for Open Source is for real, actively maintained open-source projects on public repositories. Approval is manual and lightweight: we look for a genuine project with ongoing pull-request activity, not a placeholder repo. There is no requirement to endorse MergeWatch before you have used it, and maintainers can stop at any time. Heavy usage may move to a bring-your-own-key or sponsorship arrangement so the program stays sustainable, but the starting offer is simply free hosted access in exchange for honest feedback.",
+  },
+  {
+    question: "What does MergeWatch ask for in return?",
+    answer:
+      "Use MergeWatch on your project for real pull requests, and give honest product feedback. If MergeWatch turns out to be useful, we ask for permission to list your project or logo as an early open-source user — but only after you have used it and are satisfied, never before. An optional short quote or case study is a separate, later ask that always requires its own approval. Maintainers are not paid for promotion, and nothing about the program requires a public endorsement.",
+  },
+  {
+    question: "Why is MergeWatch free for open-source maintainers?",
+    answer:
+      "Open-source maintainers are about to face more AI-generated pull requests than anyone else, and much of that code will be produced by capable frontier models used carelessly, cheaply, or adversarially. This is ecosystem defense, not charity: maintainers should not have to protect critical open-source infrastructure with weaker tools than the people flooding them with plausible but risky AI-generated PRs. MergeWatch puts frontier-model review on the maintainer's side — an open, inspectable reviewer that helps spot risk and preserve review quality while keeping human maintainers in control.",
+  },
+];

--- a/packages/dashboard/app/open-source/layout.tsx
+++ b/packages/dashboard/app/open-source/layout.tsx
@@ -1,0 +1,66 @@
+export const dynamic = "force-dynamic";
+
+import { redirect } from "next/navigation";
+import type { Metadata } from "next";
+import { ossFaqs } from "./faqs";
+
+export const metadata: Metadata = {
+  title:
+    "MergeWatch for Open Source — Free frontier-model review for maintainers",
+  description:
+    "Free hosted MergeWatch access for qualifying open-source projects. Maintainers deserve frontier-model review on their side too, as AI-generated PRs get easier to produce and harder to inspect. In exchange we ask for feedback and, if it helps, permission to list your project.",
+  alternates: { canonical: "/open-source" },
+};
+
+function serializeJsonLd(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
+const ossJsonLd = [
+  {
+    "@context": "https://schema.org",
+    "@type": "Offer",
+    name: "MergeWatch for Open Source",
+    price: "0",
+    priceCurrency: "USD",
+    description:
+      "Free hosted MergeWatch access for qualifying open-source projects, in exchange for feedback and optional permission to list the project.",
+    url: "https://mergewatch.ai/open-source",
+    availability: "https://schema.org/InStock",
+    eligibleCustomerType: "https://schema.org/Enduser",
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: ossFaqs.map((faq) => ({
+      "@type": "Question",
+      name: faq.question,
+      acceptedAnswer: { "@type": "Answer", text: faq.answer },
+    })),
+  },
+];
+
+export default function OpenSourceLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  if (process.env.DEPLOYMENT_MODE !== "saas") {
+    redirect("/signin");
+  }
+
+  return (
+    <>
+      {children}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(ossJsonLd) }}
+      />
+    </>
+  );
+}

--- a/packages/dashboard/app/open-source/page.tsx
+++ b/packages/dashboard/app/open-source/page.tsx
@@ -1,0 +1,343 @@
+"use client";
+
+import Link from "next/link";
+import { Wordmark } from "@/components/MergeWatchLogo";
+import {
+  Github,
+  ShieldCheck,
+  Eye,
+  HeartHandshake,
+  MessageSquare,
+  Check,
+} from "lucide-react";
+import { ossFaqs } from "./faqs";
+
+/**
+ * Application form for MergeWatch for Open Source.
+ *
+ * TODO(oss-program): replace the placeholder with the real Tally form URL
+ * once it exists (decision Q6 — new Tally form, matching the design-partner
+ * banner pattern). Until then the CTA points at this placeholder.
+ */
+const OSS_APPLY_URL = "https://tally.so/r/PLACEHOLDER";
+
+const GITHUB_REPO = "mergewatch/mergewatch.ai";
+
+/**
+ * MergeWatch for Open Source — program landing page.
+ *
+ * Framed as ecosystem defense, not charity: maintainers face rising volumes
+ * of plausible-but-risky AI-generated PRs and deserve frontier-model review
+ * on their side too. Self-hosted builds never see this page (the layout
+ * redirects to /signin when DEPLOYMENT_MODE !== "saas").
+ */
+export default function OpenSourcePage() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      {/* ─── Nav ───────────────────────────────────────────────────────── */}
+      <nav className="flex items-center justify-between px-6 py-4 md:px-12">
+        <Link href="/">
+          <Wordmark iconSize={20} />
+        </Link>
+        <div className="flex items-center gap-4">
+          <a
+            href="https://docs.mergewatch.ai"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hidden text-sm text-primer-muted transition hover:text-fg-primary sm:inline"
+          >
+            Docs
+          </a>
+          <Link
+            href="/pricing"
+            className="hidden text-sm text-primer-muted transition hover:text-fg-primary sm:inline"
+          >
+            Pricing
+          </Link>
+          <Link
+            href="/open-source"
+            className="hidden text-sm font-medium text-fg-primary sm:inline"
+          >
+            For Open Source
+          </Link>
+          <a
+            href={`https://github.com/${GITHUB_REPO}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hidden text-primer-muted transition hover:text-fg-primary sm:inline"
+            aria-label="GitHub repository"
+          >
+            <Github size={20} />
+          </a>
+          <Link
+            href="/signin"
+            className="inline-flex items-center rounded-lg bg-primer-green px-4 py-2 text-sm font-semibold text-black transition hover:brightness-110"
+          >
+            Get started
+            <ArrowIcon />
+          </Link>
+        </div>
+      </nav>
+
+      <main className="flex-1">
+        {/* ─── Hero ────────────────────────────────────────────────────── */}
+        <section className="flex flex-col items-center px-6 pt-16 pb-14 text-center md:pt-24">
+          <p className="mb-4 text-[11px] font-semibold uppercase tracking-widest text-primer-green">
+            MergeWatch for Open Source
+          </p>
+          <h1 className="mx-auto max-w-3xl text-3xl font-extrabold leading-tight tracking-tight md:text-5xl">
+            Free frontier-model review for{" "}
+            <span className="text-primer-green">open-source maintainers.</span>
+          </h1>
+          <p className="mx-auto mt-6 max-w-2xl text-base leading-relaxed text-primer-muted">
+            If you maintain a real open-source project, we&rsquo;ll give it free
+            hosted MergeWatch access. AI-generated PRs are getting easier to
+            produce and harder to inspect by hand&nbsp;&mdash; maintainers
+            deserve frontier-model review on their side too. In exchange we ask
+            for honest feedback and, if it helps, permission to list your
+            project as an early open-source user.
+          </p>
+          <div className="mt-9 flex w-full max-w-sm flex-col items-center gap-3 sm:w-auto sm:flex-row">
+            <a
+              href={OSS_APPLY_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex w-full items-center justify-center rounded-lg bg-primer-green px-6 py-3 text-sm font-semibold text-black transition hover:brightness-110 sm:w-auto"
+            >
+              Apply for free OSS access
+              <ArrowIcon />
+            </a>
+            <a
+              href={`https://github.com/${GITHUB_REPO}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex w-full items-center justify-center rounded-lg border border-border-default px-6 py-3 text-sm font-semibold text-fg-primary transition hover:bg-surface-card sm:w-auto"
+            >
+              Read the source code
+              <Github className="ml-2 h-4 w-4" />
+            </a>
+          </div>
+          <p className="mt-5 text-xs text-primer-muted">
+            No contract. No seat pricing. No obligation to endorse it if
+            it&rsquo;s not useful.
+          </p>
+        </section>
+
+        {/* ─── Why we're giving this away ──────────────────────────────── */}
+        <section className="border-t border-border-default px-6 py-16 md:py-24">
+          <div className="mx-auto max-w-3xl">
+            <h2 className="text-center text-2xl font-bold md:text-3xl">
+              This is ecosystem defense,{" "}
+              <span className="text-primer-green">not charity.</span>
+            </h2>
+            <div className="mx-auto mt-6 max-w-2xl space-y-4 text-sm leading-relaxed text-primer-muted">
+              <p>
+                Open-source maintainers are about to face more AI-generated code
+                than anyone else, and much of it will be produced by extremely
+                capable frontier models used carelessly, cheaply, or
+                adversarially. Models like Claude Opus and GPT-class systems can
+                generate plausible PRs at a speed maintainers cannot manually
+                match.
+              </p>
+              <p>
+                MergeWatch gives maintainers frontier-model review on their side
+                too: an open, inspectable reviewer that helps protect
+                open-source software from risky model-generated changes.
+                Frontier models are powerful, and in the wrong workflow they can
+                create convincing but dangerous code. MergeWatch helps
+                maintainers spot risk, preserve review quality, and keep human
+                maintainers in control&nbsp;&mdash; without handing the review
+                workflow to a closed black-box vendor.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* ─── The offer / the ask ─────────────────────────────────────── */}
+        <section className="border-t border-border-default px-6 py-16 md:py-24">
+          <div className="mx-auto grid max-w-4xl gap-6 md:grid-cols-2">
+            <div className="rounded-xl border border-border-default bg-surface-card/60 p-6">
+              <div className="mb-3 text-primer-green">
+                <HeartHandshake className="h-5 w-5" />
+              </div>
+              <h3 className="text-lg font-semibold text-primer-green">
+                What you get
+              </h3>
+              <ul className="mt-4 space-y-2.5 text-sm text-primer-muted">
+                <ListItem>
+                  Free access to the managed SaaS for your open-source project
+                </ListItem>
+                <ListItem>Help installing and configuring the GitHub App</ListItem>
+                <ListItem>An optional, lightweight setup call</ListItem>
+                <ListItem>
+                  A direct line to shape review behavior through your feedback
+                </ListItem>
+              </ul>
+            </div>
+            <div className="rounded-xl border border-border-default bg-surface-card/60 p-6">
+              <div className="mb-3 text-primer-blue">
+                <MessageSquare className="h-5 w-5" />
+              </div>
+              <h3 className="text-lg font-semibold text-primer-blue">
+                What we ask
+              </h3>
+              <ul className="mt-4 space-y-2.5 text-sm text-primer-muted">
+                <ListItem>Use MergeWatch on your project for real PRs</ListItem>
+                <ListItem>Give direct, honest product feedback</ListItem>
+                <ListItem>
+                  If it&rsquo;s useful, permission to list your project/logo as
+                  an early user&nbsp;&mdash; only after you&rsquo;re satisfied
+                </ListItem>
+                <ListItem>
+                  Optional, later, and separately approved: a short quote or case
+                  study
+                </ListItem>
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        {/* ─── Eligibility / guardrails ────────────────────────────────── */}
+        <section className="border-t border-border-default px-6 py-16 md:py-24">
+          <div className="mx-auto max-w-3xl">
+            <h2 className="text-center text-2xl font-bold md:text-3xl">
+              How the program works
+            </h2>
+            <div className="mt-10 grid gap-4 sm:grid-cols-2">
+              <GuardrailCard
+                icon={<Eye className="h-4 w-4" />}
+                title="Public repositories only"
+                body="The program is for public, actively maintained open-source projects — not private code."
+              />
+              <GuardrailCard
+                icon={<Check className="h-4 w-4" />}
+                title="Manual approval, fair use"
+                body="Each project is approved by hand with fair-use limits and no SLA. It stays lightweight on both sides."
+              />
+              <GuardrailCard
+                icon={<ShieldCheck className="h-4 w-4" />}
+                title="Logo permission is opt-in"
+                body="We only list your project or logo after you've used MergeWatch and told us it helped. Never before."
+              />
+              <GuardrailCard
+                icon={<HeartHandshake className="h-4 w-4" />}
+                title="Stop anytime"
+                body="No lock-in. Heavy usage may move to bring-your-own-key or sponsorship, but you can leave whenever you like."
+              />
+            </div>
+          </div>
+        </section>
+
+        {/* ─── FAQ ─────────────────────────────────────────────────────── */}
+        <section className="border-t border-border-default px-6 py-16 md:py-24">
+          <div className="mx-auto max-w-3xl">
+            <h2 className="text-center text-2xl font-bold md:text-3xl">
+              Questions maintainers ask
+            </h2>
+            <div className="mt-10 space-y-6">
+              {ossFaqs.map((faq) => (
+                <div
+                  key={faq.question}
+                  className="rounded-xl border border-border-default bg-surface-card/60 p-6"
+                >
+                  <h3 className="text-base font-semibold text-fg-primary">
+                    {faq.question}
+                  </h3>
+                  <p className="mt-3 text-sm leading-relaxed text-primer-muted">
+                    {faq.answer}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ─── CTA ─────────────────────────────────────────────────────── */}
+        <section className="border-t border-border-default px-6 py-16 text-center md:py-24">
+          <h2 className="mx-auto max-w-2xl text-2xl font-bold md:text-3xl">
+            Put frontier-model review on your{" "}
+            <span className="text-primer-green">project&rsquo;s side.</span>
+          </h2>
+          <p className="mx-auto mt-4 max-w-md text-sm text-primer-muted">
+            Tell us about your project. Approval is manual and lightweight.
+          </p>
+          <div className="mt-8 flex justify-center">
+            <a
+              href={OSS_APPLY_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center rounded-lg bg-primer-green px-6 py-3 text-sm font-semibold text-black transition hover:brightness-110"
+            >
+              Apply for free OSS access
+              <ArrowIcon />
+            </a>
+          </div>
+        </section>
+      </main>
+
+      {/* ─── Footer ────────────────────────────────────────────────────── */}
+      <footer className="border-t border-border-default px-6 py-12">
+        <p className="text-center text-xs text-primer-muted">
+          Open source under AGPL-3.0 &copy; {new Date().getFullYear()}{" "}
+          mergewatch.ai &middot;{" "}
+          <Link href="/" className="transition hover:text-fg-primary">
+            Home
+          </Link>{" "}
+          &middot;{" "}
+          <Link href="/pricing" className="transition hover:text-fg-primary">
+            Pricing
+          </Link>
+        </p>
+      </footer>
+    </div>
+  );
+}
+
+/* ─── Inline sub-components ──────────────────────────────────────────────── */
+
+function ListItem({ children }: { children: React.ReactNode }) {
+  return (
+    <li className="flex items-start gap-2">
+      <Check className="mt-0.5 h-4 w-4 shrink-0 text-primer-green" />
+      <span>{children}</span>
+    </li>
+  );
+}
+
+function GuardrailCard({
+  icon,
+  title,
+  body,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  body: string;
+}) {
+  return (
+    <div className="rounded-lg border border-border-default bg-surface-card/40 p-4">
+      <div className="flex items-center gap-2 text-primer-green">
+        {icon}
+        <h3 className="text-sm font-semibold text-fg-primary">{title}</h3>
+      </div>
+      <p className="mt-2 text-sm leading-relaxed text-primer-muted">{body}</p>
+    </div>
+  );
+}
+
+function ArrowIcon() {
+  return (
+    <svg
+      className="ml-2 h-4 w-4"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      viewBox="0 0 24 24"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M13 7l5 5m0 0l-5 5m5-5H6"
+      />
+    </svg>
+  );
+}

--- a/packages/dashboard/app/page.tsx
+++ b/packages/dashboard/app/page.tsx
@@ -65,6 +65,11 @@ const faqs: { question: string; answer: string }[] = [
     answer:
       "No. MergeWatch is open source under the GNU AGPL v3 license, and the entire review pipeline is inspectable: every agent prompt, the orchestrator that deduplicates and ranks findings, the provider routing, and each comment template live in the public repository at github.com/mergewatch/mergewatch.ai. Closed PR review bots ask you to trust a hosted pipeline you cannot see; MergeWatch lets your security team audit exactly what runs on your code before you install it, and lets your engineers fork or customize it. You also choose the model — Claude, GPT-class models via LiteLLM, Gemini, Amazon Bedrock, or local models via Ollama — so you are not locked into a single vendor's model or infrastructure. Human reviewers always keep final merge authority; MergeWatch surfaces flags, it does not gate your merges on a vendor's judgment.",
   },
+  {
+    question: "Do you offer free access for open-source maintainers?",
+    answer:
+      "Yes. MergeWatch for Open Source gives qualifying open-source projects free hosted access to the managed SaaS, because maintainers are about to face rising volumes of plausible-but-risky AI-generated pull requests and deserve frontier-model review on their side too. The program is for real, actively maintained public repositories, is approved manually with fair-use limits, and carries no SLA. In exchange we ask for honest product feedback and, only if MergeWatch proves useful, permission to list your project or logo as an early open-source user — never before you have used it. Maintainers are not paid for promotion and can stop at any time. You can apply at mergewatch.ai/open-source.",
+  },
 ];
 
 /**
@@ -138,6 +143,12 @@ export default async function LandingPage() {
             className="hidden text-sm text-primer-muted transition hover:text-fg-primary sm:inline"
           >
             Pricing
+          </Link>
+          <Link
+            href="/open-source"
+            className="hidden text-sm text-primer-muted transition hover:text-fg-primary sm:inline"
+          >
+            For Open Source
           </Link>
           <a
             href="https://github.com/mergewatch/mergewatch.ai"
@@ -632,6 +643,32 @@ export default async function LandingPage() {
         </div>
       </section>
 
+      {/* ─── 7.5 Open Source Program ───────────────────────────────────── */}
+      <section className="border-t border-border-default px-6 py-16 md:py-24">
+        <div className="mx-auto max-w-3xl rounded-2xl border border-primer-green/30 bg-primer-green/[0.04] p-8 text-center md:p-12">
+          <p className="text-[11px] font-semibold uppercase tracking-widest text-primer-green">
+            MergeWatch for Open Source
+          </p>
+          <h2 className="mx-auto mt-3 max-w-2xl text-2xl font-bold md:text-3xl">
+            Free frontier-model review for open-source maintainers.
+          </h2>
+          <p className="mx-auto mt-4 max-w-xl text-sm leading-relaxed text-primer-muted">
+            Maintain a real open-source project? We&rsquo;ll give it free hosted
+            access. AI-generated PRs are getting easier to produce and harder to
+            inspect by hand&nbsp;&mdash; maintainers deserve frontier-model
+            review on their side too. In exchange we ask for feedback and, if it
+            helps, permission to list your project.
+          </p>
+          <Link
+            href="/open-source"
+            className="mt-8 inline-flex items-center rounded-lg bg-primer-green px-6 py-3 text-sm font-semibold text-black transition hover:brightness-110"
+          >
+            Apply for free OSS access
+            <ArrowIcon />
+          </Link>
+        </div>
+      </section>
+
       {/* ─── 8. Final CTA — Loss Aversion Close ───────────────────────── */}
       <section className="border-t border-border-default px-6 py-16 text-center md:py-24">
         <h2 className="mx-auto max-w-3xl text-2xl font-bold md:text-4xl">
@@ -687,6 +724,14 @@ export default async function LandingPage() {
                   className="transition hover:text-fg-primary"
                 >
                   Pricing
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/open-source"
+                  className="transition hover:text-fg-primary"
+                >
+                  For Open Source
                 </Link>
               </li>
               <li>

--- a/packages/dashboard/app/pricing/page.tsx
+++ b/packages/dashboard/app/pricing/page.tsx
@@ -41,6 +41,12 @@ export default function PricingPage() {
           >
             Pricing
           </Link>
+          <Link
+            href="/open-source"
+            className="hidden text-sm text-primer-muted transition hover:text-fg-primary sm:inline"
+          >
+            For Open Source
+          </Link>
           <a
             href="https://github.com/mergewatch/mergewatch.ai"
             target="_blank"
@@ -434,6 +440,14 @@ export default function PricingPage() {
                   className="transition hover:text-fg-primary"
                 >
                   Pricing
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/open-source"
+                  className="transition hover:text-fg-primary"
+                >
+                  For Open Source
                 </Link>
               </li>
               <li>

--- a/packages/dashboard/app/sitemap.ts
+++ b/packages/dashboard/app/sitemap.ts
@@ -18,6 +18,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.9,
     },
     {
+      url: `${SITE_URL}/open-source`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
       url: `${SITE_URL}/about`,
       lastModified: now,
       changeFrequency: "monthly",


### PR DESCRIPTION
**PR 4/4 of the site repositioning** — see `docs/feat/20260809-01-repositioning-site.plan.md`.

⚠️ **Stacked on #245** (base = `repositioning/pr3-pricing-polish`). Merge #243 → #244 → #245 → this in order.

Adds the **MergeWatch for Open Source** program page and wires it across the site.

## New route (`app/open-source/`)
- **`page.tsx`** — program landing: ecosystem-defense framing ("not charity"), *What you get* / *What we ask* columns, guardrails (public repos only, manual approval + fair use, opt-in logo permission, stop anytime), a maintainer FAQ, and an **Apply for free OSS access** CTA.
- **`layout.tsx`** — SaaS-mode guard (redirects to `/signin` when self-hosted, mirroring `pricing/layout.tsx`), metadata, and **Offer + FAQPage JSON-LD**.
- **`faqs.ts`** — single FAQ source shared by the visible page and the structured data so they can't drift.

## Cross-site wiring
- **Homepage:** "For Open Source" nav link, an OSS teaser section before the final CTA, an OSS FAQ (visible + FAQPage JSON-LD), and a footer link.
- **Pricing:** "For Open Source" nav + footer links.
- **`sitemap.ts`:** `/open-source` entry (priority 0.8, monthly).

## 🚧 Blocker before launch
The application CTA points at a **placeholder Tally URL** (`OSS_APPLY_URL` in `page.tsx`, marked with a TODO). **Create the real Tally form and swap the constant before this page goes live.** Everything else is complete.

## Verification
- `tsc --noEmit`: pass · `vitest run`: 19/19 pass
- Rendered live (`DEPLOYMENT_MODE=saas`): `/open-source` → 200 (hero, ecosystem-defense copy, Apply CTA, JSON-LD all present); homepage → 3 `/open-source` links + OSS FAQ; pricing → 2 links; `/sitemap.xml` includes `/open-source`.
- Self-hosted guard: same `DEPLOYMENT_MODE !== "saas"` redirect pattern as the proven pricing layout.
- Lint: `next lint` is not configured in this repo (prompts interactively) — not a usable gate; typecheck + live render used instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)