### PR TITLE
docs: realign positioning, document the open-source tier and billing surface

### DIFF
--- a/docs-site/configuration/false-positives.mdx
+++ b/docs-site/configuration/false-positives.mdx
@@ -1,6 +1,6 @@
 ---
 title: "How MergeWatch Avoids False Positives"
-description: "The machinery between an agent finding something and you reading it — grounding, dedup, clustering, convergence, and the guards that keep reviews quiet enough to trust."
+description: "What happens between an agent producing a finding and you reading it — grounding, dedup, consolidation, and the guards that keep reviews trustworthy."
 ---
 
 An AI reviewer that reports everything it notices is worse than no reviewer at all. People stop reading it, and the one real bug arrives in a list of nine nits.

--- a/docs-site/dashboard/billing.mdx
+++ b/docs-site/dashboard/billing.mdx
@@ -1,0 +1,50 @@
+---
+title: "Billing"
+description: "The dashboard surface for managed SaaS billing — balance, payment method, top-ups, and auto-reload."
+---
+
+The **Billing** page manages the prepaid credit balance for a managed SaaS installation. For how pricing works — the free tier, the per-review cost formula, what counts as billable — see [SaaS billing](/saas/billing). This page covers the dashboard surface itself.
+
+<Note>
+Billing applies to **managed SaaS only**. Self-hosted deployments have no balance and no payment method; you pay your LLM provider directly. See [Self-hosted is always free](/saas/billing#self-hosted-is-always-free).
+</Note>
+
+## What the page shows
+
+**Current balance**, in credits. Reviews deduct their actual cost as they complete, so the balance moves continuously rather than in monthly steps.
+
+**Free reviews used** — the lifetime counter against the 5-review free tier, tracked per GitHub App installation.
+
+**Payment method**, managed through Stripe. MergeWatch never stores card details.
+
+## Topping up
+
+Add credits manually at any time. A top-up is a one-off charge against the payment method on file — there is no subscription and no recurring billing to cancel.
+
+## Auto-reload
+
+Auto-reload tops the balance up automatically when it falls below a threshold, so reviews do not stop mid-sprint because a balance ran down on a Friday afternoon.
+
+Enable it if MergeWatch is on your critical path. Leave it off if you would rather have reviews stop than have charges happen without you initiating them — a blocked review is visible and recoverable in a minute; a surprise charge is neither.
+
+Auto-reload is guarded against double-charging: a concurrent top-up cannot fire twice for the same drop below the threshold, even if several reviews complete simultaneously.
+
+## When the balance runs out
+
+Reviews are blocked rather than run-and-billed, and the MCP server returns a billing-blocked error (`-32002`). Nothing is silently deferred or queued — you find out immediately, on the PR.
+
+Top up or enable auto-reload to resume. See [what happens when your balance runs out](/saas/billing#what-happens-when-your-balance-runs-out).
+
+## Next steps
+
+<CardGroup cols={2}>
+
+<Card title="SaaS billing" icon="credit-card" href="/saas/billing">
+Pricing model, free tier, and the per-review cost formula.
+</Card>
+
+<Card title="Analytics" icon="chart-line" href="/dashboard/analytics">
+The Cost & Impact tab, for what that spend is buying.
+</Card>
+
+</CardGroup>

--- a/docs-site/dashboard/custom-agents.mdx
+++ b/docs-site/dashboard/custom-agents.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Org Custom Agents"
-description: "Define review agents once at the organization level, scope them to repositories, target them at paths or languages, and optionally make their findings block a merge."
+description: "Define review agents once at the organization level, scope them to repositories, target them at paths or languages, and optionally block merges."
 ---
 
 Per-repo [`customAgents`](/configuration/mergewatch-yml) let each repository add its own review agents. **Org custom agents** invert that: an organization admin defines an agent once in the dashboard, and it runs across the org's repositories whether or not each repo asks for it.

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -131,6 +131,7 @@
               "dashboard/settings",
               "dashboard/api-keys",
               "dashboard/custom-agents",
+              "dashboard/billing",
               "dashboard/profile"
             ]
           },

--- a/docs-site/overview/introduction.mdx
+++ b/docs-site/overview/introduction.mdx
@@ -3,7 +3,11 @@ title: What is MergeWatch?
 description: Open-source AI code review. Self-host on any cloud or use our managed SaaS.
 ---
 
