### PR TITLE
docs: document MCP server, org custom agents, API keys, and feedback signals

### DIFF
--- a/docs-site/configuration/false-positives.mdx
+++ b/docs-site/configuration/false-positives.mdx
@@ -1,0 +1,113 @@
+---
+title: "How MergeWatch Avoids False Positives"
+description: "What happens between an agent producing a finding and you reading it — grounding, dedup, consolidation, and the guards that keep reviews trustworthy."
+---
+
+An AI reviewer that reports everything it notices is worse than no reviewer at all. People stop reading it, and the one real bug arrives in a list of nine nits.
+
+Most of MergeWatch's review pipeline is therefore not about *finding* issues. It is about deciding which findings are worth your attention — and, just as importantly, not raising the same one twice.
+
+This page describes what happens between an agent producing a finding and you reading it. Nothing here needs configuration; it is how reviews behave by default.
+
+## The problem each guard solves
+
+<AccordionGroup>
+
+<Accordion title="Findings that cite code that isn't there">
+
+The single worst failure mode for a reviewer is confident nonsense — a critical finding about a vulnerability in code the PR does not contain.
+
+Findings are **grounded against the diff**: a claim is checked against the code it cites before it is reported. Warnings get the same treatment as criticals, and Mermaid diagrams that reference files outside the PR are dropped rather than shown.
+
+There is also a **confidence floor**. An agent that is guessing does not get to file a critical.
+
+</Accordion>
+
+<Accordion title="One problem reported as several findings">
+
+The multi-agent pipeline runs agents in parallel, and they notice the same thing from different angles. A real example from the codebase: one PR produced *"SQL injection risk in dynamic VALUES clause"*, *"Type assertion without runtime validation"*, and *"Untrusted JSON parsing from S3 without validation"* — three findings at three different lines, one root cause.
+
+Two mechanisms handle this:
+
+- **Cross-agent dedup** removes findings that different agents raised about the same line before the orchestrator ever sees them.
+- **Consolidation** clusters fragments of one concern into a single finding carrying the strongest severity, with the absorbed siblings listed under it.
+
+You keep the full audit trail — every framing is preserved inside the merged finding — but you read one row instead of three.
+
+</Accordion>
+
+<Accordion title="The same finding reappearing after you fixed something else">
+
+The whack-a-mole problem: you push a fix, the next review reports the issue you just fixed as *resolved* and an old one as *new*, because the model reworded its title.
+
+**Stable finding identity** solves half of it. Findings are matched across commits by a fingerprint derived from the code they cite, not by their title — so a reworded finding is recognised as the same issue rather than being reported as both resolved and new.
+
+**The convergence guard** solves the other half. Reply to a review with a `## mergewatch triage` comment rebutting or deferring specific findings, and those findings are not re-raised on later commits.
+
+<Note>
+The convergence guard fails safe in the direction that matters. Every error path returns an **empty** suppression set — infrastructure trouble can never *hide* a finding. Only an explicit, parseable author disposition suppresses one.
+</Note>
+
+</Accordion>
+
+<Accordion title="Style nits your linter already covers">
+
+If your repository configures a linter, the style agent defers to it.
+
+MergeWatch detects eslint, biome, ruff, flake8, clippy, golangci-lint, and stylelint from their config files at the repository root — with `pyproject.toml` requiring an actual `[tool.ruff]` section rather than mere presence, since most Python projects have one. When a linter is detected, the style agent stops reporting the things it already enforces: semicolons, quote style, import order, unused imports.
+
+Nothing to configure. Check in a linter config and the reviewer stops duplicating it.
+
+</Accordion>
+
+<Accordion title="Nagging about tests in a repo that has none on purpose">
+
+If your conventions file says the repository has no test harness yet, the test-coverage agent's findings collapse into a single non-blocking note instead of one warning per file.
+
+The detection is deliberately conservative: **the signal is a written declaration, not the absence of test files.** Plenty of repositories keep tests elsewhere, defer coverage deliberately, or are mid-migration — so MergeWatch only suppresses when a maintainer wrote it down. Under-detection is the acceptable failure here; silently dropping coverage findings because it guessed wrong is not.
+
+Write it in your [conventions file](/configuration/conventions) and the nagging stops.
+
+</Accordion>
+
+<Accordion title="One uncertain critical blocking a good PR">
+
+A single unverified critical does not block a merge on its own.
+
+Findings that survive grounding but not verification are surfaced with lower weight rather than treated as blocking facts. Where disputes have accumulated, the merge score accounts for them — an agent whose findings your team consistently rejects carries less weight in your repositories than one you act on.
+
+Reviews that suppress findings say so, with a count of what was removed by dedup and quality filters. You are told when the reviewer decided to stay quiet.
+
+</Accordion>
+
+</AccordionGroup>
+
+## What you see
+
+**One review comment per PR.** Not a verdict comment plus a findings comment plus a summary — one authoritative comment, updated in place.
+
+**Findings snapped to the call site**, not the function definition, so the line number points at the code that has the problem.
+
+**A disclosure footer** noting suppressed findings and dispute-aware adjustments, so the filtering is visible rather than silent.
+
+## What you can do about it
+
+The pipeline gets quieter the more you tell it. Three things help, in order of leverage:
+
+1. **Check in a [conventions file](/configuration/conventions).** The single highest-leverage change. It teaches MergeWatch your patterns so it stops applying generic best practice over your deliberate choices.
+2. **Reject bad findings** with `/mergewatch reject` rather than closing them silently. Disputes down-weight the agent; silence does nothing. See [feedback signals](/configuration/feedback-signals).
+3. **Triage rather than argue.** A `## mergewatch triage` reply stops a finding recurring across commits.
+
+## Next steps
+
+<CardGroup cols={2}>
+
+<Card title="Review behavior" icon="sliders" href="/configuration/review-behavior">
+When reviews trigger, and the statuses they produce.
+</Card>
+
+<Card title="Repository conventions" icon="book" href="/configuration/conventions">
+The highest-leverage way to make reviews quieter.
+</Card>
+
+</CardGroup>

