### PR TITLE
docs: document the false-positive reduction work

### DIFF
--- a/docs-site/configuration/false-positives.mdx
+++ b/docs-site/configuration/false-positives.mdx
@@ -1,0 +1,113 @@
+---
+title: "How MergeWatch Avoids False Positives"
+description: "The machinery between an agent finding something and you reading it — grounding, dedup, clustering, convergence, and the guards that keep reviews quiet enough to trust."
+---
+
+An AI reviewer that reports everything it notices is worse than no reviewer at all. People stop reading it, and the one real bug arrives in a list of nine nits.
+
+Most of MergeWatch's review pipeline is therefore not about *finding* issues. It is about deciding which findings are worth your attention — and, just as importantly, not raising the same one twice.
+
+This page describes what happens between an agent producing a finding and you reading it. Nothing here needs configuration; it is how reviews behave by default.
+
+## The problem each guard solves
+
+<AccordionGroup>
+
+<Accordion title="Findings that cite code that isn't there">
+
+The single worst failure mode for a reviewer is confident nonsense — a critical finding about a vulnerability in code the PR does not contain.
+
+Findings are **grounded against the diff**: a claim is checked against the code it cites before it is reported. Warnings get the same treatment as criticals, and Mermaid diagrams that reference files outside the PR are dropped rather than shown.
+
+There is also a **confidence floor**. An agent that is guessing does not get to file a critical.
+
+</Accordion>
+
+<Accordion title="One problem reported as several findings">
+
+The multi-agent pipeline runs agents in parallel, and they notice the same thing from different angles. A real example from the codebase: one PR produced *"SQL injection risk in dynamic VALUES clause"*, *"Type assertion without runtime validation"*, and *"Untrusted JSON parsing from S3 without validation"* — three findings at three different lines, one root cause.
+
+Two mechanisms handle this:
+
+- **Cross-agent dedup** removes findings that different agents raised about the same line before the orchestrator ever sees them.
+- **Consolidation** clusters fragments of one concern into a single finding carrying the strongest severity, with the absorbed siblings listed under it.
+
+You keep the full audit trail — every framing is preserved inside the merged finding — but you read one row instead of three.
+
+</Accordion>
+
+<Accordion title="The same finding reappearing after you fixed something else">
+
+The whack-a-mole problem: you push a fix, the next review reports the issue you just fixed as *resolved* and an old one as *new*, because the model reworded its title.
+
+**Stable finding identity** solves half of it. Findings are matched across commits by a fingerprint derived from the code they cite, not by their title — so a reworded finding is recognised as the same issue rather than being reported as both resolved and new.
+
+**The convergence guard** solves the other half. Reply to a review with a `## mergewatch triage` comment rebutting or deferring specific findings, and those findings are not re-raised on later commits.
+
+<Note>
+The convergence guard fails safe in the direction that matters. Every error path returns an **empty** suppression set — infrastructure trouble can never *hide* a finding. Only an explicit, parseable author disposition suppresses one.
+</Note>
+
+</Accordion>
+
+<Accordion title="Style nits your linter already covers">
+
+If your repository configures a linter, the style agent defers to it.
+
+MergeWatch detects eslint, biome, ruff, flake8, clippy, golangci-lint, and stylelint from their config files at the repository root — with `pyproject.toml` requiring an actual `[tool.ruff]` section rather than mere presence, since most Python projects have one. When a linter is detected, the style agent stops reporting the things it already enforces: semicolons, quote style, import order, unused imports.
+
+Nothing to configure. Check in a linter config and the reviewer stops duplicating it.
+
+</Accordion>
+
+<Accordion title="Nagging about tests in a repo that has none on purpose">
+
+If your conventions file says the repository has no test harness yet, the test-coverage agent's findings collapse into a single non-blocking note instead of one warning per file.
+
+The detection is deliberately conservative: **the signal is a written declaration, not the absence of test files.** Plenty of repositories keep tests elsewhere, defer coverage deliberately, or are mid-migration — so MergeWatch only suppresses when a maintainer wrote it down. Under-detection is the acceptable failure here; silently dropping coverage findings because it guessed wrong is not.
+
+Write it in your [conventions file](/configuration/conventions) and the nagging stops.
+
+</Accordion>
+
+<Accordion title="One uncertain critical blocking a good PR">
+
+A single unverified critical does not block a merge on its own.
+
+Findings that survive grounding but not verification are surfaced with lower weight rather than treated as blocking facts. Where disputes have accumulated, the merge score accounts for them — an agent whose findings your team consistently rejects carries less weight in your repositories than one you act on.
+
+Reviews that suppress findings say so, with a count of what was removed by dedup and quality filters. You are told when the reviewer decided to stay quiet.
+
+</Accordion>
+
+</AccordionGroup>
+
+## What you see
+
+**One review comment per PR.** Not a verdict comment plus a findings comment plus a summary — one authoritative comment, updated in place.
+
+**Findings snapped to the call site**, not the function definition, so the line number points at the code that has the problem.
+
+**A disclosure footer** noting suppressed findings and dispute-aware adjustments, so the filtering is visible rather than silent.
+
+## What you can do about it
+
+The pipeline gets quieter the more you tell it. Three things help, in order of leverage:
+
+1. **Check in a [conventions file](/configuration/conventions).** The single highest-leverage change. It teaches MergeWatch your patterns so it stops applying generic best practice over your deliberate choices.
+2. **Reject bad findings** with `/mergewatch reject` rather than closing them silently. Disputes down-weight the agent; silence does nothing. See [feedback signals](/configuration/feedback-signals).
+3. **Triage rather than argue.** A `## mergewatch triage` reply stops a finding recurring across commits.
+
+## Next steps
+
+<CardGroup cols={2}>
+
+<Card title="Review behavior" icon="sliders" href="/configuration/review-behavior">
+When reviews trigger, and the statuses they produce.
+</Card>
+
+<Card title="Repository conventions" icon="book" href="/configuration/conventions">
+The highest-leverage way to make reviews quieter.
+</Card>
+
+</CardGroup>