-MergeWatch is an open-source GitHub App that reviews pull requests using a multi-agent AI pipeline. Self-host it anywhere with Docker and Postgres, or let MergeWatch run it for you as a managed SaaS. You choose the LLM. There is no per-seat pricing. The project is licensed under AGPL v3.
+MergeWatch is an open-source GitHub App that reviews pull requests with a team of specialized AI agents running in parallel — security, bugs, style, error handling, test coverage, and comment accuracy — plus any [custom agents](/configuration/mergewatch-yml) you define. An orchestrator deduplicates their findings and scores merge readiness, so you get one review, not eight.
+
+**Your model, your infrastructure.** Self-host it anywhere with Docker and Postgres and point it at Anthropic, Amazon Bedrock, LiteLLM, or a fully local Ollama — or let MergeWatch run it for you as managed SaaS. Either way you choose the LLM, and there is no per-seat pricing: you pay per reviewed PR, not per developer. The project is licensed under AGPL v3.
+
+Open-source maintainers can [apply for free frontier-model review](/saas/billing#open-source-maintainers).
 
 ## How it compares
 
@@ -17,7 +21,7 @@ MergeWatch is an open-source GitHub App that reviews pull requests using a multi
 | **Minimum commitment** | None | None stated | 500 seats for self-hosting |
 
 <Note>
-Competitor pricing and features were last verified in April 2026. Visit each vendor's website for current information. For a full breakdown across eight tools, see [Comparisons](/comparisons/overview).
+Competitor pricing and features were last verified in **April 2026** and have not been re-checked since — treat the competitor columns as a dated snapshot, not current fact, and confirm against each vendor's own site before relying on them. MergeWatch's own column is kept current. For a full breakdown across eight tools, see [Comparisons](/comparisons/overview).
 </Note>
 
 ## Key differentiators

--- a/docs-site/saas/billing.mdx
+++ b/docs-site/saas/billing.mdx
@@ -13,6 +13,16 @@ Every installation gets **5 free PR reviews** total (lifetime, not per month). N
 The free tier is intended to let you evaluate MergeWatch on real PRs. If you reach the limit and want to keep going, add a card via **Dashboard → Billing**.
 </Tip>
 
+## Open-source maintainers
+
+MergeWatch offers **free frontier-model review to open-source maintainers**, beyond the standard free tier above. If you maintain an open-source project, you can apply rather than paying per review.
+
+<Card title="Apply for free open-source review" icon="heart" href="https://docs.google.com/forms/d/e/1FAIpQLSfiIx-0o5GJ8dwbhj_Fs1FfoCmvWpVS8ImlUR4L9gWQfh_msA/viewform">
+Applications are reviewed individually — tell us about the project and how you'd use MergeWatch.
+</Card>
+
+Self-hosting is always free regardless, and remains the right choice if you would rather run the whole pipeline yourself. See [Self-hosted is always free](#self-hosted-is-always-free).
+
 ## Per-review pricing
 
 Each review is priced transparently from the actual LLM cost. There are no tiers or commitments.


### PR DESCRIPTION
**Stack 4 of 4** for #254 — targets `docs/review-behavior` (#257). Covers **P5** plus the one genuinely-missing dashboard route.

## The gap that mattered most here

**mergewatch.ai promotes "Free frontier-model review for open-source maintainers"** with an application form, prominently, on the home page. It appeared **nowhere** in the docs. A maintainer who clicked through from that banner had nothing to read.

Now documented in `saas/billing.mdx` beside the standard free tier, with the application link.

## `dashboard/billing` — deliberately thin

The pricing model, free tier, and per-review cost formula already live in `saas/billing.mdx` and are good. This page covers only the **dashboard surface** — balance, payment method, top-ups, auto-reload — and links across rather than restating. Duplicating pricing in two places is how the two drift.

The auto-reload section gives a reason to leave it **off** as well as on: a blocked review is visible and recoverable in a minute, a surprise charge is neither. Docs that only ever argue for enabling things aren't much use for deciding.

## Positioning

`overview/introduction.mdx` opened with hosting and licensing — written before the home-page rewrite. It now leads with what the product actually does (parallel specialist agents, one orchestrated review), carries **"your model, your infrastructure"** and per-PR-not-per-seat pricing, and points at the open-source tier.

## What I did NOT do, on purpose

**I did not re-verify competitor pricing.** Doing it properly means checking eight vendor sites, and quietly bumping the "last verified" date without doing that work would be worse than leaving it stale — it converts a known-dated snapshot into a false claim of currency.

Instead the caveat now says plainly that the competitor columns are an **April 2026 snapshot that has not been re-checked**, and that MergeWatch's own column is current. Honest and stale beats confident and wrong. Re-verification is real work someone should schedule; flag it and I'll do a pass.

## Housekeeping

Two page descriptions added earlier in this stack had drifted past the 160-char limit set in #252. Fixed. **All 63 pages now sit in the 70–160 band, 63/63 in navigation, zero orphans.**

## Stack status

| PR | Covers |
|---|---|
| #255 | P0 model IDs, P4 env vars |
| #256 | P1/P2 MCP, org agents, API keys, feedback signals, analytics |
| #257 | P3 false-positive reduction |
| **#258** | **P5 positioning, open-source tier, billing** |

Merge in order; GitHub retargets each to `main` as the one below lands.

**Still open after the stack:** the GHCR namespace fix (blocked on publishing `ghcr.io/mergewatch/*` — a registry action, not a docs edit), competitor-data re-verification, and `/dashboard/reviews/[id]`, which is a detail drawer inside the existing Reviews page rather than a standalone route.

```
$ cd docs-site && mint broken-links
success no broken links found
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)