--- a/docs-site/configuration/feedback-signals.mdx
+++ b/docs-site/configuration/feedback-signals.mdx
@@ -1,0 +1,69 @@
+---
+title: "Feedback Signals"
+description: "Every way you can tell MergeWatch a finding was wrong or useful — comment commands, inline replies, reactions — and what each one feeds."
+---
+
+MergeWatch treats disagreement as data. Every signal below is recorded against the finding it concerns and rolled up into the [Accuracy](/dashboard/analytics) view, so a reviewer telling the bot it was wrong is not just a comment thread — it is the input that stops the same false positive recurring.
+
+## Comment commands
+
+| Comment | What happens |
+|---|---|
+| `@mergewatch review` | Re-run a full review on the current commit. |
+| `@mergewatch summary` | Post a summary without detailed findings. |
+| `@mergewatch <question>` | Ask a question about the PR. Answered conversationally, using the review context. |
+| `/mergewatch reject` | Reject a finding as incorrect. Recorded as an explicit dispute. |
+
+`/mergewatch reject` is the strongest negative signal available. Unlike the disposition counters below — which are inferred from what happened to a finding — a reject is timestamped at the moment you issue it, and is windowed by that timestamp rather than by when the finding was last seen. It says *this was wrong*, not *this went away*.
+
+## Inline replies
+
+Replying to an inline finding is a conversation, not just a comment. MergeWatch reads the reply, responds in the thread, and where the reply resolves the concern, resolves the review thread.
+
+Resolutions are persisted, which matters more than it sounds: a finding you have already argued down stays down. The [convergence guard](/configuration/review-behavior) uses those resolutions so a later review does not re-raise a point that was already rebutted — the whack-a-mole problem where fixing one thing makes an old finding reappear.
+
+## Reactions
+
+👍 / 👎 on the review summary comment feed the satisfaction signal in the engagement rollup.
+
+This is the lowest-friction feedback in the system — no command to remember, no thread to write. It measures whether the review as a whole was worth reading, which is a different question from whether any individual finding was correct.
+
+## What each signal feeds
+
+Signals aggregate into two rollup blocks:
+
+**Finding dispositions** — per-finding outcomes, counted as:
+
+| Disposition | Meaning |
+|---|---|
+| Agreement | The finding was acted on. |
+| Dispute | The finding was rejected or argued down. |
+| Silent drop | The finding disappeared without an explicit outcome. |
+| Resolve | The inline thread was resolved. |
+| Surface | The finding was shown at all. |
+
+**Engagement** — whether humans interacted with the review: reviews delivered, re-reviews requested, `/mergewatch reject` commands, helpful votes, and NPS responses.
+
+<Note>
+Rates distinguish "no signal" from a real zero. A rate is null — not `0` — when nothing landed in the window, so a quiet week reads as *no data* rather than as *nothing was useful*. Do not treat a blank as a bad score.
+</Note>
+
+## Why it is worth using
+
+Feedback is not a courtesy to the tool. Dispute rates by agent and by category feed directly back into review behavior: an agent whose findings are consistently rejected in your repository gets down-weighted there. Teams that reject bad findings instead of ignoring them get measurably quieter reviews over time; teams that silently close them keep seeing the same thing.
+
+If a finding is wrong, say so — `/mergewatch reject` costs a few seconds and changes future reviews.
+
+## Next steps
+
+<CardGroup cols={2}>
+
+<Card title="Accuracy" icon="chart-line" href="/dashboard/analytics">
+Where these signals surface — dispute rates, the false-positive funnel, themes.
+</Card>
+
+<Card title="Review behavior" icon="sliders" href="/configuration/review-behavior">
+How disputes change what later reviews report.
+</Card>
+
+</CardGroup>

--- a/docs-site/configuration/review-behavior.mdx
+++ b/docs-site/configuration/review-behavior.mdx
@@ -5,6 +5,10 @@ description: "When reviews trigger, what they produce, and how to control the re
 
 MergeWatch listens to GitHub webhook events and automatically reviews pull requests based on a set of configurable rules. This page explains exactly when reviews run, what statuses they produce, and how to control the lifecycle.
 
+<Note>
+This page covers **when** reviews run. What happens to a finding *after* an agent produces it — grounding, dedup, consolidation, the convergence guard, linter deference — is covered in [How MergeWatch avoids false positives](/configuration/false-positives). If reviews feel noisy or repetitive, start there.
+</Note>
+
 ## When reviews trigger
 
 MergeWatch triggers a review when it receives any of the following GitHub webhook events:
@@ -30,6 +34,8 @@ MergeWatch triggers a review when it receives any of the following GitHub webhoo
   - `@mergewatch` (any other mention) — triggers a **conversational response**. MergeWatch reads the PR diff and its previous review findings, then replies directly to the user's comment using the LLM. No review pipeline runs — the response is posted as a regular PR comment. Use this to ask questions about findings, request clarification, or discuss specific parts of the code.
 
   All mentions are case-insensitive. This works even when `autoReview` is set to `false` in your configuration.
+
+  A fourth command, `/mergewatch reject`, records a finding as an explicit dispute rather than triggering a review — see [feedback signals](/configuration/feedback-signals).
 </Step>
 </Steps>
 
@@ -111,7 +117,9 @@ Each finding produced by MergeWatch includes a **confidence score** from 1 to 10
 | 50-74 | Lower confidence — suppressed by the orchestrator |
 | 1-49 | Low confidence — suppressed by the orchestrator |
 
-The orchestrator automatically drops all findings with confidence below **75** during the dedup and ranking phase. This threshold is not user-configurable — it is designed to minimize false positives while surfacing real issues.
+Findings with confidence below **75** are dropped. The orchestrator prompt asks for this, and a deterministic filter enforces it afterwards — a prompt instruction alone was not reliable enough to depend on, so the floor is applied in code regardless of what the orchestrator returns.
+
+The threshold is not user-configurable. It is set to minimize false positives while surfacing real issues; see [How MergeWatch avoids false positives](/configuration/false-positives) for the other guards that run alongside it.
 
 <Tip>
 If you notice a legitimate issue being suppressed, consider adding a [custom agent](/configuration/mergewatch-yml#custom-agents) with a targeted prompt. Custom agents with focused prompts tend to produce higher-confidence findings for domain-specific concerns.

--- a/docs-site/dashboard/analytics.mdx
+++ b/docs-site/dashboard/analytics.mdx
@@ -1,69 +1,73 @@
 ---
 title: "Analytics"
-description: "Track review trends, severity breakdowns, and team metrics across your repositories."
+description: "The tabbed Analytics surface — review volume, LLM cost and cycle-time impact, findings, activity, and review accuracy, all under one route."
 ---
 
-The Analytics page provides aggregated metrics across all repositories in your installation. Use it to track review quality, identify patterns, and measure the impact of AI-assisted code review.
+Analytics is a single tabbed surface at `/dashboard/analytics`. Five tabs sit under one route, and the active tab syncs to the `?tab=` query parameter so any view can be linked or bookmarked directly.
 
-## Accessing analytics
-
-Navigate to **Dashboard > Analytics** from the sidebar. All data is scoped to your current installation.
-
-## Available metrics
-
-### Score trends
-
-A time-series chart showing the average merge-readiness score per day. Use this to track whether code quality is trending up or down over time.
-
-### Severity breakdown
-
-A breakdown of findings by severity level (critical, warning, info) across all reviews in the selected date range.
-
-### Duration stats
-
-Review timing statistics including average and p95 review duration. Useful for monitoring LLM performance and identifying slow reviews.
-
-### Repository breakdown
-
-A per-repository view showing review count, average score, and finding distribution. Helps identify which repositories generate the most findings.
-
-### Category breakdown
-
-Findings grouped by category (security, bug, style, error handling, test coverage, comment accuracy). Shows which types of issues are most common in your codebase.
-
-### Findings per review
-
-A trend line of the average number of findings per review over time. A decreasing trend suggests developers are incorporating review feedback.
-
-### Merge score distribution
-
-A histogram showing the distribution of merge-readiness scores (1-5) across all reviews. Healthy codebases should cluster around 4-5.
-
-## Filters
-
-| Filter | Description |
-|---|---|
-| **Repository** | Filter metrics to a specific repository |
-| **Date range** | Select a custom start and end date |
-
-## API endpoint
-
-The analytics data is served by `GET /api/analytics` with the following query parameters:
-
-| Parameter | Type | Description |
+| Tab | `?tab=` | What it answers |
 |---|---|---|
-| `installation_id` | `string` | Required. The GitHub App installation ID |
-| `repo` | `string` | Optional. Filter to a specific repository |
-| `start_date` | `string` | Optional. ISO 8601 start date |
-| `end_date` | `string` | Optional. ISO 8601 end date |
+| **Overview** | `overview` | How much is MergeWatch reviewing, and what is it finding? |
+| **Cost & Impact** | `cost` | What does this cost, and what is it buying? |
+| **Findings** | `findings` | What kinds of issues come up, and where? |
+| **Activity** | `activity` | Who is interacting with reviews, and how? |
+| **Accuracy** | `accuracy` | How often is MergeWatch right? |
 
----
+**Overview** is the default. An unknown or malformed `?tab=` value falls back to it rather than erroring.
+
+<Note>
+Older links still work. `/dashboard/accuracy` permanently redirects to `/dashboard/analytics?tab=accuracy`, and the even older `/dashboard/insights` redirects through it. The active installation (`?org=`) is preserved across both hops, so a bookmark keeps pointing at the same organization.
+</Note>
+
+## Cost & Impact
+
+Deliberately placed second — one click from the landing tab rather than buried under a wall of charts, because for most teams this is the tab that justifies the tool.
+
+**LLM cost** is tracked per review and aggregated here. Self-hosted deployments need to tell MergeWatch what their model costs before this reads anything useful — see [`LLM_MODEL_INPUT_PRICE_PER_1M`](/reference/env-vars), or the `pricing` block in [`.mergewatch.yml`](/configuration/mergewatch-yml). Without one of those, a model MergeWatch does not ship prices for shows as unpriced rather than as zero.
+
+**Cycle time** measures time-to-merge across the PR lifecycle, reported as percentiles rather than a mean — a mean is dominated by the one PR that sat open for three weeks, and tells you nothing about the typical case.
+
+Read the two together. Cost alone is a number without a denominator; cost against a movement in merge time is an argument.
+
+## Accuracy
+
+Where the [feedback signals](/configuration/feedback-signals) surface.
+
+- **The false-positive funnel** — how many findings were surfaced, how many were disputed, how many were silently dropped.
+- **Dispute rate by agent** — which agents are trusted in your repositories and which are not.
+- **Themes** — clusters of findings that keep recurring, which usually means a convention worth documenting rather than a bug worth fixing repeatedly.
+- **Per-repo heatmap** — where accuracy differs across the installation.
+
+A high dispute rate for one agent in one repository is the clearest signal available that the repository needs a [conventions file](/configuration/conventions). That is usually a faster fix than turning the agent off: conventions teach it your patterns, disabling it gives up the category entirely.
+
+<Note>
+Rates distinguish "no signal" from a real zero. A blank is *no data in this window*, not *nothing was useful*. Do not read a quiet week as a bad score.
+</Note>
+
+## Activity
+
+Developer engagement with reviews: reviews delivered, re-reviews requested, `/mergewatch reject` commands, helpful votes, and NPS responses.
+
+Engagement is the leading indicator. Accuracy tells you whether reviews are correct; activity tells you whether anyone is reading them. A high-accuracy review nobody engages with is still failing.
+
+## Rollup cadence
+
+Analytics is computed by a rollup job, not live per request. It runs **hourly** by default.
+
+Self-hosted deployments can change that with [`INSIGHTS_ROLLUP_INTERVAL_MINUTES`](/reference/env-vars) — raise it to reduce database load. A number that is unset, non-numeric, or non-positive falls back to hourly.
+
+Because the data is rolled up, a review that completed a few minutes ago may not have landed in these views yet. That is expected, not a bug.
+
+## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Reviews" icon="magnifying-glass" href="/dashboard/reviews">
-    View individual review details and findings.
-  </Card>
-  <Card title="Settings" icon="gear" href="/dashboard/settings">
-    Configure installation-level review settings.
-  </Card>
+
+<Card title="Feedback signals" icon="thumbs-up" href="/configuration/feedback-signals">
+The signals the Accuracy and Activity tabs are built from.
+</Card>
+
+<Card title="Reviews" icon="list-check" href="/dashboard/reviews">
+Per-review detail behind the aggregates.
+</Card>
+
 </CardGroup>

--- a/docs-site/dashboard/api-keys.mdx
+++ b/docs-site/dashboard/api-keys.mdx
@@ -1,0 +1,67 @@
+---
+title: "API Keys"
+description: "Create, scope, and revoke the API keys that authenticate coding agents to the MergeWatch MCP server."
+---
+
+API keys authenticate external coding agents to the [MergeWatch MCP server](/reference/mcp-server). They are the only credential that server accepts.
+
+Find them under **Settings → API keys** in the dashboard.
+
+## Who can manage keys
+
+Only **installation admins** can create or revoke keys. A user with dashboard access but no admin rights on the GitHub App installation gets a `403` — viewing the page is not enough.
+
+## Creating a key
+
+Each key needs two things:
+
+**A label** (1–100 characters). This is how you identify the key later; the key itself is never shown again. Name it after what uses it — `claude-code-laptop`, `ci-review-bot` — not after who created it.
+
+**A scope**, which is either:
+
+- **All repositories** in the installation, or
+- **An explicit list** of repositories. At least one must be selected.
+
+<Warning>
+The full key is returned **once**, in the response to the create call, and never again. MergeWatch stores only a hash — there is no recovery flow and no "show key" button. If it is lost, revoke it and create another.
+</Warning>
+
+Keys look like `mw_sk_…`. In the key list you see only a display prefix derived from the hash, which is enough to tell keys apart and reveals no secret material.
+
+## Scoping
+
+A scoped key that calls [`review_diff`](/reference/mcp-server) with a repository outside its list is rejected with a `-32001` unauthorized error.
+
+Prefer narrow scopes. A key that only ever reviews one service does not need to reach the rest of the installation, and a narrowly-scoped key that leaks is a much smaller problem than a broad one. Use one key per agent or machine rather than sharing a single key — that way revoking one does not interrupt everything else.
+
+## What the list shows
+
+| Column | Notes |
+|---|---|
+| Label | What you named it at creation. |
+| Prefix | Derived from the hash — identifies the key without exposing it. |
+| Scope | `all`, or the repositories it can reach. |
+| Created | When it was issued, and by which GitHub user. |
+| Last used | Updated on each authenticated MCP request. |
+
+**Last used** is the field worth watching. A key with no recent activity is a key you can probably revoke, and unexplained activity on a key you thought was idle is worth investigating immediately.
+
+## Revoking
+
+Revoking takes effect on the next request — there is no grace period and no expiry to wait out. Revoke a key when the machine holding it is decommissioned, when someone with access to it leaves, or whenever you cannot account for its recent use.
+
+Revocation is not reversible. Issue a new key rather than expecting to restore an old one.
+
+## Next steps
+
+<CardGroup cols={2}>
+
+<Card title="MCP server" icon="plug" href="/reference/mcp-server">
+What these keys authenticate against — tools, resources, and error codes.
+</Card>
+
+<Card title="Settings" icon="gear" href="/dashboard/settings">
+Installation-level review settings alongside key management.
+</Card>
+
+</CardGroup>

--- a/docs-site/dashboard/billing.mdx
+++ b/docs-site/dashboard/billing.mdx
@@ -1,0 +1,50 @@
+---
+title: "Billing"
+description: "The dashboard surface for managed SaaS billing — balance, payment method, top-ups, and auto-reload."
+---
+
+The **Billing** page manages the prepaid credit balance for a managed SaaS installation. For how pricing works — the free tier, the per-review cost formula, what counts as billable — see [SaaS billing](/saas/billing). This page covers the dashboard surface itself.
+
+<Note>
+Billing applies to **managed SaaS only**. Self-hosted deployments have no balance and no payment method; you pay your LLM provider directly. See [Self-hosted is always free](/saas/billing#self-hosted-is-always-free).
+</Note>
+
+## What the page shows
+
+**Current balance**, in credits. Reviews deduct their actual cost as they complete, so the balance moves continuously rather than in monthly steps.
+
+**Free reviews used** — the lifetime counter against the 5-review free tier, tracked per GitHub App installation.
+
+**Payment method**, managed through Stripe. MergeWatch never stores card details.
+
+## Topping up
+
+Add credits manually at any time. A top-up is a one-off charge against the payment method on file — there is no subscription and no recurring billing to cancel.
+
+## Auto-reload
+
+Auto-reload tops the balance up automatically when it falls below a threshold, so reviews do not stop mid-sprint because a balance ran down on a Friday afternoon.
+
+Enable it if MergeWatch is on your critical path. Leave it off if you would rather have reviews stop than have charges happen without you initiating them — a blocked review is visible and recoverable in a minute; a surprise charge is neither.
+
+Auto-reload is guarded against double-charging: a concurrent top-up cannot fire twice for the same drop below the threshold, even if several reviews complete simultaneously.
+
+## When the balance runs out
+
+Reviews are blocked rather than run-and-billed, and the MCP server returns a billing-blocked error (`-32002`). Nothing is silently deferred or queued — you find out immediately, on the PR.
+
+Top up or enable auto-reload to resume. See [what happens when your balance runs out](/saas/billing#what-happens-when-your-balance-runs-out).
+
+## Next steps
+
+<CardGroup cols={2}>
+
+<Card title="SaaS billing" icon="credit-card" href="/saas/billing">
+Pricing model, free tier, and the per-review cost formula.
+</Card>
+
+<Card title="Analytics" icon="chart-line" href="/dashboard/analytics">
+The Cost & Impact tab, for what that spend is buying.
+</Card>
+
+</CardGroup>

--- a/docs-site/dashboard/custom-agents.mdx
+++ b/docs-site/dashboard/custom-agents.mdx
@@ -1,0 +1,92 @@
+---
+title: "Org Custom Agents"
+description: "Define review agents once at the organization level, scope them to repositories, target them at paths or languages, and optionally make their findings block a merge."
+---
+
+Per-repo [`customAgents`](/configuration/mergewatch-yml) let each repository add its own review agents. **Org custom agents** invert that: an organization admin defines an agent once in the dashboard, and it runs across the org's repositories whether or not each repo asks for it.
+
+Use them for standards that are not a per-repo choice — a compliance rule, a security requirement, a house pattern every service must follow.
+
+Find them under **Settings → Custom agents**. Available on both managed SaaS and self-hosted.
+
+## Who can edit
+
+Only **organization admins** can create or edit org agents. Other members see a read-only view — they can tell what is enforced and why a finding appeared, without being able to change it.
+
+## Defining an agent
+
+| Field | Notes |
+|---|---|
+| **Name** | Display name, and the category findings are filed under. |
+| **Prompt** | The system prompt — what this agent looks for. |
+| **Default severity** | `info`, `warning`, or `critical`. |
+| **Enforcement** | `advisory` or `blocking`. See below. |
+| **Scope** | All repositories, or a selected allowlist. |
+| **Targeting** | Optional path globs and/or languages. See below. |
+| **Enabled** | Whether it runs at all. |
+
+Each agent also records **who last edited it and when**, so an unexpected finding can be traced to a change rather than argued about.
+
+## Enforcement: advisory vs blocking
+
+This is the field to think hardest about.
+
+<CardGroup cols={2}>
+
+<Card title="Advisory" icon="circle-info">
+Findings appear in the review like any other. They feed the merge-readiness score but do not independently gate anything.
+</Card>
+
+<Card title="Blocking" icon="shield-halved">
+A **critical** finding from this agent fails the check run **and** requests changes — **regardless of the overall merge score**.
+</Card>
+
+</CardGroup>
+
+<Warning>
+Blocking enforcement bypasses the normal scoring path. A PR that MergeWatch would otherwise consider ready to merge is still blocked by a single critical finding from a blocking agent. That is the point — but it also means a poorly-worded blocking prompt can stop every PR in the organization.
+
+Start new agents as **advisory**, watch what they actually flag for a week, then promote to blocking once the finding rate looks right.
+</Warning>
+
+## Scoping and targeting
+
+**Scope** decides which repositories the agent applies to: all, or an explicit allowlist.
+
+**Targeting** narrows further, within those repositories — the agent runs only when the PR actually touches relevant code:
+
+- **Path globs** — run only when a changed file matches one of these patterns.
+- **Languages** — run only when the PR touches one of these languages.
+
+Targeting is what keeps an org-wide agent cheap. A Terraform security agent scoped to all repositories but targeted at `**/*.tf` costs nothing on the PRs that do not touch Terraform, and there is no reason to pay for an LLM call that has nothing to examine.
+
+## How org agents combine with repo agents
+
+Org agents run **in addition to** each repository's own `.mergewatch.yml` `customAgents` — the two sets are unioned.
+
+**On a name collision, the org agent wins.** A repository cannot disable or override an org agent by defining one with the same name. Repositories can *add* agents; they cannot *remove* org ones. That asymmetry is deliberate: an org standard that any repo could opt out of by naming a local agent the same thing would not be a standard.
+
+## Cost
+
+**Each enabled agent adds one LLM call per review it runs on.** Ten org agents scoped to all repositories means up to ten extra calls on every pull request across the organization.
+
+The dashboard warns past **10 active agents**. It is a soft cap — nothing is blocked — but treat the warning as real: past that point, targeting is no longer optional if you care about review cost and latency.
+
+Two levers keep this under control:
+
+1. **Target aggressively.** Most org concerns apply to a subset of files, not every PR.
+2. **Consolidate prompts.** Three narrow agents that always run together are usually better as one agent with a broader prompt.
+
+## Next steps
+
+<CardGroup cols={2}>
+
+<Card title="Per-repo custom agents" icon="file-code" href="/configuration/mergewatch-yml">
+The `customAgents` block org agents union with.
+</Card>
+
+<Card title="Review behavior" icon="sliders" href="/configuration/review-behavior">
+How findings become a merge-readiness score.
+</Card>
+
+</CardGroup>

--- a/docs-site/dashboard/custom-agents.mdx
+++ b/docs-site/dashboard/custom-agents.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Org Custom Agents"
-description: "Define review agents once at the organization level, scope them to repositories, target them at paths or languages, and optionally make their findings block a merge."
+description: "Define review agents once at the organization level, scope them to repositories, target them at paths or languages, and optionally block merges."
 ---
 
 Per-repo [`customAgents`](/configuration/mergewatch-yml) let each repository add its own review agents. **Org custom agents** invert that: an organization admin defines an agent once in the dashboard, and it runs across the org's repositories whether or not each repo asks for it.

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -96,6 +96,7 @@
             "pages": [
               "configuration/mergewatch-yml",
               "configuration/review-behavior",
+              "configuration/false-positives",
               "configuration/skip-rules",
               "configuration/custom-instructions",
               "configuration/conventions",
@@ -130,6 +131,7 @@
               "dashboard/settings",
               "dashboard/api-keys",
               "dashboard/custom-agents",
+              "dashboard/billing",
               "dashboard/profile"
             ]
           },

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -3,7 +3,9 @@
   "theme": "mint",
   "name": "MergeWatch",
   "description": "Documentation for MergeWatch, the open-source AI code review GitHub App: self-hosting guides, .mergewatch.yml configuration, and LLM provider setup.",
-  "appearance": { "default": "dark" },
+  "appearance": {
+    "default": "dark"
+  },
   "seo": {
     "metatags": {
       "og:site_name": "MergeWatch Documentation"
@@ -11,7 +13,9 @@
     "organization": {
       "name": "MergeWatch",
       "url": "https://mergewatch.ai",
-      "sameAs": ["https://github.com/mergewatch"]
+      "sameAs": [
+        "https://github.com/mergewatch"
+      ]
     }
   },
   "logo": {
@@ -94,7 +98,8 @@
               "configuration/review-behavior",
               "configuration/skip-rules",
               "configuration/custom-instructions",
-              "configuration/conventions"
+              "configuration/conventions",
+              "configuration/feedback-signals"
             ]
           },
           {
@@ -123,6 +128,8 @@
               "dashboard/reviews",
               "dashboard/repositories",
               "dashboard/settings",
+              "dashboard/api-keys",
+              "dashboard/custom-agents",
               "dashboard/profile"
             ]
           },
@@ -138,6 +145,7 @@
             "group": "Reference",
             "pages": [
               "reference/cli",
+              "reference/mcp-server",
               "reference/env-vars",
               "reference/changelog",
               "reference/faq",

--- a/docs-site/overview/introduction.mdx
+++ b/docs-site/overview/introduction.mdx
@@ -3,7 +3,11 @@ title: What is MergeWatch?
 description: Open-source AI code review. Self-host on any cloud or use our managed SaaS.
 ---
 
-MergeWatch is an open-source GitHub App that reviews pull requests using a multi-agent AI pipeline. Self-host it anywhere with Docker and Postgres, or let MergeWatch run it for you as a managed SaaS. You choose the LLM. There is no per-seat pricing. The project is licensed under AGPL v3.
+MergeWatch is an open-source GitHub App that reviews pull requests with a team of specialized AI agents running in parallel — security, bugs, style, error handling, test coverage, and comment accuracy — plus any [custom agents](/configuration/mergewatch-yml) you define. An orchestrator deduplicates their findings and scores merge readiness, so you get one review, not eight.
+
+**Your model, your infrastructure.** Self-host it anywhere with Docker and Postgres and point it at Anthropic, Amazon Bedrock, LiteLLM, or a fully local Ollama — or let MergeWatch run it for you as managed SaaS. Either way you choose the LLM, and there is no per-seat pricing: you pay per reviewed PR, not per developer. The project is licensed under AGPL v3.
+
+Open-source maintainers can [apply for free frontier-model review](/saas/billing#open-source-maintainers).
 
 ## How it compares
 
@@ -17,7 +21,7 @@ MergeWatch is an open-source GitHub App that reviews pull requests using a multi
 | **Minimum commitment** | None | None stated | 500 seats for self-hosting |
 
 <Note>
-Competitor pricing and features were last verified in April 2026. Visit each vendor's website for current information. For a full breakdown across eight tools, see [Comparisons](/comparisons/overview).
+Competitor pricing and features were last verified in **April 2026** and have not been re-checked since — treat the competitor columns as a dated snapshot, not current fact, and confirm against each vendor's own site before relying on them. MergeWatch's own column is kept current. For a full breakdown across eight tools, see [Comparisons](/comparisons/overview).
 </Note>
 
 ## Key differentiators

--- a/docs-site/reference/mcp-server.mdx
+++ b/docs-site/reference/mcp-server.mdx
@@ -1,0 +1,123 @@
+---
+title: "MCP Server"
+description: "Connect coding agents to MergeWatch over the Model Context Protocol — review a diff before you open a PR, and read repo conventions from your editor."
+---
+
+MergeWatch ships an [MCP](https://modelcontextprotocol.io) server so external coding agents — Claude Code, Cursor, and anything else that speaks MCP — can run the review pipeline directly, without opening a pull request first.
+
+The usual flow is inverted: instead of pushing a branch and waiting for a review comment, your agent reviews the diff it just wrote, fixes what comes back, and only then opens the PR.
+
+## Tools
+
+<AccordionGroup>
+
+<Accordion title="review_diff — run the full review pipeline on a diff">
+
+Runs the same multi-agent pipeline that reviews a pull request, on a diff you supply.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `diff` | string | Yes | The unified diff to review. |
+| `repo` | string | No | `owner/repo`. When set, MergeWatch loads that repository's `.mergewatch.yml` and [conventions file](/configuration/conventions), so the review respects the same rules a PR review would. |
+| `description` | string | No | Freeform description of what the change is meant to do. Surfaced to the agent prompts as intent. |
+| `sessionId` | string | No | Groups repeated calls for billing. See [Session billing](#session-billing). |
+
+<Note>
+Reviews run through `review_diff` are marked **agent-authored**, which flips them into the stricter review mode described in [`agentReview`](/configuration/mergewatch-yml). That is deliberate: a diff arriving from a coding agent gets the scrutiny an agent-authored PR gets.
+</Note>
+
+Passing `repo` is worth it whenever the repository has conventions checked in — without it the review falls back to generic best practices and will flag patterns your team has deliberately chosen.
+
+</Accordion>
+
+<Accordion title="get_review_status — read the latest review for a PR">
+
+Returns the most recent review record for a pull request.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `repo` | string | Yes | `owner/repo`. |
+| `prNumber` | integer | Yes | Pull request number. Must be 1 or greater. |
+
+Use it to let an agent poll for a review it triggered, or to pull findings into an editor session without leaving it.
+
+</Accordion>
+
+</AccordionGroup>
+
+## Resources
+
+| Resource | URI | Type |
+|---|---|---|
+| Repo conventions | `mergewatch://conventions/{owner}/{repo}` | `text/markdown` |
+
+Serves the repository's resolved conventions markdown — the same file the review agents receive, resolved through the [discovery order](/configuration/conventions) (`conventions:` in `.mergewatch.yml`, then `AGENTS.md`, `CONVENTIONS.md`, `.mergewatch/conventions.md`).
+
+This lets a coding agent read your house rules *before* writing code, rather than finding out about them in review.
+
+## Authentication
+
+Every request needs a MergeWatch API key as a Bearer token:
+
+```http
+Authorization: Bearer mw_sk_...
+```
+
+Create keys in the dashboard under [**Settings → API keys**](/dashboard/api-keys). Keys are stored hashed — the full value is shown exactly once, at creation.
+
+### Scopes
+
+A key is scoped either to **all repositories** in the installation, or to an explicit list of `owner/repo` strings. A scoped key calling `review_diff` with a `repo` outside its list is rejected.
+
+Scope keys to the narrowest set that works. A key that only ever reviews one service does not need access to the rest of the installation.
+
+## Transport
+
+<CardGroup cols={2}>
+
+<Card title="HTTP (SaaS)" icon="cloud">
+A Lambda Function URL speaking JSON-RPC 2.0 over HTTPS. This is what managed SaaS users connect to. CORS is deliberately open because MCP clients run locally, on origins MergeWatch cannot enumerate.
+</Card>
+
+<Card title="stdio (self-hosted)" icon="terminal">
+The `@mergewatch/mcp` package also runs as a local stdio server, for self-hosted deployments and for clients that prefer a subprocess to a network endpoint.
+</Card>
+
+</CardGroup>
+
+## Session billing
+
+Coding agents iterate. A single change might be reviewed five times as the agent fixes what the previous pass found — and charging full price for each pass would make the tool too expensive to use the way it is meant to be used.
+
+Passing a stable `sessionId` across those calls collapses them into one session:
+
+- A session covers a **30-minute** window.
+- Within it, each call is billed only the **positive delta** above the highest cost billed so far.
+- Repeated reviews of the same diff therefore cost close to nothing after the first.
+
+Use one `sessionId` per logical task — not per call, and not one global ID forever. A UUID generated when the agent picks up a task is the right shape.
+
+## Error codes
+
+The server returns standard JSON-RPC 2.0 errors, plus two MergeWatch-specific codes:
+
+| Code | Meaning |
+|---|---|
+| `-32602` | Invalid params — a required field is missing or malformed. |
+| `-32603` | Internal error. |
+| `-32001` | Unauthorized — missing, malformed, or unrecognized API key, or a repo outside the key's scope. |
+| `-32002` | Billing blocked — the installation has no remaining review quota. See [Billing](/saas/billing). |
+
+## Next steps
+
+<CardGroup cols={2}>
+
+<Card title="API keys" icon="key" href="/dashboard/api-keys">
+Create and scope the keys this server authenticates with.
+</Card>
+
+<Card title="Repository conventions" icon="book" href="/configuration/conventions">
+What the conventions resource serves, and how it is resolved.
+</Card>
+
+</CardGroup>

--- a/docs-site/saas/billing.mdx
+++ b/docs-site/saas/billing.mdx
@@ -13,6 +13,16 @@ Every installation gets **5 free PR reviews** total (lifetime, not per month). N
 The free tier is intended to let you evaluate MergeWatch on real PRs. If you reach the limit and want to keep going, add a card via **Dashboard → Billing**.
 </Tip>
 
+## Open-source maintainers
+
+MergeWatch offers **free frontier-model review to open-source maintainers**, beyond the standard free tier above. If you maintain an open-source project, you can apply rather than paying per review.
+
+<Card title="Apply for free open-source review" icon="heart" href="https://docs.google.com/forms/d/e/1FAIpQLSfiIx-0o5GJ8dwbhj_Fs1FfoCmvWpVS8ImlUR4L9gWQfh_msA/viewform">
+Applications are reviewed individually — tell us about the project and how you'd use MergeWatch.
+</Card>
+
+Self-hosting is always free regardless, and remains the right choice if you would rather run the whole pipeline yourself. See [Self-hosted is always free](#self-hosted-is-always-free).
+
 ## Per-review pricing
 
 Each review is priced transparently from the actual LLM cost. There are no tiers or commitments.


### PR DESCRIPTION
**Stack 2 of 4** for #254 — targets `docs/fix-reference-drift` (#255), not `main`. Merge #255 first; GitHub will retarget this to `main` automatically.

Covers the largest zero-coverage gaps in **P1/P2**: four new pages plus a rewrite of Analytics.

## `reference/mcp-server` — the gap that was actively promising something

The MCP server had **no page at all**, while three comparison pages already advertise it as a differentiator against Greptile and Qodo — including a specific claim about `review_diff` + `get_review_status` over a Lambda Function URL with API-key auth. Readers who went looking had nowhere to land.

Documents both tools with full parameter tables, the conventions resource, Bearer auth and scoping, both transports (HTTP for SaaS, stdio for self-hosted), and the two MergeWatch-specific JSON-RPC error codes (`-32001` unauthorized, `-32002` billing blocked).

The **30-minute session billing window** gets its own section. It's the difference between the MCP server being usable the way it's designed — agents iterating on a diff — and being too expensive to iterate with, and nothing documented it.

## `dashboard/custom-agents` — one detail worth reviewing closely

Org custom agents (#235). The load-bearing detail is **enforcement**: a `blocking` agent's critical finding fails the check run **and** requests changes *regardless of the overall merge score*. That bypasses the normal scoring path entirely, so one badly-worded blocking prompt can stop every PR in the organization.

The page recommends starting **advisory**, watching the real finding rate, then promoting. If you'd rather it led with blocking, say so — I made that call and it's a judgment call, not a fact.

Also documents that **org agents win name collisions** with repo agents (repos can add, not remove), and that each enabled agent costs an LLM call per review it runs on — with the soft cap at 10 and targeting as the mitigation.

## `dashboard/api-keys` and `configuration/feedback-signals`

API keys: admin-only, shown once at creation, scoped to all repos or an allowlist.

Feedback signals: `/mergewatch reject`, inline replies, and 👍/👎 reactions were all undocumented. The page explains what each feeds and makes the case that rejecting a bad finding beats silently closing it — disputes down-weight the agent, silence doesn't.

## Correcting #254

**`/dashboard/accuracy` is not a missing page — it's a redirect.** `packages/dashboard/app/dashboard/accuracy/page.tsx` permanently redirects to `/dashboard/analytics?tab=accuracy`, and the older `/dashboard/insights` redirects through it. My issue listed it as a page to write.

So Accuracy is documented as a **tab**, and cross-links point at the real route rather than depending on a redirect chain. The tab list comes from `packages/dashboard/lib/analytics-tabs.ts` rather than being inferred: **Overview, Cost & Impact, Findings, Activity, Accuracy**.

That also means `/dashboard/billing` and `/dashboard/reviews/[id]` are the only genuinely-missing dashboard routes left — deferred to the next PR in the stack rather than guessed at here.

## Verification

```
$ cd docs-site && mint broken-links
success no broken links found
```

61/61 pages in navigation, zero orphans, `docs.json` parses.

## Not in this PR

P3 (the W1–W11 / FP-A–FP-K review-behavior rewrite) and P5 (positioning) are next in the stack. GHCR remains blocked on publishing the org packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)