### PR TITLE
docs: remove two behaviors that do not exist

### DIFF
--- a/docs-site/configuration/mergewatch-yml.mdx
+++ b/docs-site/configuration/mergewatch-yml.mdx
@@ -205,7 +205,7 @@ The `rules` object controls which files are reviewed and when reviews are trigge
 | Property | Type | Default | Description |
 |---|---|---|---|
 | `maxFiles` | `number` | `50` | Maximum number of changed files to review. PRs exceeding this limit are skipped with a comment explaining why. |
-| `autoReview` | `boolean` | `true` | When `true`, MergeWatch reviews every PR automatically on open and synchronize events. When `false`, MergeWatch posts a neutral check run on each PR titled *"Auto-review is disabled for this repository"* instructing the author to comment `@mergewatch review` to trigger one — see [Auto-review off](/configuration/skip-rules#auto-review-off). |
+| `autoReview` | `boolean` | `true` | When `true`, MergeWatch reviews every PR automatically on open and synchronize events. When `false`, MergeWatch leaves no trace on the PR at all — no reaction, no check run, no comment — and only a `@mergewatch` mention triggers a review. See [Auto-review off](/configuration/skip-rules#auto-review-off). |
 | `reviewOnMention` | `boolean` | `true` | When `true`, MergeWatch runs a review when mentioned in a PR comment (e.g., `@mergewatch review`). Works even if `autoReview` is `false`. |
 | `skipDrafts` | `boolean` | `true` | Skip draft pull requests. Set to `false` to review drafts automatically. |
 | `ignoreLabels` | `string[]` | `["skip-review"]` | Skip PRs with any of these GitHub labels. PRs matching these labels are not reviewed. |

--- a/docs-site/configuration/review-behavior.mdx
+++ b/docs-site/configuration/review-behavior.mdx
@@ -47,7 +47,7 @@ MergeWatch deliberately skips reviews in the following situations:
 - **Draft PRs** — Skipped by default. Set `rules.skipDrafts: false` in your `.mergewatch.yml` to review drafts.
 - **All changed files are built-in trivial** — If every file in the PR matches MergeWatch's built-in trivial-paths list (lock files, docs, build artifacts, editor/CI config), the PR is skipped. Use `includePatterns` to opt specific paths back in.
 - **PR exceeds `rules.maxFiles` limit** — PRs with more changed files than the configured `maxFiles` value (default: 50) are skipped with a comment explaining why.
-- **Repository is paused** — If MergeWatch is paused for the repository in the [dashboard](/dashboard/settings), no reviews run until it is resumed.
+- **Billing blocked (managed SaaS)** — Once the free tier is used up, reviews require a balance above the minimum. Below it, reviews are blocked *before* the model is called rather than run and billed. See [Billing](/dashboard/billing).
 </Warning>
 
 ## Review status values
@@ -91,7 +91,7 @@ There are two ways to manually re-trigger a review:
 
 Both paths work in all scenarios:
 
-- Even when `autoReview: false` is set in your configuration. In this mode MergeWatch posts a neutral check run titled *"Auto-review is disabled for this repository"* with a one-line instruction to comment `@mergewatch review` — see [Auto-review off](/configuration/skip-rules#auto-review-off).
+- Even when `autoReview: false` is set in your configuration. In this mode MergeWatch leaves no trace on the PR at all — no reaction, no check run, no comment — so a mention is the only way to get a review. See [Auto-review off](/configuration/skip-rules#auto-review-off).
 - After a failed review to retry
 - After pushing new commits, if you do not want to wait for the automatic trigger
 - On PRs that were previously skipped (the skip rules are re-evaluated)

--- a/docs-site/configuration/skip-rules.mdx
+++ b/docs-site/configuration/skip-rules.mdx
@@ -87,17 +87,18 @@ A PR that touches only files matching `includePatterns` is reviewed even though 
 
 ## Auto-review off
 
-When `rules.autoReview: false` is set, MergeWatch does not run the review pipeline on PR open or synchronize events — but it does post a **user-actionable check run** to the PR's merge box so the author knows reviews are intentionally off and how to trigger one:
+When `rules.autoReview: false` is set, MergeWatch **leaves no trace on the pull request**. No 👀 reaction, no check run, no summary comment, no formal review, and no stored review record — the config is evaluated before any GitHub side effect, so a parked installation is genuinely silent rather than quietly noisy.
 
-```text
-✓ Auto-review is disabled for this repository
-   Comment @mergewatch review on this PR to run a review.
-```
+Mention-triggered reviews (`@mergewatch review`, `@mergewatch summary`) bypass the gate and post a normal review as usual.
 
-The check run uses the `neutral` conclusion so it does not block branch protection. Mention-triggered reviews (`@mergewatch review`, `@mergewatch summary`) bypass the gate and post a normal review comment as usual.
+<Warning>
+`autoReview: false` is the **only** skip that is silent. Every other rule-based skip — drafts, ignored labels, `maxFiles` exceeded, `reviewOnMention: false` — posts a visible "Review skipped" check run with the reason.
+
+That asymmetry is deliberate. A parked repository should look untouched; a PR that *was* considered and deliberately skipped should say so, or authors are left wondering whether MergeWatch is broken.
+</Warning>
 
 <Note>
-This user-actionable copy is specific to the `autoReviewOff` skip kind. Other rule-based skips (drafts, label-ignored, `maxFiles` exceeded, `reviewOnMention: false`) post a generic "Review skipped" check run with the detailed reason as summary — those are intentional skips that don't need user-facing instructions.
+Because nothing appears on the PR, the way to confirm auto-review is off is the absence of a check run — plus a `autoReview off — silently skipping <owner>/<repo>#<N>` line in your logs. If you want a visible marker instead, leave `autoReview` on and use an ignored label ([label-based skip](#label-based-skip)), which skips visibly.
 </Note>
 
 ## Label-based skip


### PR DESCRIPTION
Both defects surfaced while auditing e2e coverage (#259), and both were **verified against the code** rather than inferred.

## 1. `autoReview: false` does not post a check run

Three pages claimed MergeWatch posts a neutral, user-actionable check run titled *"Auto-review is disabled for this repository"*, with copy telling the author how to trigger a review.

**It does not.** `review-agent.ts:396` evaluates `isAutoReviewOff` and returns **before any GitHub side effect**, logging `autoReview off — silently skipping`. `skip-logic.ts:151` documents the same contract: *"The runtime handlers consult this BEFORE any GitHub side effect (eyes reaction, check run, PR review) so a parked install leaves no trace."*

The `RulesSkipKind` discriminator *anticipates* such a check run — its comment mentions "posting a 'how to enable' check run for `autoReviewOff` only" — but **no caller implements it**. `review-agent.ts:560` states plainly that autoReviewOff is handled silently earlier.

This is the **pre-#136 behavior that was deliberately removed**. `e2e/RUNBOOK.md` E2E-04 has asserted the correct behavior all along and explicitly lists this check run as a failure mode: *"that's the pre-#136 behavior the user explicitly asked to remove."* The runbook was right; the docs described something the product stopped doing.

Fixed in `skip-rules.mdx`, `review-behavior.mdx`, and `mergewatch-yml.mdx`.

The skip-rules section now also explains **why** `autoReview` is the only silent skip — a parked repository should look untouched, while a PR that *was* considered and deliberately skipped should say so, or authors are left wondering whether MergeWatch is broken. Anyone who wants a visible marker is pointed at label-based skip.

## 2. "Repository is paused" is not a feature

`review-behavior.mdx` listed *"Repository is paused — if MergeWatch is paused for the repository in the dashboard, no reviews run until it is resumed"* as a skip reason, linking to dashboard settings.

**There is no pause control.** Grepping the entire codebase, every `paused` reference is billing-driven — `block-notify.ts` posts *"MergeWatch: reviews paused — credits required"* when an installation runs out of credits. Nothing pauses a repository from the dashboard.

Replaced with the behavior that actually exists: once the free tier is exhausted, reviews are blocked *before* the model is called rather than run and billed.

## Why this matters more than a typo

Both send a reader looking for a UI control or a check run that will never appear. The auto-review one is worse: someone who sets `autoReview: false` and then waits for the promised check run to confirm it worked gets nothing, and can't tell "configured correctly" from "MergeWatch is down".

Both predate the #254 audit and were **missed by it** — the audit compared docs against config schema and route lists, which is exactly the wrong shape of check for catching a documented behavior that no code implements. Writing e2e fixtures caught them because a fixture forces the question *"what, concretely, should I see on the PR?"*

## Verification

```
$ cd docs-site && mint broken-links
success no broken links found
$ grep -rn "Auto-review is disabled for this repository|paused for the repository" .
(no matches)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)