### PR TITLE
feat(billing): OSS Program sponsored-review entitlement (#261, stage 1)

### DIFF
--- a/docs-site/saas/billing.mdx
+++ b/docs-site/saas/billing.mdx
@@ -21,6 +21,20 @@ MergeWatch offers **free frontier-model review to open-source maintainers**, bey
 Applications are reviewed individually — tell us about the project and how you'd use MergeWatch.
 </Card>
 
+### How an approved grant behaves
+
+Once a project is approved, reviews on the covered repositories are **sponsored**: no charge, and they don't consume your free reviews or credit balance. Your **Dashboard → Billing** page shows an Open Source Program panel with the covered repositories, what's been sponsored this month, and your fair-use headroom.
+
+Specifics worth knowing:
+
+- **Only the repositories named in the grant are covered.** Approval is per project, not per organization — other repositories in the same installation bill normally. Ask us to add a repository and we will.
+- **Coverage requires the repository to be public at review time.** If a covered repository is made private, its next review is billed normally rather than sponsored.
+- **Renaming or transferring a covered repository is safe.** Grants track the repository itself, not its name.
+- **Fair use is a monthly ceiling**, shared across the repositories in your grant. Going over it doesn't block anything — reviews simply fall back to your free tier and balance for the rest of the month.
+- **Grants are time-limited** and renewed on request. When one expires, reviews fall back to the standard free tier and balance — they are never cut off outright.
+
+If a grant lapses or a project outgrows the fair-use limit, MergeWatch will say so on the pull request and point you at renewal or at [self-hosting](/self-hosting/overview), which is free and unlimited. You will not be asked for a card.
+
 Self-hosting is always free regardless, and remains the right choice if you would rather run the whole pipeline yourself. See [Self-hosted is always free](#self-hosted-is-always-free).
 
 ## Per-review pricing

--- a/docs/feat/20260812-01-oss-program-entitlement.plan.md
+++ b/docs/feat/20260812-01-oss-program-entitlement.plan.md
@@ -1,0 +1,143 @@
+# OSS Program — Sponsored-Review Entitlement
+
+**Status:** In progress
+**Tracking issue:** [#261](https://github.com/mergewatch/mergewatch.ai/issues/261)
+
+## Summary
+
+Make the runtime honor the free-hosted-access promise on [mergewatch.ai/open-source](https://mergewatch.ai/open-source). Approved open-source repositories get their PR reviews sponsored — no balance, no credit card, no `freeReviewsUsed` consumption — via an entitlement flag on the installation's `#SETTINGS` row. Grants are written by a manually-run operator script.
+
+## Why
+
+The public page and `docs-site/saas/billing.mdx` both promise free hosted review to approved OSS projects, and a live Google Form collects applications. Nothing in the runtime implements it.
+
+`billingCheck()` (`packages/billing/src/billing-check.ts:23`) is a two-branch decision — free tier, then balance, then block. The only way to service an approved application today is hand-editing `balanceCents`, which drains. When a granted balance hits zero, `packages/billing/src/block-notify.ts` files a *"reviews paused — credits required"* GitHub Issue **on the maintainer's public repo**. That is the worst outcome this program could produce, and it is the current default behavior.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Grant primitive | Entitlement flag in DynamoDB, **not** money | A balance grant drains, books sponsorship as revenue, and has no ceiling. An entitlement has none of those failure modes. |
+| Stripe coupons | **Rejected** | No subscriptions or invoices exist; top-ups are a raw off-session `paymentIntents.create` (`checkout.ts:106`) which coupons cannot attach to. Decisively: the gate reads DynamoDB, not Stripe (`record-review.ts:69`). A 100% coupon would not change whether one review runs. |
+| Grant scope | **Explicitly named repos only** | Open core: a company with one OSS repo alongside public-but-commercial repos would get all of them sponsored under an installation-wide grant. A cap bounds the money, not the principle. |
+| Repo matching | Immutable numeric `repo.id` | Renames and org transfers change `full_name`; a name-keyed list silently stops matching, sponsorship lapses, and a "credits required" issue lands on a public OSS repo. This repo has itself been transferred. |
+| Grant storage | `#SETTINGS` row, not per-repo rows | The gate already reads `#SETTINGS`, so an in-row repo list costs **zero extra reads**; per-repo flags would add a second DynamoDB read per review. Cap and accrual are installation-level regardless. |
+| New param shape | **Optional** 4th arg to `billingCheck` | `BillingCheckFn = typeof billingCheck` (`packages/mcp/src/middleware/billing.ts:17`) derives from the function. An optional param means MCP compiles untouched and keeps its current gate. |
+| MCP path | **Not sponsored** — webhook only | MCP's `repo` input is optional and defaults to `'unknown'` (`packages/mcp/src/tools/review-diff.ts:182`), so visibility cannot be verified at review time. |
+| Default cap | **$20/month** per grant, shared across named repos | ~200–2000 reviews at the $0.01–$0.10 range. Generous for any real OSS project while bounding a runaway repo. Overridable with `--cap`. |
+| Default term | **12 months** | Annual re-verification. Low-touch, but abandoned projects fall off without individual attention. |
+| Self-hosted | **Out of scope** | Billing is SaaS-only behind `isSaas()`. `installation_settings` in `packages/storage-postgres/src/schema.ts` has **no billing columns at all** — no migration, no parity work. |
+
+## Architecture
+
+### Data model
+
+New optional fields on `BillingFields` (`packages/core/src/types/db.ts:470`), stored on the existing `#SETTINGS` sentinel row. No new tables, no schema migration — DynamoDB attributes are additive.
+
+```ts
+ossGrantRepos?: Array<{ id: number; fullName: string }>;  // required non-empty for an active grant
+ossGrantExpiresAt?: string;      // ISO 8601; presence + future = active. Revoke = set to past.
+ossGrantedAt?: string;           // informational provenance
+ossGrantNote?: string;           // informational provenance
+ossMonthlyCapCents?: number;
+ossPeriod?: string;              // YYYY-MM
+ossSponsoredCentsThisPeriod?: number;
+ossSponsoredCentsLifetime?: number;
+```
+
+`getBillingFields` uses an explicit `ProjectionExpression` (`dynamo-billing.ts:21`) — the new fields **must** be added there or they read back `undefined`.
+
+### Gate
+
+```ts
+billingCheck(client, table, installationId, repoContext?)
+  → { status, firstBlock, reason: 'oss' | 'free_tier' | 'paid' }
+```
+
+`repoContext?: { repoId: number; repoFullName: string; isPublic: boolean }`. Absent → OSS branch skipped entirely, behavior identical to today.
+
+Allow as `oss` when **all** hold: grant not expired · `repoId` ∈ `ossGrantRepos` · repo is **public right now** · period spend under cap.
+
+Two behaviors carry the value:
+
+- **Named is necessary but not sufficient.** `isPublic` is evaluated live at review time, so a named repo flipped private stops being sponsored on the next review. An approval-time snapshot cannot catch that, and it is the actual cost leak.
+- **Sponsored reviews must not increment `freeReviewsUsed`.** Otherwise a lapsed grant becomes an instantly-blocked paid account with an issue on the repo, instead of landing on the 5 free reviews every install gets.
+
+### Recording
+
+`recordReview` (`record-review.ts:19`) gets a first branch: same `calculateReviewCost`, accrue to `ossSponsoredCentsThisPeriod` / `ossSponsoredCentsLifetime` with period rollover, instead of deducting balance. **No Stripe call, no auto-reload check** on this path.
+
+### Degradation
+
+Over cap → fall through to the standard gate; the install still has its free tier and any balance. Only if *that* blocks does the block path run, with `block-notify.ts` copy branching to BYOK/sponsorship rather than "add a credit card."
+
+### Call sites
+
+| Site | Repo context | Treatment |
+|---|---|---|
+| `packages/lambda/src/handlers/review-agent.ts:450` | full — webhook payload | OSS branch active |
+| `packages/mcp/src/middleware/billing.ts:37` | optional, often `'unknown'` | unchanged (param omitted) |
+
+`repository.id` and `repository.private` both live on `GitHubRepository` (`packages/core/src/types/github.ts:24-28`) and **neither** is forwarded today — the event built at `packages/lambda/src/handlers/webhook.ts:230` drops both. Same object, so one plumbing change carries both.
+
+## Phased breakdown
+
+### Phase 1 — Core entitlement (`packages/billing`, `packages/core`)
+
+- [x] `BillingFields` additions + `getBillingFields` projection.
+- [x] `billingCheck` optional `repoContext` + OSS branch + `reason` in the result.
+- [x] `recordReview` OSS accrual branch with period rollover.
+
+**Files:** `packages/core/src/types/db.ts`, `packages/billing/src/{billing-check,record-review,dynamo-billing,constants}.ts`
+
+**Tests:** named public repo sponsored · unnamed public repo in same install **not** sponsored · private repo named in grant still gated · named repo gone private · expired grant · cap exceeded → falls through, not blocked · `freeReviewsUsed` untouched on sponsored path · period rollover resets counter · repo matched by ID after rename · `repoContext` omitted → identical to current behavior.
+
+**RUNBOOK:** none (no user-visible behavior yet).
+
+Ships dark — nothing writes the fields yet, so this is a no-op in prod and safe to merge alone.
+
+### Phase 2 — Webhook plumbing + gate wiring
+
+- [ ] Forward `repoId` + `isPublic` from `webhook.ts:230` through the review-agent event.
+- [ ] Pass `repoContext` at `review-agent.ts:450`.
+- [ ] OSS-aware copy in `block-notify.ts` for the over-cap/lapsed case.
+
+**Tests:** event carries both fields · gate receives them · over-cap block copy references BYOK.
+
+**RUNBOOK:** `E2E-82` — sponsored review on a granted public repo (zero balance, zero free-tier consumption).
+
+### Phase 3 — Operator script
+
+- [ ] `scripts/grant-oss.sh` — `grant` / `--add` / `--remove` / `--revoke` / `--inspect`.
+- [ ] Repo → installation resolution via App JWT minted from SSM (as `github-auth-ssm.ts:57` does); `gh api` cannot hit `/repos/{owner}/{repo}/installation` with a user token.
+- [ ] Eligibility check (`private === false`), blast-radius print listing covered **and** uncovered repos in the installation (a `Query` on `installationId`, the partition key — no GSI needed), confirm before write.
+- [ ] Refuse to run without explicit `--stage prod|dev`.
+
+**RUNBOOK:** `E2E-83` — grant, verify sponsorship, revoke, verify fallback to free tier.
+
+### Phase 4 — Dashboard + docs (capstone)
+
+- [ ] OSS fields in the `/billing/status` response (`packages/lambda/src/handlers/billing.ts:254`).
+- [ ] OSS Program state in `BillingClient.tsx` — covered repos, sponsored this month, fair-use headroom — replacing the balance/top-up prompt.
+- [ ] Update `docs-site/saas/billing.mdx` to describe actual grant behavior.
+- [ ] Graduate `docs/pending/oss-program.md` → `docs/oss-program.md`.
+
+## Out of scope / deferred
+
+- Self-hosted — already free; no billing columns exist in Postgres.
+- MCP `review_diff` sponsorship (see Decisions).
+- Automated eligibility detection — approval stays manual, as the page promises.
+- Dashboard admin granting UI — the script is run manually by an operator, by design.
+- Replacing the Google Form with an in-app application flow.
+
+## Acceptance criteria
+
+- [ ] Named public repo reviews with zero balance and zero `freeReviewsUsed` consumption.
+- [ ] Unnamed public repo in the same installation is gated normally.
+- [ ] Private repo gated normally even when named in the grant.
+- [ ] Named repo flipped private stops being sponsored on the next review.
+- [ ] Named repo renamed or transferred stays sponsored (ID match).
+- [ ] Expired or revoked grant falls back to the standard gate — never straight to blocked.
+- [ ] Sponsored cost queryable per install, per month, and lifetime.
+- [ ] No sponsored review touches Stripe.
+- [ ] Over-cap installs degrade to the normal gate with BYOK-oriented copy.

--- a/docs/feat/20260812-01-oss-program-entitlement.plan.md
+++ b/docs/feat/20260812-01-oss-program-entitlement.plan.md
@@ -1,6 +1,6 @@
 # OSS Program — Sponsored-Review Entitlement
 
-**Status:** In progress
+**Status:** Shipped
 **Tracking issue:** [#261](https://github.com/mergewatch/mergewatch.ai/issues/261)
 
 ## Summary
@@ -98,9 +98,9 @@ Ships dark — nothing writes the fields yet, so this is a no-op in prod and saf
 
 ### Phase 2 — Webhook plumbing + gate wiring
 
-- [ ] Forward `repoId` + `isPublic` from `webhook.ts:230` through the review-agent event.
-- [ ] Pass `repoContext` at `review-agent.ts:450`.
-- [ ] OSS-aware copy in `block-notify.ts` for the over-cap/lapsed case.
+- [x] Forward `repoId` + `isPublic` from `webhook.ts:230` through the review-agent event.
+- [x] Pass `repoContext` at `review-agent.ts:450`.
+- [x] OSS-aware copy in `block-notify.ts` for the over-cap/lapsed case.
 
 **Tests:** event carries both fields · gate receives them · over-cap block copy references BYOK.
 
@@ -108,19 +108,19 @@ Ships dark — nothing writes the fields yet, so this is a no-op in prod and saf
 
 ### Phase 3 — Operator script
 
-- [ ] `scripts/grant-oss.sh` — `grant` / `--add` / `--remove` / `--revoke` / `--inspect`.
-- [ ] Repo → installation resolution via App JWT minted from SSM (as `github-auth-ssm.ts:57` does); `gh api` cannot hit `/repos/{owner}/{repo}/installation` with a user token.
-- [ ] Eligibility check (`private === false`), blast-radius print listing covered **and** uncovered repos in the installation (a `Query` on `installationId`, the partition key — no GSI needed), confirm before write.
-- [ ] Refuse to run without explicit `--stage prod|dev`.
+- [x] `scripts/grant-oss.ts` — `grant` / `--add` / `--remove` / `--revoke` / `--inspect`.
+- [x] Repo → installation resolution via App JWT minted from SSM (as `github-auth-ssm.ts:57` does); `gh api` cannot hit `/repos/{owner}/{repo}/installation` with a user token.
+- [x] Eligibility check (`private === false`), blast-radius print listing covered **and** uncovered repos in the installation (a `Query` on `installationId`, the partition key — no GSI needed), confirm before write.
+- [x] Refuse to run without explicit `--stage prod|dev`.
 
 **RUNBOOK:** `E2E-83` — grant, verify sponsorship, revoke, verify fallback to free tier.
 
 ### Phase 4 — Dashboard + docs (capstone)
 
-- [ ] OSS fields in the `/billing/status` response (`packages/lambda/src/handlers/billing.ts:254`).
-- [ ] OSS Program state in `BillingClient.tsx` — covered repos, sponsored this month, fair-use headroom — replacing the balance/top-up prompt.
-- [ ] Update `docs-site/saas/billing.mdx` to describe actual grant behavior.
-- [ ] Graduate `docs/pending/oss-program.md` → `docs/oss-program.md`.
+- [x] OSS fields in the `/billing/status` response (`packages/lambda/src/handlers/billing.ts:254`).
+- [x] OSS Program state in `BillingClient.tsx` — covered repos, sponsored this month, fair-use headroom. Rendered *alongside* the balance card rather than replacing it: a granted installation can still hold private or unnamed repos that bill normally, so both states are simultaneously true.
+- [x] Update `docs-site/saas/billing.mdx` to describe actual grant behavior.
+- [x] Graduate `docs/pending/oss-program.md` → `docs/oss-program.md`.
 
 ## Out of scope / deferred
 

--- a/docs/oss-program.md
+++ b/docs/oss-program.md
@@ -1,0 +1,96 @@
+# MergeWatch for Open Source — sponsored reviews
+
+**Status:** ✅ Shipped (#261)
+
+Approved open-source repositories have their PR reviews sponsored: no balance, no payment method, and no consumption of the standard 5-review free tier. This is the runtime behind the promise on [mergewatch.ai/open-source](https://mergewatch.ai/open-source).
+
+Self-hosting is free regardless and is unaffected by any of this — the whole mechanism sits behind `isSaas()`.
+
+## How a grant is represented
+
+A grant is an **entitlement**, not money. It lives on the installation's `#SETTINGS` sentinel row in the installations table, alongside the existing billing fields:
+
+| Field | Meaning |
+|---|---|
+| `ossGrantRepos` | `{ id, fullName }[]` — the repositories covered. Required and non-empty for an active grant. |
+| `ossGrantExpiresAt` | ISO 8601. Presence + a future date = active. Revoking is setting this to the past. |
+| `ossGrantedAt` | When the grant was written. Informational. |
+| `ossGrantNote` | Application reference, project name, approver. Informational. |
+| `ossMonthlyCapCents` | Fair-use ceiling per calendar month, shared across the named repos. |
+| `ossPeriod` | Accrual period (`YYYY-MM`) the period counter belongs to. |
+| `ossSponsoredCentsThisPeriod` | Sponsored cost accrued this period. |
+| `ossSponsoredCentsLifetime` | Sponsored cost accrued over the grant's life. Monotonic. |
+
+Three design choices are load-bearing:
+
+**Named repos only.** There is no installation-wide mode. An installation can mix a genuinely-OSS repo with public-but-commercial ones (open core), and a blanket grant would sponsor all of them. A cap bounds the money but not the principle.
+
+**Matched on the numeric repo id.** GitHub renames and org transfers change `full_name` while `id` is immutable. A name-keyed list would silently stop matching after a rename — sponsorship lapses, the next PR gets gated, and a "credits required" issue lands on a public OSS repo. `fullName` is stored for readability only and may be stale.
+
+**Stored on `#SETTINGS`, not per-repo rows.** The gate already reads `#SETTINGS` for billing, so an in-row list costs zero extra reads; per-repo flags would add a second DynamoDB read to every review. The cap and accrual counters are installation-level regardless.
+
+## When a review is sponsored
+
+All of the following must hold, evaluated fresh on every review:
+
+1. The grant has not expired.
+2. The repository's numeric id appears in `ossGrantRepos`.
+3. The repository is **public right now**.
+4. The month's accrued sponsored cost is under `ossMonthlyCapCents`.
+
+Being named is necessary but not sufficient. Visibility is read from the webhook payload of the triggering event rather than snapshotted at approval time, so a repo flipped private after approval stops being sponsored on its very next review — that is the actual cost leak, and an approval-time check cannot catch it.
+
+## What happens when a grant doesn't apply
+
+Ineligibility **never blocks directly**. The gate falls through to the standard path: the installation still has its 5 free reviews and any balance. Only if *that* path blocks does a block notification go out.
+
+When the installation had a real grant that lapsed or hit its ceiling (`grant_expired`, `cap_exceeded`), the block copy points at renewal, bring-your-own-key, and self-hosting rather than at a credit card — telling a maintainer we invited into a free program to "add credits" is the wrong message, and the public page already frames heavy usage as moving to BYOK or sponsorship.
+
+This ordering matters: a sponsored review must never increment `freeReviewsUsed`. If it did, a maintainer whose grant lapsed would become an instantly-blocked paid account, with an issue filed on their public repo, instead of landing softly on the free tier.
+
+## Accounting
+
+A sponsored review's cost is computed with the same formula the paid path charges (`llmCost + infra fee + margin`) and accrued to the two OSS counters instead of deducting balance. **No Stripe call is made on the sponsored path**, and no auto-reload check runs.
+
+Accrual is atomic: same-period accruals use DynamoDB `ADD` so concurrent reviews across repos in one installation can't lose an increment, with a conditional second path that resets the period counter on month rollover. Two reviews racing exactly at a month boundary can undercount the period figure by one review; the lifetime counter stays exact because it is always an `ADD`.
+
+## Granting
+
+Grants are written only by `scripts/grant-oss.ts`, run manually by an operator. There is no admin API route and no dashboard granting UI. Because of that, the `#SETTINGS` row is the sole record of who was granted what and why — which is what `ossGrantedAt` and `ossGrantNote` exist for, and what `--inspect` renders back.
+
+### Operating the program
+
+```bash
+# Approve a project (the maintainer must have installed the App first —
+# the installation is what a grant attaches to)
+scripts/grant-oss.ts octocat/hello-world --stage prod --note "form response #42"
+
+# Several repos in one installation
+scripts/grant-oss.ts octocat/hello-world,octocat/docs --stage prod
+
+# Amend an existing grant rather than re-granting
+scripts/grant-oss.ts --add    octocat/new-project --stage prod
+scripts/grant-oss.ts --remove octocat/old-project --stage prod
+
+# End it. Reviews fall back to the standard gate — they are NOT blocked.
+scripts/grant-oss.ts --revoke octocat/hello-world --stage prod
+
+# Audit an existing grant months later
+scripts/grant-oss.ts --inspect octocat/hello-world --stage prod
+```
+
+Options: `--cap <cents>` (default 2000 = $20/month), `--months <n>` (default 12), `--note "<text>"`, `--yes` to skip the confirmation.
+
+Three things the script does before writing:
+
+1. **Refuses to run without `--stage`.** There is no default. It writes to a live table, and defaulting the environment is how a grant lands in the wrong one.
+2. **Verifies the repo is public** and reports last-push and open-issue counts, so the human approving has the activity signal in front of them.
+3. **Prints the blast radius** — the repos this grant will cover *and* the other repos in the same installation it will not. An accidental omission is then visible before the write, not after a maintainer reports that half their project isn't being reviewed.
+
+Under the hood it needs two GitHub identities: an **App JWT** to call `GET /repos/{owner}/{repo}/installation` (the repo→installation lookup, which a user token cannot reach — this is why it isn't a `gh api` one-liner), then an **installation token** to read the repository itself. Credentials come from SSM (`/mergewatch/{stage}/github-app-id`, `/mergewatch/{stage}/github-private-key`) using the `mergewatch` AWS profile.
+
+## Scope
+
+- **SaaS only.** The gate is behind `isSaas()`; `installation_settings` in Postgres has no billing columns at all.
+- **Webhook path only.** MCP `review_diff` is not sponsored: its `repo` input is optional and often literally `'unknown'`, so visibility cannot be verified at review time.
+- Approval stays manual, as the public page promises. There is no automated eligibility detection.

--- a/docs/strategy/GOAL.md
+++ b/docs/strategy/GOAL.md
@@ -1,0 +1,98 @@
+# Goal: Position MergeWatch as the Software Validation Layer for the AI Build Era
+
+> **Status:** Brief / kickoff goal for market research + competitive analysis + strategy + execution planning.
+> **Owner:** Santthosh
+> **Use:** Hand this document to research/strategy agents as the top-level goal. Every agent should trace its output back to a workstream and deliverable defined here.
+
+---
+
+## North Star
+
+AI is now writing the majority of net-new code. The bottleneck has moved from **writing** software to **trusting** it. MergeWatch's ambition is to own that trust gap — to become the **validation layer** that sits between AI-generated code and production, verifying that what agents ship is correct, safe, and mergeable at machine speed.
+
+We are not "a better PR review bot." We are the **quality gate for autonomous and AI-assisted software development** — the system of record for whether a change is safe to merge, regardless of whether a human or an agent wrote it.
+
+## Strategic Question to Answer
+
+> As code generation becomes cheap and abundant, validation becomes the scarce, high-value layer. **Can MergeWatch credibly own that layer, and what is the sharpest wedge to get there?**
+
+Produce a market research + competitive analysis + strategy document that lets us make a confident go/no-go and sequencing decision on this pivot — and a concrete execution plan to run it.
+
+---
+
+## Research & Planning Workstreams
+
+Workstreams 1–4 run in **parallel**. Workstream 5 runs **after** them and consumes their outcomes.
+
+### 1. Market & Thesis Validation
+- Size and characterize the shift: how much code is now AI-generated, growth trajectory, where the trust/validation pain concentrates (velocity, hallucinated code, security regressions, review fatigue).
+- Who feels this pain most acutely today, and who will in 12–24 months? Identify the beachhead segment.
+- Validate or falsify the core thesis: is "validation" actually becoming the scarce layer, or does it get absorbed by the coding agents themselves (Cursor, Claude Code, Devin, Copilot)?
+
+### 2. Competitive Landscape
+- Map the field across adjacent categories: AI code review (CodeRabbit, Greptile, Graphite, Qodo, Bito/Diamond), traditional SAST/quality (Snyk, SonarQube, Semgrep), CI/testing/verification, and agent-native QA/eval tools.
+- For each: positioning, wedge, pricing, ICP, funding/momentum, and — critically — **whether they could extend into "validation layer" and how defensible we'd be against that.**
+- Identify white space: what does no one credibly own yet?
+
+### 3. Positioning & Differentiation
+- Define what "validation layer" means concretely and defensibly (vs. "AI PR review"). What capabilities, integrations, and trust guarantees make it a *layer* rather than a *feature*?
+- Articulate the wedge, the moat, and the expansion path (land → expand).
+- Draft the one-line category-defining narrative.
+
+### 4. Strategy & GTM Recommendation
+- Recommend the sharpest entry wedge and target ICP.
+- Sequencing: what to build/keep/drop from today's PR-review product to get to the validation-layer vision.
+- Pricing and packaging hypothesis for the new positioning.
+- Risks, kill-criteria, and the 2–3 experiments that would most quickly validate or invalidate the pivot.
+
+### 5. Execution Plan (derived from Workstreams 1–4)
+- Translate the recommended wedge, ICP, and sequencing into a concrete, phased project plan.
+- Every phase must trace back to a strategy outcome — no orphan work.
+- Break each phase into task items sized to be actionable (roughly PR- or sprint-sized), each with an owner-type, a definition of done, and a success metric.
+- Sequence by dependency and by "fastest path to validating the pivot" — front-load the experiments from Workstream 4.
+- Anchor against MergeWatch's real codebase today: what to build, keep, refactor, or retire from the current PR-review product.
+
+---
+
+## Tangible Artifacts (deliverables)
+
+| Artifact | Path | Purpose |
+|---|---|---|
+| **Strategy doc** | `docs/strategy/validation-layer-pivot.md` | Thesis + evidence, positioning, recommended wedge + GTM, risks, decision |
+| **Competitive matrix** | `docs/strategy/competitive-matrix.md` | Sourced comparison across categories + white-space analysis |
+| **Positioning one-pager** | `docs/strategy/positioning.md` | Category narrative, wedge, moat, expansion path |
+| **Project plan** | `docs/strategy/project-plan.md` | Phased roadmap → milestones → task items, each traced to a strategy outcome |
+| **Phase/task backlog** | `docs/strategy/backlog.md` | Flat, checkbox task list (per phase) ready to become GitHub issues/PRs |
+| **Decision & experiments** | `docs/strategy/decision.md` | Go/no-go recommendation + next 3 validating experiments with kill-criteria |
+
+---
+
+## Project Plan Shape (what `project-plan.md` should contain)
+
+- **Phase 0 — Validate the thesis:** the cheapest experiments that prove/disprove the pivot before heavy build. (Front-loaded from Workstream 4.)
+- **Phase 1 — Beachhead wedge:** the single sharpest capability for the beachhead ICP; the smallest thing that makes MergeWatch a *validation layer* not a *review bot*.
+- **Phase 2 — Expand the layer:** capabilities/integrations that turn the wedge into a defensible layer (land → expand).
+- **Phase 3 — Category & moat:** what compounds defensibility (data, integrations, trust guarantees) and establishes the category narrative.
+
+Each phase must specify: **goal · task items (checkboxed) · dependencies · success metric · exit criteria.**
+
+---
+
+## Constraints & Guardrails
+
+- Ground claims in real, cited sources — no hand-waving on market size or competitor facts.
+- Stay honest about disconfirming evidence (especially the "coding agents eat validation" risk).
+- Anchor to MergeWatch's actual assets today — multi-agent review pipeline, GitHub-native, self-host + SaaS, org custom agents (`packages/core/src/agents`, `packages/core/src/org-agents.ts`). The strategy and plan must be **reachable from where we are.**
+- Prefer **stacked, PR-sized tasks** consistent with how this repo already ships features.
+- Keep phases honest about kill-criteria — the plan should be as ready to *stop* the pivot as to pursue it.
+- Every artifact ends with a clear **recommendation and next steps.**
+
+---
+
+## Suggested Execution (how to run the agents)
+
+1. Fan out **Workstreams 1–4 in parallel** (market, competitive, positioning, GTM).
+2. Gate on a **synthesis** step that reconciles their findings into the wedge + ICP + sequencing decision.
+3. Run **Workstream 5 (execution plan) sequentially** so it consumes the real outcomes.
+4. Write all six artifacts to `docs/strategy/`.
+5. Adversarially verify the riskiest market claims and the core thesis before finalizing the decision.

--- a/docs/strategy/backlog.md
+++ b/docs/strategy/backlog.md
@@ -1,0 +1,59 @@
+# Backlog — Validation-Layer Pivot
+
+> Flat, checkbox task list per phase, ready to become GitHub issues/PRs. Derived from [`project-plan.md`](./project-plan.md).
+> **Date:** 2026-07-16. Tags: `[wedge] [moat] [product] [gtm] [thesis] [risk]` trace each task to a strategy outcome.
+> **Convention:** each unchecked box ≈ one PR- or sprint-sized unit, consistent with how this repo ships (stacked PRs, RUNBOOK scenarios).
+
+---
+
+## Phase 0 — Validate the thesis  ⛔ gates Phase 1
+
+- [ ] Build PR provenance classifier v0 (heuristic: commit trailers, `Co-Authored-By`, bot signatures, IDE metadata) in `packages/core` `[wedge]`
+- [ ] Add unit tests + accuracy harness for the classifier against a labeled PR sample `[wedge][risk]`
+- [ ] **Experiment 1:** retro provenance analysis — classify historical PRs on dogfood + design-partner repos, run existing pipeline, measure critical-finding rate by cohort `[thesis]`
+- [ ] Write up Experiment 1 results; check the **≥1.5× critical-finding-rate** threshold `[thesis]`
+- [ ] **Experiment 2:** build landing page ("validation gate for AI-generated code") + activation/CTA tracking `[gtm]`
+- [ ] **Experiment 3:** fake-door 3-tier pricing page; run Van Westendorp with 30–50 ICP contacts `[gtm]`
+- [ ] Recruit 3–5 design partners from beachhead ICP (30–150 eng, heavy agent adoption) `[gtm]`
+- [ ] **Phase gate:** confirm Exp-1 ≥1.5×, classifier ≥80%, ≥3 partners committed — else STOP & revisit wedge `[risk]`
+
+## Phase 1 — Beachhead wedge: provenance-aware blocking gate  ⛔ gates Phase 2
+
+- [ ] Productize provenance detection as a first-class signal on every review (label + score input) `[wedge]`
+- [ ] Extend `.mergewatch.yml` schema for validation policy-as-code (per-provenance, per-path rules) `[wedge][moat]`
+- [ ] Wire differentiated policy into the blocking gate via `org-agents.ts` (stricter for agent PRs) `[wedge]`
+- [ ] Make Check status + merge-readiness score the primary artifact; demote comment to secondary evidence `[product]`
+- [ ] Ship override capture: instrument accept/dismiss/override as labeled signals + storage `[moat]`
+- [ ] Refactor style/diagram agents into optional add-ons `[product]`
+- [ ] Update docs/RUNBOOK with provenance-gate scenarios `[product]`
+- [ ] Launch post publishing Experiment-1 provenance data ("validated N agent PRs, blocked X%") `[gtm]`
+- [ ] Refresh GitHub Marketplace listing around the validation-gate positioning `[gtm]`
+- [ ] **Phase gate:** ≥3 orgs run MergeWatch as a required check; blocking trusted (no false-block disables) `[risk]`
+
+## Phase 2 — Expand the layer: policy graph + evidence  ⛔ gates Phase 3
+
+- [ ] Dashboard: org-wide policy management (author rules across repos/paths/languages) `[moat]`
+- [ ] Surface org-over-repo conflict resolution clearly in the dashboard `[moat]`
+- [ ] Validation audit trail/dashboard: per-merge "validated / blocked / shipped anyway," exportable `[product][moat]`
+- [ ] Build on reviews table (`prNumber#commitSha`) + time-to-merge (#194) for the evidence surface `[product]`
+- [ ] Repo-by-repo rollout tooling (bulk-enable the gate across an org) `[gtm]`
+- [ ] Implement hybrid seat + validation-usage metering (Team quota + overage) `[gtm]`
+- [ ] Gate enterprise control plane (policy mgmt, audit, SSO) behind paid tier (open-core split) `[gtm][moat]`
+- [ ] Stand up sales-assist motion for 50+ dev / self-hosted + audit buyer `[gtm]`
+- [ ] **Phase gate:** ≥1 org running the gate across 10+ repos + first paid conversions `[risk]`
+
+## Phase 3 — Category & moat: agent governance
+
+- [ ] Agent-governance surface: per-agent policy + per-agent track record for Cursor/Claude Code/Devin/Copilot `[wedge][thesis]`
+- [ ] Verification depth v1: "did this PR add tests for what it changed?" + diff-coverage checks `[product]`
+- [ ] Compliance export as a named enterprise feature (SOC 2 / ISO / EU AI Act change-management) `[moat][thesis]`
+- [ ] Broaden integration surface beyond GitHub (GitLab/Bitbucket, CI, agent frameworks, IDEs) `[moat]`
+- [ ] Category narrative push: content/talks/ecosystem co-marketing around "the neutral, self-hostable validation gate" `[gtm]`
+- [ ] Measure feedback-loop precision advantage from accumulated override data `[moat]`
+
+---
+
+### Notes
+- **Do not start a phase until the prior phase's gate passes.** The Phase 0 gate is the highest-leverage checkpoint — it can kill the pivot cheaply.
+- Price points, quotas, and classifier thresholds are estimates pending the Phase 0 experiments (see [`decision.md`](./decision.md)).
+- Keep dogfooding: this repo's own `.mergewatch.yml` should adopt each new capability first.

--- a/docs/strategy/catch-up-plan.md
+++ b/docs/strategy/catch-up-plan.md
@@ -1,0 +1,90 @@
+# Catch-Up Plan — Closing the Gap vs. the Top 3
+
+> Companion to [`feature-gap.md`](./feature-gap.md). A detailed, phased task list to close the gaps vs. CodeRabbit, GitHub Copilot code review, and Qodo — sequenced by **wedge-alignment**, not blind parity.
+> **Date:** 2026-07-17 · **Strategy anchor:** [`validation-layer-pivot.md`](./validation-layer-pivot.md)
+
+## Guiding principle
+
+**Don't chase feature parity — close the gaps that convert "AI reviewer" into "validation gate of record," and defend the leads that make us defensible.** Every phase below is ordered so that wedge-reinforcing gaps (deterministic validation, enterprise trust, the feedback-loop moat) come before reach-expanding gaps (IDE, CLI, multi-platform).
+
+**Leads to protect throughout** (never regress these): blocking merge gate · open/unpaywalled self-host + BYO-model + air-gapped · agent-provenance detection · FP discipline · analytics depth.
+
+**Phase mapping to the strategy roadmap** ([`project-plan.md`](./project-plan.md)): Phase C1 ≈ Phase 1 (beachhead wedge), C2 ≈ Phase 2 (expand the layer), C3–C4 ≈ Phase 3 (category & moat). Gate each catch-up phase behind the strategy phase's exit criteria.
+
+Each task is tagged with the gap it closes (`#N` from [`feature-gap.md`](./feature-gap.md)) and sized ≈ one PR/sprint unit. Effort: **S** (≤1 wk) · **M** (1–3 wk) · **L** (3–6 wk) · **XL** (quarter).
+
+---
+
+## Phase C1 — Table-stakes credibility + first deterministic signal
+**Goal:** Stop reading as "less finished," and land the first deterministic validation signal that differentiates the gate. **Gate behind strategy Phase 1.**
+
+- [ ] **Committable one-click suggested fixes** `#7` — convert the prose `suggestion` field into GitHub committable `suggestion` blocks on inline comments; only for verified (W2) findings. **M** 🔴
+- [ ] **Incremental review** `#14` — review only the new-commit delta on re-review instead of re-running all agents on the full diff; reuse existing delta-tracking (`review-delta.ts`) to scope agent input. Cuts cost/latency at agent-PR volume. **L** 🟠
+- [ ] **Bundle Semgrep as a deterministic validation signal** `#15` — run Semgrep on changed files, normalize findings into the finding schema, feed into the merge score + blocking gate. First proof of "LLM + deterministic evidence." **L** 🔴
+- [ ] **Bundle secret scanning (Gitleaks/TruffleHog)** `#16` — scan the diff for secrets; a hit is a blocking-by-default validation failure. **M** 🔴
+- [ ] **PR walkthrough table** `#4` — upgrade the prose summary to a file-by-file changes table (parity with CodeRabbit/Qodo `/describe`). **S** 🟠
+- [ ] **Expand the command set** `#9` — add `@mergewatch describe`, `@mergewatch improve` (surface fixes), align naming with user expectations from CodeRabbit/Qodo. **S** 🟠
+
+**Exit criteria:** committable fixes shipped; Semgrep + secret findings flow into the gate and block on critical; incremental review live and measurably cheaper. **Success metric:** review cost/PR down ≥30% on re-reviews; ≥1 real secret/SAST finding blocked in a design-partner repo.
+
+---
+
+## Phase C2 — Enterprise trust + deterministic depth (unlock the ICP)
+**Goal:** Make MergeWatch procurable by the regulated mid-market beachhead and complete the deterministic-validation story. **Gate behind strategy Phase 2.**
+
+- [ ] **SOC 2 Type II** `#29` — begin the audit (Vanta/Drata-style continuous evidence); the single biggest procurement unlock for the ICP. **XL** (external, start early) 🔴
+- [ ] **SSO / SAML** `#29` — enterprise auth for the dashboard. **L** 🔴
+- [ ] **RBAC** `#29` — roles for org policy admin vs. viewer vs. member. **M** 🔴
+- [ ] **SCA / dependency scanning (OSV-Scanner/Trivy)** `#17` — flag vulnerable/hallucinated dependencies ("slopsquatting" defense) as a validation signal. **M** 🟠
+- [ ] **Sandboxed custom pre-merge checks** `#19` — extend blocking custom agents to run sandboxed shell commands / project tests (not just LLM prompts); matches CodeRabbit's agentic checks. **XL** 🟠
+- [ ] **Ticket/requirement compliance** `#21` — validate a PR against its linked Jira/Linear/GitHub issue; surface non-compliance as a gate signal. **L** 🟠
+- [ ] **Compliance/audit evidence export** `#22` — export the per-merge validation record (what was checked, verdict, policies, evidence) for SOC 2/ISO/EU AI Act change-management. Builds on the reviews table + TTM (#194). **L** 🟠
+
+**Exit criteria:** SOC 2 audit in progress + SSO/RBAC shipped; SCA live; at least one enterprise-grade validation evidence export usable in a real compliance context. **Success metric:** first regulated-mid-market design partner passes procurement; audit export used by ≥1 buyer.
+
+---
+
+## Phase C3 — The feedback-loop moat + context depth
+**Goal:** Build the compounding differentiators — learning from feedback and deeper repo understanding. **Gate behind strategy Phase 3.**
+
+- [ ] **Override/feedback capture (moat foundation)** `#10` — instrument every accept/dismiss/`/resolve`/override as a labeled signal (partly present via `finding_dispositions`; make it a first-class mechanic). Prereq for learnings. **M** 🔴
+- [ ] **Learnings / memory engine** `#10` — aggregate accepted/dismissed patterns per org/repo and feed them back into agent prompts (MergeWatch's answer to CodeRabbit "learnings" / Qodo "auto best-practices"). Reinforces the feedback-loop moat from the strategy. **XL** 🔴
+- [ ] **Whole-repo context / lightweight index** `#13` — persistent per-repo index for cross-file reasoning, beyond on-demand file fetch; improves correctness on large PRs. **XL** 🟠
+- [ ] **Test-generation / behavior-coverage signal (v1)** `#12` — "did this PR add tests for what it changed?" → optionally generate a candidate test and verify it runs/increases coverage (Qodo Cover's differentiator; scope tightly as a validation signal, not a full test-gen product). **XL** 🟠
+- [ ] **Agentic fix handoff** `#11` — hand a finding to a coding agent (Claude Code/Cursor/Copilot) to auto-open a fix PR; ride the agent ecosystem. **L** 🟠
+
+**Exit criteria:** override data driving measurable review precision improvement; learnings applied in production; a behavior-coverage signal feeding the gate. **Success metric:** demonstrable FP-rate reduction from learnings; feedback-loop precision advantage visible in analytics.
+
+---
+
+## Phase C4 — Reach (defer until wedge is won)
+**Goal:** Expand surface area and TAM *after* the validation-gate position is established. Explicitly deferred — off the core wedge.
+
+- [ ] **IDE extension (VS Code / Cursor)** `#23` — local pre-PR validation; MCP server partially covers this today, so lower urgency. **XL** 🔴 (deferred)
+- [ ] **CLI local review** `#24` — terminal/agent-mode self-review, JSON output for agent loops. **L** (deferred)
+- [ ] **GitLab support** `#25` — first non-GitHub platform; abstract the GitHub client behind the existing provider interfaces. **XL** (deferred)
+- [ ] **Bitbucket / Azure DevOps** `#25` — follow GitLab. **XL** (deferred)
+
+**Exit criteria:** none gating — pursue opportunistically once C1–C3 land and the ICP is proven. Note: Copilot is also GitHub-only, so multi-platform is not urgent against the platform threat.
+
+---
+
+## What we deliberately are NOT doing (and why)
+
+- **Not chasing CodeRabbit's ~50 bundled linters wholesale.** Bundle the few that produce *gate-worthy* signals (Semgrep, Gitleaks/TruffleHog, OSV-Scanner/Trivy). Breadth-for-breadth is off-wedge.
+- **Not positioning on "multi-agent pipeline."** Qodo 2.0 has the same architecture. Position on the gate + provenance + open neutrality instead.
+- **Not building a full test-generation product.** Take only the behavior-coverage *validation signal*, not a Qodo-Cover competitor.
+- **Not prioritizing IDE/CLI/multi-platform early.** They power CodeRabbit's PLG but don't advance "the merge gate of record."
+
+---
+
+## Sequencing at a glance
+
+```
+C1 Table-stakes + first deterministic signal   →  C2 Enterprise trust + deterministic depth  →  C3 Feedback-loop moat + context  →  C4 Reach (deferred)
+   committable fixes, Semgrep, secrets,            SOC2/SSO/RBAC, SCA, sandboxed checks,          learnings, index, coverage,          IDE, CLI, GitLab,
+   incremental, walkthrough                        ticket compliance, audit export                agentic handoff                      Bitbucket/Azure
+   (≈ strategy Phase 1)                            (≈ strategy Phase 2)                           (≈ strategy Phase 3)                 (post-wedge)
+```
+
+**Bottom line:** MergeWatch's core review quality is already competitive and its wedge features (blocking gate, open neutrality, provenance detection) are *ahead*. The catch-up work is real but bounded — close the deterministic-validation, enterprise-trust, and feedback-loop gaps first; defer the reach/ecosystem gaps that don't serve the validation-layer wedge.

--- a/docs/strategy/competitive-matrix.md
+++ b/docs/strategy/competitive-matrix.md
@@ -1,0 +1,73 @@
+# Competitive Matrix — AI Code Validation Landscape
+
+> Companion to [`validation-layer-pivot.md`](./validation-layer-pivot.md). Sourced comparison + white-space analysis.
+> **Date:** 2026-07-16. Pricing/funding claims are URL-cited; estimates and unverified figures are flagged inline.
+
+## Executive framing
+
+The market has bifurcated into three layers:
+1. **AI code review** — hottest, best-funded, most crowded — and actively re-branding from "review" to "quality gate / validation" in real time.
+2. **Traditional SAST / quality** (Snyk, Sonar, Semgrep) — owns enterprise trust, compliance, and distribution, but bolting AI onto legacy engines.
+3. **Autonomous testing / verification** (Diffblue, Qodo test-gen) — adjacent but narrow.
+
+**Uncomfortable headline:** "validation layer" is not white space — it is the single most contested piece of narrative real estate in dev tools right now, with two funded incumbents (CodeRabbit, Qodo) already planting flags. MergeWatch must win on *substance* (neutrality, deployment flexibility, policy-gating with a real readiness verdict), not on the phrase.
+
+---
+
+## Comparison matrix
+
+| Competitor | Category | Positioning | Wedge | ICP | Pricing | Funding / Momentum | Could own "validation layer"? |
+|---|---|---|---|---|---|---|---|
+| **CodeRabbit** | AI review | "Quality gates for AI coding" — #1 GitHub Marketplace AI app | Line-by-line PR review + agentic chat + pre-merge checks | SMB→mid-market; OSS free | Pro $24/user/mo (annual), Pro+ $48; Enterprise ~$15k/mo (500+) | $60M Series B @ **$550M** val (Sep 2025); $88M total; >$15M ARR, ~20%/mo; 8,000+ paying customers | **HIGH** — building "standards & governance platform"; distribution + capital + narrative aligned |
+| **Qodo** (ex-CodiumAI) | AI review + test-gen | "Code verification as AI coding scales" | Verification + test-gen + governance; full-codebase context | Enterprise (Nvidia, Walmart, Red Hat, Intuit) | Free dev; Teams ~$19–30/user/mo; Enterprise custom | $70M Series B (Mar 2026); **$120M total**; framing verification as "a category, not a feature" | **HIGH** — most on-nose competitor; spans review AND test-gen; using our exact language |
+| **Graphite (Diamond)** | AI review | "Reimagine code review for the age of AI" | Stacked PRs + workflow lock-in + Diamond reviewer | Elite eng orgs (Shopify, Snowflake, Figma) | Diamond free ≤100 PRs/mo; $15/contributor add-on; $20 standalone | $52M Series B (Accel; Anthropic/Menlo); ~$72–91M total; ~$5.3M ARR (*est.*) | **MED-HIGH** — strong brand + workflow moat; review is a feature, not the whole thesis |
+| **Greptile** | AI review | Codebase-aware ("full-repo RAG") review agent | Deep whole-codebase context vs. diff-only | Mid-market / enterprise | $30/active dev/mo incl. 50 reviews, then $1/review; self-host custom | $4.1M seed → **$25M Series A** (Benchmark); ~$180M val *in talks* (unconfirmed) | **MED** — strong tech + tier-1 VC, but "better review" wedge, not yet a gate/governance story |
+| **Ellipsis** | AI review | AI review + auto-fix PRs | Finds bug → writes fix | SMB / startups | $20/dev/mo; free public repos | $2M seed (YC W24) | **LOW** — feature-level; no enterprise trust/compliance surface |
+| **Korbit** | AI review | AI reviewer for GitHub/Bitbucket | Mentorship / education framing | SMB | Free ≤5 reviews/mo; Pro $24/user/mo | ~$11M (Khosla); **acquired by Boost Security May 2026** (verify) | **LOW** — absorbed into AppSec vendor; independent thesis gone |
+| **Sourcery** | AI review | Cheap Python-first review | Price + language niche | Python teams | ~$10–12/seat/mo | Not disclosed | **LOW** — commodity, niche |
+| **Bito** | AI review | Codebase-aware review + "AI Architect" | Usage-based indexing | SMB | Team $12/seat, Pro $20; usage-based Architect | $5.7M seed ext ($8.8M total) | **LOW** — under-capitalized vs. leaders |
+| **GitHub Copilot code review** | Platform-native | "Zero incremental cost" review inside Copilot | **Distribution** — bundled with existing Copilot seats | Everyone on GitHub | Included in Copilot (Free/$10 Pro; Max $100/mo) | Microsoft-scale; agentic review shipped Mar 2026 | **HIGH (as bundler)** — owns the merge button and the diff; existential platform risk |
+| **Cursor Bugbot** | Editor-native | Background bug-catcher pre-review | Lives in Cursor ecosystem | Cursor teams | Inside Teams $40/user/mo; ~$1–1.50/run (Jun 2026); GitHub-only | Cursor's scale/valuation | **MED** — owns the generation surface, but review is a side feature, GitHub-only |
+| **Snyk** | SAST / security | Developer-first security; "close the AI trust gap" | Security shift-left + compliance | Enterprise AppSec | Team ~$25/contributing dev; Enterprise custom | **$7.4B val (2022)**; ~$326M ARR (~7% YoY); S-1 filed, 2026 IPO watch | **HIGH (security slice)** — owns enterprise trust/compliance, but validation ≠ security; slower growth |
+| **Sonar (SonarQube)** | Quality | "Fight AI slop & verify AI code" — AI Code Assurance | Deterministic quality gates + huge install base | Enterprise + mid-market | Cloud from ~$34/mo (LOC-based); Server ~$720/yr → $15k–$500k+ | Large private co (revenue undisclosed); shipping AI Code Assurance 2025–26 | **MED-HIGH** — "quality gate" is literally their term; deterministic engine + install base, but legacy AI velocity |
+| **Semgrep** | SAST | AppSec platform (SAST/SCA/Secrets) + Assistant | Custom rules + fast SAST | Security-led orgs | Free ≤10 contributors; Team $35/contributor/mo; Enterprise custom | **$100M Series D** (Menlo, Feb 2025); ~$193–204M total | **MED** — strong AppSec wedge, but security-scoped |
+| **Codacy / DeepSource** | Quality | Multi-tool quality + security platforms | Bundled analysis | SMB→mid | Codacy $15/user; DeepSource $24/user | Mid-size; no recent mega-rounds | **LOW-MED** — commoditizing |
+| **Diffblue** | Autonomous testing | "AI testing agent for enterprise unit testing" (Java) | Deterministic auto-generated tests | Enterprise Java | From $1,500/5k LOC; Dev $30/mo | Oxford spinout; enterprise niche | **LOW** — narrow (Java tests), but *test-as-validation* is a complementary angle to watch |
+
+*Sources & flags at bottom.*
+
+---
+
+## White-space analysis
+
+**The word is taken; the substance is only partially claimed.** CodeRabbit, Qodo, and Sonar all push the identical "quality gate / verify AI code" narrative, and the top two are far better funded. MergeWatch cannot win by planting the same flag. Genuine gaps that remain:
+
+1. **Deployment-mode neutrality + air-gapped / self-hosted with any LLM.** Nearly every funded competitor is SaaS-first and cloud-LLM-locked. MergeWatch's dual SaaS **and** self-hosted-with-any-LLM (Bedrock/Anthropic/LiteLLM/Ollama) is genuinely differentiated for regulated/defense/on-prem buyers — a segment Snyk/Sonar serve but at legacy prices and without an AI-native pipeline. **Defensible wedge.**
+
+2. **A composable merge-readiness *score* + org-defined blocking custom agents.** Competitors emit findings; few emit an auditable, policy-driven **verdict** that gates the merge with org-authored, path/language-targeted agents that can *block*. MergeWatch's org custom agents (#235) + 1–5 score is closer to a "policy engine for AI code" than a reviewer. Lean into "the programmable gate," not "better review."
+
+3. **The neutral / open-source trust position.** Every commercial incumbent either sells the generator or is VC-pressured to maximize seat revenue. An open-source, model-agnostic, generator-agnostic validator can honestly say *"we don't sell the AI that wrote your code, so we can grade it."* MergeWatch's most durable strategic asset.
+
+4. **Verification depth (does the code actually work) — not just review.** Nobody credibly owns static review + generated tests + runtime/behavioral verification. Qodo is closest. Expensive to build, but the true "validation layer" whitespace; review alone is table stakes.
+
+**Verdict:** Position as **"the neutral, self-hostable validation gate,"** not "best review."
+
+---
+
+## Threat ranking — 3 most likely to own the validation layer
+
+1. **CodeRabbit — highest threat.** Capital ($550M val), distribution (#1 GitHub Marketplace, 8,000+ customers), growth (>$15M ARR, ~20%/mo), *and* the exact strategic intent ("quality gates for AI coding," extending pre-merge checks into a governance platform). Beating us to the positioning with more resources.
+
+2. **GitHub Copilot code review — structural/platform threat.** Microsoft owns the repo, the diff, and the merge button, and ships agentic review at zero incremental cost. It only needs to be good-enough and free — the commoditization risk that caps every standalone reviewer's TAM. Our defense is exactly what Copilot can't be: self-hosted, model-neutral, generator-neutral.
+
+3. **Qodo — most direct narrative threat.** Using our literal language ("code verification"), $120M raised, enterprise logos, and uniquely spans review AND test-generation — the deepest claim on "does the code actually work."
+
+**Honorable mention — Snyk:** enterprise-trust incumbent ($326M ARR, 2026 IPO watch) that could annex "validation" from the security/compliance direction, but ~7% YoY growth suggests a slower-moving giant.
+
+---
+
+## Sources & flags
+
+Pricing/funding cited to primary sources where possible: [CodeRabbit pricing](https://www.coderabbit.ai/pricing) & [Series B](https://sacra.com/c/coderabbit/); [Qodo $70M](https://techcrunch.com/2026/03/30/qodo-bets-on-code-verification-as-ai-coding-scales-raises-70m/) & [pricing](https://www.qodo.ai/pricing/); [Graphite Series B + Diamond](https://graphite.com/pricing); [Greptile pricing](https://www.greptile.com/pricing) & [per-review analysis](https://www.agent-wars.com/news/2026-05-01-greptile-per-review-pricing); [Snyk plans](https://snyk.io/plans/); [Sonar pricing](https://www.sonarsource.com/plans-and-pricing/); [Semgrep pricing](https://semgrep.dev/pricing); [Diffblue pricing](https://www.diffblue.com/pricing).
+
+**Flags:** Graphite ARR (~$5.3M) and Greptile $180M valuation are estimates/in-talks, not confirmed. Sonar and Diffblue revenue are not public. Korbit acquisition (per PitchBook/Crunchbase) should be verified. Cursor/Copilot review-pricing details are from third-party comparison sites — confirm on the vendors' own pages before external use.

--- a/docs/strategy/decision.md
+++ b/docs/strategy/decision.md
@@ -1,0 +1,63 @@
+# Decision & Validating Experiments
+
+> Companion to [`validation-layer-pivot.md`](./validation-layer-pivot.md). Go/no-go recommendation + the experiments that de-risk the pivot before heavy build.
+> **Date:** 2026-07-16 · **Status:** For decision
+
+---
+
+## Recommendation: **GO — validate then build**
+
+Pivot MergeWatch's narrative and product toward the **neutral, self-hostable, provenance-aware validation gate**, but do **not** open with heavy build. The thesis is well-supported and the wedge is defensible, yet the space is contested by better-funded incumbents (CodeRabbit $550M, Qodo $120M) and a platform threat (GitHub Copilot native review). The correct sequence is to run the cheapest disproving experiment first, then build only what the evidence justifies.
+
+### Why GO
+- **Thesis SUPPORTED (with a live threat):** AI writes ~40–50% of net-new code; review time up 91% on high-AI teams; 45% of AI code fails security tests; trust *falling* as usage rises; >$1.2B flowing to standalone verification. The pain is real, quantified, and concentrated at the merge chokepoint.
+- **Defensible wedge exists:** neutrality + deployment flexibility + policy-gating + evidence is what a self-reviewing generator and a SaaS-only incumbent structurally *cannot* offer.
+- **~70% already built:** the blocking org-custom-agent gate (#235), Check Runs, and the 1–5 merge-readiness score are shipped. This is a productization, not a rebuild.
+
+### Why not "GO, full build"
+- "Validation layer" as a phrase is the most contested narrative in dev tools right now; we win on substance, not by out-marketing $550M.
+- The single biggest thesis risk — *do agent PRs actually fail validation more than human PRs?* — is cheaply testable and, if false, collapses the wedge. Test it before building it.
+
+---
+
+## The next 3 experiments (in priority order)
+
+### Experiment 1 — Retro provenance analysis *(run this first — it's the cheapest and the thesis hinges on it)*
+- **Hypothesis:** agent-authored PRs fail validation materially more than human-authored PRs.
+- **Method:** classify historical PRs on our dogfood repo + 3–5 design-partner repos by authorship (commit trailers, `Co-Authored-By`, bot signatures), run the existing pipeline, measure block/critical-finding rate by cohort.
+- **Success metric:** agent PRs show **≥1.5× higher critical-finding rate** than human PRs.
+- **Effort:** ~1 week (scripting over existing agents + provenance heuristics).
+- **Why first:** if agent PRs *don't* fail more, the entire wedge collapses — before any build. If they do, we get both proof *and* the killer marketing stat ("we validated N agent PRs and blocked X% for security flaws").
+- **Kill signal:** critical-finding rates are statistically indistinguishable across cohorts.
+
+### Experiment 2 — Provenance-value smoke test
+- **Hypothesis:** teams will pay for a stricter gate specifically on agent-authored PRs.
+- **Method:** landing page + demo positioning MergeWatch as "the validation gate for AI-generated code"; drive traffic from HN/GitHub Marketplace; measure install→activation and a "Book Enterprise" CTA.
+- **Success metric:** **>8% of qualified visitors install or book** *(est.)*.
+- **Effort:** ~1 week (copy + existing product, no new build).
+- **Kill signal:** activation far below generic-review benchmarks — the provenance framing doesn't move buyers.
+
+### Experiment 3 — Pricing willingness test
+- **Hypothesis:** the hybrid seat + validation-usage model clears vs. flat-seat incumbents.
+- **Method:** Van Westendorp / fake-door pricing page with the three tiers shown to 30–50 ICP contacts.
+- **Success metric:** **>50% find the Team tier "acceptable value" and <30% flag usage-billing as a dealbreaker.**
+- **Effort:** ~3–4 days.
+- **Kill signal:** usage-on-top-of-seats triggers the same backlash Greptile's per-review pricing drew.
+
+---
+
+## Risks & kill-criteria
+
+| # | Risk | Kill-criterion (stop signal) |
+|---|---|---|
+| 1 | **Coding agents absorb validation** (already partial — Copilot ships native review free) | In a customer sample, >40% say native agent self-review is "good enough" and drop/refuse independent validation within 2 quarters |
+| 2 | **Market too crowded / commoditized** (race to the bottom on price) | CAC exceeds 12-month gross margin per customer for 2 consecutive quarters with no provenance-driven win-rate lift over generic reviewers |
+| 3 | **Provenance signal weak / gameable** | Classifier accuracy <80% on real customer PR streams after reasonable effort |
+| 4 | **Buyers won't pay usage on top of seats** | >30% of Team accounts hit their quota and churn/downgrade rather than expand |
+| 5 | **Enterprise motion too heavy for a small team** | Enterprise sales cycle median >6 months with <20% close rate after 10 qualified opportunities |
+
+---
+
+## Decision gate
+
+**Proceed to [Phase 0 of the project plan](./project-plan.md) immediately** (it *is* Experiment 1 plus provenance detection). Gate the Phase 1 build on Experiment 1 clearing its ≥1.5× threshold. If Experiment 1 fails, stop and revisit the wedge — do not spend build cycles on a differentiator the data doesn't support.

--- a/docs/strategy/feature-gap.md
+++ b/docs/strategy/feature-gap.md
@@ -1,0 +1,122 @@
+# Feature Gap Analysis — MergeWatch vs. Top 3 Players
+
+> Companion to [`validation-layer-pivot.md`](./validation-layer-pivot.md) and [`competitive-matrix.md`](./competitive-matrix.md). Detailed, dimension-by-dimension feature gap vs. the three ranked threats. Catch-up plan: [`catch-up-plan.md`](./catch-up-plan.md).
+> **Date:** 2026-07-17
+> **Compared against:** **CodeRabbit** (highest threat, $550M), **GitHub Copilot code review** (platform/bundling threat), **Qodo** (narrative/verification threat).
+> **Sources:** MergeWatch capabilities are cited from the codebase; competitor capabilities from each vendor's docs/changelog (see [`competitive-matrix.md`](./competitive-matrix.md) and the research briefs). Competitor claims dated 2025–2026.
+
+---
+
+## How to read this
+
+Legend for each cell:
+- ✅ **Strong / ahead** — implemented and competitive or better
+- 🟡 **Partial** — exists but thinner than competitors
+- ❌ **Missing** — not implemented
+
+Gap severity (MergeWatch's position vs. the *best* of the three):
+- 🔴 **Major gap** — table-stakes or wedge-relevant capability we lack
+- 🟠 **Moderate gap** — meaningful but not existential
+- 🟢 **At parity or ahead** — no catch-up needed; defend it
+
+---
+
+## Executive read
+
+**MergeWatch is not behind on core review quality — it's behind on surface area and ecosystem, and *ahead* on exactly the things the validation-layer wedge needs.**
+
+**Where MergeWatch already leads (defend these — they are the wedge):**
+1. **Blocking merge gate** — real `REQUEST_CHANGES` + blocking org custom agents that fail the check. **Copilot literally cannot approve/request-changes (comment-only); Qodo can't hard-block either (labels + CI wiring).** Only CodeRabbit matches. This is our sharpest structural edge over 2 of 3.
+2. **Open, unpaywalled deployment + model neutrality** — self-hosted (Docker+Postgres) + any LLM (Bedrock/Anthropic/LiteLLM/Ollama) + air-gapped, available on the open-source/self-host path rather than behind an enterprise contract. **Copilot has no GHES/self-host at all; CodeRabbit has no BYO-model at all; Qodo *does* match (on-prem + air-gapped + BYOK) but only at its Enterprise tier.** The differentiator is *neutrality without a paywall* + genuinely open-source — not neutrality per se.
+3. **Agent-authored PR detection** — already implemented (`agent-detection.ts`, strict-mode prompt suffix). **None of the three ship explicit provenance detection.** The wedge feature is *already built* — this is the one lead that is unique vs. all three.
+4. **False-positive discipline** — W2 critical-verification, W9 fingerprinting, FP-G/H/J passes, confidence floor. More sophisticated FP-suppression than the "~15–25% FP rate" reported for Copilot. (Note: Qodo 2.0's judge agent is comparable; CodeRabbit's agentic validation partial. Parity-to-ahead, not a moat by itself.)
+5. **Analytics depth** — FP-insight rollups, TTM (#194), cost, engagement/dispute tracking. CodeRabbit's reporting is prompt-driven (no dashboards); Copilot thin; Qodo has an Enterprise dashboard (active users, acceptance rate, findings/risk) that is roughly comparable.
+
+**Reality check on architecture:** Qodo 2.0 (Feb 2026) is itself a *parallel multi-agent review + judge/orchestrator* design — the same pattern MergeWatch uses, with a (self-reported) benchmark lead. **The multi-agent pipeline is not a differentiator; the wedge (blocking gate + provenance + open neutrality) is.** Do not position on "we use multiple agents."
+
+**Where MergeWatch is behind (the catch-up list):**
+Committable one-click fixes · bundled SAST/secret/SCA scanners · learnings/memory · whole-repo context/index · test generation · IDE extension · CLI · multi-platform (GitLab/Bitbucket/Azure) · ticket/requirement compliance · agentic fix handoff · enterprise trust certs (SOC2/SSO/RBAC) · incremental review · richer command set/walkthrough.
+
+---
+
+## The gap matrix
+
+| # | Capability | MergeWatch | CodeRabbit | Copilot review | Qodo | Gap |
+|---|---|---|---|---|---|---|
+| **Core review** |
+| 1 | LLM multi-category review (bug/security/perf/style) | ✅ 6 agents + orchestrator | ✅ | ✅ | ✅ | 🟢 |
+| 2 | Merge-readiness / effort score | ✅ 1–5 score | 🟡 checks | ❌ | 🟡 effort label | 🟢 ahead |
+| 3 | False-positive suppression (verification passes) | ✅ W2/W9/FP-G/H/J | 🟡 agentic validation | 🟡 (high FP reported) | 🟡 threshold | 🟢 ahead |
+| 4 | PR summary + walkthrough table | 🟡 prose summary | ✅ walkthrough + file table | ✅ summary | ✅ /describe rich | 🟠 |
+| 5 | Architecture/sequence diagrams | ✅ Mermaid | ✅ sequence diagrams | ❌ | 🟡 | 🟢 |
+| 6 | Line-by-line inline comments | ✅ | ✅ | ✅ | ✅ | 🟢 |
+| **Fixes & interactivity** |
+| 7 | Committable one-click suggested fixes | ❌ prose only | ✅ | ✅ | ✅ commitable | 🔴 |
+| 8 | Chat / conversational Q&A on PR | 🟡 @mergewatch Q&A + inline reply | ✅ full chat | 🟡 limited | ✅ /ask | 🟠 |
+| 9 | Command set (/review /improve /describe …) | 🟡 review/summary/question | ✅ rich | 🟡 | ✅ rich | 🟠 |
+| 10 | Learnings / memory from team feedback | ❌ conventions only | ✅ learnings engine | ❌ | ✅ auto best-practices | 🔴 |
+| 11 | Agentic fix handoff / auto-open fix PR | ❌ | ✅ agent handoff | ✅ coding agent PR | ✅ /implement | 🔴 |
+| 12 | Test generation | ❌ flags gaps only | 🟡 docstrings | 🟡 via agent | ✅ Cover/Gen | 🟠 |
+| **Context** |
+| 13 | Whole-repo context (graph/RAG/index) | 🟡 on-demand file fetch | ✅ code-graph | ❌ diff-only | ✅ Context Engine RAG | 🟠 |
+| 14 | Incremental review (new commits only) | ❌ full diff each time | ✅ | ✅ | 🟡 chunking | 🟠 |
+| **Deterministic validation** |
+| 15 | Bundled linters/SAST | ❌ linter-awareness only | ✅ ~50 tools (Semgrep…) | 🟡 CodeQL | 🟡 some | 🔴 |
+| 16 | Secret scanning | ❌ LLM review only | ✅ TruffleHog/Gitleaks | ✅ secret scanning | 🟡 | 🔴 |
+| 17 | SCA / dependency scanning | ❌ | ✅ OSV-Scanner/Trivy | ✅ Dependabot | 🟡 | 🟠 |
+| **Gating & governance** |
+| 18 | **Blocking merge gate (approve/request-changes/required check)** | ✅ REQUEST_CHANGES + blocking org agents | ✅ request-changes workflow | ❌ comment-only | ❌ labels + CI wiring | 🟢 **ahead of 2/3** |
+| 19 | Custom pre-merge checks (sandboxed shell/CI) | 🟡 custom agents (LLM) | ✅ sandboxed shell + MCP | ❌ | 🟡 compliance checklists | 🟠 |
+| 20 | Org-level policy / standards hierarchy | ✅ org custom agents + targeting | ✅ path instructions | 🟡 instruction files | ✅ pr-agent-settings repo | 🟢 |
+| 21 | Ticket/requirement compliance (Jira/Linear) | ❌ | ✅ | ❌ | ✅ ticket compliance | 🟠 |
+| 22 | Compliance/audit evidence export | 🟡 review records, no export | 🟡 | ❌ | 🟡 compliance labels | 🟠 |
+| **Platform & reach** |
+| 23 | IDE extension (VS Code/JetBrains/Cursor) | ❌ MCP server only | ✅ VS Code/Cursor/Windsurf | ✅ native | ✅ Qodo Gen | 🔴 |
+| 24 | CLI local review | ❌ | ✅ | 🟡 | ✅ | 🟠 |
+| 25 | Multi-platform (GitLab/Bitbucket/Azure/Gitea) | ❌ GitHub only | ✅ 4 platforms | ❌ GitHub only | ✅ 5 platforms | 🟠 |
+| 26 | MCP support | ✅ MCP server | ✅ in checks | ❌ | ✅ | 🟢 |
+| **Deployment & trust** |
+| 27 | Self-hosted / on-prem (open path) | ✅ Docker+Postgres, all tiers | 🟡 Enterprise only | ❌ no GHES | 🟡 Enterprise only | 🟢 **ahead of Copilot; open vs. paywalled for CR/Qodo** |
+| 28 | BYO-model / any LLM / air-gapped | ✅ 4 providers + Ollama, open | ❌ no BYO | 🟡 cloud model picker | 🟡 BYOK Enterprise | 🟢 **ahead of CR + Copilot; open vs. Qodo Enterprise** |
+| 29 | Enterprise trust (SOC2, SSO/SAML, RBAC) | 🟡 self-host helps; certs unclear | ✅ SOC2 II, SSO, RBAC | ✅ SSO, indemnity | ✅ SOC2, SSO | 🔴 |
+| **Wedge-specific** |
+| 30 | Agent-authored PR detection / provenance | ✅ agent-detection.ts + strict mode | 🟡 workflow only | ❌ | ❌ | 🟢 **unique — the wedge** |
+| 31 | Analytics dashboards (cost/FP/TTM/engagement) | ✅ rich | 🟡 prompt-driven reports | 🟡 | 🟡 | 🟢 ahead |
+
+---
+
+## The gaps that matter (ranked by strategic priority)
+
+Priority is set by **wedge-alignment** (does closing it strengthen the validation-gate positioning?) × **table-stakes pressure** (do we lose deals without it?), *not* by raw competitor parity.
+
+### Tier 1 — Close now (wedge-critical or table-stakes)
+- **🔴 #15/16/17 Bundled deterministic scanners (SAST + secret + SCA).** *The single biggest wedge-reinforcing gap.* "Validation layer" demands more than LLM opinion — CodeRabbit fuses ~50 deterministic tools with review; Copilot has CodeQL. Wrapping Semgrep + Gitleaks/TruffleHog + OSV-Scanner as validation signals that feed the merge score/gate turns "AI reviewer" into "validation gate with evidence." High wedge value.
+- **🔴 #7 Committable one-click fixes.** Pure table-stakes credibility — all three have it; we ship prose only. Without it we read as less finished.
+- **🔴 #29 Enterprise trust (SOC2 Type II, SSO/SAML, RBAC).** Gates the regulated mid-market ICP the strategy targets. Self-hosting helps but certs/SSO are procurement checkboxes.
+- **🟠 #14 Incremental review.** We re-run all agents on the full diff every time — a real cost/latency disadvantage at agent-PR volume (the exact scale our ICP hits). Efficiency + scale.
+
+### Tier 2 — Differentiator-adjacent (build to deepen the moat)
+- **🔴 #10 Learnings / memory from feedback.** Both CodeRabbit and Qodo learn from accepted/dismissed feedback; we only inject static conventions. This *is* the feedback-loop moat the strategy flagged — instrument override capture and close it.
+- **🟠 #19 Sandboxed custom pre-merge checks.** Extend blocking custom agents beyond LLM prompts to run sandboxed commands/tests — matches CodeRabbit's agentic checks and strengthens "gate with teeth."
+- **🟠 #21/22 Ticket compliance + audit/evidence export.** Requirement-traceability (Jira/Linear) and change-management export are the "system of record" surfaces — high value for the compliance-buyer expansion.
+- **🟠 #13 Whole-repo context.** On-demand fetch is thinner than CodeRabbit's code-graph / Qodo's RAG; matters for cross-file correctness on large PRs.
+- **🟠 #12 Test generation / verification depth.** Qodo's differentiator ("does the code actually work"). The true validation-layer whitespace; expensive — scope carefully.
+- **🟠 #11 Agentic fix handoff.** Hand a finding to a coding agent to auto-open a fix PR — closes the loop, rides the agent ecosystem.
+
+### Tier 3 — Reach (defer; off-wedge or low near-term ROI)
+- **🔴 #23 IDE extension** and **🟠 #24 CLI** — big for CodeRabbit's PLG, but off the "merge gate" wedge. MCP server partially covers agent/IDE reach today. Defer.
+- **🟠 #25 Multi-platform (GitLab/Bitbucket/Azure).** Expands TAM (Copilot is also GitHub-only, so not urgent vs. the platform threat). Defer to post-wedge.
+- **🟠 #4/8/9 Walkthrough table + richer command set/chat.** Incremental polish; fold into Tier 1 work opportunistically.
+
+---
+
+## Leads to defend while catching up
+
+Catching up must **not** erode the five things that make MergeWatch defensible. Every catch-up item should reinforce, not dilute, these:
+1. The **blocking gate** (ahead of Copilot + Qodo).
+2. **Self-host + BYO-model + air-gapped** (unique across the three).
+3. **Agent-provenance detection** (the wedge — already built).
+4. **FP discipline** (verification passes).
+5. **Analytics/insight depth**.
+
+**Strategic framing:** don't chase CodeRabbit on IDE/CLI/platform breadth. Chase the gaps that convert "AI reviewer" into "validation gate of record" — deterministic scanners, committable fixes, enterprise trust, learnings, and evidence/compliance export. See [`catch-up-plan.md`](./catch-up-plan.md).

--- a/docs/strategy/positioning.md
+++ b/docs/strategy/positioning.md
@@ -1,0 +1,74 @@
+# Positioning One-Pager
+
+> Companion to [`validation-layer-pivot.md`](./validation-layer-pivot.md). Category narrative, wedge, moat, expansion path.
+> **Date:** 2026-07-16
+
+---
+
+## The category statement
+
+> **MergeWatch is the software validation layer for the AI build era — the neutral, self-hostable gate that decides what's safe to merge, for code written by humans or agents.**
+
+Reinforced with the "merge gate of record" idea: MergeWatch doesn't just check a change — it **blocks** it, **records why**, and can **prove it later**.
+
+## The 100-word positioning statement
+
+> Software is now written as much by agents as by engineers, and merge volume is outpacing anyone's ability to review it by hand. MergeWatch is the **software validation layer for the AI build era** — the required gate that decides whether a change is safe to merge, regardless of whether a human or an AI agent wrote it. It enforces your organization's policy on every pull request, blocks what doesn't pass, and records a durable, auditable verdict for every change. Not a review bot that leaves comments — the system of record for *"is this safe to ship."* MergeWatch is where code earns the right to merge.
+
+---
+
+## Review vs. validation — the load-bearing distinction
+
+**"AI PR review" is a feature. A "validation layer" is infrastructure the pipeline depends on.** The difference is authority, statefulness, and coverage — not comment quality. Five concrete properties turn MergeWatch from a bot into a layer:
+
+1. **Gating authority (the merge gate).** A *required, blocking* status check on protected branches — a decision with teeth, not advice. (Seed: #235 blocking custom-agent gate.)
+2. **System-of-record for merge-safety.** A durable verdict (score 1–5), the reason, the policies evaluated, and the evidence, keyed to `prNumber#commitSha`. Answerable months later: "why was commit abc123 allowed to merge, and what did we check?"
+3. **Policy/compliance as code.** `.mergewatch.yml` + org custom agents = an **org policy graph**: which rules apply to which repos/paths/languages, which are blocking, who wins in a conflict (org over repo). The org's merge policy, codified and enforced uniformly.
+4. **Evidence & audit trails.** Machine-readable validation records per merge, exportable for SOC 2 / ISO change-management controls — generated automatically instead of screenshotted quarterly.
+5. **Uniform validation of human AND agent output.** MergeWatch validates the *artifact*, not the author. In an era of blurring provenance and exploding volume, a gate at the merge boundary that treats all sources uniformly (and agent PRs more strictly) is the only defensible checkpoint.
+
+**One line:** *Review advises a human. Validation blocks a merge, records why, and proves it later — for code written by humans or agents.*
+
+---
+
+## The wedge
+
+**The neutral, provenance-aware, blocking merge gate** — the required check that classifies each PR as human- or agent-authored, applies org policy (stricter for agent PRs), blocks what fails, and records the verdict.
+
+Chosen because: it's ~70% built (#235 + Check Runs + 1–5 score), it creates day-one dependency (required checks get budget; advisory bots get muted), no competitor leads with provenance, and it's the credible on-ramp to the system-of-record.
+
+**To a buyer:** *"You're about to let AI write a lot of your code. MergeWatch is the gate that decides what's allowed to merge — and proves it was checked."*
+
+---
+
+## The moat (honestly rated)
+
+| Moat | Thickness |
+|---|---|
+| Neutrality / open-source trust ("we don't sell the AI that wrote your code") | **Durable & unique** |
+| Deployment neutrality (self-host + any LLM, air-gapped) | **Thick** |
+| Org policy graph (accumulated config) | **Thick** |
+| Being the merge gate of record | **Thick but slow** |
+| Proprietary feedback loop (override capture) | **Medium — only if instrumented now** |
+| The LLM pipeline itself | **Thin — don't over-invest** |
+
+**Invest in:** neutrality, deployment flexibility, the policy graph, the evidence trail. **Not:** raw review quality (commoditizing).
+
+---
+
+## Expansion path (land → expand)
+
+- **Land — The Gate.** One required check on one team's protected branch. "Nothing bad merges." GitHub-native, self-hosted or SaaS.
+- **Expand 1 — Org rollout & policy graph.** The gate spreads repo-by-repo; the org codifies its merge policy centrally. Value shifts from "catch bugs" to "enforce our standards everywhere."
+- **Expand 2 — System of record & evidence.** The accumulating verdict/evidence trail becomes a product surface: change-management audit exports, "why did this merge" lookups, merge-safety dashboards, time-to-merge metrics (#194).
+- **Expand 3 — Agent governance.** As orgs adopt autonomous coding agents, MergeWatch becomes the *control plane for AI-generated code*: the gate that validates agent output, the record of what agents shipped, the policy that constrains them. The "AI build era" payoff.
+- **Full layer.** Every change — human or agent, in CI, IDE, or agent runtime — flows through MergeWatch for validation, verdict, and evidence. Other systems consume its output. It's infrastructure.
+
+---
+
+## Precedents to learn from
+
+- **Vanta (compliance):** won by becoming the *continuous system of record* for compliance evidence — replacing a painful manual ritual (screenshotting controls at audit time) with automatic, audit-ready proof. **Lesson:** the moat is being the *record*, not the checker. MergeWatch's equivalent: replace manual change-management/review evidence with an automatic per-merge validation record.
+- **Datadog (observability):** turned monitoring from a feature into a foundational layer by becoming the single pane every workload reports into, then expanding module-by-module (83% of customers use 2+ products). **Lesson:** land narrow (one required integration), expand relentlessly, let integration breadth become the lock-in.
+
+**Common thread:** both became layers by owning a *continuous, authoritative record at a chokepoint*. MergeWatch's chokepoint is **merge-time** — the last moment before code enters production, and the one point where human and agent output converge.

--- a/docs/strategy/project-plan.md
+++ b/docs/strategy/project-plan.md
@@ -1,0 +1,98 @@
+# Project Plan — Pivot to the Validation Layer
+
+> Companion to [`validation-layer-pivot.md`](./validation-layer-pivot.md). Phased roadmap → milestones → task items, each traced to a strategy outcome.
+> **Date:** 2026-07-16 · **Flat checkbox version:** [`backlog.md`](./backlog.md)
+
+## How to read this
+
+Four phases, sequenced by **dependency** and by **fastest path to validating the pivot**. Each phase lists its **goal**, **task items**, **dependencies**, **success metric**, and **exit criteria**. Every phase traces back to a strategy outcome — no orphan work. Phases gate on each other: **do not start Phase 1 until Phase 0's experiment clears its threshold.**
+
+Traceability tags: **[thesis]** = §1 market thesis · **[wedge]** = §3 wedge · **[moat]** = §3 moat · **[product]** = §4 build/keep/drop · **[gtm]** = §5 GTM · **[risk]** = §6 kill-criteria.
+
+---
+
+## Phase 0 — Validate the thesis (cheapest disproving experiments)
+
+**Goal:** Prove or kill the core wedge — *do agent-authored PRs actually fail validation more than human PRs?* — before any heavy build. **[thesis][wedge][risk-3]**
+
+**Task items:**
+- Build a **PR provenance classifier (heuristic v0)**: detect human vs. agent authorship from commit trailers, `Co-Authored-By`, bot signatures, IDE metadata. Extends `packages/core/src/skip-logic.ts` patterns. **[wedge]**
+- Run **retro provenance analysis** (Experiment 1) on the dogfood repo + 3–5 design-partner repos: classify historical PRs, run the existing pipeline, measure block/critical-finding rate by cohort. **[thesis]**
+- Stand up the **provenance-value smoke test** (Experiment 2): landing page positioning "validation gate for AI-generated code" + activation/CTA tracking. **[gtm]**
+- Run the **pricing willingness test** (Experiment 3): fake-door 3-tier pricing page to 30–50 ICP contacts. **[gtm]**
+- Recruit **3–5 design partners** from the beachhead ICP (30–150 eng, heavy agent adoption). **[gtm]**
+
+**Dependencies:** none — uses existing pipeline and repos.
+
+**Success metric:** Experiment 1 shows agent PRs at **≥1.5× the critical-finding rate** of human PRs; classifier accuracy **≥80%**; smoke-test activation **>8%** of qualified visitors.
+
+**Exit criteria:** Experiment 1 clears its threshold **and** ≥3 design partners committed. If Experiment 1 fails, **STOP** and revisit the wedge (see [`decision.md`](./decision.md) kill-criteria).
+
+---
+
+## Phase 1 — Beachhead wedge: the provenance-aware blocking gate
+
+**Goal:** Ship the smallest thing that makes MergeWatch a *validation layer* not a *review bot* — a required, provenance-aware merge gate that applies differentiated policy to agent PRs. **[wedge][product]**
+
+**Task items:**
+- Productize **PR provenance detection** as a first-class signal surfaced on every review (label + score input). **[wedge]**
+- Extend **`.mergewatch.yml` into validation policy-as-code**: declarative rules like "agent PRs touching `/payments` require passing security agent + human sign-off." Builds on `org-agents.ts` scope/target/blocking logic (#235). **[wedge][moat]**
+- Make **check status + merge-readiness score the primary artifact** (comment demoted to secondary evidence). **[product]**
+- Ship **override capture**: instrument accept/dismiss/override on every finding as a labeled signal — the feedback-loop moat starts compounding now. **[moat]**
+- **Refactor:** demote style/diagram agents to optional add-ons to sharpen the validation narrative. **[product]**
+- **GTM:** publish the Experiment-1 provenance data as a launch post ("we validated N agent PRs, blocked X%"); list/refresh on GitHub Marketplace. **[gtm]**
+
+**Dependencies:** Phase 0 (classifier + validated thesis + design partners).
+
+**Success metric:** ≥3 design partners make MergeWatch a **required status check** on ≥1 protected branch; provenance-differentiated policy blocks real unsafe agent PRs in production.
+
+**Exit criteria:** the gate is load-bearing (required check) for ≥3 orgs and blocking is trusted (no design partner disables it over false-blocks).
+
+---
+
+## Phase 2 — Expand the layer: org rollout, policy graph, evidence
+
+**Goal:** Turn the single-team wedge into an org-wide, defensible layer — the policy graph and the evidence trail that make it sticky. **[moat][product]**
+
+**Task items:**
+- **Org policy management** in the dashboard: central authoring of the merge policy across repos/paths/languages; org-over-repo conflict resolution surfaced clearly. **[moat]**
+- **Validation audit trail / dashboard**: "what we validated, blocked, and shipped anyway," per merge, exportable. Builds on the reviews table (`prNumber#commitSha`) and time-to-merge work (#194). **[product][moat]**
+- **Repo-by-repo rollout tooling**: make it trivial to spread the gate across an org's repos. **[gtm]**
+- **Packaging & metering**: implement the hybrid seat + validation-usage model (Team quota + overage); gate the enterprise control plane (policy mgmt, audit, SSO) behind the paid tier. **[gtm]**
+- **Sales-assist motion** for the 50+ dev / self-hosted + audit buyer. **[gtm]**
+
+**Dependencies:** Phase 1 (a trusted, required gate to spread).
+
+**Success metric:** first orgs running the gate across **10+ repos**; first **paid** conversions on the new packaging; audit export used by ≥1 buyer in a real compliance context.
+
+**Exit criteria:** ≥1 org has adopted org-wide policy management and is paying; net-revenue retention signals expansion (gate spreads without churn).
+
+---
+
+## Phase 3 — Category & moat: agent governance and durable defensibility
+
+**Goal:** Compound defensibility and establish the category — MergeWatch as the control plane for AI-generated code. **[moat][thesis]**
+
+**Task items:**
+- **Agent-governance surface**: treat autonomous coding agents (Cursor, Claude Code, Devin, Copilot) as first-class validated sources; per-agent policy and per-agent track record. **[wedge][thesis]**
+- **Verification depth (v1)**: lightweight behavioral signals — "did this PR add tests for what it changed?", diff-coverage checks — moving beyond static critique toward "does the code actually work." (This is the true validation-layer whitespace; scope carefully.) **[product]**
+- **Compliance/evidence productization**: SOC 2 / ISO / EU AI Act change-management export as a named enterprise feature. Times with EU AI Act enforcement (Aug 2, 2026). **[moat][thesis]**
+- **Broaden the integration surface** beyond GitHub (GitLab/Bitbucket, CI systems, agent frameworks, IDEs) to deepen lock-in. **[moat]**
+- **Category narrative push**: own "the neutral, self-hostable validation gate" in content, talks, and ecosystem co-marketing. **[gtm]**
+
+**Dependencies:** Phase 2 (paying orgs, policy graph, evidence trail in place).
+
+**Success metric:** MergeWatch cited/positioned as a distinct category ("validation gate") by customers and analysts; multi-product / multi-repo adoption is the norm among paying orgs; measurable feedback-loop precision advantage from accumulated override data.
+
+**Exit criteria:** durable moats demonstrably compounding (policy graph depth, evidence usage, cross-agent coverage, override-driven precision) and a defensible position vs. the three ranked threats.
+
+---
+
+## Sequencing at a glance
+
+```
+Phase 0  ──(gate: Exp-1 ≥1.5×)──▶  Phase 1  ──(gate: required check @ ≥3 orgs)──▶  Phase 2  ──(gate: paying + org-wide)──▶  Phase 3
+Validate                           Wedge                                           Expand                                    Category & moat
+```
+
+**Front-loaded principle:** Phase 0 is deliberately the fastest, cheapest phase and carries the highest kill-power. Everything expensive lives behind a passed experiment.

--- a/docs/strategy/validation-layer-pivot.md
+++ b/docs/strategy/validation-layer-pivot.md
@@ -1,0 +1,148 @@
+# MergeWatch: The Software Validation Layer for the AI Build Era
+
+> **Strategy doc — the master artifact.** Synthesizes market, competitive, positioning, and GTM research into a single wedge + ICP + sequencing decision.
+> **Date:** 2026-07-16 · **Owner:** Santthosh · **Status:** For decision
+> **Companion docs:** [`competitive-matrix.md`](./competitive-matrix.md) · [`positioning.md`](./positioning.md) · [`project-plan.md`](./project-plan.md) · [`backlog.md`](./backlog.md) · [`decision.md`](./decision.md)
+
+---
+
+## TL;DR
+
+The bottleneck in software has moved from **writing** code to **trusting** it. AI now writes ~40–50% of net-new code, adoption is near-total (84% of developers), yet the validation capacity to keep up hasn't scaled — review times are up 91% on high-AI-adoption teams, 45% of AI-generated code fails security tests, and trust is *falling* even as usage rises.
+
+The pivot thesis — that validation becomes the scarce, high-value layer — is **SUPPORTED, with one live threat**: the coding agents (Cursor, Claude Code, Copilot, Devin) and well-funded review incumbents (CodeRabbit at $550M, Qodo at $120M raised) are racing for the same ground. "Validation layer" as a *phrase* is already contested.
+
+**Our defensible wedge is not "better review." It is the one thing a self-reviewing generator and a SaaS-only incumbent structurally cannot be: the neutral, self-hostable, provenance-aware merge gate** — the required check that blocks unsafe changes (human *or* agent) against org policy and records an auditable verdict for every merge.
+
+**Recommendation: GO** — pivot the narrative and product toward the validation gate, but **validate cheaply first** (Experiment #2 below) before heavy build. The moat lives in *independence, policy, and evidence* — not in bug-catching.
+
+---
+
+## 1. The thesis and the evidence
+
+### The shift is real and accelerating
+- GitHub Copilot generates ~46% of code for active users (up from ~27% at launch), 20M+ users. ([source](https://www.getpanto.ai/blog/github-copilot-statistics))
+- Google: >25% → >30% of new code AI-generated in ~6 months, at one of the most mature eng orgs on earth. ([source](https://thehill.com/policy/technology/4962336-google-ceo-says-more-than-25-percent-of-companys-new-code-written-by-ai/))
+- 84% of developers use or plan to use AI tools (Stack Overflow 2025). ([source](https://survey.stackoverflow.co/2025/ai))
+- The frontier is agentic: 25% of YC W25 startups had codebases ~95% AI-generated. ([source](https://techstartups.com/2025/12/11/the-vibe-coding-delusion-why-thousands-of-startups-are-now-paying-the-price-for-ai-generated-technical-debt/))
+
+### The pain has migrated to the validation chokepoint — and it's measurable
+- **Throughput collapse:** high-AI-adoption teams merge 98% more PRs but review time rose 91% and PR size grew 154% (Faros, >10k devs). ([source](https://blog.codacy.com/ai-breaking-code-review-how-engineering-teams-survive-pr-bottleneck))
+- **Stability drop:** DORA 2024 found AI adoption correlated with ~7.2% lower delivery stability; 39.2% distrust AI-generated code. ([source](https://dora.dev/research/2024/dora-report/))
+- **Quality erosion:** copy-pasted code rose 9.4% → 15.7%; refactoring line-moves down ~70% (GitClear, 623M changes). ([source](https://www.gitclear.com/the_ai_code_quality_maintainability_gap))
+- **Security:** AI picks the insecure option in 45% of tasks; 2.74× more vulnerabilities than human code (Veracode 2025). ([source](https://www.businesswire.com/news/home/20250730694951/en/AI-Generated-Code-Poses-Major-Security-Risks-in-Nearly-Half-of-All-Development-Tasks-Veracode-Research-Reveals))
+- **The false-confidence gap (this *is* the market):** ~80% of developers believe AI code is more secure than human code, yet only ~10% scan most of it (Snyk). ([source](https://cloudwars.com/cybersecurity/snyks-ai-code-security-report-reveals-software-developers-false-sense-of-security/))
+- **New attack surface:** ~20% of LLM-recommended packages don't exist ("slopsquatting"). ([source](https://www.bleepingcomputer.com/news/security/ai-hallucinated-code-dependencies-become-new-supply-chain-risk/))
+
+### The market is voting with capital
+Standalone AI code-review/verification startups raised >$1.2B (Jan 2024–Dec 2025). Qodo raised $70M explicitly on "code verification as AI coding scales"; CodeRabbit hit ~$15M+ ARR growing ~20%/mo at a $550M valuation. ([Qodo](https://techcrunch.com/2026/03/30/qodo-bets-on-code-verification-as-ai-coding-scales-raises-70m/) · [CodeRabbit](https://sacra.com/c/coderabbit/))
+
+### The honest counter-evidence (do not wave this away)
+- Coding agents are building verification **in-house and bundling it**: Cursor Security Review + Bugbot, Claude self-validation, Devin self-verify (merged-PR rate 34% → 67%), and **GitHub Copilot code review shipped agentic review at zero incremental cost** to existing seats. ([Cursor/Copilot](https://workos.com/blog/cursor-bugbot-autoreview-claude-code-prs) · [Devin](https://cognition.ai/blog/devin-annual-performance-review-2025))
+- The "validation layer" narrative is **already claimed** by better-funded incumbents: CodeRabbit ("quality gates for AI coding"), Qodo ("code verification"), Sonar ("verify AI code / AI Code Assurance").
+
+**Verdict: SUPPORTED, with a live threat.** The macro case is quantified and strong; the risk is commoditization of "catch obvious bugs" by bundled first-party self-review. Therefore our durable wedge must be what a self-reviewing generator *cannot* own — see §3.
+
+---
+
+## 2. Who we sell to (ICP + beachhead)
+
+**Beachhead: mid-market, high-AI-adoption engineering orgs — Series A–C, ~30–150 engineers (widening to 500) — that have already turned on coding agents at scale and are now drowning in agent-generated PR volume.**
+
+Why this beachhead:
+- **Acute, quantified pain today** — review queues balloon from 8–12 to 25–40 open PRs within months of agent adoption; senior ICs report spending 60–70% of time on review.
+- **They have budget, process, and accountability** — unlike vibe-coding startups (highest pain, lowest willingness to pay), someone's name is on the merge.
+- **Short sales cycles** — sellable without 12-month enterprise procurement.
+- **Natural expansion path up-market** — an audit-trail / compliance angle carries us into regulated mid-market and enterprise as EU AI Act enforcement lands (Aug 2, 2026) and the enterprise AI-governance market grows ($2.2B → $11B+). ([source](https://www.futuremarketinsights.com/reports/enterprise-ai-governance-and-compliance-market))
+
+**Buyer:** VP Eng / Head of Platform / DevEx lead — accountable for "we shipped an AI-written bug to prod." **Champion:** the senior IC who set up the coding agents. **Purchase trigger:** a production incident traced to un-reviewed agent code, or review-queue collapse.
+
+---
+
+## 3. The wedge, the moat, the positioning
+
+### The wedge (synthesized across all four workstreams)
+**The neutral, provenance-aware, blocking merge gate.**
+
+Not the security agent, not the summary, not the diagram — those are commodity and advisory by nature. The sharp entry is **enforcement authority applied differentially to AI-authored code**:
+
+> MergeWatch is the required status check that classifies every PR as human- or agent-authored, applies your org's policy (stricter for agent PRs), **blocks** what doesn't pass, and records a durable, auditable verdict.
+
+Why this wedge wins:
+- **It's ~70% built.** The blocking org-custom-agent gate (#235, `packages/core/src/org-agents.ts`), Check Run integration, and the 1–5 merge-readiness score already exist. We're productizing an asset, not inventing one.
+- **It creates day-one dependency.** An advisory bot gets muted; a required gate gets budget. Removing it becomes a policy decision, not a churn event.
+- **No competitor leads with provenance.** The incumbents attack this as *generic review*, leaving the provenance-aware gate open.
+- **It's the credible on-ramp to "layer."** You can't sell "system of record" cold — but every blocked merge silently accumulates the evidence trail that makes the system-of-record real later.
+
+### The moat — rated honestly
+| Moat | Thickness | Note |
+|---|---|---|
+| **Neutrality / open-source trust** | **Durable & unique** | We don't sell the AI that wrote the code, so we can honestly grade it. CodeRabbit/Qodo/Cursor/Copilot structurally can't tell this story. Our most defensible asset. |
+| **Deployment neutrality (self-host + any LLM, air-gapped)** | **Thick** | Nearly every funded competitor is SaaS-first and cloud-LLM-locked. Real differentiation for regulated/defense/on-prem buyers. |
+| **Org policy graph** | **Thick** | Accumulated org config (which agents, repos, paths, blocking rules) is sticky institutional knowledge; painful to rebuild elsewhere. |
+| **Being the merge gate of record** | **Thick but slow** | Structural lock-in once you're the required check org-wide; Vanta/Datadog dynamic. One high-profile false-block erodes it fast. |
+| **Proprietary feedback loop** | **Medium — only if instrumented now** | Every accept/dismiss/override is a labeled signal. Make override-capture a first-class mechanic *now* or this stays thin. |
+| **The LLM pipeline itself** | **Thin** | Models commoditize monthly. Do not over-invest here. |
+
+**Where to invest: neutrality, deployment flexibility, the policy graph, and the evidence trail — not raw review quality.**
+
+### The positioning line
+> **MergeWatch is the software validation layer for the AI build era — the neutral, self-hostable gate that decides what's safe to merge, for code written by humans or agents.**
+
+Full positioning in [`positioning.md`](./positioning.md).
+
+---
+
+## 4. Product direction — build / keep / drop
+
+**KEEP:** multi-agent pipeline + orchestrator + **merge-readiness score** (the validation primitive); org-defined **blocking custom agents** + Check Run gate; **self-hosted + open-core** dual mode (the moat).
+
+**BUILD:**
+1. **PR provenance detection** — classify human vs. agent-authored (commit trailers, `Co-Authored-By`, bot signatures) and apply differentiated policy. The wedge feature; cheap to build on existing `skip-logic.ts`.
+2. **Validation policy-as-code** — extend `.mergewatch.yml` into a declarative gate ("agent PRs touching `/payments` require passing security agent + human sign-off").
+3. **Validation audit trail / dashboard** — "what we validated, blocked, and shipped anyway" — the compliance artifact enterprises pay for. Builds on the reviews table (`prNumber#commitSha`) and time-to-merge work (#194).
+4. **Override capture** — instrument accept/dismiss to feed the feedback-loop moat.
+5. *(Later)* **Verification depth** — test-generation / diff-coverage signals ("did this PR add tests for what it changed?"). True validation-layer whitespace; expensive.
+
+**REFACTOR:** demote style/diagram agents to optional add-ons; make **check status + score** the primary artifact, comment secondary.
+
+**DROP:** any ambition to be a "general AI reviewer for all PRs." Cede generic review to CodeRabbit/Copilot-native to sharpen positioning.
+
+---
+
+## 5. Go-to-market
+
+**Motion:** open-source-led PLG, bottom-up via GitHub Marketplace, with a sales-assist layer at the 50+ dev / Enterprise line (self-hosted + audit trail).
+
+**Pricing (open-core, hybrid seat + validation-usage — mirroring where the market is converging as agents decouple "developers" from "code volume"):**
+- **Free / OSS** — unlimited on public repos; primary top-of-funnel.
+- **Team — ~$20/dev/mo** incl. a validation quota (~100 validated PRs/dev/mo), then ~$0.50–$1 per additional validation. Deliberately undercuts Greptile's $30 base while capturing agent-volume upside.
+- **Enterprise — ~$45–60/dev/mo (est.)** — self-hosted, SSO, blocking policies, audit trail, SLA.
+- Gate the **enterprise control plane** (org policy management, provenance dashboards, audit/compliance, SSO) in paid; keep pipeline + agents + self-hosted server open. *(Price points are estimates pending Experiment #3.)*
+
+**First 3 channels:** (1) GitHub Marketplace (highest-intent discovery); (2) dogfood + open-source content — publish real provenance data ("we validated N agent PRs, blocked X% for security flaws"); (3) coding-agent ecosystem co-marketing ("the safety net for your agents").
+
+---
+
+## 6. Risks & kill-criteria (summary — full detail in [`decision.md`](./decision.md))
+
+1. **Agents absorb validation** (already partially happening via Copilot-native review). *Kill:* >40% of a customer sample say native self-review is "good enough" and drop independent validation within 2 quarters.
+2. **Market too crowded / commoditized.** *Kill:* CAC > 12-month gross margin for 2 consecutive quarters with no provenance-driven win-rate lift.
+3. **Provenance signal weak / gameable.** *Kill:* classifier accuracy <80% on real customer PR streams.
+4. **Buyers won't pay usage on top of seats.** *Kill:* >30% of Team accounts hit quota and downgrade rather than expand.
+5. **Enterprise motion too heavy for a small team.** *Kill:* median sales cycle >6 months with <20% close after 10 qualified opps.
+
+---
+
+## 7. Decision
+
+**GO on the pivot — sequence as validate-then-build.** The thesis is well-supported and the wedge (neutral, self-hostable, provenance-aware gate) is genuinely defensible against both the self-reviewing generators and the SaaS-only incumbents. But because the space is contested and better-funded, we **do not** open with heavy build. We run the cheapest disproving experiment first:
+
+**Run Experiment #2 (retro provenance analysis) before anything else** — classify historical PRs on our dogfood repo + 3–5 design-partner repos by authorship and measure block/critical-finding rate by cohort. If agent PRs *don't* fail materially more (target ≥1.5× critical-finding rate), the entire wedge collapses cheaply, before we've built it. If they do, we have both proof *and* the killer marketing stat.
+
+Full phased plan in [`project-plan.md`](./project-plan.md); go/no-go and experiments in [`decision.md`](./decision.md).
+
+---
+
+### Sourcing & confidence notes
+Market/security/funding stats trace to named primary studies (GitClear, Veracode, Snyk, DORA, Faros) and are high-confidence. Aggregate "% of code AI-generated" figures come from secondary compilations — directionally reliable, exact digits treated with mild caution. All pricing/valuation figures are cited in [`competitive-matrix.md`](./competitive-matrix.md); estimates are flagged there. Recommended price points and classifier thresholds are strategic estimates pending the validating experiments.

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -208,6 +208,8 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-79](#e2e-79-ux-block--comment-presentation) | `ux` toggles change only their own section; `tone` rewords without changing findings; `commentHeader` is escaped against injection | 3m | 60s | core |
 | [E2E-80](#e2e-80-conventions--discovery-order-and-the-16-kb-cap) | Conventions resolve first-hit-wins in documented order; explicit `conventions:` never falls back on miss; >16 KB truncates with a visible marker | 3m | 60s | core |
 | [E2E-81](#e2e-81-codebase-awareness--file-request-budget) | `codebaseAwareness` fetches out-of-diff files; `maxFileRequestRounds` / `maxContextKB` enforced; hitting the budget degrades gracefully | 3m | 60s | core |
+| [E2E-82](#e2e-82-oss-program--sponsored-review-on-a-granted-public-repo) | OSS grant sponsors a named public repo; unnamed/private/expired all fall back correctly; rename keeps the grant | 5m | 60s | #263, #265 |
+| [E2E-83](#e2e-83-oss-program--operator-grant-lifecycle) | `grant-oss.ts` grant/add/remove/revoke/inspect; `--stage` guard; private repo rejected | 5m | n/a | #266 |
 
 ---
 
@@ -2826,6 +2828,76 @@ curl -s "$MCP_URL" \
 - ❌ An agent describes a file it never fetched (hallucinated context — the exact failure grounding exists to prevent).
 - ❌ The budget is exceeded, inflating cost on large repos.
 - ❌ Hitting the cap fails the review instead of degrading.
+
+---
+
+### E2E-82: OSS Program — sponsored review on a granted public repo
+
+**Status:** ✅ SHIPPED (#263, #265) — fixture not yet run.
+
+**Behavior:** A repository named in an active OSS grant (#261) is reviewed with no balance, no payment method, and no free-tier consumption. Being named is necessary but not sufficient — the repo must also be public at review time, the grant must not have expired, and the month must be under its fair-use cap. See `docs/oss-program.md`.
+
+**Setup**
+
+Branch: `fixture/82-oss-sponsored-review`. Any diff that produces a real review is fine (reuse `fixture/01-clean-pr`).
+
+Prerequisites on the fixtures installation:
+1. Exhaust the free tier (`freeReviewsUsed >= 5`) and leave `balanceCents` at 0 — without a grant this install is blocked.
+2. Grant the fixtures repo: `scripts/grant-oss.ts <owner>/<fixtures-repo> --stage dev`.
+
+**How to run.**
+1. Open a PR. Confirm it is reviewed normally despite zero balance.
+2. Confirm the free-tier counter did **not** move and `balanceCents` is unchanged.
+3. Confirm `ossSponsoredCentsThisPeriod` and `ossSponsoredCentsLifetime` increased by the review's cost.
+4. Open a PR on a **different** public repo in the same installation that is *not* named in the grant → confirm it is blocked (credits copy).
+5. Flip the granted repo to private, push again → confirm the next review is **not** sponsored.
+6. Rename the granted repo, push again → confirm it **is** still sponsored (grants match on the numeric repo id).
+7. Revoke the grant (`--revoke`) and push again → confirm it falls back to the free tier, not straight to a block.
+
+**Pass:**
+- [ ] Sponsored review completes with zero balance and no card on file.
+- [ ] `freeReviewsUsed` unchanged; `balanceCents` unchanged; no Stripe activity.
+- [ ] Both sponsored-cost counters increase by the review's cost.
+- [ ] An unnamed public repo in the same installation is still gated.
+- [ ] Flipping the repo private stops sponsorship on the next review.
+- [ ] Renaming the repo does **not** stop sponsorship.
+- [ ] A revoked grant degrades to the free tier.
+
+**Fail signals:**
+- ❌ A sponsored review consumes the free tier — a lapsed grant would then block the maintainer and file a "credits required" issue on their public repo.
+- ❌ An unnamed repo in a granted installation is sponsored (open-core leak).
+- ❌ A repo flipped private stays sponsored (the cost leak an approval-time check cannot catch).
+- ❌ Any Stripe call on the sponsored path.
+
+---
+
+### E2E-83: OSS Program — operator grant lifecycle
+
+**Status:** ✅ SHIPPED (#266) — fixture not yet run.
+
+**Behavior:** `scripts/grant-oss.ts` is the only way a grant is written. It resolves a repo to its installation via an App JWT, verifies the repo is public, shows the blast radius, and refuses to run without an explicit `--stage`.
+
+**How to run.**
+1. `scripts/grant-oss.ts <owner>/<repo>` with no `--stage` → confirm it refuses rather than defaulting to prod.
+2. `--inspect` on an ungranted repo → confirm it reports no grant.
+3. Grant with `--stage dev --cap 500 --months 1`; confirm the confirmation prompt lists the covered repo **and** the installation's other repos that are *not* covered.
+4. `--inspect` again → confirm cap, expiry, `ossGrantedAt`, and `ossGrantNote` render back.
+5. `--add` a second repo, then `--remove` it; confirm the list changes and nothing else does.
+6. Attempt to grant a **private** repo → confirm it refuses.
+7. `--revoke`; confirm expiry moves to the past and `--inspect` reports it inactive.
+
+**Pass:**
+- [ ] Refuses to run without `--stage`.
+- [ ] Private repo is rejected at grant time.
+- [ ] Blast radius lists both covered and uncovered repos before writing.
+- [ ] `--add` / `--remove` mutate only the repo list.
+- [ ] `--inspect` renders provenance (`ossGrantedAt`, `ossGrantNote`) for auditing months later.
+- [ ] `--revoke` leaves the install on the standard gate, not blocked.
+
+**Fail signals:**
+- ❌ Runs against prod without an explicit stage.
+- ❌ Grants a private repo.
+- ❌ Writes without showing what it will cover.
 
 ---
 

--- a/packages/billing/src/billing-check.test.ts
+++ b/packages/billing/src/billing-check.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { billingCheck } from './billing-check';
+import { billingCheck, isLapsedOssGrant } from './billing-check';
 import { FREE_REVIEW_LIMIT, MIN_BALANCE_CENTS } from './constants';
 
 // Mock the DynamoDB layer — we test billing logic, not DynamoDB calls
@@ -144,7 +144,9 @@ describe('billingCheck — OSS Program (#261)', () => {
       freeReviewsUsed: 0,
     });
     const result = await billingCheck(client, table, installationId, grantedRepo);
-    expect(result).toEqual({ status: 'allow', firstBlock: false, reason: 'free_tier' });
+    expect(result).toEqual({
+      status: 'allow', firstBlock: false, reason: 'free_tier', ossReason: 'grant_expired',
+    });
   });
 
   it('falls through to the standard gate when over the fair-use cap', async () => {
@@ -156,7 +158,9 @@ describe('billingCheck — OSS Program (#261)', () => {
       balanceCents: 10_000,
     });
     const result = await billingCheck(client, table, installationId, grantedRepo);
-    expect(result).toEqual({ status: 'allow', firstBlock: false, reason: 'paid' });
+    expect(result).toEqual({
+      status: 'allow', firstBlock: false, reason: 'paid', ossReason: 'cap_exceeded',
+    });
   });
 
   it('is byte-for-byte pre-#261 when repo context is omitted', async () => {
@@ -164,5 +168,24 @@ describe('billingCheck — OSS Program (#261)', () => {
     mockGetFields.mockResolvedValue({ ...exhausted, ...activeGrant });
     const result = await billingCheck(client, table, installationId);
     expect(result.status).toBe('block');
+    // Self-describing rather than undefined; isLapsedOssGrant treats it as false,
+    // so the block copy stays the standard credits wording.
+    expect(result.ossReason).toBe('no_repo_context');
+  });
+});
+
+describe('isLapsedOssGrant', () => {
+  it('is true only for a grant relationship that lapsed or hit its ceiling', () => {
+    expect(isLapsedOssGrant('grant_expired')).toBe(true);
+    expect(isLapsedOssGrant('cap_exceeded')).toBe(true);
+  });
+
+  it('is false when the repo was simply never sponsored', () => {
+    // These get standard billing copy — there is no grant to renew.
+    expect(isLapsedOssGrant('no_grant')).toBe(false);
+    expect(isLapsedOssGrant('repo_not_granted')).toBe(false);
+    expect(isLapsedOssGrant('repo_not_public')).toBe(false);
+    expect(isLapsedOssGrant('no_repo_context')).toBe(false);
+    expect(isLapsedOssGrant(undefined)).toBe(false);
   });
 });

--- a/packages/billing/src/billing-check.test.ts
+++ b/packages/billing/src/billing-check.test.ts
@@ -96,3 +96,73 @@ describe('billingCheck', () => {
     await expect(billingCheck(client, table, installationId)).rejects.toThrow('DynamoDB timeout');
   });
 });
+
+describe('billingCheck — OSS Program (#261)', () => {
+  const REPO_ID = 4242;
+  const grantedRepo = { repoId: REPO_ID, repoFullName: 'octocat/hello-world', isPublic: true };
+
+  /** Exhausted free tier + zero balance: without a grant this install is blocked. */
+  const exhausted = {
+    freeReviewsUsed: FREE_REVIEW_LIMIT,
+    balanceCents: 0,
+  };
+
+  const activeGrant = {
+    ossGrantRepos: [{ id: REPO_ID, fullName: 'octocat/hello-world' }],
+    ossGrantExpiresAt: '2099-01-01T00:00:00.000Z',
+    ossMonthlyCapCents: 2000,
+  };
+
+  it('allows with reason=oss for a named public repo, even with no free tier and no balance', async () => {
+    mockGetFields.mockResolvedValue({ ...exhausted, ...activeGrant });
+    const result = await billingCheck(client, table, installationId, grantedRepo);
+    expect(result).toEqual({ status: 'allow', firstBlock: false, reason: 'oss' });
+  });
+
+  it('blocks an unnamed public repo in the same installation', async () => {
+    mockGetFields.mockResolvedValue({ ...exhausted, ...activeGrant });
+    const other = { repoId: 9999, repoFullName: 'octocat/commercial', isPublic: true };
+    const result = await billingCheck(client, table, installationId, other);
+    expect(result.status).toBe('block');
+  });
+
+  it('blocks a named repo that has been flipped private', async () => {
+    mockGetFields.mockResolvedValue({ ...exhausted, ...activeGrant });
+    const result = await billingCheck(client, table, installationId, {
+      ...grantedRepo,
+      isPublic: false,
+    });
+    expect(result.status).toBe('block');
+  });
+
+  it('falls back to the free tier — not a block — when the grant has expired', async () => {
+    // A lapsed grant must land softly on the 5 free reviews every install gets,
+    // never straight to a "credits required" issue on a public OSS repo.
+    mockGetFields.mockResolvedValue({
+      ...activeGrant,
+      ossGrantExpiresAt: '2020-01-01T00:00:00.000Z',
+      freeReviewsUsed: 0,
+    });
+    const result = await billingCheck(client, table, installationId, grantedRepo);
+    expect(result).toEqual({ status: 'allow', firstBlock: false, reason: 'free_tier' });
+  });
+
+  it('falls through to the standard gate when over the fair-use cap', async () => {
+    mockGetFields.mockResolvedValue({
+      ...activeGrant,
+      ossPeriod: new Date().toISOString().slice(0, 7),
+      ossSponsoredCentsThisPeriod: 2000,
+      freeReviewsUsed: FREE_REVIEW_LIMIT,
+      balanceCents: 10_000,
+    });
+    const result = await billingCheck(client, table, installationId, grantedRepo);
+    expect(result).toEqual({ status: 'allow', firstBlock: false, reason: 'paid' });
+  });
+
+  it('is byte-for-byte pre-#261 when repo context is omitted', async () => {
+    // The MCP path calls this with three arguments and must be unaffected.
+    mockGetFields.mockResolvedValue({ ...exhausted, ...activeGrant });
+    const result = await billingCheck(client, table, installationId);
+    expect(result.status).toBe('block');
+  });
+});

--- a/packages/billing/src/billing-check.ts
+++ b/packages/billing/src/billing-check.ts
@@ -1,6 +1,8 @@
 import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { getBillingFields } from './dynamo-billing';
 import { FREE_REVIEW_LIMIT, MIN_BALANCE_CENTS } from './constants';
+import { evaluateOssGrant } from './oss-grant';
+import type { RepoContext } from './oss-grant';
 
 export interface BillingCheckResult {
   /** Whether the review is allowed. */
@@ -10,36 +12,64 @@ export interface BillingCheckResult {
    * (no prior blockedAt timestamp). Used to decide whether to file a GitHub Issue.
    */
   firstBlock: boolean;
+  /**
+   * Why the review was allowed. `oss` means the cost is sponsored under the
+   * OSS Program and must not be charged or counted against the free tier —
+   * `recordReview` re-derives this rather than trusting it, but callers use it
+   * for logging and for the dashboard's billing state.
+   */
+  reason?: 'oss' | 'free_tier' | 'paid';
 }
 
 /**
  * Determine whether an installation is allowed to run a review.
  *
  * Decision tree:
- *   1. freeReviewsUsed < FREE_REVIEW_LIMIT → allow (free tier)
- *   2. balanceCents >= MIN_BALANCE_CENTS → allow (paid)
- *   3. Otherwise → block
+ *   1. Covered by an active OSS grant → allow (sponsored, #261)
+ *   2. freeReviewsUsed < FREE_REVIEW_LIMIT → allow (free tier)
+ *   3. balanceCents >= MIN_BALANCE_CENTS → allow (paid)
+ *   4. Otherwise → block
+ *
+ * `repo` is optional. Omit it and the OSS branch is skipped entirely, leaving
+ * behavior byte-for-byte identical to pre-#261 — that's what lets the MCP path
+ * keep calling this with three arguments.
  */
 export async function billingCheck(
   client: DynamoDBDocumentClient,
   table: string,
   installationId: string,
+  repo?: RepoContext,
 ): Promise<BillingCheckResult> {
   const fields = await getBillingFields(client, table, installationId);
 
   const freeUsed = fields.freeReviewsUsed ?? 0;
   const balanceCents = fields.balanceCents ?? 0;
 
+  // OSS Program path — sponsored, so it never touches the free tier or balance.
+  // Falling through on an ineligible result is deliberate: an expired grant or
+  // a month over its fair-use cap degrades to normal billing instead of
+  // blocking a maintainer outright.
+  const oss = evaluateOssGrant(fields, repo);
+  if (oss.eligible) {
+    console.log(`[billing] allow install=${installationId} reason=oss repo=${repo?.repoFullName}`);
+    return { status: 'allow', firstBlock: false, reason: 'oss' };
+  }
+  if (repo && oss.reason !== 'no_grant') {
+    console.log(
+      `[billing] oss not applied install=${installationId} repo=${repo.repoFullName} reason=${oss.reason}`,
+    );
+  }
+
   // Free tier path
   if (freeUsed < FREE_REVIEW_LIMIT) {
     console.log(`[billing] allow install=${installationId} reason=free_tier used=${freeUsed}/${FREE_REVIEW_LIMIT}`);
-    return { status: 'allow', firstBlock: false };
+    return { status: 'allow', firstBlock: false, reason: 'free_tier' };
   }
 
   // Paid path
   if (balanceCents >= MIN_BALANCE_CENTS) {
     console.log(`[billing] allow install=${installationId} reason=paid balance=${balanceCents}c`);
-    return { status: 'allow', firstBlock: false };
+    return { status: 'allow', firstBlock: false, reason: 'paid' };
   }
 
   // Blocked

--- a/packages/billing/src/billing-check.ts
+++ b/packages/billing/src/billing-check.ts
@@ -2,7 +2,7 @@ import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { getBillingFields } from './dynamo-billing';
 import { FREE_REVIEW_LIMIT, MIN_BALANCE_CENTS } from './constants';
 import { evaluateOssGrant } from './oss-grant';
-import type { RepoContext } from './oss-grant';
+import type { RepoContext, OssIneligibleReason } from './oss-grant';
 
 export interface BillingCheckResult {
   /** Whether the review is allowed. */
@@ -19,6 +19,24 @@ export interface BillingCheckResult {
    * for logging and for the dashboard's billing state.
    */
   reason?: 'oss' | 'free_tier' | 'paid';
+  /**
+   * Why the OSS grant did not apply, when repo context was supplied and the
+   * review wasn't sponsored. Lets the block path tell a lapsed or over-cap
+   * maintainer something useful ("your grant expired") instead of the generic
+   * "add a credit card", which is the wrong thing to say to someone we invited
+   * into a free program.
+   */
+  ossReason?: OssIneligibleReason;
+}
+
+/**
+ * Reasons that warrant OSS-specific block copy: the installation has a real
+ * grant relationship that lapsed or hit its ceiling. The others
+ * (`no_grant`, `repo_not_granted`, `repo_not_public`) mean this repo was never
+ * sponsored, so standard billing copy is correct.
+ */
+export function isLapsedOssGrant(reason: OssIneligibleReason | undefined): boolean {
+  return reason === 'grant_expired' || reason === 'cap_exceeded';
 }
 
 /**
@@ -54,6 +72,9 @@ export async function billingCheck(
     console.log(`[billing] allow install=${installationId} reason=oss repo=${repo?.repoFullName}`);
     return { status: 'allow', firstBlock: false, reason: 'oss' };
   }
+  // Always the concrete reason — `no_repo_context` when OSS wasn't evaluated at
+  // all. Self-describing beats an undefined a reader has to reason about.
+  const ossReason = oss.reason;
   if (repo && oss.reason !== 'no_grant') {
     console.log(
       `[billing] oss not applied install=${installationId} repo=${repo.repoFullName} reason=${oss.reason}`,
@@ -63,17 +84,17 @@ export async function billingCheck(
   // Free tier path
   if (freeUsed < FREE_REVIEW_LIMIT) {
     console.log(`[billing] allow install=${installationId} reason=free_tier used=${freeUsed}/${FREE_REVIEW_LIMIT}`);
-    return { status: 'allow', firstBlock: false, reason: 'free_tier' };
+    return { status: 'allow', firstBlock: false, reason: 'free_tier', ossReason };
   }
 
   // Paid path
   if (balanceCents >= MIN_BALANCE_CENTS) {
     console.log(`[billing] allow install=${installationId} reason=paid balance=${balanceCents}c`);
-    return { status: 'allow', firstBlock: false, reason: 'paid' };
+    return { status: 'allow', firstBlock: false, reason: 'paid', ossReason };
   }
 
   // Blocked
   const firstBlock = !fields.blockedAt;
   console.log(`[billing] block install=${installationId} balance=${balanceCents}c firstBlock=${firstBlock}`);
-  return { status: 'block', firstBlock };
+  return { status: 'block', firstBlock, ossReason };
 }

--- a/packages/billing/src/block-notify.test.ts
+++ b/packages/billing/src/block-notify.test.ts
@@ -172,3 +172,41 @@ describe('postBlockedCheckRun', () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// OSS Program block copy (#261)
+// ---------------------------------------------------------------------------
+
+describe('block notifications — OSS variant (#261)', () => {
+  it('defaults to credits copy, unchanged from pre-#261', async () => {
+    const octokit = createMockOctokit();
+    await postBlockedCheckRun(octokit, owner, repo, 'sha123');
+
+    const { output } = octokit.checks.create.mock.calls[0][0];
+    expect(output.title).toContain('credits required');
+    expect(output.summary).toContain('dashboard/billing');
+  });
+
+  it('points a lapsed OSS grant at renewal and BYOK, never at a credit card', async () => {
+    const octokit = createMockOctokit();
+    await postBlockedCheckRun(octokit, owner, repo, 'sha123', 'oss');
+
+    const { output } = octokit.checks.create.mock.calls[0][0];
+    expect(output.title).toContain('open-source grant');
+    expect(output.summary).toContain('mergewatch.ai/open-source');
+    expect(output.summary).not.toContain('dashboard/billing');
+    expect(output.summary).not.toContain('add credits');
+  });
+
+  it('files an OSS-worded issue rather than a credits one', async () => {
+    const octokit = createMockOctokit();
+    const client = createMockDynamo();
+
+    await ensureBillingIssue(octokit, owner, repo, 'inst-1', client, 'tbl', 'oss');
+
+    const issue = octokit.issues.create.mock.calls[0][0];
+    expect(issue.title).toContain('open-source grant');
+    expect(issue.body).toContain('there is no charge');
+    expect(issue.body).not.toContain('dashboard/billing');
+  });
+});

--- a/packages/billing/src/block-notify.ts
+++ b/packages/billing/src/block-notify.ts
@@ -14,20 +14,42 @@ const SETTINGS_SK = '#SETTINGS';
 
 type Octokit = Parameters<typeof createCheckRun>[0];
 
+/**
+ * Copy variant for the block notifications.
+ *
+ * `oss` is used when the installation had an OSS Program grant that lapsed or
+ * hit its fair-use ceiling (#261). Telling an open-source maintainer we
+ * invited into a free program to "add a credit card" is the wrong message —
+ * the public page promises heavy usage moves to bring-your-own-key or
+ * sponsorship, so the copy points there instead.
+ */
+export type BlockVariant = 'credits' | 'oss';
+
+const OSS_PROGRAM_URL = 'https://mergewatch.ai/open-source';
+const BILLING_URL = 'https://mergewatch.ai/dashboard/billing';
+
 /** Post a Check Run indicating the review was blocked by billing. */
 export async function postBlockedCheckRun(
   octokit: Octokit,
   owner: string,
   repo: string,
   sha: string,
+  variant: BlockVariant = 'credits',
 ): Promise<void> {
+  const oss = variant === 'oss';
   await createCheckRun(octokit, owner, repo, sha, {
     status: 'completed',
     conclusion: 'action_required',
-    title: 'Review blocked — credits required',
-    summary:
-      'This PR was not reviewed because this installation has no remaining credits. '
-      + 'Please add credits at https://mergewatch.ai/dashboard/billing to resume reviews.',
+    title: oss
+      ? 'Review paused — open-source grant needs renewing'
+      : 'Review blocked — credits required',
+    summary: oss
+      ? 'This PR was not reviewed because this project\'s MergeWatch open-source '
+        + 'grant has expired or reached its fair-use limit for this month. '
+        + `Get in touch via ${OSS_PROGRAM_URL} to renew it, or switch to `
+        + 'bring-your-own-key or self-hosting — both are free and unlimited.'
+      : 'This PR was not reviewed because this installation has no remaining credits. '
+        + `Please add credits at ${BILLING_URL} to resume reviews.`,
   });
 }
 
@@ -42,6 +64,7 @@ export async function ensureBillingIssue(
   installationId: string,
   client: DynamoDBDocumentClient,
   table: string,
+  variant: BlockVariant = 'credits',
 ): Promise<void> {
   // Atomically claim the right to create the issue
   try {
@@ -69,13 +92,23 @@ export async function ensureBillingIssue(
     const issue = await octokit.issues.create({
       owner,
       repo,
-      title: 'MergeWatch: reviews paused — credits required',
-      body:
-        'MergeWatch has paused PR reviews for this repository because the installation '
-        + 'has used all free reviews and has no remaining credits.\n\n'
-        + 'To resume reviews, please add credits at '
-        + '[mergewatch.ai/dashboard/billing](https://mergewatch.ai/dashboard/billing).\n\n'
-        + 'This issue will be closed automatically once credits are added.',
+      title: variant === 'oss'
+        ? 'MergeWatch: reviews paused — open-source grant needs renewing'
+        : 'MergeWatch: reviews paused — credits required',
+      body: variant === 'oss'
+        ? 'MergeWatch has paused PR reviews for this repository because its '
+          + 'open-source grant has expired or reached its fair-use limit for '
+          + 'this month.\n\n'
+          + `Reply here or get in touch via [mergewatch.ai/open-source](${OSS_PROGRAM_URL}) `
+          + 'and we will renew it — there is no charge.\n\n'
+          + 'If this project has outgrown the program, bring-your-own-key and '
+          + 'self-hosting are both free and unlimited.\n\n'
+          + 'This issue will be closed automatically once reviews resume.'
+        : 'MergeWatch has paused PR reviews for this repository because the installation '
+          + 'has used all free reviews and has no remaining credits.\n\n'
+          + 'To resume reviews, please add credits at '
+          + `[mergewatch.ai/dashboard/billing](${BILLING_URL}).\n\n`
+          + 'This issue will be closed automatically once credits are added.',
       labels: ['mergewatch'],
     });
     issueNumber = issue.data.number;

--- a/packages/billing/src/constants.ts
+++ b/packages/billing/src/constants.ts
@@ -12,3 +12,14 @@ export const MIN_BALANCE_USD = 0.05;
 
 /** Minimum balance in cents (derived from MIN_BALANCE_USD). */
 export const MIN_BALANCE_CENTS = Math.round(MIN_BALANCE_USD * 100);
+
+/**
+ * #261 — Default fair-use ceiling for an OSS grant, per calendar month, shared
+ * across every repo named in the grant. At the $0.01–$0.10 per-review range
+ * this is ~200–2000 reviews: generous for any real OSS project while bounding
+ * a runaway repo. Overridable per grant via `scripts/grant-oss.sh --cap`.
+ */
+export const OSS_DEFAULT_MONTHLY_CAP_CENTS = 2000;
+
+/** #261 — Default OSS grant term in months, after which it needs renewal. */
+export const OSS_DEFAULT_TERM_MONTHS = 12;

--- a/packages/billing/src/dynamo-billing.test.ts
+++ b/packages/billing/src/dynamo-billing.test.ts
@@ -4,6 +4,7 @@ import {
   incrementFreeReviewsUsed,
   deductBalance,
   deductBalanceAndRecordUsage,
+  accrueOssSponsoredCost,
   updateBillingFields,
 } from './dynamo-billing';
 
@@ -156,5 +157,81 @@ describe('updateBillingFields', () => {
     expect(input.ExpressionAttributeNames['#balanceCents']).toBe('balanceCents');
     expect(input.ExpressionAttributeNames['#blockedAt']).toBe('blockedAt');
     expect(input.ExpressionAttributeValues[':balanceCents']).toBe(1000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// accrueOssSponsoredCost (#261)
+// ---------------------------------------------------------------------------
+
+describe('accrueOssSponsoredCost', () => {
+  /** Mimics DynamoDB rejecting the same-period ADD because ossPeriod differs. */
+  function conditionalCheckFailure() {
+    const err = new Error('The conditional request failed');
+    err.name = 'ConditionalCheckFailedException';
+    return err;
+  }
+
+  it('atomically ADDs both counters when the period matches', async () => {
+    const client = createMockClient();
+
+    await accrueOssSponsoredCost(client, table, installationId, 33, '2026-08');
+
+    expect(client.send).toHaveBeenCalledTimes(1);
+    const input = client.send.mock.calls[0][0].input;
+    expect(input.UpdateExpression).toContain('ADD ossSponsoredCentsThisPeriod :amount');
+    expect(input.UpdateExpression).toContain('ossSponsoredCentsLifetime :amount');
+    expect(input.ConditionExpression).toBe('ossPeriod = :period');
+    expect(input.ExpressionAttributeValues[':amount']).toBe(33);
+    expect(input.ExpressionAttributeValues[':period']).toBe('2026-08');
+  });
+
+  it('resets the period counter when the month rolls over', async () => {
+    const client = {
+      send: vi.fn()
+        .mockRejectedValueOnce(conditionalCheckFailure())
+        .mockResolvedValueOnce({}),
+    } as any;
+
+    await accrueOssSponsoredCost(client, table, installationId, 33, '2026-09');
+
+    expect(client.send).toHaveBeenCalledTimes(2);
+    const input = client.send.mock.calls[1][0].input;
+    // Period counter is SET to this review's cost, lifetime still accumulates.
+    expect(input.UpdateExpression).toContain('SET ossPeriod = :period');
+    expect(input.UpdateExpression).toContain('ossSponsoredCentsThisPeriod = :amount');
+    expect(input.UpdateExpression).toContain('ADD ossSponsoredCentsLifetime :amount');
+  });
+
+  it('takes the reset path on the very first accrual (no ossPeriod yet)', async () => {
+    const client = {
+      send: vi.fn()
+        .mockRejectedValueOnce(conditionalCheckFailure())
+        .mockResolvedValueOnce({}),
+    } as any;
+
+    await accrueOssSponsoredCost(client, table, installationId, 12, '2026-08');
+
+    expect(client.send).toHaveBeenCalledTimes(2);
+  });
+
+  it('rethrows a non-conditional DynamoDB error instead of silently resetting', async () => {
+    const client = {
+      send: vi.fn().mockRejectedValue(new Error('DynamoDB timeout')),
+    } as any;
+
+    await expect(
+      accrueOssSponsoredCost(client, table, installationId, 33, '2026-08'),
+    ).rejects.toThrow('DynamoDB timeout');
+    expect(client.send).toHaveBeenCalledTimes(1);
+  });
+
+  it('writes to the #SETTINGS sentinel row', async () => {
+    const client = createMockClient();
+    await accrueOssSponsoredCost(client, table, installationId, 33, '2026-08');
+    expect(client.send.mock.calls[0][0].input.Key).toEqual({
+      installationId,
+      repoFullName: '#SETTINGS',
+    });
   });
 });

--- a/packages/billing/src/dynamo-billing.ts
+++ b/packages/billing/src/dynamo-billing.ts
@@ -22,7 +22,13 @@ export async function getBillingFields(
       'freeReviewsUsed, stripeCustomerId, balanceCents, billingPeriod, '
       + 'prCount, prTimestamps, totalBilledCents, autoReloadEnabled, '
       + 'autoReloadThresholdCents, autoReloadAmountCents, autoReloadInFlight, '
-      + 'blockedAt, blockIssueNumber, blockIssueRepo',
+      + 'blockedAt, blockIssueNumber, blockIssueRepo, '
+      // OSS Program (#261). Omitting a field here reads it back as undefined
+      // with no error, which would silently disable sponsorship — keep this
+      // list in sync with BillingFields.
+      + 'ossGrantRepos, ossGrantExpiresAt, ossGrantedAt, ossGrantNote, '
+      + 'ossMonthlyCapCents, ossPeriod, ossSponsoredCentsThisPeriod, '
+      + 'ossSponsoredCentsLifetime',
   }));
 
   return (result.Item as BillingFields) ?? {};
@@ -104,6 +110,54 @@ export async function deductBalanceAndRecordUsage(
       ':period': params.billingPeriod,
       ':timestamps': params.prTimestamps,
     },
+  }));
+}
+
+/**
+ * #261 — Atomically accrue a sponsored review's cost against the OSS grant.
+ *
+ * Two paths, because DynamoDB can't branch between ADD and SET in one
+ * expression:
+ *   1. Same period → `ADD` both counters. Atomic, so concurrent reviews across
+ *      repos in the same installation can't lose an increment.
+ *   2. Period rolled over (or first ever accrual) → `SET` the period counter to
+ *      this review's cost while still `ADD`-ing lifetime.
+ *
+ * Two reviews racing across a month boundary can both take path 2, and one
+ * overwrites the other's period counter. That undercounts a fair-use figure by
+ * one review at the rollover instant and is not worth a transaction; the
+ * lifetime counter stays exact because it is always an ADD.
+ */
+export async function accrueOssSponsoredCost(
+  client: DynamoDBDocumentClient,
+  table: string,
+  installationId: string,
+  amountCents: number,
+  period: string,
+): Promise<void> {
+  const key = { installationId, repoFullName: SETTINGS_SK };
+
+  try {
+    await client.send(new UpdateCommand({
+      TableName: table,
+      Key: key,
+      UpdateExpression:
+        'ADD ossSponsoredCentsThisPeriod :amount, ossSponsoredCentsLifetime :amount',
+      ConditionExpression: 'ossPeriod = :period',
+      ExpressionAttributeValues: { ':amount': amountCents, ':period': period },
+    }));
+    return;
+  } catch (err) {
+    if ((err as { name?: string }).name !== 'ConditionalCheckFailedException') throw err;
+  }
+
+  await client.send(new UpdateCommand({
+    TableName: table,
+    Key: key,
+    UpdateExpression:
+      'SET ossPeriod = :period, ossSponsoredCentsThisPeriod = :amount '
+      + 'ADD ossSponsoredCentsLifetime :amount',
+    ExpressionAttributeValues: { ':amount': amountCents, ':period': period },
   }));
 }
 

--- a/packages/billing/src/index.ts
+++ b/packages/billing/src/index.ts
@@ -26,7 +26,7 @@ export { calculateReviewCost } from './cost';
 export type { ReviewCost } from './cost';
 
 // ─── Billing check ──────────────────────────────────────────────────────────
-export { billingCheck } from './billing-check';
+export { billingCheck, isLapsedOssGrant } from './billing-check';
 export type { BillingCheckResult } from './billing-check';
 
 // ─── Record review ──────────────────────────────────────────────────────────
@@ -44,6 +44,7 @@ export {
 
 // ─── Block notifications ────────────────────────────────────────────────────
 export { postBlockedCheckRun, ensureBillingIssue, closeBillingIssue } from './block-notify';
+export type { BlockVariant } from './block-notify';
 
 // ─── Stripe client ──────────────────────────────────────────────────────────
 export { getStripe } from './stripe-client';

--- a/packages/billing/src/index.ts
+++ b/packages/billing/src/index.ts
@@ -9,7 +9,17 @@ export {
   MARGIN_PERCENT,
   MIN_BALANCE_USD,
   MIN_BALANCE_CENTS,
+  OSS_DEFAULT_MONTHLY_CAP_CENTS,
+  OSS_DEFAULT_TERM_MONTHS,
 } from './constants';
+
+// ─── OSS Program grant (#261) ───────────────────────────────────────────────
+export {
+  evaluateOssGrant,
+  currentPeriod,
+  sponsoredCentsThisPeriod,
+} from './oss-grant';
+export type { RepoContext, OssEligibility, OssIneligibleReason } from './oss-grant';
 
 // ─── Cost calculation ───────────────────────────────────────────────────────
 export { calculateReviewCost } from './cost';
@@ -28,6 +38,7 @@ export {
   incrementFreeReviewsUsed,
   deductBalance,
   deductBalanceAndRecordUsage,
+  accrueOssSponsoredCost,
   updateBillingFields,
 } from './dynamo-billing';
 

--- a/packages/billing/src/oss-grant.test.ts
+++ b/packages/billing/src/oss-grant.test.ts
@@ -1,0 +1,194 @@
+/**
+ * #261 — OSS Program grant evaluation.
+ *
+ * The predicate both the gate and the accrual path depend on, so the negative
+ * cases matter as much as the positive one: a false positive sponsors work we
+ * didn't approve, and a false negative silently bills a maintainer we promised
+ * free review.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  evaluateOssGrant,
+  currentPeriod,
+  sponsoredCentsThisPeriod,
+} from './oss-grant';
+import type { RepoContext } from './oss-grant';
+import type { BillingFields } from '@mergewatch/core';
+
+const NOW = new Date('2026-08-12T00:00:00.000Z');
+const PERIOD = '2026-08';
+
+const GRANTED_REPO_ID = 4242;
+
+const grantedRepo: RepoContext = {
+  repoId: GRANTED_REPO_ID,
+  repoFullName: 'octocat/hello-world',
+  isPublic: true,
+};
+
+/** An active grant covering exactly `GRANTED_REPO_ID`, expiring in ~4 months. */
+function activeGrant(overrides: Partial<BillingFields> = {}): BillingFields {
+  return {
+    ossGrantRepos: [{ id: GRANTED_REPO_ID, fullName: 'octocat/hello-world' }],
+    ossGrantExpiresAt: '2026-12-01T00:00:00.000Z',
+    ossMonthlyCapCents: 2000,
+    ...overrides,
+  };
+}
+
+describe('evaluateOssGrant', () => {
+  it('sponsors a named public repo under an active grant', () => {
+    expect(evaluateOssGrant(activeGrant(), grantedRepo, NOW)).toEqual({ eligible: true });
+  });
+
+  it('skips evaluation entirely when no repo context is supplied', () => {
+    // The MCP path calls billingCheck with three args; that must stay pre-#261.
+    expect(evaluateOssGrant(activeGrant(), undefined, NOW)).toEqual({
+      eligible: false,
+      reason: 'no_repo_context',
+    });
+  });
+
+  it('does not sponsor an installation with no grant at all', () => {
+    expect(evaluateOssGrant({}, grantedRepo, NOW)).toEqual({
+      eligible: false,
+      reason: 'no_grant',
+    });
+  });
+
+  it('does not sponsor when the grant names no repos', () => {
+    // An empty list is not "all repos" — there is no installation-wide mode.
+    const fields = activeGrant({ ossGrantRepos: [] });
+    expect(evaluateOssGrant(fields, grantedRepo, NOW)).toEqual({
+      eligible: false,
+      reason: 'no_grant',
+    });
+  });
+
+  it('does not sponsor an UNNAMED public repo in the same installation', () => {
+    // The open-core case: a genuinely-OSS repo alongside public-but-commercial
+    // ones. Only the named repo is sponsored.
+    const otherRepo: RepoContext = {
+      repoId: 9999,
+      repoFullName: 'octocat/commercial-product',
+      isPublic: true,
+    };
+    expect(evaluateOssGrant(activeGrant(), otherRepo, NOW)).toEqual({
+      eligible: false,
+      reason: 'repo_not_granted',
+    });
+  });
+
+  it('does not sponsor a named repo that is private', () => {
+    // Being named is necessary but not sufficient.
+    const privateRepo: RepoContext = { ...grantedRepo, isPublic: false };
+    expect(evaluateOssGrant(activeGrant(), privateRepo, NOW)).toEqual({
+      eligible: false,
+      reason: 'repo_not_public',
+    });
+  });
+
+  it('stops sponsoring a named repo the moment it is flipped private', () => {
+    // The actual cost leak an approval-time snapshot cannot catch.
+    const fields = activeGrant();
+    expect(evaluateOssGrant(fields, grantedRepo, NOW).eligible).toBe(true);
+    expect(evaluateOssGrant(fields, { ...grantedRepo, isPublic: false }, NOW)).toEqual({
+      eligible: false,
+      reason: 'repo_not_public',
+    });
+  });
+
+  it('keeps sponsoring a repo that was renamed or transferred', () => {
+    // full_name changed, numeric id did not. Matching on the name here would
+    // lapse the grant and file a "credits required" issue on a public OSS repo.
+    const renamed: RepoContext = {
+      repoId: GRANTED_REPO_ID,
+      repoFullName: 'new-org/renamed-project',
+      isPublic: true,
+    };
+    expect(evaluateOssGrant(activeGrant(), renamed, NOW)).toEqual({ eligible: true });
+  });
+
+  it('does not sponsor once the grant has expired', () => {
+    const fields = activeGrant({ ossGrantExpiresAt: '2026-08-01T00:00:00.000Z' });
+    expect(evaluateOssGrant(fields, grantedRepo, NOW)).toEqual({
+      eligible: false,
+      reason: 'grant_expired',
+    });
+  });
+
+  it('treats a revoked grant (expiry set to the past) as expired', () => {
+    const fields = activeGrant({ ossGrantExpiresAt: '2020-01-01T00:00:00.000Z' });
+    expect(evaluateOssGrant(fields, grantedRepo, NOW).eligible).toBe(false);
+  });
+
+  it('fails closed on an unparseable expiry rather than sponsoring forever', () => {
+    const fields = activeGrant({ ossGrantExpiresAt: 'not-a-date' });
+    expect(evaluateOssGrant(fields, grantedRepo, NOW)).toEqual({
+      eligible: false,
+      reason: 'grant_expired',
+    });
+  });
+
+  it('does not sponsor once the month is at the fair-use cap', () => {
+    const fields = activeGrant({
+      ossMonthlyCapCents: 2000,
+      ossPeriod: PERIOD,
+      ossSponsoredCentsThisPeriod: 2000,
+    });
+    expect(evaluateOssGrant(fields, grantedRepo, NOW)).toEqual({
+      eligible: false,
+      reason: 'cap_exceeded',
+    });
+  });
+
+  it('still sponsors while under the cap', () => {
+    const fields = activeGrant({
+      ossMonthlyCapCents: 2000,
+      ossPeriod: PERIOD,
+      ossSponsoredCentsThisPeriod: 1999,
+    });
+    expect(evaluateOssGrant(fields, grantedRepo, NOW).eligible).toBe(true);
+  });
+
+  it('ignores accrual from a previous period when applying the cap', () => {
+    // Last month's spend must not carry over and starve this month.
+    const fields = activeGrant({
+      ossMonthlyCapCents: 2000,
+      ossPeriod: '2026-07',
+      ossSponsoredCentsThisPeriod: 999_999,
+    });
+    expect(evaluateOssGrant(fields, grantedRepo, NOW).eligible).toBe(true);
+  });
+
+  it('sponsors without limit when no cap is configured', () => {
+    const fields = activeGrant({
+      ossMonthlyCapCents: undefined,
+      ossPeriod: PERIOD,
+      ossSponsoredCentsThisPeriod: 999_999,
+    });
+    expect(evaluateOssGrant(fields, grantedRepo, NOW).eligible).toBe(true);
+  });
+});
+
+describe('currentPeriod', () => {
+  it('formats the accrual period as YYYY-MM', () => {
+    expect(currentPeriod(NOW)).toBe(PERIOD);
+  });
+});
+
+describe('sponsoredCentsThisPeriod', () => {
+  it('returns the accrued amount when the period matches', () => {
+    const fields: BillingFields = { ossPeriod: PERIOD, ossSponsoredCentsThisPeriod: 750 };
+    expect(sponsoredCentsThisPeriod(fields, PERIOD)).toBe(750);
+  });
+
+  it('returns 0 when the stored period is stale', () => {
+    const fields: BillingFields = { ossPeriod: '2026-07', ossSponsoredCentsThisPeriod: 750 };
+    expect(sponsoredCentsThisPeriod(fields, PERIOD)).toBe(0);
+  });
+
+  it('returns 0 when nothing has accrued yet', () => {
+    expect(sponsoredCentsThisPeriod({}, PERIOD)).toBe(0);
+  });
+});

--- a/packages/billing/src/oss-grant.ts
+++ b/packages/billing/src/oss-grant.ts
@@ -1,0 +1,101 @@
+/**
+ * #261 — OSS Program grant evaluation.
+ *
+ * Pure predicate over the OSS fields on the `#SETTINGS` row, shared by the
+ * billing gate (`billingCheck`) and the accrual path (`recordReview`) so the
+ * two can never disagree about whether a review is sponsored.
+ */
+
+import type { BillingFields } from '@mergewatch/core';
+
+/**
+ * Repo context the OSS gate needs. Optional at every call site: when it's
+ * absent the OSS branch is skipped entirely and behavior is identical to
+ * pre-#261. That's what keeps the MCP path (`packages/mcp/src/middleware/
+ * billing.ts`, whose `repo` input is optional and often literally 'unknown')
+ * compiling and behaving unchanged.
+ */
+export interface RepoContext {
+  /** GitHub's immutable numeric repository ID. The only field matched on. */
+  repoId: number;
+  /** owner/repo. Logging and diagnostics only — never matched on. */
+  repoFullName: string;
+  /**
+   * Whether the repo is public **right now**, read from the current webhook
+   * payload rather than a snapshot taken at approval time. A repo approved as
+   * public can be flipped private afterward; that's the actual cost leak, and
+   * only a live check catches it.
+   */
+  isPublic: boolean;
+}
+
+/** Current accrual period key (YYYY-MM) for a given instant. */
+export function currentPeriod(now: Date = new Date()): string {
+  return now.toISOString().slice(0, 7);
+}
+
+/**
+ * Sponsored cost already accrued in the current period. Accrual from an
+ * earlier period doesn't count against this month's cap, so a stale
+ * `ossPeriod` reads as zero rather than carrying over.
+ */
+export function sponsoredCentsThisPeriod(fields: BillingFields, period: string): number {
+  if (fields.ossPeriod !== period) return 0;
+  return fields.ossSponsoredCentsThisPeriod ?? 0;
+}
+
+export type OssIneligibleReason =
+  | 'no_repo_context'
+  | 'no_grant'
+  | 'grant_expired'
+  | 'repo_not_granted'
+  | 'repo_not_public'
+  | 'cap_exceeded';
+
+export type OssEligibility =
+  | { eligible: true }
+  | { eligible: false; reason: OssIneligibleReason };
+
+/**
+ * Decide whether this review is covered by an active OSS grant.
+ *
+ * Being named in the grant is necessary but **not sufficient** — the repo must
+ * also be public at this moment, the grant must not have expired, and the
+ * month's sponsored spend must be under the fair-use cap.
+ *
+ * Over the cap is deliberately not a hard stop: the caller falls through to
+ * the normal free-tier/balance gate, so a busy month degrades to standard
+ * billing rather than blocking a maintainer outright.
+ */
+export function evaluateOssGrant(
+  fields: BillingFields,
+  repo: RepoContext | undefined,
+  now: Date = new Date(),
+): OssEligibility {
+  if (!repo) return { eligible: false, reason: 'no_repo_context' };
+
+  const repos = fields.ossGrantRepos;
+  if (!fields.ossGrantExpiresAt || !repos || repos.length === 0) {
+    return { eligible: false, reason: 'no_grant' };
+  }
+
+  // Revoking a grant is setting the expiry to the past, so this covers both
+  // lapsed and revoked. An unparseable date fails closed.
+  const expiresAt = Date.parse(fields.ossGrantExpiresAt);
+  if (!Number.isFinite(expiresAt) || expiresAt <= now.getTime()) {
+    return { eligible: false, reason: 'grant_expired' };
+  }
+
+  if (!repos.some((r) => r.id === repo.repoId)) {
+    return { eligible: false, reason: 'repo_not_granted' };
+  }
+
+  if (!repo.isPublic) return { eligible: false, reason: 'repo_not_public' };
+
+  const cap = fields.ossMonthlyCapCents;
+  if (cap != null && sponsoredCentsThisPeriod(fields, currentPeriod(now)) >= cap) {
+    return { eligible: false, reason: 'cap_exceeded' };
+  }
+
+  return { eligible: true };
+}

--- a/packages/billing/src/record-review.test.ts
+++ b/packages/billing/src/record-review.test.ts
@@ -7,12 +7,19 @@ vi.mock('./dynamo-billing', () => ({
   getBillingFields: vi.fn(),
   incrementFreeReviewsUsed: vi.fn(),
   deductBalanceAndRecordUsage: vi.fn(),
+  accrueOssSponsoredCost: vi.fn(),
 }));
 
-import { getBillingFields, incrementFreeReviewsUsed, deductBalanceAndRecordUsage } from './dynamo-billing';
+import {
+  getBillingFields,
+  incrementFreeReviewsUsed,
+  deductBalanceAndRecordUsage,
+  accrueOssSponsoredCost,
+} from './dynamo-billing';
 const mockGetFields = vi.mocked(getBillingFields);
 const mockIncrement = vi.mocked(incrementFreeReviewsUsed);
 const mockDeductAndRecord = vi.mocked(deductBalanceAndRecordUsage);
+const mockAccrueOss = vi.mocked(accrueOssSponsoredCost);
 
 const client = {} as any;
 const table = 'test-table';
@@ -146,5 +153,101 @@ describe('recordReview', () => {
 
     // DynamoDB deduction still happened
     expect(mockDeductAndRecord).toHaveBeenCalled();
+  });
+});
+
+describe('recordReview — OSS Program (#261)', () => {
+  const REPO_ID = 4242;
+  const grantedRepo = { repoId: REPO_ID, repoFullName: 'octocat/hello-world', isPublic: true };
+  const activeGrant = {
+    ossGrantRepos: [{ id: REPO_ID, fullName: 'octocat/hello-world' }],
+    ossGrantExpiresAt: '2099-01-01T00:00:00.000Z',
+    ossMonthlyCapCents: 2000,
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('accrues sponsored cost instead of charging', async () => {
+    mockGetFields.mockResolvedValue({ ...activeGrant, freeReviewsUsed: FREE_REVIEW_LIMIT });
+
+    await recordReview(client, table, installationId, 0.02, reviewKey, undefined, grantedRepo);
+
+    // Same formula the paid path charges: $0.02 LLM + $0.005 infra + 40%
+    // margin = $0.033, rounded up by calculateReviewCost to 4 cents.
+    expect(mockAccrueOss).toHaveBeenCalledWith(
+      client,
+      table,
+      installationId,
+      4,
+      new Date().toISOString().slice(0, 7),
+    );
+    expect(mockDeductAndRecord).not.toHaveBeenCalled();
+  });
+
+  it('does NOT consume the free tier on a sponsored review', async () => {
+    // Burning freeReviewsUsed here would turn a lapsed grant into an instantly
+    // blocked account with an issue filed on the maintainer's public repo.
+    mockGetFields.mockResolvedValue({ ...activeGrant, freeReviewsUsed: 0 });
+
+    await recordReview(client, table, installationId, 0.02, reviewKey, undefined, grantedRepo);
+
+    expect(mockIncrement).not.toHaveBeenCalled();
+    expect(mockAccrueOss).toHaveBeenCalled();
+  });
+
+  it('never touches Stripe on a sponsored review', async () => {
+    const mockStripe = {
+      customers: { createBalanceTransaction: vi.fn() },
+    } as any;
+    mockGetFields.mockResolvedValue({
+      ...activeGrant,
+      freeReviewsUsed: FREE_REVIEW_LIMIT,
+      balanceCents: 10_000,
+      stripeCustomerId: 'cus_123',
+    });
+
+    await recordReview(client, table, installationId, 0.02, reviewKey, mockStripe, grantedRepo);
+
+    expect(mockStripe.customers.createBalanceTransaction).not.toHaveBeenCalled();
+    expect(mockAccrueOss).toHaveBeenCalled();
+  });
+
+  it('charges normally for an unnamed repo in a granted installation', async () => {
+    mockGetFields.mockResolvedValue({
+      ...activeGrant,
+      freeReviewsUsed: FREE_REVIEW_LIMIT,
+      balanceCents: 10_000,
+    });
+    const other = { repoId: 9999, repoFullName: 'octocat/commercial', isPublic: true };
+
+    await recordReview(client, table, installationId, 0.02, reviewKey, undefined, other);
+
+    expect(mockAccrueOss).not.toHaveBeenCalled();
+    expect(mockDeductAndRecord).toHaveBeenCalled();
+  });
+
+  it('charges normally once the grant has expired', async () => {
+    mockGetFields.mockResolvedValue({
+      ...activeGrant,
+      ossGrantExpiresAt: '2020-01-01T00:00:00.000Z',
+      freeReviewsUsed: FREE_REVIEW_LIMIT,
+      balanceCents: 10_000,
+    });
+
+    await recordReview(client, table, installationId, 0.02, reviewKey, undefined, grantedRepo);
+
+    expect(mockAccrueOss).not.toHaveBeenCalled();
+    expect(mockDeductAndRecord).toHaveBeenCalled();
+  });
+
+  it('is unchanged from pre-#261 when repo context is omitted', async () => {
+    mockGetFields.mockResolvedValue({ ...activeGrant, freeReviewsUsed: 2 });
+
+    await recordReview(client, table, installationId, 0.02, reviewKey);
+
+    expect(mockAccrueOss).not.toHaveBeenCalled();
+    expect(mockIncrement).toHaveBeenCalled();
   });
 });

--- a/packages/billing/src/record-review.ts
+++ b/packages/billing/src/record-review.ts
@@ -2,12 +2,22 @@ import type Stripe from 'stripe';
 import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { FREE_REVIEW_LIMIT } from './constants';
 import { calculateReviewCost } from './cost';
-import { getBillingFields, incrementFreeReviewsUsed, deductBalanceAndRecordUsage } from './dynamo-billing';
+import {
+  getBillingFields,
+  incrementFreeReviewsUsed,
+  deductBalanceAndRecordUsage,
+  accrueOssSponsoredCost,
+} from './dynamo-billing';
 import { maybeAutoReload } from './auto-reload';
+// Aliased: the paid branch below already has a local `currentPeriod`.
+import { currentPeriod as ossAccrualPeriod, evaluateOssGrant } from './oss-grant';
+import type { RepoContext } from './oss-grant';
 
 /**
  * Record a completed review against billing.
  *
+ * - OSS Program: accrue the cost against the grant; no charge, no free-tier
+ *   consumption, no Stripe call (#261)
  * - Free tier: atomically increment freeReviewsUsed
  * - Paid tier: atomically deduct totalCents from DynamoDB balanceCents,
  *   then debit the Stripe Customer Balance to keep them in sync.
@@ -15,6 +25,9 @@ import { maybeAutoReload } from './auto-reload';
  * @param reviewKey — unique key for this review (e.g. prNumberCommitSha),
  *   used as idempotency guard to prevent double-billing on Lambda retries
  * @param stripe — optional Stripe client; when provided, Stripe balance is also debited
+ * @param repo — optional repo context; omit to skip OSS evaluation entirely.
+ *   Pass the same value given to `billingCheck` so the gate and the recording
+ *   path agree on whether the review was sponsored.
  */
 export async function recordReview(
   client: DynamoDBDocumentClient,
@@ -23,8 +36,29 @@ export async function recordReview(
   estimatedCostUsd: number,
   reviewKey: string,
   stripe?: Stripe,
+  repo?: RepoContext,
 ): Promise<void> {
   const fields = await getBillingFields(client, table, installationId);
+
+  // OSS Program — sponsored. Track what the review would have cost so program
+  // spend is a reportable number rather than an invisible subsidy, but never
+  // touch balance, freeReviewsUsed, or Stripe.
+  //
+  // Re-derived from the stored fields rather than passed in from the gate: a
+  // sponsored review that wrongly consumed the free tier would turn a lapsed
+  // grant into an instantly-blocked account, with a "credits required" issue
+  // filed on the maintainer's public repo.
+  if (evaluateOssGrant(fields, repo).eligible) {
+    const cost = calculateReviewCost(estimatedCostUsd);
+    await accrueOssSponsoredCost(
+      client,
+      table,
+      installationId,
+      cost.totalCents,
+      ossAccrualPeriod(),
+    );
+    return;
+  }
 
   if ((fields.freeReviewsUsed ?? 0) < FREE_REVIEW_LIMIT) {
     // Free tier — just bump the counter

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -268,6 +268,7 @@ export type {
   InstallationItem,
   InstallationSettings,
   BillingFields,
+  OssGrantRepo,
   ReviewItem,
   ReviewStatus,
   ReviewFinding,

--- a/packages/core/src/types/db.ts
+++ b/packages/core/src/types/db.ts
@@ -494,6 +494,50 @@ export interface BillingFields {
   blockIssueNumber?: number;
   /** Repo where the billing block issue was filed (owner/repo). */
   blockIssueRepo?: string;
+
+  // --- OSS Program (#261) ---
+  // Sponsored-review entitlement for approved open-source repositories. Set by
+  // the manually-run `scripts/grant-oss.sh`; never written by the review path
+  // except for the accrual counters below.
+
+  /**
+   * Repositories covered by this grant. Required and non-empty for an active
+   * grant — there is no installation-wide mode, because an installation can
+   * mix a genuinely-OSS repo with public-but-commercial ones (open core).
+   *
+   * Matched on the immutable numeric `id`: GitHub renames and org transfers
+   * change `fullName`, so a name-keyed list would silently stop matching and
+   * lapse the sponsorship. `fullName` is retained for display/debuggability
+   * only and may be stale — never match on it.
+   */
+  ossGrantRepos?: OssGrantRepo[];
+  /**
+   * ISO 8601. Presence + a future date = active grant; absent or past = no
+   * grant. Deliberately the only status field — revoking is setting this to
+   * the past, so there are no two-field states to keep consistent.
+   */
+  ossGrantExpiresAt?: string;
+  /** ISO 8601 of when the grant was written. Informational — no gate logic reads it. */
+  ossGrantedAt?: string;
+  /** Free-text provenance: application reference, project name, approver. Informational. */
+  ossGrantNote?: string;
+  /** Fair-use ceiling on sponsored review cost per calendar month, across the named repos. */
+  ossMonthlyCapCents?: number;
+  /** Accrual period (YYYY-MM) that `ossSponsoredCentsThisPeriod` belongs to. */
+  ossPeriod?: string;
+  /** Sponsored review cost accrued during `ossPeriod`. Reset when the period rolls over. */
+  ossSponsoredCentsThisPeriod?: number;
+  /** Sponsored review cost accrued over the lifetime of the grant. Monotonic. */
+  ossSponsoredCentsLifetime?: number;
+}
+
+/**
+ * One repository covered by an OSS grant. `id` is GitHub's immutable numeric
+ * repository ID and is the only field the gate matches on.
+ */
+export interface OssGrantRepo {
+  id: number;
+  fullName: string;
 }
 
 // =============================================================================

--- a/packages/core/src/types/github.ts
+++ b/packages/core/src/types/github.ts
@@ -316,4 +316,18 @@ export interface ReviewJobPayload {
   source?: 'agent' | 'human';
   /** Agent kind when source='agent' (derived from whichever detection rule matched). */
   agentKind?: 'claude' | 'cursor' | 'codex' | 'other';
+  /**
+   * OSS Program (#261) — GitHub's immutable numeric repository ID. The OSS
+   * billing gate matches grants on this rather than `owner/repo`, because a
+   * rename or org transfer changes the name and would silently lapse a grant.
+   * Optional: job payloads already in flight when this shipped won't carry it,
+   * and its absence simply skips OSS evaluation.
+   */
+  repoId?: number;
+  /**
+   * OSS Program (#261) — whether the repo is public, as of the webhook that
+   * triggered this job. Read live rather than snapshotted at grant time so a
+   * repo flipped private stops being sponsored on its next review.
+   */
+  isPublic?: boolean;
 }

--- a/packages/dashboard/app/dashboard/billing/BillingClient.tsx
+++ b/packages/dashboard/app/dashboard/billing/BillingClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { CreditCard, Zap, TrendingUp, AlertCircle, CheckCircle2, Loader2, RefreshCw } from "lucide-react";
+import { CreditCard, Zap, TrendingUp, AlertCircle, CheckCircle2, Loader2, RefreshCw, HeartHandshake } from "lucide-react";
 
 interface BillingStatus {
   freeReviewsUsed: number;
@@ -16,6 +16,21 @@ interface BillingStatus {
   totalBilledCents: number;
   prCount: number;
   prTimestamps: string[];
+  /**
+   * OSS Program (#261). Null for every installation without a grant.
+   * `active` is computed server-side so this panel can't drift from the
+   * billing gate's own notion of an active grant.
+   */
+  oss: {
+    active: boolean;
+    repos: string[];
+    expiresAt: string;
+    grantedAt: string | null;
+    note: string | null;
+    monthlyCapCents: number | null;
+    sponsoredThisPeriodCents: number;
+    sponsoredLifetimeCents: number;
+  } | null;
 }
 
 interface BillingClientProps {
@@ -210,6 +225,106 @@ export default function BillingClient({ installationId, accountLogin, setupCompl
             >
               Dismiss
             </button>
+          </div>
+        )}
+
+        {/* OSS Program (#261) — sponsored reviews.
+            Rendered alongside the credit balance rather than replacing it:
+            a granted installation can still contain private or unnamed repos
+            that bill normally, so both states are true at once. */}
+        {status.oss && (
+          <div className="rounded-lg border border-border-default bg-surface-card p-5 sm:p-6">
+            <div className="flex items-center gap-2 mb-4">
+              <HeartHandshake className="h-4 w-4 text-accent-green" />
+              <h2 className="text-[11px] font-semibold uppercase tracking-widest text-fg-muted">
+                Open Source Program
+              </h2>
+              {!status.oss.active && (
+                <span className="ml-auto rounded-full border border-yellow-500/30 bg-yellow-500/5 px-2 py-0.5 text-[10px] font-medium text-yellow-300">
+                  Expired
+                </span>
+              )}
+            </div>
+
+            {status.oss.active ? (
+              <p className="text-sm text-fg-secondary">
+                Reviews on the repositories below are sponsored by MergeWatch — no charge, and
+                they don&rsquo;t use your free reviews or balance.
+              </p>
+            ) : (
+              <p className="text-sm text-fg-secondary">
+                This grant expired on {new Date(status.oss.expiresAt).toLocaleDateString()}. Reviews
+                now fall back to your free tier and balance. Get in touch at{" "}
+                <a
+                  href="https://mergewatch.ai/open-source"
+                  className="text-accent-green hover:underline"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  mergewatch.ai/open-source
+                </a>{" "}
+                to renew it — there&rsquo;s no charge.
+              </p>
+            )}
+
+            <div className="mt-5 grid gap-5 sm:grid-cols-3">
+              <div>
+                <div className="text-2xl font-bold text-fg-primary tabular-nums">
+                  ${(status.oss.sponsoredThisPeriodCents / 100).toFixed(2)}
+                </div>
+                <p className="mt-1 text-xs text-fg-tertiary">Sponsored this month</p>
+                {status.oss.monthlyCapCents !== null && (
+                  <>
+                    <div className="mt-2 h-2 rounded-full bg-surface-card-hover">
+                      <div
+                        className="h-2 rounded-full bg-accent-green transition-all"
+                        style={{
+                          // A zero cap means no allowance at all, so the bar is
+                          // full. Guarding the divide matters: 0/0 is NaN, which
+                          // renders as `width: "NaN%"` and silently drops the bar.
+                          width: `${status.oss.monthlyCapCents > 0
+                            ? Math.min(100, (status.oss.sponsoredThisPeriodCents / status.oss.monthlyCapCents) * 100)
+                            : 100}%`,
+                        }}
+                      />
+                    </div>
+                    <p className="mt-1 text-[11px] text-fg-muted">
+                      of ${(status.oss.monthlyCapCents / 100).toFixed(2)} fair-use limit
+                    </p>
+                  </>
+                )}
+              </div>
+
+              <div>
+                <div className="text-2xl font-bold text-fg-primary tabular-nums">
+                  ${(status.oss.sponsoredLifetimeCents / 100).toFixed(2)}
+                </div>
+                <p className="mt-1 text-xs text-fg-tertiary">Sponsored to date</p>
+              </div>
+
+              <div>
+                <div className="text-2xl font-bold text-fg-primary tabular-nums">
+                  {status.oss.repos.length}
+                </div>
+                <p className="mt-1 text-xs text-fg-tertiary">
+                  {status.oss.repos.length === 1 ? "Covered repository" : "Covered repositories"}
+                </p>
+              </div>
+            </div>
+
+            <div className="mt-5 pt-4 border-t border-border-default">
+              <p className="text-xs text-fg-tertiary mb-2">Covered repositories</p>
+              <ul className="space-y-1">
+                {status.oss.repos.map((r) => (
+                  <li key={r} className="text-sm text-fg-secondary">{r}</li>
+                ))}
+              </ul>
+              <p className="mt-3 text-[11px] text-fg-muted">
+                Only these repositories are sponsored, and only while they are public. Anything
+                else in this installation bills normally.
+                {status.oss.active && ` Grant runs until ${new Date(status.oss.expiresAt).toLocaleDateString()}.`}
+              </p>
+            </div>
           </div>
         )}
 

--- a/packages/lambda/src/handlers/billing.ts
+++ b/packages/lambda/src/handlers/billing.ts
@@ -227,6 +227,37 @@ async function handleWebhook(event: APIGatewayProxyEventV2): Promise<APIGatewayP
   return json(200, { received: true });
 }
 
+/**
+ * #261 — OSS Program status for the dashboard, or null when the installation
+ * has no grant.
+ *
+ * `active` is computed here rather than left to the client so the dashboard
+ * can't drift from the gate's own notion of "active" (`evaluateOssGrant`).
+ * Period spend is reported as 0 once `ossPeriod` goes stale, matching how the
+ * cap is actually applied — last month's spend never eats this month's
+ * allowance.
+ */
+function ossStatus(fields: Awaited<ReturnType<typeof getBillingFields>>) {
+  const repos = fields.ossGrantRepos ?? [];
+  if (!fields.ossGrantExpiresAt || repos.length === 0) return null;
+
+  const expiresAt = Date.parse(fields.ossGrantExpiresAt);
+  const period = new Date().toISOString().slice(0, 7);
+
+  return {
+    active: Number.isFinite(expiresAt) && expiresAt > Date.now(),
+    repos: repos.map((r) => r.fullName),
+    expiresAt: fields.ossGrantExpiresAt,
+    grantedAt: fields.ossGrantedAt ?? null,
+    note: fields.ossGrantNote ?? null,
+    monthlyCapCents: fields.ossMonthlyCapCents ?? null,
+    sponsoredThisPeriodCents: fields.ossPeriod === period
+      ? (fields.ossSponsoredCentsThisPeriod ?? 0)
+      : 0,
+    sponsoredLifetimeCents: fields.ossSponsoredCentsLifetime ?? 0,
+  };
+}
+
 async function handleStatus(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyResultV2> {
   const installationId = event.queryStringParameters?.installationId;
   if (!installationId) {
@@ -264,6 +295,11 @@ async function handleStatus(event: APIGatewayProxyEventV2): Promise<APIGatewayPr
     totalBilledCents: fields.totalBilledCents ?? 0,
     prCount: fields.prCount ?? 0,
     prTimestamps: fields.prTimestamps ?? [],
+
+    // OSS Program (#261). `oss` is null for every installation without a
+    // grant, which is what the dashboard keys off to decide whether to show
+    // the program panel instead of the balance/top-up one.
+    oss: ossStatus(fields),
   });
 }
 

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -86,7 +86,7 @@ import {
   DEFAULT_REVIEW_COSTS_TABLE,
 } from '@mergewatch/storage-dynamo';
 import { BedrockLLMProvider, SUPPORTED_MODELS } from '@mergewatch/llm-bedrock';
-import { isSaas, billingCheck, recordReview, postBlockedCheckRun, ensureBillingIssue, updateBillingFields, getStripe } from '@mergewatch/billing';
+import { isSaas, billingCheck, recordReview, postBlockedCheckRun, ensureBillingIssue, updateBillingFields, getStripe, isLapsedOssGrant } from '@mergewatch/billing';
 import { SSMGitHubAuthProvider } from '../github-auth-ssm.js';
 
 // -- Singletons (re-used across warm invocations) ----------------------------
@@ -446,15 +446,32 @@ export async function handler(
   }
 
   // ── Billing gate (SaaS only) ────
+  //
+  // OSS Program (#261): repo context is only present when the webhook carried
+  // it. Absent (older in-flight jobs), the gate skips OSS evaluation and
+  // behaves exactly as it did pre-#261.
+  const ossRepoContext = event.repoId != null && event.isPublic != null
+    ? { repoId: event.repoId, repoFullName, isPublic: event.isPublic }
+    : undefined;
+
   if (isSaas()) {
-    const billing = await billingCheck(dynamodb, INSTALLATIONS_TABLE, String(installationId));
+    const billing = await billingCheck(
+      dynamodb,
+      INSTALLATIONS_TABLE,
+      String(installationId),
+      ossRepoContext,
+    );
     if (billing.status === 'block') {
       console.log(`Billing blocked for installation ${installationId}`);
 
-      await postBlockedCheckRun(octokit, owner, repo, headSha);
+      // #261 — a maintainer whose OSS grant lapsed or hit its cap gets copy
+      // pointing at renewal / BYOK, not "add a credit card".
+      const blockVariant = isLapsedOssGrant(billing.ossReason) ? 'oss' as const : 'credits' as const;
+
+      await postBlockedCheckRun(octokit, owner, repo, headSha, blockVariant);
 
       if (billing.firstBlock) {
-        await ensureBillingIssue(octokit, owner, repo, String(installationId), dynamodb, INSTALLATIONS_TABLE);
+        await ensureBillingIssue(octokit, owner, repo, String(installationId), dynamodb, INSTALLATIONS_TABLE, blockVariant);
         await updateBillingFields(dynamodb, INSTALLATIONS_TABLE, String(installationId), {
           blockedAt: new Date().toISOString(),
         });
@@ -1016,7 +1033,7 @@ export async function handler(
       let billingRecorded = false;
       for (let attempt = 1; attempt <= 2; attempt++) {
         try {
-          await recordReview(dynamodb, INSTALLATIONS_TABLE, String(installationId), result.estimatedCostUsd, prNumberCommitSha, stripe);
+          await recordReview(dynamodb, INSTALLATIONS_TABLE, String(installationId), result.estimatedCostUsd, prNumberCommitSha, stripe, ossRepoContext);
           billingRecorded = true;
           break;
         } catch (err) {

--- a/packages/lambda/src/handlers/webhook.test.ts
+++ b/packages/lambda/src/handlers/webhook.test.ts
@@ -556,3 +556,51 @@ describe('handler — check_run.rerequested', () => {
     expect(mockEnqueue).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// OSS Program repo identity (#261)
+// ---------------------------------------------------------------------------
+
+describe('handler — OSS repo identity on the job payload (#261)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetInstallationOctokit.mockResolvedValue({});
+    mockFetchRepoConfig.mockResolvedValue(null);
+    mockClassifyPrSource.mockResolvedValue({ source: 'human' });
+  });
+
+  function enqueuedPayload() {
+    const invokeInput = (mockEnqueue.mock.calls[0][0] as { input: { Payload: Buffer } }).input;
+    return JSON.parse(invokeInput.Payload.toString());
+  }
+
+  it('forwards repoId and isPublic for a public repo', async () => {
+    const body = JSON.stringify(makePullRequestEvent());
+    await handler(makeApiGatewayEvent(body));
+
+    const payload = enqueuedPayload();
+    expect(payload.repoId).toBe(1);
+    expect(payload.isPublic).toBe(true);
+  });
+
+  it('reports isPublic=false for a private repo', async () => {
+    // The gate re-checks visibility on every review precisely so a repo
+    // flipped private stops being sponsored — this is the signal it reads.
+    const event = makePullRequestEvent();
+    event.repository.private = true;
+    const body = JSON.stringify(event);
+    await handler(makeApiGatewayEvent(body));
+
+    expect(enqueuedPayload().isPublic).toBe(false);
+  });
+
+  it('carries the numeric repo id, not the name', async () => {
+    // Grants match on the immutable id so a rename or transfer can't lapse them.
+    const event = makePullRequestEvent();
+    event.repository.id = 987654;
+    const body = JSON.stringify(event);
+    await handler(makeApiGatewayEvent(body));
+
+    expect(enqueuedPayload().repoId).toBe(987654);
+  });
+});

--- a/packages/lambda/src/handlers/webhook.ts
+++ b/packages/lambda/src/handlers/webhook.ts
@@ -106,6 +106,19 @@ export function parseReviewMode(commentBody: string): ReviewMode | null {
 /**
  * Asynchronously invoke the ReviewAgent Lambda with the given payload.
  */
+/**
+ * OSS Program (#261) — repo identity the sponsored-review gate needs, in the
+ * shape `ReviewJobPayload` carries it.
+ *
+ * Every enqueue path gets these, not just `pull_request`: an `@mergewatch`
+ * mention or a re-requested check on a sponsored repo runs the same billing
+ * gate, and omitting them there would silently bill a maintainer we promised
+ * free review.
+ */
+function ossRepoFields(repository: { id: number; private: boolean }) {
+  return { repoId: repository.id, isPublic: !repository.private };
+}
+
 async function enqueueReviewJob(payload: ReviewJobPayload): Promise<void> {
   const functionName =
     process.env.REVIEW_AGENT_FUNCTION_NAME ?? "mergewatch-review-agent";
@@ -275,6 +288,7 @@ async function handlePullRequestEvent(
     source: classification.source,
     agentKind: classification.agentKind,
     headSha: pr.head?.sha,
+    ...ossRepoFields(repository),
   });
 
   console.log(
@@ -326,6 +340,7 @@ async function handleIssueCommentEvent(
     mode,
     existingCommentId,
     mentionTriggered: true,
+    ...ossRepoFields(event.repository),
   };
 
   if (mode === "respond") {
@@ -383,6 +398,7 @@ async function handleReviewCommentEvent(
     prNumber: event.pull_request.number,
     mode: 'inline_reply',
     inlineReplyCommentId: event.comment.id,
+    ...ossRepoFields(event.repository),
   };
 
   await enqueueReviewJob(payload);
@@ -461,6 +477,7 @@ async function handleCheckRunEvent(event: CheckRunEvent): Promise<void> {
     source: classification.source,
     agentKind: classification.agentKind,
     headSha: pr.head?.sha,
+    ...ossRepoFields(event.repository),
   });
 
   console.log(

--- a/packages/server/src/webhook-handler.ts
+++ b/packages/server/src/webhook-handler.ts
@@ -130,6 +130,18 @@ async function recordPrLifecycle(payload: PullRequestEvent, deps: WebhookDeps) {
   }
 }
 
+/**
+ * OSS Program (#261) — repo identity carried on every review job.
+ *
+ * Self-hosted doesn't run the billing gate (it's behind `isSaas()`), so these
+ * are inert here. They're populated anyway to keep `ReviewJobPayload` honest
+ * across both runtimes — a payload that means different things depending on
+ * which webhook built it is a trap for the next person.
+ */
+function ossRepoFields(repository: { id: number; private: boolean }) {
+  return { repoId: repository.id, isPublic: !repository.private };
+}
+
 async function handlePullRequest(payload: PullRequestEvent, deps: WebhookDeps) {
   const { action, pull_request, repository, installation } = payload;
   if (!installation) return;
@@ -214,6 +226,7 @@ async function handlePullRequest(payload: PullRequestEvent, deps: WebhookDeps) {
     source,
     agentKind,
     headSha: pull_request.head?.sha,
+    ...ossRepoFields(repository),
   };
 
   // Process in background
@@ -244,6 +257,7 @@ async function handleIssueComment(payload: IssueCommentEvent, deps: WebhookDeps)
     prNumber: issue.number,
     mode,
     mentionTriggered: true,
+    ...ossRepoFields(repository),
     ...(userComment ? { userComment, userCommentAuthor: comment.user.login } : {}),
   };
 
@@ -265,6 +279,7 @@ async function handleReviewComment(payload: PullRequestReviewCommentEvent, deps:
     prNumber: pull_request.number,
     mode: 'inline_reply',
     inlineReplyCommentId: comment.id,
+    ...ossRepoFields(repository),
   };
 
   processReviewJob(job, deps).catch((err) => {
@@ -337,6 +352,7 @@ async function handleCheckRun(payload: CheckRunEvent, deps: WebhookDeps) {
     source: classification.source,
     agentKind: classification.agentKind,
     headSha: pr.head?.sha,
+    ...ossRepoFields(payload.repository),
   };
 
   processReviewJob(job, deps).catch((err) => {

--- a/scripts/grant-oss.ts
+++ b/scripts/grant-oss.ts
@@ -1,0 +1,427 @@
+#!/usr/bin/env npx tsx
+/**
+ * =============================================================================
+ * MergeWatch OSS Program — grant management (#261)
+ * =============================================================================
+ *
+ * Writes the sponsored-review entitlement for approved open-source
+ * repositories. This is the ONLY thing that writes OSS grant fields; there is
+ * no admin API route and no dashboard granting UI, by design. The `#SETTINGS`
+ * row is therefore the sole record of who was granted what and why, which is
+ * what `--note` and `--inspect` exist for.
+ *
+ * Usage:
+ *   scripts/grant-oss.ts <owner/repo>[,<owner/repo>…] --stage dev|prod [options]
+ *   scripts/grant-oss.ts --add <owner/repo>     --stage …
+ *   scripts/grant-oss.ts --remove <owner/repo>  --stage …
+ *   scripts/grant-oss.ts --revoke <owner/repo>  --stage …
+ *   scripts/grant-oss.ts --inspect <owner/repo> --stage …
+ *
+ * Options:
+ *   --stage dev|prod   REQUIRED. No default — a grant must never land in the
+ *                      wrong environment because someone forgot a flag.
+ *   --cap <cents>      Monthly fair-use ceiling (default 2000 = $20).
+ *   --months <n>       Grant term (default 12).
+ *   --note "<text>"    Provenance: application reference, project, approver.
+ *   --yes              Skip the confirmation prompt (for scripted use).
+ *
+ * Prerequisites:
+ *   - AWS credentials for the `mergewatch` profile, with SSM read on the
+ *     GitHub App parameters and write access to the installations table.
+ *   - The maintainer has already installed the GitHub App on the repository
+ *     (that is what creates the installation this grant attaches to).
+ * =============================================================================
+ */
+
+import { createInterface } from 'node:readline/promises';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, QueryCommand, UpdateCommand, GetCommand } from '@aws-sdk/lib-dynamodb';
+import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
+import { createAppAuth } from '@octokit/auth-app';
+import { Octokit } from '@octokit/rest';
+
+const PROFILE = 'mergewatch';
+const REGION = process.env.AWS_REGION ?? 'us-west-2';
+const SETTINGS_SK = '#SETTINGS';
+const DEFAULT_CAP_CENTS = 2000;
+const DEFAULT_TERM_MONTHS = 12;
+
+// --- Arg parsing -------------------------------------------------------------
+
+interface Args {
+  repos: string[];
+  stage: string;
+  mode: 'grant' | 'add' | 'remove' | 'revoke' | 'inspect';
+  capCents: number;
+  months: number;
+  note?: string;
+  yes: boolean;
+}
+
+function flag(argv: string[], name: string): string | undefined {
+  const i = argv.indexOf(name);
+  return i === -1 ? undefined : argv[i + 1];
+}
+
+function parseArgs(argv: string[]): Args {
+  const modes = [
+    ['--add', 'add'],
+    ['--remove', 'remove'],
+    ['--revoke', 'revoke'],
+    ['--inspect', 'inspect'],
+  ] as const;
+
+  let mode: Args['mode'] = 'grant';
+  let repoArg: string | undefined;
+
+  for (const [f, m] of modes) {
+    const v = flag(argv, f);
+    if (v !== undefined) {
+      mode = m;
+      repoArg = v;
+      break;
+    }
+  }
+  if (mode === 'grant') repoArg = argv.find((a) => !a.startsWith('--') && a.includes('/'));
+
+  const stage = flag(argv, '--stage');
+  if (!stage || !['dev', 'prod'].includes(stage)) {
+    fail(
+      'Refusing to run without an explicit --stage dev|prod.\n'
+      + 'This writes to a live table; defaulting the environment is how a grant\n'
+      + 'lands in the wrong one.',
+    );
+  }
+  if (!repoArg) fail('No repository given. Expected owner/repo.');
+
+  const repos = repoArg!.split(',').map((r) => r.trim()).filter(Boolean);
+  for (const r of repos) {
+    if (!/^[^/\s]+\/[^/\s]+$/.test(r)) fail(`Not an owner/repo: ${r}`);
+  }
+
+  const capCents = Number(flag(argv, '--cap') ?? DEFAULT_CAP_CENTS);
+  const months = Number(flag(argv, '--months') ?? DEFAULT_TERM_MONTHS);
+  // A zero or negative cap is almost certainly a typo, and it produces a grant
+  // that is active but sponsors nothing — the most confusing possible state for
+  // a maintainer. Reject it here rather than letting it reach the row.
+  if (!Number.isFinite(capCents) || capCents <= 0) {
+    fail(`--cap must be a positive number of cents (got ${flag(argv, '--cap')}). Use --revoke to end a grant.`);
+  }
+  if (!Number.isFinite(months) || months <= 0) {
+    fail(`--months must be a positive number (got ${flag(argv, '--months')}).`);
+  }
+
+  return {
+    repos,
+    stage: stage!,
+    mode,
+    capCents,
+    months,
+    note: flag(argv, '--note'),
+    yes: argv.includes('--yes'),
+  };
+}
+
+function fail(msg: string): never {
+  console.error(`\n✗ ${msg}\n`);
+  process.exit(1);
+}
+
+// --- AWS + GitHub clients -----------------------------------------------------
+
+const dynamo = DynamoDBDocumentClient.from(new DynamoDBClient({ profile: PROFILE, region: REGION }));
+const ssm = new SSMClient({ profile: PROFILE, region: REGION });
+
+async function ssmParam(name: string): Promise<string> {
+  const res = await ssm.send(new GetParameterCommand({ Name: name, WithDecryption: true }));
+  const value = res.Parameter?.Value;
+  if (!value) fail(`SSM parameter ${name} is empty or missing.`);
+  return value!;
+}
+
+/**
+ * Two Octokit flavors are needed, because they can reach different endpoints.
+ *
+ * A GitHub **App JWT** can call `GET /repos/{owner}/{repo}/installation` — the
+ * repo→installation lookup this whole script hinges on, and the reason this
+ * isn't a `gh api` one-liner (`gh` authenticates as a user and cannot reach
+ * it). But a JWT cannot read repository content endpoints.
+ *
+ * An **installation token** can call `GET /repos/{owner}/{repo}` for the id,
+ * visibility, and activity signals. So: JWT resolves the installation, then an
+ * installation client reads the repo.
+ */
+async function githubClients(stage: string) {
+  const [appIdRaw, privateKey] = await Promise.all([
+    ssmParam(`/mergewatch/${stage}/github-app-id`),
+    ssmParam(`/mergewatch/${stage}/github-private-key`),
+  ]);
+  const appId = Number(appIdRaw);
+
+  const auth = createAppAuth({ appId, privateKey });
+  const { token: jwt } = await auth({ type: 'app' });
+
+  return {
+    jwt: new Octokit({ auth: jwt }),
+    forInstallation: (installationId: number) =>
+      new Octokit({
+        authStrategy: createAppAuth,
+        auth: { appId, privateKey, installationId },
+      }),
+  };
+}
+
+type GitHubClients = Awaited<ReturnType<typeof githubClients>>;
+
+// --- Repo + installation resolution -------------------------------------------
+
+interface ResolvedRepo {
+  id: number;
+  fullName: string;
+  isPublic: boolean;
+  pushedAt: string | null;
+  openIssues: number;
+  installationId: string;
+}
+
+async function resolveRepo(gh: GitHubClients, fullName: string): Promise<ResolvedRepo> {
+  const [owner, repo] = fullName.split('/');
+
+  // 1. JWT: which installation owns this repo?
+  let installationId: number;
+  try {
+    const inst = await gh.jwt.apps.getRepoInstallation({ owner, repo });
+    installationId = inst.data.id;
+  } catch (err) {
+    fail(
+      `The MergeWatch App is not installed on ${fullName} (or it does not exist).\n`
+      + 'Ask the maintainer to install it first — the installation is what a grant\n'
+      + `attaches to. GitHub said: ${(err as Error).message}`,
+    );
+  }
+
+  // 2. Installation token: read the repo itself.
+  let data;
+  try {
+    ({ data } = await gh.forInstallation(installationId!).repos.get({ owner, repo }));
+  } catch (err) {
+    fail(`Could not read ${fullName}: ${(err as Error).message}`);
+  }
+
+  return {
+    id: data!.id,
+    fullName: data!.full_name,
+    isPublic: !data!.private,
+    pushedAt: data!.pushed_at ?? null,
+    openIssues: data!.open_issues_count ?? 0,
+    installationId: String(installationId!),
+  };
+}
+
+// --- DynamoDB -----------------------------------------------------------------
+
+const table = (stage: string) => process.env.INSTALLATIONS_TABLE ?? `mergewatch-installations-${stage}`;
+
+interface OssGrantRepo { id: number; fullName: string }
+
+interface GrantFields {
+  ossGrantRepos?: OssGrantRepo[];
+  ossGrantExpiresAt?: string;
+  ossGrantedAt?: string;
+  ossGrantNote?: string;
+  ossMonthlyCapCents?: number;
+  ossPeriod?: string;
+  ossSponsoredCentsThisPeriod?: number;
+  ossSponsoredCentsLifetime?: number;
+}
+
+async function readGrant(stage: string, installationId: string): Promise<GrantFields> {
+  const res = await dynamo.send(new GetCommand({
+    TableName: table(stage),
+    Key: { installationId, repoFullName: SETTINGS_SK },
+  }));
+  return (res.Item as GrantFields) ?? {};
+}
+
+/** Every repo row under this installation — the blast-radius view. */
+async function installationRepos(stage: string, installationId: string): Promise<string[]> {
+  const out: string[] = [];
+  let lastKey: Record<string, unknown> | undefined;
+  do {
+    const res = await dynamo.send(new QueryCommand({
+      TableName: table(stage),
+      KeyConditionExpression: 'installationId = :id',
+      ExpressionAttributeValues: { ':id': installationId },
+      ProjectionExpression: 'repoFullName',
+      ExclusiveStartKey: lastKey,
+    }));
+    for (const item of res.Items ?? []) {
+      const name = (item as { repoFullName: string }).repoFullName;
+      if (!name.startsWith('#')) out.push(name);
+    }
+    lastKey = res.LastEvaluatedKey;
+  } while (lastKey);
+  return out.sort();
+}
+
+async function writeGrant(
+  stage: string,
+  installationId: string,
+  fields: Required<Pick<GrantFields, 'ossGrantRepos' | 'ossGrantExpiresAt' | 'ossMonthlyCapCents'>>
+    & Pick<GrantFields, 'ossGrantedAt' | 'ossGrantNote'>,
+): Promise<void> {
+  const names: Record<string, string> = {};
+  const values: Record<string, unknown> = {};
+  const sets: string[] = [];
+  for (const [k, v] of Object.entries(fields)) {
+    if (v === undefined) continue;
+    names[`#${k}`] = k;
+    values[`:${k}`] = v;
+    sets.push(`#${k} = :${k}`);
+  }
+  await dynamo.send(new UpdateCommand({
+    TableName: table(stage),
+    Key: { installationId, repoFullName: SETTINGS_SK },
+    UpdateExpression: `SET ${sets.join(', ')}`,
+    ExpressionAttributeNames: names,
+    ExpressionAttributeValues: values,
+  }));
+}
+
+// --- Presentation --------------------------------------------------------------
+
+const usd = (cents: number) => `$${(cents / 100).toFixed(2)}`;
+
+function renderGrant(grant: GrantFields, installationId: string): void {
+  const repos = grant.ossGrantRepos ?? [];
+  const expires = grant.ossGrantExpiresAt;
+  const active = !!expires && Date.parse(expires) > Date.now() && repos.length > 0;
+
+  console.log(`\nInstallation ${installationId}`);
+  console.log(`  Status        ${active ? '✓ active' : '✗ no active grant'}`);
+  if (!expires && repos.length === 0) return;
+
+  console.log(`  Covered repos ${repos.length ? repos.map((r) => `${r.fullName} (id ${r.id})`).join('\n                ') : '(none)'}`);
+  console.log(`  Expires       ${expires ?? '(unset)'}`);
+  console.log(`  Granted       ${grant.ossGrantedAt ?? '(unknown)'}`);
+  console.log(`  Note          ${grant.ossGrantNote ?? '(none)'}`);
+  console.log(`  Monthly cap   ${grant.ossMonthlyCapCents != null ? usd(grant.ossMonthlyCapCents) : '(uncapped)'}`);
+  console.log(`  This period   ${grant.ossPeriod ?? '(none)'} — ${usd(grant.ossSponsoredCentsThisPeriod ?? 0)} sponsored`);
+  console.log(`  Lifetime      ${usd(grant.ossSponsoredCentsLifetime ?? 0)} sponsored`);
+}
+
+async function confirm(question: string, skip: boolean): Promise<boolean> {
+  if (skip) return true;
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  const answer = (await rl.question(`${question} [y/N] `)).trim().toLowerCase();
+  rl.close();
+  return answer === 'y' || answer === 'yes';
+}
+
+// --- Main ----------------------------------------------------------------------
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const gh = await githubClients(args.stage);
+
+  const resolved = await Promise.all(args.repos.map((r) => resolveRepo(gh, r)));
+
+  // One grant lives on one installation. Mixing repos from different
+  // installations into a single invocation would silently write only one.
+  const installationIds = [...new Set(resolved.map((r) => r.installationId))];
+  if (installationIds.length > 1) {
+    fail(
+      `Those repos belong to different installations (${installationIds.join(', ')}).\n`
+      + 'Grants are per-installation — run the script once per installation.',
+    );
+  }
+  const installationId = installationIds[0];
+  const existing = await readGrant(args.stage, installationId);
+
+  if (args.mode === 'inspect') {
+    renderGrant(existing, installationId);
+    console.log();
+    return;
+  }
+
+  // Eligibility: public repos only. Checked here as a courtesy to the operator;
+  // the gate re-checks visibility live on every review, which is what actually
+  // stops a repo flipped private later from staying sponsored.
+  if (args.mode === 'grant' || args.mode === 'add') {
+    for (const r of resolved) {
+      if (!r.isPublic) fail(`${r.fullName} is private. The OSS Program covers public repositories only.`);
+      console.log(`✓ ${r.fullName} — public, last pushed ${r.pushedAt ?? 'unknown'}, ${r.openIssues} open issues`);
+    }
+  }
+
+  const current = existing.ossGrantRepos ?? [];
+  let next: OssGrantRepo[];
+  switch (args.mode) {
+    case 'grant':
+      next = resolved.map((r) => ({ id: r.id, fullName: r.fullName }));
+      break;
+    case 'add':
+      next = [...current.filter((c) => !resolved.some((r) => r.id === c.id)),
+              ...resolved.map((r) => ({ id: r.id, fullName: r.fullName }))];
+      break;
+    case 'remove':
+      next = current.filter((c) => !resolved.some((r) => r.id === c.id));
+      break;
+    case 'revoke':
+      next = current;
+      break;
+  }
+
+  const revoking = args.mode === 'revoke';
+  const expiresAt = revoking
+    ? new Date(Date.now() - 1000).toISOString()
+    : new Date(new Date().setMonth(new Date().getMonth() + args.months)).toISOString();
+
+  // Blast radius: what this covers, and — just as important — what in the same
+  // installation it does not, so an accidental omission is visible before the write.
+  const allRepos = await installationRepos(args.stage, installationId);
+  const coveredNames = new Set(next.map((r) => r.fullName));
+  const uncovered = allRepos.filter((n) => !coveredNames.has(n));
+
+  console.log(`\n── ${args.mode.toUpperCase()} · stage=${args.stage} · installation ${installationId} ──`);
+  if (revoking) {
+    console.log(`  Revoking the grant (expiry set to the past). Reviews fall back to the`);
+    console.log(`  standard free-tier/balance gate — they are not blocked outright.`);
+  } else {
+    console.log(`  Will sponsor ${next.length} repo(s):`);
+    for (const r of next) console.log(`    • ${r.fullName} (id ${r.id})`);
+    if (uncovered.length) {
+      console.log(`  NOT covered in this installation:`);
+      for (const n of uncovered) console.log(`    · ${n}`);
+    }
+    console.log(`  Monthly cap  ${usd(args.capCents)} (shared across the repos above)`);
+    console.log(`  Expires      ${expiresAt}`);
+    if (args.note) console.log(`  Note         ${args.note}`);
+  }
+
+  if (!next.length && !revoking) {
+    fail('That would leave the grant with no repositories. Use --revoke to end it instead.');
+  }
+
+  if (!(await confirm('\nProceed?', args.yes))) {
+    console.log('Aborted. Nothing written.\n');
+    return;
+  }
+
+  await writeGrant(args.stage, installationId, {
+    ossGrantRepos: next,
+    ossGrantExpiresAt: expiresAt,
+    ossMonthlyCapCents: args.capCents,
+    ossGrantedAt: new Date().toISOString(),
+    ...(args.note ? { ossGrantNote: args.note } : {}),
+  });
+
+  console.log('\n✓ Written.');
+  renderGrant(await readGrant(args.stage, installationId), installationId);
+  console.log();
+}
+
+main().catch((err) => {
+  console.error('\n✗ Failed:', err instanceof Error ? err.message : err, '\n');
+  process.exit(1);
+});


### PR DESCRIPTION
**Stage 1 of 4** for #261. Plan: `docs/feat/20260812-01-oss-program-entitlement.plan.md`.

## What this ships

The core entitlement behind the free-hosted-access promise on [mergewatch.ai/open-source](https://mergewatch.ai/open-source). Approved open-source repositories get sponsored reviews — no balance, no card, no free-tier consumption.

- `BillingFields` gains the OSS grant fields on the existing `#SETTINGS` sentinel row (no new tables, no migration — DynamoDB attributes are additive).
- `getBillingFields` projects them. Its `ProjectionExpression` is explicit, so omitting a field reads back `undefined` with no error and would silently disable sponsorship — called out in a comment there.
- `billingCheck` gains an OSS branch evaluated first, plus `reason: 'oss' | 'free_tier' | 'paid'`.
- `recordReview` gains a matching accrual branch.
- New `oss-grant.ts` holds the eligibility predicate, shared by the gate and the accrual path so the two can't disagree about whether a review was sponsored.

## Design decisions worth reviewing

**Named repos only, matched on numeric `repo.id`.** No installation-wide mode. The deciding case is open core: a genuinely-OSS repo alongside public-but-commercial ones, where a blanket grant sponsors all of them — a cap bounds the money but not the principle. Matching on `full_name` would silently stop working after a rename or org transfer, lapsing sponsorship and filing a "credits required" issue on a public OSS repo, which is the exact outcome this design exists to prevent.

**Grant state on `#SETTINGS`, not per-repo rows.** The gate already reads `#SETTINGS`, so an in-row repo list costs zero extra reads; per-repo flags would add a second DynamoDB read to every review. Cap and accrual counters are installation-level regardless.

**The new repo-context parameter is optional.** `BillingCheckFn = typeof billingCheck` in `packages/mcp/src/middleware/billing.ts`, and MCP's `repo` input is optional (defaults to `'unknown'`), so visibility can't be verified there. An optional parameter means MCP compiles and behaves unchanged, with zero coordinated changes.

## Edge cases covered

- Named public repo sponsored; **unnamed** public repo in the same installation is not.
- Named repo flipped private stops being sponsored on the next review (live `isPublic` check, not an approval-time snapshot).
- Named repo renamed or transferred stays sponsored (ID match).
- Expired or revoked grant falls back to the **free tier**, never straight to blocked.
- Over the fair-use cap falls through to the standard gate rather than blocking.
- Sponsored reviews never increment `freeReviewsUsed` and never touch Stripe.
- Accrual is atomic (`ADD`) with a conditional reset path for month rollover, so concurrent reviews across repos in one installation can't lose an increment.
- Unparseable expiry fails closed.

## Verification

`pnpm run build`, `pnpm run typecheck`, `pnpm run test` all green — **118 billing tests** pass (up from 79).

## Risk

**Ships dark.** Nothing writes the grant fields until stage 3's operator script, so every code path here is a no-op in production until a grant exists.

## Deferred to later stages

- **Stage 2** — forward `repoId` + `isPublic` from the webhook (both live on `GitHubRepository`, neither is plumbed today) and pass them at `review-agent.ts:450`; OSS-aware block-notify copy; `E2E-82`.
- **Stage 3** — `scripts/grant-oss.sh` (grant/add/remove/revoke/inspect) with App-JWT repo→installation resolution; `E2E-83`.
- **Stage 4** — OSS state in `/billing/status` and `BillingClient.tsx`; docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)