--- a/docs-site/configuration/false-positives.mdx
+++ b/docs-site/configuration/false-positives.mdx
@@ -1,6 +1,6 @@
 ---
 title: "How MergeWatch Avoids False Positives"
-description: "The machinery between an agent finding something and you reading it — grounding, dedup, clustering, convergence, and the guards that keep reviews quiet enough to trust."
+description: "What happens between an agent producing a finding and you reading it — grounding, dedup, consolidation, and the guards that keep reviews trustworthy."
 ---
 
 An AI reviewer that reports everything it notices is worse than no reviewer at all. People stop reading it, and the one real bug arrives in a list of nine nits.

--- a/docs-site/configuration/review-behavior.mdx
+++ b/docs-site/configuration/review-behavior.mdx
@@ -5,6 +5,10 @@ description: "When reviews trigger, what they produce, and how to control the re
 
 MergeWatch listens to GitHub webhook events and automatically reviews pull requests based on a set of configurable rules. This page explains exactly when reviews run, what statuses they produce, and how to control the lifecycle.
 
+<Note>
+This page covers **when** reviews run. What happens to a finding *after* an agent produces it — grounding, dedup, consolidation, the convergence guard, linter deference — is covered in [How MergeWatch avoids false positives](/configuration/false-positives). If reviews feel noisy or repetitive, start there.
+</Note>
+
 ## When reviews trigger
 
 MergeWatch triggers a review when it receives any of the following GitHub webhook events:
@@ -30,6 +34,8 @@ MergeWatch triggers a review when it receives any of the following GitHub webhoo
   - `@mergewatch` (any other mention) — triggers a **conversational response**. MergeWatch reads the PR diff and its previous review findings, then replies directly to the user's comment using the LLM. No review pipeline runs — the response is posted as a regular PR comment. Use this to ask questions about findings, request clarification, or discuss specific parts of the code.
 
   All mentions are case-insensitive. This works even when `autoReview` is set to `false` in your configuration.
+
+  A fourth command, `/mergewatch reject`, records a finding as an explicit dispute rather than triggering a review — see [feedback signals](/configuration/feedback-signals).
 </Step>
 </Steps>
 
@@ -111,7 +117,9 @@ Each finding produced by MergeWatch includes a **confidence score** from 1 to 10
 | 50-74 | Lower confidence — suppressed by the orchestrator |
 | 1-49 | Low confidence — suppressed by the orchestrator |
 
-The orchestrator automatically drops all findings with confidence below **75** during the dedup and ranking phase. This threshold is not user-configurable — it is designed to minimize false positives while surfacing real issues.
+Findings with confidence below **75** are dropped. The orchestrator prompt asks for this, and a deterministic filter enforces it afterwards — a prompt instruction alone was not reliable enough to depend on, so the floor is applied in code regardless of what the orchestrator returns.
+
+The threshold is not user-configurable. It is set to minimize false positives while surfacing real issues; see [How MergeWatch avoids false positives](/configuration/false-positives) for the other guards that run alongside it.
 
 <Tip>
 If you notice a legitimate issue being suppressed, consider adding a [custom agent](/configuration/mergewatch-yml#custom-agents) with a targeted prompt. Custom agents with focused prompts tend to produce higher-confidence findings for domain-specific concerns.

--- a/docs-site/dashboard/billing.mdx
+++ b/docs-site/dashboard/billing.mdx
@@ -1,0 +1,50 @@
+---
+title: "Billing"
+description: "The dashboard surface for managed SaaS billing — balance, payment method, top-ups, and auto-reload."
+---
+
+The **Billing** page manages the prepaid credit balance for a managed SaaS installation. For how pricing works — the free tier, the per-review cost formula, what counts as billable — see [SaaS billing](/saas/billing). This page covers the dashboard surface itself.
+
+<Note>
+Billing applies to **managed SaaS only**. Self-hosted deployments have no balance and no payment method; you pay your LLM provider directly. See [Self-hosted is always free](/saas/billing#self-hosted-is-always-free).
+</Note>
+
+## What the page shows
+
+**Current balance**, in credits. Reviews deduct their actual cost as they complete, so the balance moves continuously rather than in monthly steps.
+
+**Free reviews used** — the lifetime counter against the 5-review free tier, tracked per GitHub App installation.
+
+**Payment method**, managed through Stripe. MergeWatch never stores card details.
+
+## Topping up
+
+Add credits manually at any time. A top-up is a one-off charge against the payment method on file — there is no subscription and no recurring billing to cancel.
+
+## Auto-reload
+
+Auto-reload tops the balance up automatically when it falls below a threshold, so reviews do not stop mid-sprint because a balance ran down on a Friday afternoon.
+
+Enable it if MergeWatch is on your critical path. Leave it off if you would rather have reviews stop than have charges happen without you initiating them — a blocked review is visible and recoverable in a minute; a surprise charge is neither.
+
+Auto-reload is guarded against double-charging: a concurrent top-up cannot fire twice for the same drop below the threshold, even if several reviews complete simultaneously.
+
+## When the balance runs out
+
+Reviews are blocked rather than run-and-billed, and the MCP server returns a billing-blocked error (`-32002`). Nothing is silently deferred or queued — you find out immediately, on the PR.
+
+Top up or enable auto-reload to resume. See [what happens when your balance runs out](/saas/billing#what-happens-when-your-balance-runs-out).
+
+## Next steps
+
+<CardGroup cols={2}>
+
+<Card title="SaaS billing" icon="credit-card" href="/saas/billing">
+Pricing model, free tier, and the per-review cost formula.
+</Card>
+
+<Card title="Analytics" icon="chart-line" href="/dashboard/analytics">
+The Cost & Impact tab, for what that spend is buying.
+</Card>
+
+</CardGroup>

--- a/docs-site/dashboard/custom-agents.mdx
+++ b/docs-site/dashboard/custom-agents.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Org Custom Agents"
-description: "Define review agents once at the organization level, scope them to repositories, target them at paths or languages, and optionally make their findings block a merge."
+description: "Define review agents once at the organization level, scope them to repositories, target them at paths or languages, and optionally block merges."
 ---
 
 Per-repo [`customAgents`](/configuration/mergewatch-yml) let each repository add its own review agents. **Org custom agents** invert that: an organization admin defines an agent once in the dashboard, and it runs across the org's repositories whether or not each repo asks for it.

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -131,6 +131,7 @@
               "dashboard/settings",
               "dashboard/api-keys",
               "dashboard/custom-agents",
+              "dashboard/billing",
               "dashboard/profile"
             ]
           },

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -96,6 +96,7 @@
             "pages": [
               "configuration/mergewatch-yml",
               "configuration/review-behavior",
+              "configuration/false-positives",
               "configuration/skip-rules",
               "configuration/custom-instructions",
               "configuration/conventions",

--- a/docs-site/overview/introduction.mdx
+++ b/docs-site/overview/introduction.mdx
@@ -3,7 +3,11 @@ title: What is MergeWatch?
 description: Open-source AI code review. Self-host on any cloud or use our managed SaaS.
 ---
 
-MergeWatch is an open-source GitHub App that reviews pull requests using a multi-agent AI pipeline. Self-host it anywhere with Docker and Postgres, or let MergeWatch run it for you as a managed SaaS. You choose the LLM. There is no per-seat pricing. The project is licensed under AGPL v3.
+MergeWatch is an open-source GitHub App that reviews pull requests with a team of specialized AI agents running in parallel — security, bugs, style, error handling, test coverage, and comment accuracy — plus any [custom agents](/configuration/mergewatch-yml) you define. An orchestrator deduplicates their findings and scores merge readiness, so you get one review, not eight.
+
+**Your model, your infrastructure.** Self-host it anywhere with Docker and Postgres and point it at Anthropic, Amazon Bedrock, LiteLLM, or a fully local Ollama — or let MergeWatch run it for you as managed SaaS. Either way you choose the LLM, and there is no per-seat pricing: you pay per reviewed PR, not per developer. The project is licensed under AGPL v3.
+
+Open-source maintainers can [apply for free frontier-model review](/saas/billing#open-source-maintainers).
 
 ## How it compares
 
@@ -17,7 +21,7 @@ MergeWatch is an open-source GitHub App that reviews pull requests using a multi
 | **Minimum commitment** | None | None stated | 500 seats for self-hosting |
 
 <Note>
-Competitor pricing and features were last verified in April 2026. Visit each vendor's website for current information. For a full breakdown across eight tools, see [Comparisons](/comparisons/overview).
+Competitor pricing and features were last verified in **April 2026** and have not been re-checked since — treat the competitor columns as a dated snapshot, not current fact, and confirm against each vendor's own site before relying on them. MergeWatch's own column is kept current. For a full breakdown across eight tools, see [Comparisons](/comparisons/overview).
 </Note>
 
 ## Key differentiators

--- a/docs-site/saas/billing.mdx
+++ b/docs-site/saas/billing.mdx
@@ -13,6 +13,16 @@ Every installation gets **5 free PR reviews** total (lifetime, not per month). N
 The free tier is intended to let you evaluate MergeWatch on real PRs. If you reach the limit and want to keep going, add a card via **Dashboard → Billing**.
 </Tip>
 
+## Open-source maintainers
+
+MergeWatch offers **free frontier-model review to open-source maintainers**, beyond the standard free tier above. If you maintain an open-source project, you can apply rather than paying per review.
+
+<Card title="Apply for free open-source review" icon="heart" href="https://docs.google.com/forms/d/e/1FAIpQLSfiIx-0o5GJ8dwbhj_Fs1FfoCmvWpVS8ImlUR4L9gWQfh_msA/viewform">
+Applications are reviewed individually — tell us about the project and how you'd use MergeWatch.
+</Card>
+
+Self-hosting is always free regardless, and remains the right choice if you would rather run the whole pipeline yourself. See [Self-hosted is always free](#self-hosted-is-always-free).
+
 ## Per-review pricing
 
 Each review is priced transparently from the actual LLM cost. There are no tiers or commitments.


### PR DESCRIPTION
**Stack 3 of 4** for #254 — targets `docs/document-new-features` (#256). Covers **P3**, which the issue called the highest-value writing in the backlog.

The W1–W11 and FP-A–FP-K work that landed across May 2026 visibly changes what a review looks like. None of it was documented, and it's a genuine differentiator no reader could see.

## The structural choice

**Organized by the problem each guard solves, not by work-item ID.** Readers arrive at this page thinking *"my reviews are noisy"* or *"why did it flag this again?"* — not *"what does FP-C do?"* So the sections are:

- Findings that cite code that isn't there
- One problem reported as several findings
- The same finding reappearing after you fixed something else
- Style nits your linter already covers
- Nagging about tests in a repo that has none on purpose
- One uncertain critical blocking a good PR

The internal IDs appear nowhere. They're the right index for the codebase and the wrong one for a user.

## Two fail-safe directions documented deliberately

These are the parts that make the machinery trustworthy rather than spooky, and both are stated explicitly:

**The convergence guard returns an empty suppression set on every error path.** Infrastructure trouble can never *hide* a finding — only an explicit, parseable author disposition suppresses one. A reader who doesn't know that has to assume a silent failure could be swallowing real bugs.

**Test-coverage suppression keys on a written declaration, never on the absence of test files.** Repos keep tests elsewhere, defer coverage deliberately, or are mid-migration. Under-detection is the acceptable failure here; silently dropping coverage findings because it guessed wrong is not.

## Two corrections to `review-behavior.mdx`

**`/mergewatch reject` was missing from the command list entirely** — the page documented three commands where there are four.

**The confidence floor was described as something the orchestrator does.** The value (75) was right, but the mechanism wasn't: it's enforced by a *deterministic post-orchestrator filter*, added precisely because the prompt instruction alone wasn't reliably followed — `reviewer.ts` says so at the call site. That distinction matters to anyone reasoning about whether the threshold actually holds.

## Verification

```
$ cd docs-site && mint broken-links
success no broken links found
```

Every claim traced to source: `triage.ts`, `scope-awareness.ts`, `finding-clustering.ts`, `review-delta.ts`, `conventions.ts` (linter detection), `reviewer.ts` (`CONFIDENCE_FLOOR`).

## What's left after this

Stack 4 covers P5 (positioning realignment, the open-source free tier, comparison-data refresh) and the two genuinely-missing dashboard routes (`/dashboard/billing`, `/dashboard/reviews/[id]`). GHCR stays blocked on publishing the org packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)