### PR TITLE
feat(scripts): grant-oss operator script for the OSS Program (#261, stage 3)

### DIFF
--- a/docs-site/saas/billing.mdx
+++ b/docs-site/saas/billing.mdx
@@ -21,6 +21,20 @@ MergeWatch offers **free frontier-model review to open-source maintainers**, bey
 Applications are reviewed individually — tell us about the project and how you'd use MergeWatch.
 </Card>
 
+### How an approved grant behaves
+
+Once a project is approved, reviews on the covered repositories are **sponsored**: no charge, and they don't consume your free reviews or credit balance. Your **Dashboard → Billing** page shows an Open Source Program panel with the covered repositories, what's been sponsored this month, and your fair-use headroom.
+
+Specifics worth knowing:
+
+- **Only the repositories named in the grant are covered.** Approval is per project, not per organization — other repositories in the same installation bill normally. Ask us to add a repository and we will.
+- **Coverage requires the repository to be public at review time.** If a covered repository is made private, its next review is billed normally rather than sponsored.
+- **Renaming or transferring a covered repository is safe.** Grants track the repository itself, not its name.
+- **Fair use is a monthly ceiling**, shared across the repositories in your grant. Going over it doesn't block anything — reviews simply fall back to your free tier and balance for the rest of the month.
+- **Grants are time-limited** and renewed on request. When one expires, reviews fall back to the standard free tier and balance — they are never cut off outright.
+
+If a grant lapses or a project outgrows the fair-use limit, MergeWatch will say so on the pull request and point you at renewal or at [self-hosting](/self-hosting/overview), which is free and unlimited. You will not be asked for a card.
+
 Self-hosting is always free regardless, and remains the right choice if you would rather run the whole pipeline yourself. See [Self-hosted is always free](#self-hosted-is-always-free).
 
 ## Per-review pricing

--- a/docs/feat/20260812-01-oss-program-entitlement.plan.md
+++ b/docs/feat/20260812-01-oss-program-entitlement.plan.md
@@ -108,10 +108,10 @@ Ships dark — nothing writes the fields yet, so this is a no-op in prod and saf
 
 ### Phase 3 — Operator script
 
-- [ ] `scripts/grant-oss.sh` — `grant` / `--add` / `--remove` / `--revoke` / `--inspect`.
-- [ ] Repo → installation resolution via App JWT minted from SSM (as `github-auth-ssm.ts:57` does); `gh api` cannot hit `/repos/{owner}/{repo}/installation` with a user token.
-- [ ] Eligibility check (`private === false`), blast-radius print listing covered **and** uncovered repos in the installation (a `Query` on `installationId`, the partition key — no GSI needed), confirm before write.
-- [ ] Refuse to run without explicit `--stage prod|dev`.
+- [x] `scripts/grant-oss.ts` — `grant` / `--add` / `--remove` / `--revoke` / `--inspect`.
+- [x] Repo → installation resolution via App JWT minted from SSM (as `github-auth-ssm.ts:57` does); `gh api` cannot hit `/repos/{owner}/{repo}/installation` with a user token.
+- [x] Eligibility check (`private === false`), blast-radius print listing covered **and** uncovered repos in the installation (a `Query` on `installationId`, the partition key — no GSI needed), confirm before write.
+- [x] Refuse to run without explicit `--stage prod|dev`.
 
 **RUNBOOK:** `E2E-83` — grant, verify sponsorship, revoke, verify fallback to free tier.
 

--- a/docs/feat/20260812-01-oss-program-entitlement.plan.md
+++ b/docs/feat/20260812-01-oss-program-entitlement.plan.md
@@ -1,6 +1,6 @@
 # OSS Program — Sponsored-Review Entitlement
 
-**Status:** In progress
+**Status:** Shipped
 **Tracking issue:** [#261](https://github.com/mergewatch/mergewatch.ai/issues/261)
 
 ## Summary
@@ -117,10 +117,10 @@ Ships dark — nothing writes the fields yet, so this is a no-op in prod and saf
 
 ### Phase 4 — Dashboard + docs (capstone)
 
-- [ ] OSS fields in the `/billing/status` response (`packages/lambda/src/handlers/billing.ts:254`).
-- [ ] OSS Program state in `BillingClient.tsx` — covered repos, sponsored this month, fair-use headroom — replacing the balance/top-up prompt.
-- [ ] Update `docs-site/saas/billing.mdx` to describe actual grant behavior.
-- [ ] Graduate `docs/pending/oss-program.md` → `docs/oss-program.md`.
+- [x] OSS fields in the `/billing/status` response (`packages/lambda/src/handlers/billing.ts:254`).
+- [x] OSS Program state in `BillingClient.tsx` — covered repos, sponsored this month, fair-use headroom. Rendered *alongside* the balance card rather than replacing it: a granted installation can still hold private or unnamed repos that bill normally, so both states are simultaneously true.
+- [x] Update `docs-site/saas/billing.mdx` to describe actual grant behavior.
+- [x] Graduate `docs/pending/oss-program.md` → `docs/oss-program.md`.
 
 ## Out of scope / deferred
 

--- a/docs/oss-program.md
+++ b/docs/oss-program.md
@@ -1,6 +1,6 @@
 # MergeWatch for Open Source — sponsored reviews
 
-**Status:** 🚧 In progress (#261)
+**Status:** ✅ Shipped (#261)
 
 Approved open-source repositories have their PR reviews sponsored: no balance, no payment method, and no consumption of the standard 5-review free tier. This is the runtime behind the promise on [mergewatch.ai/open-source](https://mergewatch.ai/open-source).
 

--- a/docs/pending/oss-program.md
+++ b/docs/pending/oss-program.md
@@ -56,9 +56,38 @@ Accrual is atomic: same-period accruals use DynamoDB `ADD` so concurrent reviews
 
 ## Granting
 
-Grants are written only by `scripts/grant-oss.sh`, run manually by an operator. There is no admin API route and no dashboard granting UI. Because of that, the `#SETTINGS` row is the sole record of who was granted what and why — which is what `ossGrantedAt` and `ossGrantNote` exist for, and what `--inspect` renders back.
+Grants are written only by `scripts/grant-oss.ts`, run manually by an operator. There is no admin API route and no dashboard granting UI. Because of that, the `#SETTINGS` row is the sole record of who was granted what and why — which is what `ossGrantedAt` and `ossGrantNote` exist for, and what `--inspect` renders back.
 
-See [Operating the OSS Program](#operating-the-oss-program) below (added in stage 3).
+### Operating the program
+
+```bash
+# Approve a project (the maintainer must have installed the App first —
+# the installation is what a grant attaches to)
+scripts/grant-oss.ts octocat/hello-world --stage prod --note "form response #42"
+
+# Several repos in one installation
+scripts/grant-oss.ts octocat/hello-world,octocat/docs --stage prod
+
+# Amend an existing grant rather than re-granting
+scripts/grant-oss.ts --add    octocat/new-project --stage prod
+scripts/grant-oss.ts --remove octocat/old-project --stage prod
+
+# End it. Reviews fall back to the standard gate — they are NOT blocked.
+scripts/grant-oss.ts --revoke octocat/hello-world --stage prod
+
+# Audit an existing grant months later
+scripts/grant-oss.ts --inspect octocat/hello-world --stage prod
+```
+
+Options: `--cap <cents>` (default 2000 = $20/month), `--months <n>` (default 12), `--note "<text>"`, `--yes` to skip the confirmation.
+
+Three things the script does before writing:
+
+1. **Refuses to run without `--stage`.** There is no default. It writes to a live table, and defaulting the environment is how a grant lands in the wrong one.
+2. **Verifies the repo is public** and reports last-push and open-issue counts, so the human approving has the activity signal in front of them.
+3. **Prints the blast radius** — the repos this grant will cover *and* the other repos in the same installation it will not. An accidental omission is then visible before the write, not after a maintainer reports that half their project isn't being reviewed.
+
+Under the hood it needs two GitHub identities: an **App JWT** to call `GET /repos/{owner}/{repo}/installation` (the repo→installation lookup, which a user token cannot reach — this is why it isn't a `gh api` one-liner), then an **installation token** to read the repository itself. Credentials come from SSM (`/mergewatch/{stage}/github-app-id`, `/mergewatch/{stage}/github-private-key`) using the `mergewatch` AWS profile.
 
 ## Scope
 

--- a/docs/strategy/GOAL.md
+++ b/docs/strategy/GOAL.md
@@ -1,0 +1,98 @@
+# Goal: Position MergeWatch as the Software Validation Layer for the AI Build Era
+
+> **Status:** Brief / kickoff goal for market research + competitive analysis + strategy + execution planning.
+> **Owner:** Santthosh
+> **Use:** Hand this document to research/strategy agents as the top-level goal. Every agent should trace its output back to a workstream and deliverable defined here.
+
+---
+
+## North Star
+
+AI is now writing the majority of net-new code. The bottleneck has moved from **writing** software to **trusting** it. MergeWatch's ambition is to own that trust gap — to become the **validation layer** that sits between AI-generated code and production, verifying that what agents ship is correct, safe, and mergeable at machine speed.
+
+We are not "a better PR review bot." We are the **quality gate for autonomous and AI-assisted software development** — the system of record for whether a change is safe to merge, regardless of whether a human or an agent wrote it.
+
+## Strategic Question to Answer
+
+> As code generation becomes cheap and abundant, validation becomes the scarce, high-value layer. **Can MergeWatch credibly own that layer, and what is the sharpest wedge to get there?**
+
+Produce a market research + competitive analysis + strategy document that lets us make a confident go/no-go and sequencing decision on this pivot — and a concrete execution plan to run it.
+
+---
+
+## Research & Planning Workstreams
+
+Workstreams 1–4 run in **parallel**. Workstream 5 runs **after** them and consumes their outcomes.
+
+### 1. Market & Thesis Validation
+- Size and characterize the shift: how much code is now AI-generated, growth trajectory, where the trust/validation pain concentrates (velocity, hallucinated code, security regressions, review fatigue).
+- Who feels this pain most acutely today, and who will in 12–24 months? Identify the beachhead segment.
+- Validate or falsify the core thesis: is "validation" actually becoming the scarce layer, or does it get absorbed by the coding agents themselves (Cursor, Claude Code, Devin, Copilot)?
+
+### 2. Competitive Landscape
+- Map the field across adjacent categories: AI code review (CodeRabbit, Greptile, Graphite, Qodo, Bito/Diamond), traditional SAST/quality (Snyk, SonarQube, Semgrep), CI/testing/verification, and agent-native QA/eval tools.
+- For each: positioning, wedge, pricing, ICP, funding/momentum, and — critically — **whether they could extend into "validation layer" and how defensible we'd be against that.**
+- Identify white space: what does no one credibly own yet?
+
+### 3. Positioning & Differentiation
+- Define what "validation layer" means concretely and defensibly (vs. "AI PR review"). What capabilities, integrations, and trust guarantees make it a *layer* rather than a *feature*?
+- Articulate the wedge, the moat, and the expansion path (land → expand).
+- Draft the one-line category-defining narrative.
+
+### 4. Strategy & GTM Recommendation
+- Recommend the sharpest entry wedge and target ICP.
+- Sequencing: what to build/keep/drop from today's PR-review product to get to the validation-layer vision.
+- Pricing and packaging hypothesis for the new positioning.
+- Risks, kill-criteria, and the 2–3 experiments that would most quickly validate or invalidate the pivot.
+
+### 5. Execution Plan (derived from Workstreams 1–4)
+- Translate the recommended wedge, ICP, and sequencing into a concrete, phased project plan.
+- Every phase must trace back to a strategy outcome — no orphan work.
+- Break each phase into task items sized to be actionable (roughly PR- or sprint-sized), each with an owner-type, a definition of done, and a success metric.
+- Sequence by dependency and by "fastest path to validating the pivot" — front-load the experiments from Workstream 4.
+- Anchor against MergeWatch's real codebase today: what to build, keep, refactor, or retire from the current PR-review product.
+
+---
+
+## Tangible Artifacts (deliverables)
+
+| Artifact | Path | Purpose |
+|---|---|---|
+| **Strategy doc** | `docs/strategy/validation-layer-pivot.md` | Thesis + evidence, positioning, recommended wedge + GTM, risks, decision |
+| **Competitive matrix** | `docs/strategy/competitive-matrix.md` | Sourced comparison across categories + white-space analysis |
+| **Positioning one-pager** | `docs/strategy/positioning.md` | Category narrative, wedge, moat, expansion path |
+| **Project plan** | `docs/strategy/project-plan.md` | Phased roadmap → milestones → task items, each traced to a strategy outcome |
+| **Phase/task backlog** | `docs/strategy/backlog.md` | Flat, checkbox task list (per phase) ready to become GitHub issues/PRs |
+| **Decision & experiments** | `docs/strategy/decision.md` | Go/no-go recommendation + next 3 validating experiments with kill-criteria |
+
+---
+
+## Project Plan Shape (what `project-plan.md` should contain)
+
+- **Phase 0 — Validate the thesis:** the cheapest experiments that prove/disprove the pivot before heavy build. (Front-loaded from Workstream 4.)
+- **Phase 1 — Beachhead wedge:** the single sharpest capability for the beachhead ICP; the smallest thing that makes MergeWatch a *validation layer* not a *review bot*.
+- **Phase 2 — Expand the layer:** capabilities/integrations that turn the wedge into a defensible layer (land → expand).
+- **Phase 3 — Category & moat:** what compounds defensibility (data, integrations, trust guarantees) and establishes the category narrative.
+
+Each phase must specify: **goal · task items (checkboxed) · dependencies · success metric · exit criteria.**
+
+---
+
+## Constraints & Guardrails
+
+- Ground claims in real, cited sources — no hand-waving on market size or competitor facts.
+- Stay honest about disconfirming evidence (especially the "coding agents eat validation" risk).
+- Anchor to MergeWatch's actual assets today — multi-agent review pipeline, GitHub-native, self-host + SaaS, org custom agents (`packages/core/src/agents`, `packages/core/src/org-agents.ts`). The strategy and plan must be **reachable from where we are.**
+- Prefer **stacked, PR-sized tasks** consistent with how this repo already ships features.
+- Keep phases honest about kill-criteria — the plan should be as ready to *stop* the pivot as to pursue it.
+- Every artifact ends with a clear **recommendation and next steps.**
+
+---
+
+## Suggested Execution (how to run the agents)
+
+1. Fan out **Workstreams 1–4 in parallel** (market, competitive, positioning, GTM).
+2. Gate on a **synthesis** step that reconciles their findings into the wedge + ICP + sequencing decision.
+3. Run **Workstream 5 (execution plan) sequentially** so it consumes the real outcomes.
+4. Write all six artifacts to `docs/strategy/`.
+5. Adversarially verify the riskiest market claims and the core thesis before finalizing the decision.

--- a/docs/strategy/backlog.md
+++ b/docs/strategy/backlog.md
@@ -1,0 +1,59 @@
+# Backlog — Validation-Layer Pivot
+
+> Flat, checkbox task list per phase, ready to become GitHub issues/PRs. Derived from [`project-plan.md`](./project-plan.md).
+> **Date:** 2026-07-16. Tags: `[wedge] [moat] [product] [gtm] [thesis] [risk]` trace each task to a strategy outcome.
+> **Convention:** each unchecked box ≈ one PR- or sprint-sized unit, consistent with how this repo ships (stacked PRs, RUNBOOK scenarios).
+
+---
+
+## Phase 0 — Validate the thesis  ⛔ gates Phase 1
+
+- [ ] Build PR provenance classifier v0 (heuristic: commit trailers, `Co-Authored-By`, bot signatures, IDE metadata) in `packages/core` `[wedge]`
+- [ ] Add unit tests + accuracy harness for the classifier against a labeled PR sample `[wedge][risk]`
+- [ ] **Experiment 1:** retro provenance analysis — classify historical PRs on dogfood + design-partner repos, run existing pipeline, measure critical-finding rate by cohort `[thesis]`
+- [ ] Write up Experiment 1 results; check the **≥1.5× critical-finding-rate** threshold `[thesis]`
+- [ ] **Experiment 2:** build landing page ("validation gate for AI-generated code") + activation/CTA tracking `[gtm]`
+- [ ] **Experiment 3:** fake-door 3-tier pricing page; run Van Westendorp with 30–50 ICP contacts `[gtm]`
+- [ ] Recruit 3–5 design partners from beachhead ICP (30–150 eng, heavy agent adoption) `[gtm]`
+- [ ] **Phase gate:** confirm Exp-1 ≥1.5×, classifier ≥80%, ≥3 partners committed — else STOP & revisit wedge `[risk]`
+
+## Phase 1 — Beachhead wedge: provenance-aware blocking gate  ⛔ gates Phase 2
+
+- [ ] Productize provenance detection as a first-class signal on every review (label + score input) `[wedge]`
+- [ ] Extend `.mergewatch.yml` schema for validation policy-as-code (per-provenance, per-path rules) `[wedge][moat]`
+- [ ] Wire differentiated policy into the blocking gate via `org-agents.ts` (stricter for agent PRs) `[wedge]`
+- [ ] Make Check status + merge-readiness score the primary artifact; demote comment to secondary evidence `[product]`
+- [ ] Ship override capture: instrument accept/dismiss/override as labeled signals + storage `[moat]`
+- [ ] Refactor style/diagram agents into optional add-ons `[product]`
+- [ ] Update docs/RUNBOOK with provenance-gate scenarios `[product]`
+- [ ] Launch post publishing Experiment-1 provenance data ("validated N agent PRs, blocked X%") `[gtm]`
+- [ ] Refresh GitHub Marketplace listing around the validation-gate positioning `[gtm]`
+- [ ] **Phase gate:** ≥3 orgs run MergeWatch as a required check; blocking trusted (no false-block disables) `[risk]`
+
+## Phase 2 — Expand the layer: policy graph + evidence  ⛔ gates Phase 3
+
+- [ ] Dashboard: org-wide policy management (author rules across repos/paths/languages) `[moat]`
+- [ ] Surface org-over-repo conflict resolution clearly in the dashboard `[moat]`
+- [ ] Validation audit trail/dashboard: per-merge "validated / blocked / shipped anyway," exportable `[product][moat]`
+- [ ] Build on reviews table (`prNumber#commitSha`) + time-to-merge (#194) for the evidence surface `[product]`
+- [ ] Repo-by-repo rollout tooling (bulk-enable the gate across an org) `[gtm]`
+- [ ] Implement hybrid seat + validation-usage metering (Team quota + overage) `[gtm]`
+- [ ] Gate enterprise control plane (policy mgmt, audit, SSO) behind paid tier (open-core split) `[gtm][moat]`
+- [ ] Stand up sales-assist motion for 50+ dev / self-hosted + audit buyer `[gtm]`
+- [ ] **Phase gate:** ≥1 org running the gate across 10+ repos + first paid conversions `[risk]`
+
+## Phase 3 — Category & moat: agent governance
+
+- [ ] Agent-governance surface: per-agent policy + per-agent track record for Cursor/Claude Code/Devin/Copilot `[wedge][thesis]`
+- [ ] Verification depth v1: "did this PR add tests for what it changed?" + diff-coverage checks `[product]`
+- [ ] Compliance export as a named enterprise feature (SOC 2 / ISO / EU AI Act change-management) `[moat][thesis]`
+- [ ] Broaden integration surface beyond GitHub (GitLab/Bitbucket, CI, agent frameworks, IDEs) `[moat]`
+- [ ] Category narrative push: content/talks/ecosystem co-marketing around "the neutral, self-hostable validation gate" `[gtm]`
+- [ ] Measure feedback-loop precision advantage from accumulated override data `[moat]`
+
+---
+
+### Notes
+- **Do not start a phase until the prior phase's gate passes.** The Phase 0 gate is the highest-leverage checkpoint — it can kill the pivot cheaply.
+- Price points, quotas, and classifier thresholds are estimates pending the Phase 0 experiments (see [`decision.md`](./decision.md)).
+- Keep dogfooding: this repo's own `.mergewatch.yml` should adopt each new capability first.

--- a/docs/strategy/catch-up-plan.md
+++ b/docs/strategy/catch-up-plan.md
@@ -1,0 +1,90 @@
+# Catch-Up Plan — Closing the Gap vs. the Top 3
+
+> Companion to [`feature-gap.md`](./feature-gap.md). A detailed, phased task list to close the gaps vs. CodeRabbit, GitHub Copilot code review, and Qodo — sequenced by **wedge-alignment**, not blind parity.
+> **Date:** 2026-07-17 · **Strategy anchor:** [`validation-layer-pivot.md`](./validation-layer-pivot.md)
+
+## Guiding principle
+
+**Don't chase feature parity — close the gaps that convert "AI reviewer" into "validation gate of record," and defend the leads that make us defensible.** Every phase below is ordered so that wedge-reinforcing gaps (deterministic validation, enterprise trust, the feedback-loop moat) come before reach-expanding gaps (IDE, CLI, multi-platform).
+
+**Leads to protect throughout** (never regress these): blocking merge gate · open/unpaywalled self-host + BYO-model + air-gapped · agent-provenance detection · FP discipline · analytics depth.
+
+**Phase mapping to the strategy roadmap** ([`project-plan.md`](./project-plan.md)): Phase C1 ≈ Phase 1 (beachhead wedge), C2 ≈ Phase 2 (expand the layer), C3–C4 ≈ Phase 3 (category & moat). Gate each catch-up phase behind the strategy phase's exit criteria.
+
+Each task is tagged with the gap it closes (`#N` from [`feature-gap.md`](./feature-gap.md)) and sized ≈ one PR/sprint unit. Effort: **S** (≤1 wk) · **M** (1–3 wk) · **L** (3–6 wk) · **XL** (quarter).
+
+---
+
+## Phase C1 — Table-stakes credibility + first deterministic signal
+**Goal:** Stop reading as "less finished," and land the first deterministic validation signal that differentiates the gate. **Gate behind strategy Phase 1.**
+
+- [ ] **Committable one-click suggested fixes** `#7` — convert the prose `suggestion` field into GitHub committable `suggestion` blocks on inline comments; only for verified (W2) findings. **M** 🔴
+- [ ] **Incremental review** `#14` — review only the new-commit delta on re-review instead of re-running all agents on the full diff; reuse existing delta-tracking (`review-delta.ts`) to scope agent input. Cuts cost/latency at agent-PR volume. **L** 🟠
+- [ ] **Bundle Semgrep as a deterministic validation signal** `#15` — run Semgrep on changed files, normalize findings into the finding schema, feed into the merge score + blocking gate. First proof of "LLM + deterministic evidence." **L** 🔴
+- [ ] **Bundle secret scanning (Gitleaks/TruffleHog)** `#16` — scan the diff for secrets; a hit is a blocking-by-default validation failure. **M** 🔴
+- [ ] **PR walkthrough table** `#4` — upgrade the prose summary to a file-by-file changes table (parity with CodeRabbit/Qodo `/describe`). **S** 🟠
+- [ ] **Expand the command set** `#9` — add `@mergewatch describe`, `@mergewatch improve` (surface fixes), align naming with user expectations from CodeRabbit/Qodo. **S** 🟠
+
+**Exit criteria:** committable fixes shipped; Semgrep + secret findings flow into the gate and block on critical; incremental review live and measurably cheaper. **Success metric:** review cost/PR down ≥30% on re-reviews; ≥1 real secret/SAST finding blocked in a design-partner repo.
+
+---
+
+## Phase C2 — Enterprise trust + deterministic depth (unlock the ICP)
+**Goal:** Make MergeWatch procurable by the regulated mid-market beachhead and complete the deterministic-validation story. **Gate behind strategy Phase 2.**
+
+- [ ] **SOC 2 Type II** `#29` — begin the audit (Vanta/Drata-style continuous evidence); the single biggest procurement unlock for the ICP. **XL** (external, start early) 🔴
+- [ ] **SSO / SAML** `#29` — enterprise auth for the dashboard. **L** 🔴
+- [ ] **RBAC** `#29` — roles for org policy admin vs. viewer vs. member. **M** 🔴
+- [ ] **SCA / dependency scanning (OSV-Scanner/Trivy)** `#17` — flag vulnerable/hallucinated dependencies ("slopsquatting" defense) as a validation signal. **M** 🟠
+- [ ] **Sandboxed custom pre-merge checks** `#19` — extend blocking custom agents to run sandboxed shell commands / project tests (not just LLM prompts); matches CodeRabbit's agentic checks. **XL** 🟠
+- [ ] **Ticket/requirement compliance** `#21` — validate a PR against its linked Jira/Linear/GitHub issue; surface non-compliance as a gate signal. **L** 🟠
+- [ ] **Compliance/audit evidence export** `#22` — export the per-merge validation record (what was checked, verdict, policies, evidence) for SOC 2/ISO/EU AI Act change-management. Builds on the reviews table + TTM (#194). **L** 🟠
+
+**Exit criteria:** SOC 2 audit in progress + SSO/RBAC shipped; SCA live; at least one enterprise-grade validation evidence export usable in a real compliance context. **Success metric:** first regulated-mid-market design partner passes procurement; audit export used by ≥1 buyer.
+
+---
+
+## Phase C3 — The feedback-loop moat + context depth
+**Goal:** Build the compounding differentiators — learning from feedback and deeper repo understanding. **Gate behind strategy Phase 3.**
+
+- [ ] **Override/feedback capture (moat foundation)** `#10` — instrument every accept/dismiss/`/resolve`/override as a labeled signal (partly present via `finding_dispositions`; make it a first-class mechanic). Prereq for learnings. **M** 🔴
+- [ ] **Learnings / memory engine** `#10` — aggregate accepted/dismissed patterns per org/repo and feed them back into agent prompts (MergeWatch's answer to CodeRabbit "learnings" / Qodo "auto best-practices"). Reinforces the feedback-loop moat from the strategy. **XL** 🔴
+- [ ] **Whole-repo context / lightweight index** `#13` — persistent per-repo index for cross-file reasoning, beyond on-demand file fetch; improves correctness on large PRs. **XL** 🟠
+- [ ] **Test-generation / behavior-coverage signal (v1)** `#12` — "did this PR add tests for what it changed?" → optionally generate a candidate test and verify it runs/increases coverage (Qodo Cover's differentiator; scope tightly as a validation signal, not a full test-gen product). **XL** 🟠
+- [ ] **Agentic fix handoff** `#11` — hand a finding to a coding agent (Claude Code/Cursor/Copilot) to auto-open a fix PR; ride the agent ecosystem. **L** 🟠
+
+**Exit criteria:** override data driving measurable review precision improvement; learnings applied in production; a behavior-coverage signal feeding the gate. **Success metric:** demonstrable FP-rate reduction from learnings; feedback-loop precision advantage visible in analytics.
+
+---
+
+## Phase C4 — Reach (defer until wedge is won)
+**Goal:** Expand surface area and TAM *after* the validation-gate position is established. Explicitly deferred — off the core wedge.
+
+- [ ] **IDE extension (VS Code / Cursor)** `#23` — local pre-PR validation; MCP server partially covers this today, so lower urgency. **XL** 🔴 (deferred)
+- [ ] **CLI local review** `#24` — terminal/agent-mode self-review, JSON output for agent loops. **L** (deferred)
+- [ ] **GitLab support** `#25` — first non-GitHub platform; abstract the GitHub client behind the existing provider interfaces. **XL** (deferred)
+- [ ] **Bitbucket / Azure DevOps** `#25` — follow GitLab. **XL** (deferred)
+
+**Exit criteria:** none gating — pursue opportunistically once C1–C3 land and the ICP is proven. Note: Copilot is also GitHub-only, so multi-platform is not urgent against the platform threat.
+
+---
+
+## What we deliberately are NOT doing (and why)
+
+- **Not chasing CodeRabbit's ~50 bundled linters wholesale.** Bundle the few that produce *gate-worthy* signals (Semgrep, Gitleaks/TruffleHog, OSV-Scanner/Trivy). Breadth-for-breadth is off-wedge.
+- **Not positioning on "multi-agent pipeline."** Qodo 2.0 has the same architecture. Position on the gate + provenance + open neutrality instead.
+- **Not building a full test-generation product.** Take only the behavior-coverage *validation signal*, not a Qodo-Cover competitor.
+- **Not prioritizing IDE/CLI/multi-platform early.** They power CodeRabbit's PLG but don't advance "the merge gate of record."
+
+---
+
+## Sequencing at a glance
+
+```
+C1 Table-stakes + first deterministic signal   →  C2 Enterprise trust + deterministic depth  →  C3 Feedback-loop moat + context  →  C4 Reach (deferred)
+   committable fixes, Semgrep, secrets,            SOC2/SSO/RBAC, SCA, sandboxed checks,          learnings, index, coverage,          IDE, CLI, GitLab,
+   incremental, walkthrough                        ticket compliance, audit export                agentic handoff                      Bitbucket/Azure
+   (≈ strategy Phase 1)                            (≈ strategy Phase 2)                           (≈ strategy Phase 3)                 (post-wedge)
+```
+
+**Bottom line:** MergeWatch's core review quality is already competitive and its wedge features (blocking gate, open neutrality, provenance detection) are *ahead*. The catch-up work is real but bounded — close the deterministic-validation, enterprise-trust, and feedback-loop gaps first; defer the reach/ecosystem gaps that don't serve the validation-layer wedge.

--- a/docs/strategy/competitive-matrix.md
+++ b/docs/strategy/competitive-matrix.md
@@ -1,0 +1,73 @@
+# Competitive Matrix — AI Code Validation Landscape
+
+> Companion to [`validation-layer-pivot.md`](./validation-layer-pivot.md). Sourced comparison + white-space analysis.
+> **Date:** 2026-07-16. Pricing/funding claims are URL-cited; estimates and unverified figures are flagged inline.
+
+## Executive framing
+
+The market has bifurcated into three layers:
+1. **AI code review** — hottest, best-funded, most crowded — and actively re-branding from "review" to "quality gate / validation" in real time.
+2. **Traditional SAST / quality** (Snyk, Sonar, Semgrep) — owns enterprise trust, compliance, and distribution, but bolting AI onto legacy engines.
+3. **Autonomous testing / verification** (Diffblue, Qodo test-gen) — adjacent but narrow.
+
+**Uncomfortable headline:** "validation layer" is not white space — it is the single most contested piece of narrative real estate in dev tools right now, with two funded incumbents (CodeRabbit, Qodo) already planting flags. MergeWatch must win on *substance* (neutrality, deployment flexibility, policy-gating with a real readiness verdict), not on the phrase.
+
+---
+
+## Comparison matrix
+
+| Competitor | Category | Positioning | Wedge | ICP | Pricing | Funding / Momentum | Could own "validation layer"? |
+|---|---|---|---|---|---|---|---|
+| **CodeRabbit** | AI review | "Quality gates for AI coding" — #1 GitHub Marketplace AI app | Line-by-line PR review + agentic chat + pre-merge checks | SMB→mid-market; OSS free | Pro $24/user/mo (annual), Pro+ $48; Enterprise ~$15k/mo (500+) | $60M Series B @ **$550M** val (Sep 2025); $88M total; >$15M ARR, ~20%/mo; 8,000+ paying customers | **HIGH** — building "standards & governance platform"; distribution + capital + narrative aligned |
+| **Qodo** (ex-CodiumAI) | AI review + test-gen | "Code verification as AI coding scales" | Verification + test-gen + governance; full-codebase context | Enterprise (Nvidia, Walmart, Red Hat, Intuit) | Free dev; Teams ~$19–30/user/mo; Enterprise custom | $70M Series B (Mar 2026); **$120M total**; framing verification as "a category, not a feature" | **HIGH** — most on-nose competitor; spans review AND test-gen; using our exact language |
+| **Graphite (Diamond)** | AI review | "Reimagine code review for the age of AI" | Stacked PRs + workflow lock-in + Diamond reviewer | Elite eng orgs (Shopify, Snowflake, Figma) | Diamond free ≤100 PRs/mo; $15/contributor add-on; $20 standalone | $52M Series B (Accel; Anthropic/Menlo); ~$72–91M total; ~$5.3M ARR (*est.*) | **MED-HIGH** — strong brand + workflow moat; review is a feature, not the whole thesis |
+| **Greptile** | AI review | Codebase-aware ("full-repo RAG") review agent | Deep whole-codebase context vs. diff-only | Mid-market / enterprise | $30/active dev/mo incl. 50 reviews, then $1/review; self-host custom | $4.1M seed → **$25M Series A** (Benchmark); ~$180M val *in talks* (unconfirmed) | **MED** — strong tech + tier-1 VC, but "better review" wedge, not yet a gate/governance story |
+| **Ellipsis** | AI review | AI review + auto-fix PRs | Finds bug → writes fix | SMB / startups | $20/dev/mo; free public repos | $2M seed (YC W24) | **LOW** — feature-level; no enterprise trust/compliance surface |
+| **Korbit** | AI review | AI reviewer for GitHub/Bitbucket | Mentorship / education framing | SMB | Free ≤5 reviews/mo; Pro $24/user/mo | ~$11M (Khosla); **acquired by Boost Security May 2026** (verify) | **LOW** — absorbed into AppSec vendor; independent thesis gone |
+| **Sourcery** | AI review | Cheap Python-first review | Price + language niche | Python teams | ~$10–12/seat/mo | Not disclosed | **LOW** — commodity, niche |
+| **Bito** | AI review | Codebase-aware review + "AI Architect" | Usage-based indexing | SMB | Team $12/seat, Pro $20; usage-based Architect | $5.7M seed ext ($8.8M total) | **LOW** — under-capitalized vs. leaders |
+| **GitHub Copilot code review** | Platform-native | "Zero incremental cost" review inside Copilot | **Distribution** — bundled with existing Copilot seats | Everyone on GitHub | Included in Copilot (Free/$10 Pro; Max $100/mo) | Microsoft-scale; agentic review shipped Mar 2026 | **HIGH (as bundler)** — owns the merge button and the diff; existential platform risk |
+| **Cursor Bugbot** | Editor-native | Background bug-catcher pre-review | Lives in Cursor ecosystem | Cursor teams | Inside Teams $40/user/mo; ~$1–1.50/run (Jun 2026); GitHub-only | Cursor's scale/valuation | **MED** — owns the generation surface, but review is a side feature, GitHub-only |
+| **Snyk** | SAST / security | Developer-first security; "close the AI trust gap" | Security shift-left + compliance | Enterprise AppSec | Team ~$25/contributing dev; Enterprise custom | **$7.4B val (2022)**; ~$326M ARR (~7% YoY); S-1 filed, 2026 IPO watch | **HIGH (security slice)** — owns enterprise trust/compliance, but validation ≠ security; slower growth |
+| **Sonar (SonarQube)** | Quality | "Fight AI slop & verify AI code" — AI Code Assurance | Deterministic quality gates + huge install base | Enterprise + mid-market | Cloud from ~$34/mo (LOC-based); Server ~$720/yr → $15k–$500k+ | Large private co (revenue undisclosed); shipping AI Code Assurance 2025–26 | **MED-HIGH** — "quality gate" is literally their term; deterministic engine + install base, but legacy AI velocity |
+| **Semgrep** | SAST | AppSec platform (SAST/SCA/Secrets) + Assistant | Custom rules + fast SAST | Security-led orgs | Free ≤10 contributors; Team $35/contributor/mo; Enterprise custom | **$100M Series D** (Menlo, Feb 2025); ~$193–204M total | **MED** — strong AppSec wedge, but security-scoped |
+| **Codacy / DeepSource** | Quality | Multi-tool quality + security platforms | Bundled analysis | SMB→mid | Codacy $15/user; DeepSource $24/user | Mid-size; no recent mega-rounds | **LOW-MED** — commoditizing |
+| **Diffblue** | Autonomous testing | "AI testing agent for enterprise unit testing" (Java) | Deterministic auto-generated tests | Enterprise Java | From $1,500/5k LOC; Dev $30/mo | Oxford spinout; enterprise niche | **LOW** — narrow (Java tests), but *test-as-validation* is a complementary angle to watch |
+
+*Sources & flags at bottom.*
+
+---
+
+## White-space analysis
+
+**The word is taken; the substance is only partially claimed.** CodeRabbit, Qodo, and Sonar all push the identical "quality gate / verify AI code" narrative, and the top two are far better funded. MergeWatch cannot win by planting the same flag. Genuine gaps that remain:
+
+1. **Deployment-mode neutrality + air-gapped / self-hosted with any LLM.** Nearly every funded competitor is SaaS-first and cloud-LLM-locked. MergeWatch's dual SaaS **and** self-hosted-with-any-LLM (Bedrock/Anthropic/LiteLLM/Ollama) is genuinely differentiated for regulated/defense/on-prem buyers — a segment Snyk/Sonar serve but at legacy prices and without an AI-native pipeline. **Defensible wedge.**
+
+2. **A composable merge-readiness *score* + org-defined blocking custom agents.** Competitors emit findings; few emit an auditable, policy-driven **verdict** that gates the merge with org-authored, path/language-targeted agents that can *block*. MergeWatch's org custom agents (#235) + 1–5 score is closer to a "policy engine for AI code" than a reviewer. Lean into "the programmable gate," not "better review."
+
+3. **The neutral / open-source trust position.** Every commercial incumbent either sells the generator or is VC-pressured to maximize seat revenue. An open-source, model-agnostic, generator-agnostic validator can honestly say *"we don't sell the AI that wrote your code, so we can grade it."* MergeWatch's most durable strategic asset.
+
+4. **Verification depth (does the code actually work) — not just review.** Nobody credibly owns static review + generated tests + runtime/behavioral verification. Qodo is closest. Expensive to build, but the true "validation layer" whitespace; review alone is table stakes.
+
+**Verdict:** Position as **"the neutral, self-hostable validation gate,"** not "best review."
+
+---
+
+## Threat ranking — 3 most likely to own the validation layer
+
+1. **CodeRabbit — highest threat.** Capital ($550M val), distribution (#1 GitHub Marketplace, 8,000+ customers), growth (>$15M ARR, ~20%/mo), *and* the exact strategic intent ("quality gates for AI coding," extending pre-merge checks into a governance platform). Beating us to the positioning with more resources.
+
+2. **GitHub Copilot code review — structural/platform threat.** Microsoft owns the repo, the diff, and the merge button, and ships agentic review at zero incremental cost. It only needs to be good-enough and free — the commoditization risk that caps every standalone reviewer's TAM. Our defense is exactly what Copilot can't be: self-hosted, model-neutral, generator-neutral.
+
+3. **Qodo — most direct narrative threat.** Using our literal language ("code verification"), $120M raised, enterprise logos, and uniquely spans review AND test-generation — the deepest claim on "does the code actually work."
+
+**Honorable mention — Snyk:** enterprise-trust incumbent ($326M ARR, 2026 IPO watch) that could annex "validation" from the security/compliance direction, but ~7% YoY growth suggests a slower-moving giant.
+
+---
+
+## Sources & flags
+
+Pricing/funding cited to primary sources where possible: [CodeRabbit pricing](https://www.coderabbit.ai/pricing) & [Series B](https://sacra.com/c/coderabbit/); [Qodo $70M](https://techcrunch.com/2026/03/30/qodo-bets-on-code-verification-as-ai-coding-scales-raises-70m/) & [pricing](https://www.qodo.ai/pricing/); [Graphite Series B + Diamond](https://graphite.com/pricing); [Greptile pricing](https://www.greptile.com/pricing) & [per-review analysis](https://www.agent-wars.com/news/2026-05-01-greptile-per-review-pricing); [Snyk plans](https://snyk.io/plans/); [Sonar pricing](https://www.sonarsource.com/plans-and-pricing/); [Semgrep pricing](https://semgrep.dev/pricing); [Diffblue pricing](https://www.diffblue.com/pricing).
+
+**Flags:** Graphite ARR (~$5.3M) and Greptile $180M valuation are estimates/in-talks, not confirmed. Sonar and Diffblue revenue are not public. Korbit acquisition (per PitchBook/Crunchbase) should be verified. Cursor/Copilot review-pricing details are from third-party comparison sites — confirm on the vendors' own pages before external use.

--- a/docs/strategy/decision.md
+++ b/docs/strategy/decision.md
@@ -1,0 +1,63 @@
+# Decision & Validating Experiments
+
+> Companion to [`validation-layer-pivot.md`](./validation-layer-pivot.md). Go/no-go recommendation + the experiments that de-risk the pivot before heavy build.
+> **Date:** 2026-07-16 · **Status:** For decision
+
+---
+
+## Recommendation: **GO — validate then build**
+
+Pivot MergeWatch's narrative and product toward the **neutral, self-hostable, provenance-aware validation gate**, but do **not** open with heavy build. The thesis is well-supported and the wedge is defensible, yet the space is contested by better-funded incumbents (CodeRabbit $550M, Qodo $120M) and a platform threat (GitHub Copilot native review). The correct sequence is to run the cheapest disproving experiment first, then build only what the evidence justifies.
+
+### Why GO
+- **Thesis SUPPORTED (with a live threat):** AI writes ~40–50% of net-new code; review time up 91% on high-AI teams; 45% of AI code fails security tests; trust *falling* as usage rises; >$1.2B flowing to standalone verification. The pain is real, quantified, and concentrated at the merge chokepoint.
+- **Defensible wedge exists:** neutrality + deployment flexibility + policy-gating + evidence is what a self-reviewing generator and a SaaS-only incumbent structurally *cannot* offer.
+- **~70% already built:** the blocking org-custom-agent gate (#235), Check Runs, and the 1–5 merge-readiness score are shipped. This is a productization, not a rebuild.
+
+### Why not "GO, full build"
+- "Validation layer" as a phrase is the most contested narrative in dev tools right now; we win on substance, not by out-marketing $550M.
+- The single biggest thesis risk — *do agent PRs actually fail validation more than human PRs?* — is cheaply testable and, if false, collapses the wedge. Test it before building it.
+
+---
+
+## The next 3 experiments (in priority order)
+
+### Experiment 1 — Retro provenance analysis *(run this first — it's the cheapest and the thesis hinges on it)*
+- **Hypothesis:** agent-authored PRs fail validation materially more than human-authored PRs.
+- **Method:** classify historical PRs on our dogfood repo + 3–5 design-partner repos by authorship (commit trailers, `Co-Authored-By`, bot signatures), run the existing pipeline, measure block/critical-finding rate by cohort.
+- **Success metric:** agent PRs show **≥1.5× higher critical-finding rate** than human PRs.
+- **Effort:** ~1 week (scripting over existing agents + provenance heuristics).
+- **Why first:** if agent PRs *don't* fail more, the entire wedge collapses — before any build. If they do, we get both proof *and* the killer marketing stat ("we validated N agent PRs and blocked X% for security flaws").
+- **Kill signal:** critical-finding rates are statistically indistinguishable across cohorts.
+
+### Experiment 2 — Provenance-value smoke test
+- **Hypothesis:** teams will pay for a stricter gate specifically on agent-authored PRs.
+- **Method:** landing page + demo positioning MergeWatch as "the validation gate for AI-generated code"; drive traffic from HN/GitHub Marketplace; measure install→activation and a "Book Enterprise" CTA.
+- **Success metric:** **>8% of qualified visitors install or book** *(est.)*.
+- **Effort:** ~1 week (copy + existing product, no new build).
+- **Kill signal:** activation far below generic-review benchmarks — the provenance framing doesn't move buyers.
+
+### Experiment 3 — Pricing willingness test
+- **Hypothesis:** the hybrid seat + validation-usage model clears vs. flat-seat incumbents.
+- **Method:** Van Westendorp / fake-door pricing page with the three tiers shown to 30–50 ICP contacts.
+- **Success metric:** **>50% find the Team tier "acceptable value" and <30% flag usage-billing as a dealbreaker.**
+- **Effort:** ~3–4 days.
+- **Kill signal:** usage-on-top-of-seats triggers the same backlash Greptile's per-review pricing drew.
+
+---
+
+## Risks & kill-criteria
+
+| # | Risk | Kill-criterion (stop signal) |
+|---|---|---|
+| 1 | **Coding agents absorb validation** (already partial — Copilot ships native review free) | In a customer sample, >40% say native agent self-review is "good enough" and drop/refuse independent validation within 2 quarters |
+| 2 | **Market too crowded / commoditized** (race to the bottom on price) | CAC exceeds 12-month gross margin per customer for 2 consecutive quarters with no provenance-driven win-rate lift over generic reviewers |
+| 3 | **Provenance signal weak / gameable** | Classifier accuracy <80% on real customer PR streams after reasonable effort |
+| 4 | **Buyers won't pay usage on top of seats** | >30% of Team accounts hit their quota and churn/downgrade rather than expand |
+| 5 | **Enterprise motion too heavy for a small team** | Enterprise sales cycle median >6 months with <20% close rate after 10 qualified opportunities |
+
+---
+
+## Decision gate
+
+**Proceed to [Phase 0 of the project plan](./project-plan.md) immediately** (it *is* Experiment 1 plus provenance detection). Gate the Phase 1 build on Experiment 1 clearing its ≥1.5× threshold. If Experiment 1 fails, stop and revisit the wedge — do not spend build cycles on a differentiator the data doesn't support.

--- a/docs/strategy/feature-gap.md
+++ b/docs/strategy/feature-gap.md
@@ -1,0 +1,122 @@
+# Feature Gap Analysis — MergeWatch vs. Top 3 Players
+
+> Companion to [`validation-layer-pivot.md`](./validation-layer-pivot.md) and [`competitive-matrix.md`](./competitive-matrix.md). Detailed, dimension-by-dimension feature gap vs. the three ranked threats. Catch-up plan: [`catch-up-plan.md`](./catch-up-plan.md).
+> **Date:** 2026-07-17
+> **Compared against:** **CodeRabbit** (highest threat, $550M), **GitHub Copilot code review** (platform/bundling threat), **Qodo** (narrative/verification threat).
+> **Sources:** MergeWatch capabilities are cited from the codebase; competitor capabilities from each vendor's docs/changelog (see [`competitive-matrix.md`](./competitive-matrix.md) and the research briefs). Competitor claims dated 2025–2026.
+
+---
+
+## How to read this
+
+Legend for each cell:
+- ✅ **Strong / ahead** — implemented and competitive or better
+- 🟡 **Partial** — exists but thinner than competitors
+- ❌ **Missing** — not implemented
+
+Gap severity (MergeWatch's position vs. the *best* of the three):
+- 🔴 **Major gap** — table-stakes or wedge-relevant capability we lack
+- 🟠 **Moderate gap** — meaningful but not existential
+- 🟢 **At parity or ahead** — no catch-up needed; defend it
+
+---
+
+## Executive read
+
+**MergeWatch is not behind on core review quality — it's behind on surface area and ecosystem, and *ahead* on exactly the things the validation-layer wedge needs.**
+
+**Where MergeWatch already leads (defend these — they are the wedge):**
+1. **Blocking merge gate** — real `REQUEST_CHANGES` + blocking org custom agents that fail the check. **Copilot literally cannot approve/request-changes (comment-only); Qodo can't hard-block either (labels + CI wiring).** Only CodeRabbit matches. This is our sharpest structural edge over 2 of 3.
+2. **Open, unpaywalled deployment + model neutrality** — self-hosted (Docker+Postgres) + any LLM (Bedrock/Anthropic/LiteLLM/Ollama) + air-gapped, available on the open-source/self-host path rather than behind an enterprise contract. **Copilot has no GHES/self-host at all; CodeRabbit has no BYO-model at all; Qodo *does* match (on-prem + air-gapped + BYOK) but only at its Enterprise tier.** The differentiator is *neutrality without a paywall* + genuinely open-source — not neutrality per se.
+3. **Agent-authored PR detection** — already implemented (`agent-detection.ts`, strict-mode prompt suffix). **None of the three ship explicit provenance detection.** The wedge feature is *already built* — this is the one lead that is unique vs. all three.
+4. **False-positive discipline** — W2 critical-verification, W9 fingerprinting, FP-G/H/J passes, confidence floor. More sophisticated FP-suppression than the "~15–25% FP rate" reported for Copilot. (Note: Qodo 2.0's judge agent is comparable; CodeRabbit's agentic validation partial. Parity-to-ahead, not a moat by itself.)
+5. **Analytics depth** — FP-insight rollups, TTM (#194), cost, engagement/dispute tracking. CodeRabbit's reporting is prompt-driven (no dashboards); Copilot thin; Qodo has an Enterprise dashboard (active users, acceptance rate, findings/risk) that is roughly comparable.
+
+**Reality check on architecture:** Qodo 2.0 (Feb 2026) is itself a *parallel multi-agent review + judge/orchestrator* design — the same pattern MergeWatch uses, with a (self-reported) benchmark lead. **The multi-agent pipeline is not a differentiator; the wedge (blocking gate + provenance + open neutrality) is.** Do not position on "we use multiple agents."
+
+**Where MergeWatch is behind (the catch-up list):**
+Committable one-click fixes · bundled SAST/secret/SCA scanners · learnings/memory · whole-repo context/index · test generation · IDE extension · CLI · multi-platform (GitLab/Bitbucket/Azure) · ticket/requirement compliance · agentic fix handoff · enterprise trust certs (SOC2/SSO/RBAC) · incremental review · richer command set/walkthrough.
+
+---
+
+## The gap matrix
+
+| # | Capability | MergeWatch | CodeRabbit | Copilot review | Qodo | Gap |
+|---|---|---|---|---|---|---|
+| **Core review** |
+| 1 | LLM multi-category review (bug/security/perf/style) | ✅ 6 agents + orchestrator | ✅ | ✅ | ✅ | 🟢 |
+| 2 | Merge-readiness / effort score | ✅ 1–5 score | 🟡 checks | ❌ | 🟡 effort label | 🟢 ahead |
+| 3 | False-positive suppression (verification passes) | ✅ W2/W9/FP-G/H/J | 🟡 agentic validation | 🟡 (high FP reported) | 🟡 threshold | 🟢 ahead |
+| 4 | PR summary + walkthrough table | 🟡 prose summary | ✅ walkthrough + file table | ✅ summary | ✅ /describe rich | 🟠 |
+| 5 | Architecture/sequence diagrams | ✅ Mermaid | ✅ sequence diagrams | ❌ | 🟡 | 🟢 |
+| 6 | Line-by-line inline comments | ✅ | ✅ | ✅ | ✅ | 🟢 |
+| **Fixes & interactivity** |
+| 7 | Committable one-click suggested fixes | ❌ prose only | ✅ | ✅ | ✅ commitable | 🔴 |
+| 8 | Chat / conversational Q&A on PR | 🟡 @mergewatch Q&A + inline reply | ✅ full chat | 🟡 limited | ✅ /ask | 🟠 |
+| 9 | Command set (/review /improve /describe …) | 🟡 review/summary/question | ✅ rich | 🟡 | ✅ rich | 🟠 |
+| 10 | Learnings / memory from team feedback | ❌ conventions only | ✅ learnings engine | ❌ | ✅ auto best-practices | 🔴 |
+| 11 | Agentic fix handoff / auto-open fix PR | ❌ | ✅ agent handoff | ✅ coding agent PR | ✅ /implement | 🔴 |
+| 12 | Test generation | ❌ flags gaps only | 🟡 docstrings | 🟡 via agent | ✅ Cover/Gen | 🟠 |
+| **Context** |
+| 13 | Whole-repo context (graph/RAG/index) | 🟡 on-demand file fetch | ✅ code-graph | ❌ diff-only | ✅ Context Engine RAG | 🟠 |
+| 14 | Incremental review (new commits only) | ❌ full diff each time | ✅ | ✅ | 🟡 chunking | 🟠 |
+| **Deterministic validation** |
+| 15 | Bundled linters/SAST | ❌ linter-awareness only | ✅ ~50 tools (Semgrep…) | 🟡 CodeQL | 🟡 some | 🔴 |
+| 16 | Secret scanning | ❌ LLM review only | ✅ TruffleHog/Gitleaks | ✅ secret scanning | 🟡 | 🔴 |
+| 17 | SCA / dependency scanning | ❌ | ✅ OSV-Scanner/Trivy | ✅ Dependabot | 🟡 | 🟠 |
+| **Gating & governance** |
+| 18 | **Blocking merge gate (approve/request-changes/required check)** | ✅ REQUEST_CHANGES + blocking org agents | ✅ request-changes workflow | ❌ comment-only | ❌ labels + CI wiring | 🟢 **ahead of 2/3** |
+| 19 | Custom pre-merge checks (sandboxed shell/CI) | 🟡 custom agents (LLM) | ✅ sandboxed shell + MCP | ❌ | 🟡 compliance checklists | 🟠 |
+| 20 | Org-level policy / standards hierarchy | ✅ org custom agents + targeting | ✅ path instructions | 🟡 instruction files | ✅ pr-agent-settings repo | 🟢 |
+| 21 | Ticket/requirement compliance (Jira/Linear) | ❌ | ✅ | ❌ | ✅ ticket compliance | 🟠 |
+| 22 | Compliance/audit evidence export | 🟡 review records, no export | 🟡 | ❌ | 🟡 compliance labels | 🟠 |
+| **Platform & reach** |
+| 23 | IDE extension (VS Code/JetBrains/Cursor) | ❌ MCP server only | ✅ VS Code/Cursor/Windsurf | ✅ native | ✅ Qodo Gen | 🔴 |
+| 24 | CLI local review | ❌ | ✅ | 🟡 | ✅ | 🟠 |
+| 25 | Multi-platform (GitLab/Bitbucket/Azure/Gitea) | ❌ GitHub only | ✅ 4 platforms | ❌ GitHub only | ✅ 5 platforms | 🟠 |
+| 26 | MCP support | ✅ MCP server | ✅ in checks | ❌ | ✅ | 🟢 |
+| **Deployment & trust** |
+| 27 | Self-hosted / on-prem (open path) | ✅ Docker+Postgres, all tiers | 🟡 Enterprise only | ❌ no GHES | 🟡 Enterprise only | 🟢 **ahead of Copilot; open vs. paywalled for CR/Qodo** |
+| 28 | BYO-model / any LLM / air-gapped | ✅ 4 providers + Ollama, open | ❌ no BYO | 🟡 cloud model picker | 🟡 BYOK Enterprise | 🟢 **ahead of CR + Copilot; open vs. Qodo Enterprise** |
+| 29 | Enterprise trust (SOC2, SSO/SAML, RBAC) | 🟡 self-host helps; certs unclear | ✅ SOC2 II, SSO, RBAC | ✅ SSO, indemnity | ✅ SOC2, SSO | 🔴 |
+| **Wedge-specific** |
+| 30 | Agent-authored PR detection / provenance | ✅ agent-detection.ts + strict mode | 🟡 workflow only | ❌ | ❌ | 🟢 **unique — the wedge** |
+| 31 | Analytics dashboards (cost/FP/TTM/engagement) | ✅ rich | 🟡 prompt-driven reports | 🟡 | 🟡 | 🟢 ahead |
+
+---
+
+## The gaps that matter (ranked by strategic priority)
+
+Priority is set by **wedge-alignment** (does closing it strengthen the validation-gate positioning?) × **table-stakes pressure** (do we lose deals without it?), *not* by raw competitor parity.
+
+### Tier 1 — Close now (wedge-critical or table-stakes)
+- **🔴 #15/16/17 Bundled deterministic scanners (SAST + secret + SCA).** *The single biggest wedge-reinforcing gap.* "Validation layer" demands more than LLM opinion — CodeRabbit fuses ~50 deterministic tools with review; Copilot has CodeQL. Wrapping Semgrep + Gitleaks/TruffleHog + OSV-Scanner as validation signals that feed the merge score/gate turns "AI reviewer" into "validation gate with evidence." High wedge value.
+- **🔴 #7 Committable one-click fixes.** Pure table-stakes credibility — all three have it; we ship prose only. Without it we read as less finished.
+- **🔴 #29 Enterprise trust (SOC2 Type II, SSO/SAML, RBAC).** Gates the regulated mid-market ICP the strategy targets. Self-hosting helps but certs/SSO are procurement checkboxes.
+- **🟠 #14 Incremental review.** We re-run all agents on the full diff every time — a real cost/latency disadvantage at agent-PR volume (the exact scale our ICP hits). Efficiency + scale.
+
+### Tier 2 — Differentiator-adjacent (build to deepen the moat)
+- **🔴 #10 Learnings / memory from feedback.** Both CodeRabbit and Qodo learn from accepted/dismissed feedback; we only inject static conventions. This *is* the feedback-loop moat the strategy flagged — instrument override capture and close it.
+- **🟠 #19 Sandboxed custom pre-merge checks.** Extend blocking custom agents beyond LLM prompts to run sandboxed commands/tests — matches CodeRabbit's agentic checks and strengthens "gate with teeth."
+- **🟠 #21/22 Ticket compliance + audit/evidence export.** Requirement-traceability (Jira/Linear) and change-management export are the "system of record" surfaces — high value for the compliance-buyer expansion.
+- **🟠 #13 Whole-repo context.** On-demand fetch is thinner than CodeRabbit's code-graph / Qodo's RAG; matters for cross-file correctness on large PRs.
+- **🟠 #12 Test generation / verification depth.** Qodo's differentiator ("does the code actually work"). The true validation-layer whitespace; expensive — scope carefully.
+- **🟠 #11 Agentic fix handoff.** Hand a finding to a coding agent to auto-open a fix PR — closes the loop, rides the agent ecosystem.
+
+### Tier 3 — Reach (defer; off-wedge or low near-term ROI)
+- **🔴 #23 IDE extension** and **🟠 #24 CLI** — big for CodeRabbit's PLG, but off the "merge gate" wedge. MCP server partially covers agent/IDE reach today. Defer.
+- **🟠 #25 Multi-platform (GitLab/Bitbucket/Azure).** Expands TAM (Copilot is also GitHub-only, so not urgent vs. the platform threat). Defer to post-wedge.
+- **🟠 #4/8/9 Walkthrough table + richer command set/chat.** Incremental polish; fold into Tier 1 work opportunistically.
+
+---
+
+## Leads to defend while catching up
+
+Catching up must **not** erode the five things that make MergeWatch defensible. Every catch-up item should reinforce, not dilute, these:
+1. The **blocking gate** (ahead of Copilot + Qodo).
+2. **Self-host + BYO-model + air-gapped** (unique across the three).
+3. **Agent-provenance detection** (the wedge — already built).
+4. **FP discipline** (verification passes).
+5. **Analytics/insight depth**.
+
+**Strategic framing:** don't chase CodeRabbit on IDE/CLI/platform breadth. Chase the gaps that convert "AI reviewer" into "validation gate of record" — deterministic scanners, committable fixes, enterprise trust, learnings, and evidence/compliance export. See [`catch-up-plan.md`](./catch-up-plan.md).

--- a/docs/strategy/positioning.md
+++ b/docs/strategy/positioning.md
@@ -1,0 +1,74 @@
+# Positioning One-Pager
+
+> Companion to [`validation-layer-pivot.md`](./validation-layer-pivot.md). Category narrative, wedge, moat, expansion path.
+> **Date:** 2026-07-16
+
+---
+
+## The category statement
+
+> **MergeWatch is the software validation layer for the AI build era — the neutral, self-hostable gate that decides what's safe to merge, for code written by humans or agents.**
+
+Reinforced with the "merge gate of record" idea: MergeWatch doesn't just check a change — it **blocks** it, **records why**, and can **prove it later**.
+
+## The 100-word positioning statement
+
+> Software is now written as much by agents as by engineers, and merge volume is outpacing anyone's ability to review it by hand. MergeWatch is the **software validation layer for the AI build era** — the required gate that decides whether a change is safe to merge, regardless of whether a human or an AI agent wrote it. It enforces your organization's policy on every pull request, blocks what doesn't pass, and records a durable, auditable verdict for every change. Not a review bot that leaves comments — the system of record for *"is this safe to ship."* MergeWatch is where code earns the right to merge.
+
+---
+
+## Review vs. validation — the load-bearing distinction
+
+**"AI PR review" is a feature. A "validation layer" is infrastructure the pipeline depends on.** The difference is authority, statefulness, and coverage — not comment quality. Five concrete properties turn MergeWatch from a bot into a layer:
+
+1. **Gating authority (the merge gate).** A *required, blocking* status check on protected branches — a decision with teeth, not advice. (Seed: #235 blocking custom-agent gate.)
+2. **System-of-record for merge-safety.** A durable verdict (score 1–5), the reason, the policies evaluated, and the evidence, keyed to `prNumber#commitSha`. Answerable months later: "why was commit abc123 allowed to merge, and what did we check?"
+3. **Policy/compliance as code.** `.mergewatch.yml` + org custom agents = an **org policy graph**: which rules apply to which repos/paths/languages, which are blocking, who wins in a conflict (org over repo). The org's merge policy, codified and enforced uniformly.
+4. **Evidence & audit trails.** Machine-readable validation records per merge, exportable for SOC 2 / ISO change-management controls — generated automatically instead of screenshotted quarterly.
+5. **Uniform validation of human AND agent output.** MergeWatch validates the *artifact*, not the author. In an era of blurring provenance and exploding volume, a gate at the merge boundary that treats all sources uniformly (and agent PRs more strictly) is the only defensible checkpoint.
+
+**One line:** *Review advises a human. Validation blocks a merge, records why, and proves it later — for code written by humans or agents.*
+
+---
+
+## The wedge
+
+**The neutral, provenance-aware, blocking merge gate** — the required check that classifies each PR as human- or agent-authored, applies org policy (stricter for agent PRs), blocks what fails, and records the verdict.
+
+Chosen because: it's ~70% built (#235 + Check Runs + 1–5 score), it creates day-one dependency (required checks get budget; advisory bots get muted), no competitor leads with provenance, and it's the credible on-ramp to the system-of-record.
+
+**To a buyer:** *"You're about to let AI write a lot of your code. MergeWatch is the gate that decides what's allowed to merge — and proves it was checked."*
+
+---
+
+## The moat (honestly rated)
+
+| Moat | Thickness |
+|---|---|
+| Neutrality / open-source trust ("we don't sell the AI that wrote your code") | **Durable & unique** |
+| Deployment neutrality (self-host + any LLM, air-gapped) | **Thick** |
+| Org policy graph (accumulated config) | **Thick** |
+| Being the merge gate of record | **Thick but slow** |
+| Proprietary feedback loop (override capture) | **Medium — only if instrumented now** |
+| The LLM pipeline itself | **Thin — don't over-invest** |
+
+**Invest in:** neutrality, deployment flexibility, the policy graph, the evidence trail. **Not:** raw review quality (commoditizing).
+
+---
+
+## Expansion path (land → expand)
+
+- **Land — The Gate.** One required check on one team's protected branch. "Nothing bad merges." GitHub-native, self-hosted or SaaS.
+- **Expand 1 — Org rollout & policy graph.** The gate spreads repo-by-repo; the org codifies its merge policy centrally. Value shifts from "catch bugs" to "enforce our standards everywhere."
+- **Expand 2 — System of record & evidence.** The accumulating verdict/evidence trail becomes a product surface: change-management audit exports, "why did this merge" lookups, merge-safety dashboards, time-to-merge metrics (#194).
+- **Expand 3 — Agent governance.** As orgs adopt autonomous coding agents, MergeWatch becomes the *control plane for AI-generated code*: the gate that validates agent output, the record of what agents shipped, the policy that constrains them. The "AI build era" payoff.
+- **Full layer.** Every change — human or agent, in CI, IDE, or agent runtime — flows through MergeWatch for validation, verdict, and evidence. Other systems consume its output. It's infrastructure.
+
+---
+
+## Precedents to learn from
+
+- **Vanta (compliance):** won by becoming the *continuous system of record* for compliance evidence — replacing a painful manual ritual (screenshotting controls at audit time) with automatic, audit-ready proof. **Lesson:** the moat is being the *record*, not the checker. MergeWatch's equivalent: replace manual change-management/review evidence with an automatic per-merge validation record.
+- **Datadog (observability):** turned monitoring from a feature into a foundational layer by becoming the single pane every workload reports into, then expanding module-by-module (83% of customers use 2+ products). **Lesson:** land narrow (one required integration), expand relentlessly, let integration breadth become the lock-in.
+
+**Common thread:** both became layers by owning a *continuous, authoritative record at a chokepoint*. MergeWatch's chokepoint is **merge-time** — the last moment before code enters production, and the one point where human and agent output converge.

--- a/docs/strategy/project-plan.md
+++ b/docs/strategy/project-plan.md
@@ -1,0 +1,98 @@
+# Project Plan — Pivot to the Validation Layer
+
+> Companion to [`validation-layer-pivot.md`](./validation-layer-pivot.md). Phased roadmap → milestones → task items, each traced to a strategy outcome.
+> **Date:** 2026-07-16 · **Flat checkbox version:** [`backlog.md`](./backlog.md)
+
+## How to read this
+
+Four phases, sequenced by **dependency** and by **fastest path to validating the pivot**. Each phase lists its **goal**, **task items**, **dependencies**, **success metric**, and **exit criteria**. Every phase traces back to a strategy outcome — no orphan work. Phases gate on each other: **do not start Phase 1 until Phase 0's experiment clears its threshold.**
+
+Traceability tags: **[thesis]** = §1 market thesis · **[wedge]** = §3 wedge · **[moat]** = §3 moat · **[product]** = §4 build/keep/drop · **[gtm]** = §5 GTM · **[risk]** = §6 kill-criteria.
+
+---
+
+## Phase 0 — Validate the thesis (cheapest disproving experiments)
+
+**Goal:** Prove or kill the core wedge — *do agent-authored PRs actually fail validation more than human PRs?* — before any heavy build. **[thesis][wedge][risk-3]**
+
+**Task items:**
+- Build a **PR provenance classifier (heuristic v0)**: detect human vs. agent authorship from commit trailers, `Co-Authored-By`, bot signatures, IDE metadata. Extends `packages/core/src/skip-logic.ts` patterns. **[wedge]**
+- Run **retro provenance analysis** (Experiment 1) on the dogfood repo + 3–5 design-partner repos: classify historical PRs, run the existing pipeline, measure block/critical-finding rate by cohort. **[thesis]**
+- Stand up the **provenance-value smoke test** (Experiment 2): landing page positioning "validation gate for AI-generated code" + activation/CTA tracking. **[gtm]**
+- Run the **pricing willingness test** (Experiment 3): fake-door 3-tier pricing page to 30–50 ICP contacts. **[gtm]**
+- Recruit **3–5 design partners** from the beachhead ICP (30–150 eng, heavy agent adoption). **[gtm]**
+
+**Dependencies:** none — uses existing pipeline and repos.
+
+**Success metric:** Experiment 1 shows agent PRs at **≥1.5× the critical-finding rate** of human PRs; classifier accuracy **≥80%**; smoke-test activation **>8%** of qualified visitors.
+
+**Exit criteria:** Experiment 1 clears its threshold **and** ≥3 design partners committed. If Experiment 1 fails, **STOP** and revisit the wedge (see [`decision.md`](./decision.md) kill-criteria).
+
+---
+
+## Phase 1 — Beachhead wedge: the provenance-aware blocking gate
+
+**Goal:** Ship the smallest thing that makes MergeWatch a *validation layer* not a *review bot* — a required, provenance-aware merge gate that applies differentiated policy to agent PRs. **[wedge][product]**
+
+**Task items:**
+- Productize **PR provenance detection** as a first-class signal surfaced on every review (label + score input). **[wedge]**
+- Extend **`.mergewatch.yml` into validation policy-as-code**: declarative rules like "agent PRs touching `/payments` require passing security agent + human sign-off." Builds on `org-agents.ts` scope/target/blocking logic (#235). **[wedge][moat]**
+- Make **check status + merge-readiness score the primary artifact** (comment demoted to secondary evidence). **[product]**
+- Ship **override capture**: instrument accept/dismiss/override on every finding as a labeled signal — the feedback-loop moat starts compounding now. **[moat]**
+- **Refactor:** demote style/diagram agents to optional add-ons to sharpen the validation narrative. **[product]**
+- **GTM:** publish the Experiment-1 provenance data as a launch post ("we validated N agent PRs, blocked X%"); list/refresh on GitHub Marketplace. **[gtm]**
+
+**Dependencies:** Phase 0 (classifier + validated thesis + design partners).
+
+**Success metric:** ≥3 design partners make MergeWatch a **required status check** on ≥1 protected branch; provenance-differentiated policy blocks real unsafe agent PRs in production.
+
+**Exit criteria:** the gate is load-bearing (required check) for ≥3 orgs and blocking is trusted (no design partner disables it over false-blocks).
+
+---
+
+## Phase 2 — Expand the layer: org rollout, policy graph, evidence
+
+**Goal:** Turn the single-team wedge into an org-wide, defensible layer — the policy graph and the evidence trail that make it sticky. **[moat][product]**
+
+**Task items:**
+- **Org policy management** in the dashboard: central authoring of the merge policy across repos/paths/languages; org-over-repo conflict resolution surfaced clearly. **[moat]**
+- **Validation audit trail / dashboard**: "what we validated, blocked, and shipped anyway," per merge, exportable. Builds on the reviews table (`prNumber#commitSha`) and time-to-merge work (#194). **[product][moat]**
+- **Repo-by-repo rollout tooling**: make it trivial to spread the gate across an org's repos. **[gtm]**
+- **Packaging & metering**: implement the hybrid seat + validation-usage model (Team quota + overage); gate the enterprise control plane (policy mgmt, audit, SSO) behind the paid tier. **[gtm]**
+- **Sales-assist motion** for the 50+ dev / self-hosted + audit buyer. **[gtm]**
+
+**Dependencies:** Phase 1 (a trusted, required gate to spread).
+
+**Success metric:** first orgs running the gate across **10+ repos**; first **paid** conversions on the new packaging; audit export used by ≥1 buyer in a real compliance context.
+
+**Exit criteria:** ≥1 org has adopted org-wide policy management and is paying; net-revenue retention signals expansion (gate spreads without churn).
+
+---
+
+## Phase 3 — Category & moat: agent governance and durable defensibility
+
+**Goal:** Compound defensibility and establish the category — MergeWatch as the control plane for AI-generated code. **[moat][thesis]**
+
+**Task items:**
+- **Agent-governance surface**: treat autonomous coding agents (Cursor, Claude Code, Devin, Copilot) as first-class validated sources; per-agent policy and per-agent track record. **[wedge][thesis]**
+- **Verification depth (v1)**: lightweight behavioral signals — "did this PR add tests for what it changed?", diff-coverage checks — moving beyond static critique toward "does the code actually work." (This is the true validation-layer whitespace; scope carefully.) **[product]**
+- **Compliance/evidence productization**: SOC 2 / ISO / EU AI Act change-management export as a named enterprise feature. Times with EU AI Act enforcement (Aug 2, 2026). **[moat][thesis]**
+- **Broaden the integration surface** beyond GitHub (GitLab/Bitbucket, CI systems, agent frameworks, IDEs) to deepen lock-in. **[moat]**
+- **Category narrative push**: own "the neutral, self-hostable validation gate" in content, talks, and ecosystem co-marketing. **[gtm]**
+
+**Dependencies:** Phase 2 (paying orgs, policy graph, evidence trail in place).
+
+**Success metric:** MergeWatch cited/positioned as a distinct category ("validation gate") by customers and analysts; multi-product / multi-repo adoption is the norm among paying orgs; measurable feedback-loop precision advantage from accumulated override data.
+
+**Exit criteria:** durable moats demonstrably compounding (policy graph depth, evidence usage, cross-agent coverage, override-driven precision) and a defensible position vs. the three ranked threats.
+
+---
+
+## Sequencing at a glance
+
+```
+Phase 0  ──(gate: Exp-1 ≥1.5×)──▶  Phase 1  ──(gate: required check @ ≥3 orgs)──▶  Phase 2  ──(gate: paying + org-wide)──▶  Phase 3
+Validate                           Wedge                                           Expand                                    Category & moat
+```
+
+**Front-loaded principle:** Phase 0 is deliberately the fastest, cheapest phase and carries the highest kill-power. Everything expensive lives behind a passed experiment.

--- a/docs/strategy/validation-layer-pivot.md
+++ b/docs/strategy/validation-layer-pivot.md
@@ -1,0 +1,148 @@
+# MergeWatch: The Software Validation Layer for the AI Build Era
+
+> **Strategy doc — the master artifact.** Synthesizes market, competitive, positioning, and GTM research into a single wedge + ICP + sequencing decision.
+> **Date:** 2026-07-16 · **Owner:** Santthosh · **Status:** For decision
+> **Companion docs:** [`competitive-matrix.md`](./competitive-matrix.md) · [`positioning.md`](./positioning.md) · [`project-plan.md`](./project-plan.md) · [`backlog.md`](./backlog.md) · [`decision.md`](./decision.md)
+
+---
+
+## TL;DR
+
+The bottleneck in software has moved from **writing** code to **trusting** it. AI now writes ~40–50% of net-new code, adoption is near-total (84% of developers), yet the validation capacity to keep up hasn't scaled — review times are up 91% on high-AI-adoption teams, 45% of AI-generated code fails security tests, and trust is *falling* even as usage rises.
+
+The pivot thesis — that validation becomes the scarce, high-value layer — is **SUPPORTED, with one live threat**: the coding agents (Cursor, Claude Code, Copilot, Devin) and well-funded review incumbents (CodeRabbit at $550M, Qodo at $120M raised) are racing for the same ground. "Validation layer" as a *phrase* is already contested.
+
+**Our defensible wedge is not "better review." It is the one thing a self-reviewing generator and a SaaS-only incumbent structurally cannot be: the neutral, self-hostable, provenance-aware merge gate** — the required check that blocks unsafe changes (human *or* agent) against org policy and records an auditable verdict for every merge.
+
+**Recommendation: GO** — pivot the narrative and product toward the validation gate, but **validate cheaply first** (Experiment #2 below) before heavy build. The moat lives in *independence, policy, and evidence* — not in bug-catching.
+
+---
+
+## 1. The thesis and the evidence
+
+### The shift is real and accelerating
+- GitHub Copilot generates ~46% of code for active users (up from ~27% at launch), 20M+ users. ([source](https://www.getpanto.ai/blog/github-copilot-statistics))
+- Google: >25% → >30% of new code AI-generated in ~6 months, at one of the most mature eng orgs on earth. ([source](https://thehill.com/policy/technology/4962336-google-ceo-says-more-than-25-percent-of-companys-new-code-written-by-ai/))
+- 84% of developers use or plan to use AI tools (Stack Overflow 2025). ([source](https://survey.stackoverflow.co/2025/ai))
+- The frontier is agentic: 25% of YC W25 startups had codebases ~95% AI-generated. ([source](https://techstartups.com/2025/12/11/the-vibe-coding-delusion-why-thousands-of-startups-are-now-paying-the-price-for-ai-generated-technical-debt/))
+
+### The pain has migrated to the validation chokepoint — and it's measurable
+- **Throughput collapse:** high-AI-adoption teams merge 98% more PRs but review time rose 91% and PR size grew 154% (Faros, >10k devs). ([source](https://blog.codacy.com/ai-breaking-code-review-how-engineering-teams-survive-pr-bottleneck))
+- **Stability drop:** DORA 2024 found AI adoption correlated with ~7.2% lower delivery stability; 39.2% distrust AI-generated code. ([source](https://dora.dev/research/2024/dora-report/))
+- **Quality erosion:** copy-pasted code rose 9.4% → 15.7%; refactoring line-moves down ~70% (GitClear, 623M changes). ([source](https://www.gitclear.com/the_ai_code_quality_maintainability_gap))
+- **Security:** AI picks the insecure option in 45% of tasks; 2.74× more vulnerabilities than human code (Veracode 2025). ([source](https://www.businesswire.com/news/home/20250730694951/en/AI-Generated-Code-Poses-Major-Security-Risks-in-Nearly-Half-of-All-Development-Tasks-Veracode-Research-Reveals))
+- **The false-confidence gap (this *is* the market):** ~80% of developers believe AI code is more secure than human code, yet only ~10% scan most of it (Snyk). ([source](https://cloudwars.com/cybersecurity/snyks-ai-code-security-report-reveals-software-developers-false-sense-of-security/))
+- **New attack surface:** ~20% of LLM-recommended packages don't exist ("slopsquatting"). ([source](https://www.bleepingcomputer.com/news/security/ai-hallucinated-code-dependencies-become-new-supply-chain-risk/))
+
+### The market is voting with capital
+Standalone AI code-review/verification startups raised >$1.2B (Jan 2024–Dec 2025). Qodo raised $70M explicitly on "code verification as AI coding scales"; CodeRabbit hit ~$15M+ ARR growing ~20%/mo at a $550M valuation. ([Qodo](https://techcrunch.com/2026/03/30/qodo-bets-on-code-verification-as-ai-coding-scales-raises-70m/) · [CodeRabbit](https://sacra.com/c/coderabbit/))
+
+### The honest counter-evidence (do not wave this away)
+- Coding agents are building verification **in-house and bundling it**: Cursor Security Review + Bugbot, Claude self-validation, Devin self-verify (merged-PR rate 34% → 67%), and **GitHub Copilot code review shipped agentic review at zero incremental cost** to existing seats. ([Cursor/Copilot](https://workos.com/blog/cursor-bugbot-autoreview-claude-code-prs) · [Devin](https://cognition.ai/blog/devin-annual-performance-review-2025))
+- The "validation layer" narrative is **already claimed** by better-funded incumbents: CodeRabbit ("quality gates for AI coding"), Qodo ("code verification"), Sonar ("verify AI code / AI Code Assurance").
+
+**Verdict: SUPPORTED, with a live threat.** The macro case is quantified and strong; the risk is commoditization of "catch obvious bugs" by bundled first-party self-review. Therefore our durable wedge must be what a self-reviewing generator *cannot* own — see §3.
+
+---
+
+## 2. Who we sell to (ICP + beachhead)
+
+**Beachhead: mid-market, high-AI-adoption engineering orgs — Series A–C, ~30–150 engineers (widening to 500) — that have already turned on coding agents at scale and are now drowning in agent-generated PR volume.**
+
+Why this beachhead:
+- **Acute, quantified pain today** — review queues balloon from 8–12 to 25–40 open PRs within months of agent adoption; senior ICs report spending 60–70% of time on review.
+- **They have budget, process, and accountability** — unlike vibe-coding startups (highest pain, lowest willingness to pay), someone's name is on the merge.
+- **Short sales cycles** — sellable without 12-month enterprise procurement.
+- **Natural expansion path up-market** — an audit-trail / compliance angle carries us into regulated mid-market and enterprise as EU AI Act enforcement lands (Aug 2, 2026) and the enterprise AI-governance market grows ($2.2B → $11B+). ([source](https://www.futuremarketinsights.com/reports/enterprise-ai-governance-and-compliance-market))
+
+**Buyer:** VP Eng / Head of Platform / DevEx lead — accountable for "we shipped an AI-written bug to prod." **Champion:** the senior IC who set up the coding agents. **Purchase trigger:** a production incident traced to un-reviewed agent code, or review-queue collapse.
+
+---
+
+## 3. The wedge, the moat, the positioning
+
+### The wedge (synthesized across all four workstreams)
+**The neutral, provenance-aware, blocking merge gate.**
+
+Not the security agent, not the summary, not the diagram — those are commodity and advisory by nature. The sharp entry is **enforcement authority applied differentially to AI-authored code**:
+
+> MergeWatch is the required status check that classifies every PR as human- or agent-authored, applies your org's policy (stricter for agent PRs), **blocks** what doesn't pass, and records a durable, auditable verdict.
+
+Why this wedge wins:
+- **It's ~70% built.** The blocking org-custom-agent gate (#235, `packages/core/src/org-agents.ts`), Check Run integration, and the 1–5 merge-readiness score already exist. We're productizing an asset, not inventing one.
+- **It creates day-one dependency.** An advisory bot gets muted; a required gate gets budget. Removing it becomes a policy decision, not a churn event.
+- **No competitor leads with provenance.** The incumbents attack this as *generic review*, leaving the provenance-aware gate open.
+- **It's the credible on-ramp to "layer."** You can't sell "system of record" cold — but every blocked merge silently accumulates the evidence trail that makes the system-of-record real later.
+
+### The moat — rated honestly
+| Moat | Thickness | Note |
+|---|---|---|
+| **Neutrality / open-source trust** | **Durable & unique** | We don't sell the AI that wrote the code, so we can honestly grade it. CodeRabbit/Qodo/Cursor/Copilot structurally can't tell this story. Our most defensible asset. |
+| **Deployment neutrality (self-host + any LLM, air-gapped)** | **Thick** | Nearly every funded competitor is SaaS-first and cloud-LLM-locked. Real differentiation for regulated/defense/on-prem buyers. |
+| **Org policy graph** | **Thick** | Accumulated org config (which agents, repos, paths, blocking rules) is sticky institutional knowledge; painful to rebuild elsewhere. |
+| **Being the merge gate of record** | **Thick but slow** | Structural lock-in once you're the required check org-wide; Vanta/Datadog dynamic. One high-profile false-block erodes it fast. |
+| **Proprietary feedback loop** | **Medium — only if instrumented now** | Every accept/dismiss/override is a labeled signal. Make override-capture a first-class mechanic *now* or this stays thin. |
+| **The LLM pipeline itself** | **Thin** | Models commoditize monthly. Do not over-invest here. |
+
+**Where to invest: neutrality, deployment flexibility, the policy graph, and the evidence trail — not raw review quality.**
+
+### The positioning line
+> **MergeWatch is the software validation layer for the AI build era — the neutral, self-hostable gate that decides what's safe to merge, for code written by humans or agents.**
+
+Full positioning in [`positioning.md`](./positioning.md).
+
+---
+
+## 4. Product direction — build / keep / drop
+
+**KEEP:** multi-agent pipeline + orchestrator + **merge-readiness score** (the validation primitive); org-defined **blocking custom agents** + Check Run gate; **self-hosted + open-core** dual mode (the moat).
+
+**BUILD:**
+1. **PR provenance detection** — classify human vs. agent-authored (commit trailers, `Co-Authored-By`, bot signatures) and apply differentiated policy. The wedge feature; cheap to build on existing `skip-logic.ts`.
+2. **Validation policy-as-code** — extend `.mergewatch.yml` into a declarative gate ("agent PRs touching `/payments` require passing security agent + human sign-off").
+3. **Validation audit trail / dashboard** — "what we validated, blocked, and shipped anyway" — the compliance artifact enterprises pay for. Builds on the reviews table (`prNumber#commitSha`) and time-to-merge work (#194).
+4. **Override capture** — instrument accept/dismiss to feed the feedback-loop moat.
+5. *(Later)* **Verification depth** — test-generation / diff-coverage signals ("did this PR add tests for what it changed?"). True validation-layer whitespace; expensive.
+
+**REFACTOR:** demote style/diagram agents to optional add-ons; make **check status + score** the primary artifact, comment secondary.
+
+**DROP:** any ambition to be a "general AI reviewer for all PRs." Cede generic review to CodeRabbit/Copilot-native to sharpen positioning.
+
+---
+
+## 5. Go-to-market
+
+**Motion:** open-source-led PLG, bottom-up via GitHub Marketplace, with a sales-assist layer at the 50+ dev / Enterprise line (self-hosted + audit trail).
+
+**Pricing (open-core, hybrid seat + validation-usage — mirroring where the market is converging as agents decouple "developers" from "code volume"):**
+- **Free / OSS** — unlimited on public repos; primary top-of-funnel.
+- **Team — ~$20/dev/mo** incl. a validation quota (~100 validated PRs/dev/mo), then ~$0.50–$1 per additional validation. Deliberately undercuts Greptile's $30 base while capturing agent-volume upside.
+- **Enterprise — ~$45–60/dev/mo (est.)** — self-hosted, SSO, blocking policies, audit trail, SLA.
+- Gate the **enterprise control plane** (org policy management, provenance dashboards, audit/compliance, SSO) in paid; keep pipeline + agents + self-hosted server open. *(Price points are estimates pending Experiment #3.)*
+
+**First 3 channels:** (1) GitHub Marketplace (highest-intent discovery); (2) dogfood + open-source content — publish real provenance data ("we validated N agent PRs, blocked X% for security flaws"); (3) coding-agent ecosystem co-marketing ("the safety net for your agents").
+
+---
+
+## 6. Risks & kill-criteria (summary — full detail in [`decision.md`](./decision.md))
+
+1. **Agents absorb validation** (already partially happening via Copilot-native review). *Kill:* >40% of a customer sample say native self-review is "good enough" and drop independent validation within 2 quarters.
+2. **Market too crowded / commoditized.** *Kill:* CAC > 12-month gross margin for 2 consecutive quarters with no provenance-driven win-rate lift.
+3. **Provenance signal weak / gameable.** *Kill:* classifier accuracy <80% on real customer PR streams.
+4. **Buyers won't pay usage on top of seats.** *Kill:* >30% of Team accounts hit quota and downgrade rather than expand.
+5. **Enterprise motion too heavy for a small team.** *Kill:* median sales cycle >6 months with <20% close after 10 qualified opps.
+
+---
+
+## 7. Decision
+
+**GO on the pivot — sequence as validate-then-build.** The thesis is well-supported and the wedge (neutral, self-hostable, provenance-aware gate) is genuinely defensible against both the self-reviewing generators and the SaaS-only incumbents. But because the space is contested and better-funded, we **do not** open with heavy build. We run the cheapest disproving experiment first:
+
+**Run Experiment #2 (retro provenance analysis) before anything else** — classify historical PRs on our dogfood repo + 3–5 design-partner repos by authorship and measure block/critical-finding rate by cohort. If agent PRs *don't* fail materially more (target ≥1.5× critical-finding rate), the entire wedge collapses cheaply, before we've built it. If they do, we have both proof *and* the killer marketing stat.
+
+Full phased plan in [`project-plan.md`](./project-plan.md); go/no-go and experiments in [`decision.md`](./decision.md).
+
+---
+
+### Sourcing & confidence notes
+Market/security/funding stats trace to named primary studies (GitClear, Veracode, Snyk, DORA, Faros) and are high-confidence. Aggregate "% of code AI-generated" figures come from secondary compilations — directionally reliable, exact digits treated with mild caution. All pricing/valuation figures are cited in [`competitive-matrix.md`](./competitive-matrix.md); estimates are flagged there. Recommended price points and classifier thresholds are strategic estimates pending the validating experiments.

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -209,7 +209,7 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-80](#e2e-80-conventions--discovery-order-and-the-16-kb-cap) | Conventions resolve first-hit-wins in documented order; explicit `conventions:` never falls back on miss; >16 KB truncates with a visible marker | 3m | 60s | core |
 | [E2E-81](#e2e-81-codebase-awareness--file-request-budget) | `codebaseAwareness` fetches out-of-diff files; `maxFileRequestRounds` / `maxContextKB` enforced; hitting the budget degrades gracefully | 3m | 60s | core |
 | [E2E-82](#e2e-82-oss-program--sponsored-review-on-a-granted-public-repo) | OSS grant sponsors a named public repo; unnamed/private/expired all fall back correctly; rename keeps the grant | 5m | 60s | #263, #265 |
-| [E2E-83](#e2e-83-oss-program--operator-grant-lifecycle) | `grant-oss.sh` grant/add/remove/revoke/inspect; `--stage` guard; private repo rejected | 5m | n/a | #266 |
+| [E2E-83](#e2e-83-oss-program--operator-grant-lifecycle) | `grant-oss.ts` grant/add/remove/revoke/inspect; `--stage` guard; private repo rejected | 5m | n/a | #266 |
 
 ---
 
@@ -2843,7 +2843,7 @@ Branch: `fixture/82-oss-sponsored-review`. Any diff that produces a real review 
 
 Prerequisites on the fixtures installation:
 1. Exhaust the free tier (`freeReviewsUsed >= 5`) and leave `balanceCents` at 0 — without a grant this install is blocked.
-2. Grant the fixtures repo: `scripts/grant-oss.sh <owner>/<fixtures-repo> --stage dev`.
+2. Grant the fixtures repo: `scripts/grant-oss.ts <owner>/<fixtures-repo> --stage dev`.
 
 **How to run.**
 1. Open a PR. Confirm it is reviewed normally despite zero balance.
@@ -2875,10 +2875,10 @@ Prerequisites on the fixtures installation:
 
 **Status:** ⬜ NOT YET COVERED.
 
-**Behavior:** `scripts/grant-oss.sh` is the only way a grant is written. It resolves a repo to its installation via an App JWT, verifies the repo is public, shows the blast radius, and refuses to run without an explicit `--stage`.
+**Behavior:** `scripts/grant-oss.ts` is the only way a grant is written. It resolves a repo to its installation via an App JWT, verifies the repo is public, shows the blast radius, and refuses to run without an explicit `--stage`.
 
 **How to run.**
-1. `scripts/grant-oss.sh <owner>/<repo>` with no `--stage` → confirm it refuses rather than defaulting to prod.
+1. `scripts/grant-oss.ts <owner>/<repo>` with no `--stage` → confirm it refuses rather than defaulting to prod.
 2. `--inspect` on an ungranted repo → confirm it reports no grant.
 3. Grant with `--stage dev --cap 500 --months 1`; confirm the confirmation prompt lists the covered repo **and** the installation's other repos that are *not* covered.
 4. `--inspect` again → confirm cap, expiry, `ossGrantedAt`, and `ossGrantNote` render back.

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -2833,9 +2833,9 @@ curl -s "$MCP_URL" \
 
 ### E2E-82: OSS Program — sponsored review on a granted public repo
 
-**Status:** ⬜ NOT YET COVERED.
+**Status:** ✅ SHIPPED (#263, #265) — fixture not yet run.
 
-**Behavior:** A repository named in an active OSS grant (#261) is reviewed with no balance, no payment method, and no free-tier consumption. Being named is necessary but not sufficient — the repo must also be public at review time, the grant must not have expired, and the month must be under its fair-use cap. See `docs/pending/oss-program.md`.
+**Behavior:** A repository named in an active OSS grant (#261) is reviewed with no balance, no payment method, and no free-tier consumption. Being named is necessary but not sufficient — the repo must also be public at review time, the grant must not have expired, and the month must be under its fair-use cap. See `docs/oss-program.md`.
 
 **Setup**
 
@@ -2873,7 +2873,7 @@ Prerequisites on the fixtures installation:
 
 ### E2E-83: OSS Program — operator grant lifecycle
 
-**Status:** ⬜ NOT YET COVERED.
+**Status:** ✅ SHIPPED (#266) — fixture not yet run.
 
 **Behavior:** `scripts/grant-oss.ts` is the only way a grant is written. It resolves a repo to its installation via an App JWT, verifies the repo is public, shows the blast radius, and refuses to run without an explicit `--stage`.
 

--- a/packages/dashboard/app/dashboard/billing/BillingClient.tsx
+++ b/packages/dashboard/app/dashboard/billing/BillingClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { CreditCard, Zap, TrendingUp, AlertCircle, CheckCircle2, Loader2, RefreshCw } from "lucide-react";
+import { CreditCard, Zap, TrendingUp, AlertCircle, CheckCircle2, Loader2, RefreshCw, HeartHandshake } from "lucide-react";
 
 interface BillingStatus {
   freeReviewsUsed: number;
@@ -16,6 +16,21 @@ interface BillingStatus {
   totalBilledCents: number;
   prCount: number;
   prTimestamps: string[];
+  /**
+   * OSS Program (#261). Null for every installation without a grant.
+   * `active` is computed server-side so this panel can't drift from the
+   * billing gate's own notion of an active grant.
+   */
+  oss: {
+    active: boolean;
+    repos: string[];
+    expiresAt: string;
+    grantedAt: string | null;
+    note: string | null;
+    monthlyCapCents: number | null;
+    sponsoredThisPeriodCents: number;
+    sponsoredLifetimeCents: number;
+  } | null;
 }
 
 interface BillingClientProps {
@@ -210,6 +225,106 @@ export default function BillingClient({ installationId, accountLogin, setupCompl
             >
               Dismiss
             </button>
+          </div>
+        )}
+
+        {/* OSS Program (#261) — sponsored reviews.
+            Rendered alongside the credit balance rather than replacing it:
+            a granted installation can still contain private or unnamed repos
+            that bill normally, so both states are true at once. */}
+        {status.oss && (
+          <div className="rounded-lg border border-border-default bg-surface-card p-5 sm:p-6">
+            <div className="flex items-center gap-2 mb-4">
+              <HeartHandshake className="h-4 w-4 text-accent-green" />
+              <h2 className="text-[11px] font-semibold uppercase tracking-widest text-fg-muted">
+                Open Source Program
+              </h2>
+              {!status.oss.active && (
+                <span className="ml-auto rounded-full border border-yellow-500/30 bg-yellow-500/5 px-2 py-0.5 text-[10px] font-medium text-yellow-300">
+                  Expired
+                </span>
+              )}
+            </div>
+
+            {status.oss.active ? (
+              <p className="text-sm text-fg-secondary">
+                Reviews on the repositories below are sponsored by MergeWatch — no charge, and
+                they don&rsquo;t use your free reviews or balance.
+              </p>
+            ) : (
+              <p className="text-sm text-fg-secondary">
+                This grant expired on {new Date(status.oss.expiresAt).toLocaleDateString()}. Reviews
+                now fall back to your free tier and balance. Get in touch at{" "}
+                <a
+                  href="https://mergewatch.ai/open-source"
+                  className="text-accent-green hover:underline"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  mergewatch.ai/open-source
+                </a>{" "}
+                to renew it — there&rsquo;s no charge.
+              </p>
+            )}
+
+            <div className="mt-5 grid gap-5 sm:grid-cols-3">
+              <div>
+                <div className="text-2xl font-bold text-fg-primary tabular-nums">
+                  ${(status.oss.sponsoredThisPeriodCents / 100).toFixed(2)}
+                </div>
+                <p className="mt-1 text-xs text-fg-tertiary">Sponsored this month</p>
+                {status.oss.monthlyCapCents !== null && (
+                  <>
+                    <div className="mt-2 h-2 rounded-full bg-surface-card-hover">
+                      <div
+                        className="h-2 rounded-full bg-accent-green transition-all"
+                        style={{
+                          // A zero cap means no allowance at all, so the bar is
+                          // full. Guarding the divide matters: 0/0 is NaN, which
+                          // renders as `width: "NaN%"` and silently drops the bar.
+                          width: `${status.oss.monthlyCapCents > 0
+                            ? Math.min(100, (status.oss.sponsoredThisPeriodCents / status.oss.monthlyCapCents) * 100)
+                            : 100}%`,
+                        }}
+                      />
+                    </div>
+                    <p className="mt-1 text-[11px] text-fg-muted">
+                      of ${(status.oss.monthlyCapCents / 100).toFixed(2)} fair-use limit
+                    </p>
+                  </>
+                )}
+              </div>
+
+              <div>
+                <div className="text-2xl font-bold text-fg-primary tabular-nums">
+                  ${(status.oss.sponsoredLifetimeCents / 100).toFixed(2)}
+                </div>
+                <p className="mt-1 text-xs text-fg-tertiary">Sponsored to date</p>
+              </div>
+
+              <div>
+                <div className="text-2xl font-bold text-fg-primary tabular-nums">
+                  {status.oss.repos.length}
+                </div>
+                <p className="mt-1 text-xs text-fg-tertiary">
+                  {status.oss.repos.length === 1 ? "Covered repository" : "Covered repositories"}
+                </p>
+              </div>
+            </div>
+
+            <div className="mt-5 pt-4 border-t border-border-default">
+              <p className="text-xs text-fg-tertiary mb-2">Covered repositories</p>
+              <ul className="space-y-1">
+                {status.oss.repos.map((r) => (
+                  <li key={r} className="text-sm text-fg-secondary">{r}</li>
+                ))}
+              </ul>
+              <p className="mt-3 text-[11px] text-fg-muted">
+                Only these repositories are sponsored, and only while they are public. Anything
+                else in this installation bills normally.
+                {status.oss.active && ` Grant runs until ${new Date(status.oss.expiresAt).toLocaleDateString()}.`}
+              </p>
+            </div>
           </div>
         )}
 

--- a/packages/lambda/src/handlers/billing.ts
+++ b/packages/lambda/src/handlers/billing.ts
@@ -227,6 +227,37 @@ async function handleWebhook(event: APIGatewayProxyEventV2): Promise<APIGatewayP
   return json(200, { received: true });
 }
 
+/**
+ * #261 — OSS Program status for the dashboard, or null when the installation
+ * has no grant.
+ *
+ * `active` is computed here rather than left to the client so the dashboard
+ * can't drift from the gate's own notion of "active" (`evaluateOssGrant`).
+ * Period spend is reported as 0 once `ossPeriod` goes stale, matching how the
+ * cap is actually applied — last month's spend never eats this month's
+ * allowance.
+ */
+function ossStatus(fields: Awaited<ReturnType<typeof getBillingFields>>) {
+  const repos = fields.ossGrantRepos ?? [];
+  if (!fields.ossGrantExpiresAt || repos.length === 0) return null;
+
+  const expiresAt = Date.parse(fields.ossGrantExpiresAt);
+  const period = new Date().toISOString().slice(0, 7);
+
+  return {
+    active: Number.isFinite(expiresAt) && expiresAt > Date.now(),
+    repos: repos.map((r) => r.fullName),
+    expiresAt: fields.ossGrantExpiresAt,
+    grantedAt: fields.ossGrantedAt ?? null,
+    note: fields.ossGrantNote ?? null,
+    monthlyCapCents: fields.ossMonthlyCapCents ?? null,
+    sponsoredThisPeriodCents: fields.ossPeriod === period
+      ? (fields.ossSponsoredCentsThisPeriod ?? 0)
+      : 0,
+    sponsoredLifetimeCents: fields.ossSponsoredCentsLifetime ?? 0,
+  };
+}
+
 async function handleStatus(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyResultV2> {
   const installationId = event.queryStringParameters?.installationId;
   if (!installationId) {
@@ -264,6 +295,11 @@ async function handleStatus(event: APIGatewayProxyEventV2): Promise<APIGatewayPr
     totalBilledCents: fields.totalBilledCents ?? 0,
     prCount: fields.prCount ?? 0,
     prTimestamps: fields.prTimestamps ?? [],
+
+    // OSS Program (#261). `oss` is null for every installation without a
+    // grant, which is what the dashboard keys off to decide whether to show
+    // the program panel instead of the balance/top-up one.
+    oss: ossStatus(fields),
   });
 }
 

--- a/scripts/grant-oss.ts
+++ b/scripts/grant-oss.ts
@@ -99,12 +99,24 @@ function parseArgs(argv: string[]): Args {
     if (!/^[^/\s]+\/[^/\s]+$/.test(r)) fail(`Not an owner/repo: ${r}`);
   }
 
+  const capCents = Number(flag(argv, '--cap') ?? DEFAULT_CAP_CENTS);
+  const months = Number(flag(argv, '--months') ?? DEFAULT_TERM_MONTHS);
+  // A zero or negative cap is almost certainly a typo, and it produces a grant
+  // that is active but sponsors nothing — the most confusing possible state for
+  // a maintainer. Reject it here rather than letting it reach the row.
+  if (!Number.isFinite(capCents) || capCents <= 0) {
+    fail(`--cap must be a positive number of cents (got ${flag(argv, '--cap')}). Use --revoke to end a grant.`);
+  }
+  if (!Number.isFinite(months) || months <= 0) {
+    fail(`--months must be a positive number (got ${flag(argv, '--months')}).`);
+  }
+
   return {
     repos,
     stage: stage!,
     mode,
-    capCents: Number(flag(argv, '--cap') ?? DEFAULT_CAP_CENTS),
-    months: Number(flag(argv, '--months') ?? DEFAULT_TERM_MONTHS),
+    capCents,
+    months,
     note: flag(argv, '--note'),
     yes: argv.includes('--yes'),
   };

--- a/scripts/grant-oss.ts
+++ b/scripts/grant-oss.ts
@@ -1,0 +1,415 @@
+#!/usr/bin/env npx tsx
+/**
+ * =============================================================================
+ * MergeWatch OSS Program — grant management (#261)
+ * =============================================================================
+ *
+ * Writes the sponsored-review entitlement for approved open-source
+ * repositories. This is the ONLY thing that writes OSS grant fields; there is
+ * no admin API route and no dashboard granting UI, by design. The `#SETTINGS`
+ * row is therefore the sole record of who was granted what and why, which is
+ * what `--note` and `--inspect` exist for.
+ *
+ * Usage:
+ *   scripts/grant-oss.ts <owner/repo>[,<owner/repo>…] --stage dev|prod [options]
+ *   scripts/grant-oss.ts --add <owner/repo>     --stage …
+ *   scripts/grant-oss.ts --remove <owner/repo>  --stage …
+ *   scripts/grant-oss.ts --revoke <owner/repo>  --stage …
+ *   scripts/grant-oss.ts --inspect <owner/repo> --stage …
+ *
+ * Options:
+ *   --stage dev|prod   REQUIRED. No default — a grant must never land in the
+ *                      wrong environment because someone forgot a flag.
+ *   --cap <cents>      Monthly fair-use ceiling (default 2000 = $20).
+ *   --months <n>       Grant term (default 12).
+ *   --note "<text>"    Provenance: application reference, project, approver.
+ *   --yes              Skip the confirmation prompt (for scripted use).
+ *
+ * Prerequisites:
+ *   - AWS credentials for the `mergewatch` profile, with SSM read on the
+ *     GitHub App parameters and write access to the installations table.
+ *   - The maintainer has already installed the GitHub App on the repository
+ *     (that is what creates the installation this grant attaches to).
+ * =============================================================================
+ */
+
+import { createInterface } from 'node:readline/promises';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, QueryCommand, UpdateCommand, GetCommand } from '@aws-sdk/lib-dynamodb';
+import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
+import { createAppAuth } from '@octokit/auth-app';
+import { Octokit } from '@octokit/rest';
+
+const PROFILE = 'mergewatch';
+const REGION = process.env.AWS_REGION ?? 'us-west-2';
+const SETTINGS_SK = '#SETTINGS';
+const DEFAULT_CAP_CENTS = 2000;
+const DEFAULT_TERM_MONTHS = 12;
+
+// --- Arg parsing -------------------------------------------------------------
+
+interface Args {
+  repos: string[];
+  stage: string;
+  mode: 'grant' | 'add' | 'remove' | 'revoke' | 'inspect';
+  capCents: number;
+  months: number;
+  note?: string;
+  yes: boolean;
+}
+
+function flag(argv: string[], name: string): string | undefined {
+  const i = argv.indexOf(name);
+  return i === -1 ? undefined : argv[i + 1];
+}
+
+function parseArgs(argv: string[]): Args {
+  const modes = [
+    ['--add', 'add'],
+    ['--remove', 'remove'],
+    ['--revoke', 'revoke'],
+    ['--inspect', 'inspect'],
+  ] as const;
+
+  let mode: Args['mode'] = 'grant';
+  let repoArg: string | undefined;
+
+  for (const [f, m] of modes) {
+    const v = flag(argv, f);
+    if (v !== undefined) {
+      mode = m;
+      repoArg = v;
+      break;
+    }
+  }
+  if (mode === 'grant') repoArg = argv.find((a) => !a.startsWith('--') && a.includes('/'));
+
+  const stage = flag(argv, '--stage');
+  if (!stage || !['dev', 'prod'].includes(stage)) {
+    fail(
+      'Refusing to run without an explicit --stage dev|prod.\n'
+      + 'This writes to a live table; defaulting the environment is how a grant\n'
+      + 'lands in the wrong one.',
+    );
+  }
+  if (!repoArg) fail('No repository given. Expected owner/repo.');
+
+  const repos = repoArg!.split(',').map((r) => r.trim()).filter(Boolean);
+  for (const r of repos) {
+    if (!/^[^/\s]+\/[^/\s]+$/.test(r)) fail(`Not an owner/repo: ${r}`);
+  }
+
+  return {
+    repos,
+    stage: stage!,
+    mode,
+    capCents: Number(flag(argv, '--cap') ?? DEFAULT_CAP_CENTS),
+    months: Number(flag(argv, '--months') ?? DEFAULT_TERM_MONTHS),
+    note: flag(argv, '--note'),
+    yes: argv.includes('--yes'),
+  };
+}
+
+function fail(msg: string): never {
+  console.error(`\n✗ ${msg}\n`);
+  process.exit(1);
+}
+
+// --- AWS + GitHub clients -----------------------------------------------------
+
+const dynamo = DynamoDBDocumentClient.from(new DynamoDBClient({ profile: PROFILE, region: REGION }));
+const ssm = new SSMClient({ profile: PROFILE, region: REGION });
+
+async function ssmParam(name: string): Promise<string> {
+  const res = await ssm.send(new GetParameterCommand({ Name: name, WithDecryption: true }));
+  const value = res.Parameter?.Value;
+  if (!value) fail(`SSM parameter ${name} is empty or missing.`);
+  return value!;
+}
+
+/**
+ * Two Octokit flavors are needed, because they can reach different endpoints.
+ *
+ * A GitHub **App JWT** can call `GET /repos/{owner}/{repo}/installation` — the
+ * repo→installation lookup this whole script hinges on, and the reason this
+ * isn't a `gh api` one-liner (`gh` authenticates as a user and cannot reach
+ * it). But a JWT cannot read repository content endpoints.
+ *
+ * An **installation token** can call `GET /repos/{owner}/{repo}` for the id,
+ * visibility, and activity signals. So: JWT resolves the installation, then an
+ * installation client reads the repo.
+ */
+async function githubClients(stage: string) {
+  const [appIdRaw, privateKey] = await Promise.all([
+    ssmParam(`/mergewatch/${stage}/github-app-id`),
+    ssmParam(`/mergewatch/${stage}/github-private-key`),
+  ]);
+  const appId = Number(appIdRaw);
+
+  const auth = createAppAuth({ appId, privateKey });
+  const { token: jwt } = await auth({ type: 'app' });
+
+  return {
+    jwt: new Octokit({ auth: jwt }),
+    forInstallation: (installationId: number) =>
+      new Octokit({
+        authStrategy: createAppAuth,
+        auth: { appId, privateKey, installationId },
+      }),
+  };
+}
+
+type GitHubClients = Awaited<ReturnType<typeof githubClients>>;
+
+// --- Repo + installation resolution -------------------------------------------
+
+interface ResolvedRepo {
+  id: number;
+  fullName: string;
+  isPublic: boolean;
+  pushedAt: string | null;
+  openIssues: number;
+  installationId: string;
+}
+
+async function resolveRepo(gh: GitHubClients, fullName: string): Promise<ResolvedRepo> {
+  const [owner, repo] = fullName.split('/');
+
+  // 1. JWT: which installation owns this repo?
+  let installationId: number;
+  try {
+    const inst = await gh.jwt.apps.getRepoInstallation({ owner, repo });
+    installationId = inst.data.id;
+  } catch (err) {
+    fail(
+      `The MergeWatch App is not installed on ${fullName} (or it does not exist).\n`
+      + 'Ask the maintainer to install it first — the installation is what a grant\n'
+      + `attaches to. GitHub said: ${(err as Error).message}`,
+    );
+  }
+
+  // 2. Installation token: read the repo itself.
+  let data;
+  try {
+    ({ data } = await gh.forInstallation(installationId!).repos.get({ owner, repo }));
+  } catch (err) {
+    fail(`Could not read ${fullName}: ${(err as Error).message}`);
+  }
+
+  return {
+    id: data!.id,
+    fullName: data!.full_name,
+    isPublic: !data!.private,
+    pushedAt: data!.pushed_at ?? null,
+    openIssues: data!.open_issues_count ?? 0,
+    installationId: String(installationId!),
+  };
+}
+
+// --- DynamoDB -----------------------------------------------------------------
+
+const table = (stage: string) => process.env.INSTALLATIONS_TABLE ?? `mergewatch-installations-${stage}`;
+
+interface OssGrantRepo { id: number; fullName: string }
+
+interface GrantFields {
+  ossGrantRepos?: OssGrantRepo[];
+  ossGrantExpiresAt?: string;
+  ossGrantedAt?: string;
+  ossGrantNote?: string;
+  ossMonthlyCapCents?: number;
+  ossPeriod?: string;
+  ossSponsoredCentsThisPeriod?: number;
+  ossSponsoredCentsLifetime?: number;
+}
+
+async function readGrant(stage: string, installationId: string): Promise<GrantFields> {
+  const res = await dynamo.send(new GetCommand({
+    TableName: table(stage),
+    Key: { installationId, repoFullName: SETTINGS_SK },
+  }));
+  return (res.Item as GrantFields) ?? {};
+}
+
+/** Every repo row under this installation — the blast-radius view. */
+async function installationRepos(stage: string, installationId: string): Promise<string[]> {
+  const out: string[] = [];
+  let lastKey: Record<string, unknown> | undefined;
+  do {
+    const res = await dynamo.send(new QueryCommand({
+      TableName: table(stage),
+      KeyConditionExpression: 'installationId = :id',
+      ExpressionAttributeValues: { ':id': installationId },
+      ProjectionExpression: 'repoFullName',
+      ExclusiveStartKey: lastKey,
+    }));
+    for (const item of res.Items ?? []) {
+      const name = (item as { repoFullName: string }).repoFullName;
+      if (!name.startsWith('#')) out.push(name);
+    }
+    lastKey = res.LastEvaluatedKey;
+  } while (lastKey);
+  return out.sort();
+}
+
+async function writeGrant(
+  stage: string,
+  installationId: string,
+  fields: Required<Pick<GrantFields, 'ossGrantRepos' | 'ossGrantExpiresAt' | 'ossMonthlyCapCents'>>
+    & Pick<GrantFields, 'ossGrantedAt' | 'ossGrantNote'>,
+): Promise<void> {
+  const names: Record<string, string> = {};
+  const values: Record<string, unknown> = {};
+  const sets: string[] = [];
+  for (const [k, v] of Object.entries(fields)) {
+    if (v === undefined) continue;
+    names[`#${k}`] = k;
+    values[`:${k}`] = v;
+    sets.push(`#${k} = :${k}`);
+  }
+  await dynamo.send(new UpdateCommand({
+    TableName: table(stage),
+    Key: { installationId, repoFullName: SETTINGS_SK },
+    UpdateExpression: `SET ${sets.join(', ')}`,
+    ExpressionAttributeNames: names,
+    ExpressionAttributeValues: values,
+  }));
+}
+
+// --- Presentation --------------------------------------------------------------
+
+const usd = (cents: number) => `$${(cents / 100).toFixed(2)}`;
+
+function renderGrant(grant: GrantFields, installationId: string): void {
+  const repos = grant.ossGrantRepos ?? [];
+  const expires = grant.ossGrantExpiresAt;
+  const active = !!expires && Date.parse(expires) > Date.now() && repos.length > 0;
+
+  console.log(`\nInstallation ${installationId}`);
+  console.log(`  Status        ${active ? '✓ active' : '✗ no active grant'}`);
+  if (!expires && repos.length === 0) return;
+
+  console.log(`  Covered repos ${repos.length ? repos.map((r) => `${r.fullName} (id ${r.id})`).join('\n                ') : '(none)'}`);
+  console.log(`  Expires       ${expires ?? '(unset)'}`);
+  console.log(`  Granted       ${grant.ossGrantedAt ?? '(unknown)'}`);
+  console.log(`  Note          ${grant.ossGrantNote ?? '(none)'}`);
+  console.log(`  Monthly cap   ${grant.ossMonthlyCapCents != null ? usd(grant.ossMonthlyCapCents) : '(uncapped)'}`);
+  console.log(`  This period   ${grant.ossPeriod ?? '(none)'} — ${usd(grant.ossSponsoredCentsThisPeriod ?? 0)} sponsored`);
+  console.log(`  Lifetime      ${usd(grant.ossSponsoredCentsLifetime ?? 0)} sponsored`);
+}
+
+async function confirm(question: string, skip: boolean): Promise<boolean> {
+  if (skip) return true;
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  const answer = (await rl.question(`${question} [y/N] `)).trim().toLowerCase();
+  rl.close();
+  return answer === 'y' || answer === 'yes';
+}
+
+// --- Main ----------------------------------------------------------------------
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const gh = await githubClients(args.stage);
+
+  const resolved = await Promise.all(args.repos.map((r) => resolveRepo(gh, r)));
+
+  // One grant lives on one installation. Mixing repos from different
+  // installations into a single invocation would silently write only one.
+  const installationIds = [...new Set(resolved.map((r) => r.installationId))];
+  if (installationIds.length > 1) {
+    fail(
+      `Those repos belong to different installations (${installationIds.join(', ')}).\n`
+      + 'Grants are per-installation — run the script once per installation.',
+    );
+  }
+  const installationId = installationIds[0];
+  const existing = await readGrant(args.stage, installationId);
+
+  if (args.mode === 'inspect') {
+    renderGrant(existing, installationId);
+    console.log();
+    return;
+  }
+
+  // Eligibility: public repos only. Checked here as a courtesy to the operator;
+  // the gate re-checks visibility live on every review, which is what actually
+  // stops a repo flipped private later from staying sponsored.
+  if (args.mode === 'grant' || args.mode === 'add') {
+    for (const r of resolved) {
+      if (!r.isPublic) fail(`${r.fullName} is private. The OSS Program covers public repositories only.`);
+      console.log(`✓ ${r.fullName} — public, last pushed ${r.pushedAt ?? 'unknown'}, ${r.openIssues} open issues`);
+    }
+  }
+
+  const current = existing.ossGrantRepos ?? [];
+  let next: OssGrantRepo[];
+  switch (args.mode) {
+    case 'grant':
+      next = resolved.map((r) => ({ id: r.id, fullName: r.fullName }));
+      break;
+    case 'add':
+      next = [...current.filter((c) => !resolved.some((r) => r.id === c.id)),
+              ...resolved.map((r) => ({ id: r.id, fullName: r.fullName }))];
+      break;
+    case 'remove':
+      next = current.filter((c) => !resolved.some((r) => r.id === c.id));
+      break;
+    case 'revoke':
+      next = current;
+      break;
+  }
+
+  const revoking = args.mode === 'revoke';
+  const expiresAt = revoking
+    ? new Date(Date.now() - 1000).toISOString()
+    : new Date(new Date().setMonth(new Date().getMonth() + args.months)).toISOString();
+
+  // Blast radius: what this covers, and — just as important — what in the same
+  // installation it does not, so an accidental omission is visible before the write.
+  const allRepos = await installationRepos(args.stage, installationId);
+  const coveredNames = new Set(next.map((r) => r.fullName));
+  const uncovered = allRepos.filter((n) => !coveredNames.has(n));
+
+  console.log(`\n── ${args.mode.toUpperCase()} · stage=${args.stage} · installation ${installationId} ──`);
+  if (revoking) {
+    console.log(`  Revoking the grant (expiry set to the past). Reviews fall back to the`);
+    console.log(`  standard free-tier/balance gate — they are not blocked outright.`);
+  } else {
+    console.log(`  Will sponsor ${next.length} repo(s):`);
+    for (const r of next) console.log(`    • ${r.fullName} (id ${r.id})`);
+    if (uncovered.length) {
+      console.log(`  NOT covered in this installation:`);
+      for (const n of uncovered) console.log(`    · ${n}`);
+    }
+    console.log(`  Monthly cap  ${usd(args.capCents)} (shared across the repos above)`);
+    console.log(`  Expires      ${expiresAt}`);
+    if (args.note) console.log(`  Note         ${args.note}`);
+  }
+
+  if (!next.length && !revoking) {
+    fail('That would leave the grant with no repositories. Use --revoke to end it instead.');
+  }
+
+  if (!(await confirm('\nProceed?', args.yes))) {
+    console.log('Aborted. Nothing written.\n');
+    return;
+  }
+
+  await writeGrant(args.stage, installationId, {
+    ossGrantRepos: next,
+    ossGrantExpiresAt: expiresAt,
+    ossMonthlyCapCents: args.capCents,
+    ossGrantedAt: new Date().toISOString(),
+    ...(args.note ? { ossGrantNote: args.note } : {}),
+  });
+
+  console.log('\n✓ Written.');
+  renderGrant(await readGrant(args.stage, installationId), installationId);
+  console.log();
+}
+
+main().catch((err) => {
+  console.error('\n✗ Failed:', err instanceof Error ? err.message : err, '\n');
+  process.exit(1);
+});


### PR DESCRIPTION
**Stage 3 of 4** for #261. **Stacks on #265** → which stacks on #263. Review those first.

This is the piece that makes the entitlement real — until now nothing wrote grant fields, so stages 1 and 2 shipped dark.

```
scripts/grant-oss.ts <owner/repo> --stage prod [--cap N] [--months N] [--note "..."]
scripts/grant-oss.ts --add|--remove|--revoke|--inspect <owner/repo> --stage ...
```

## Deviation from the plan: `.ts`, not `.sh`

The plan and #261 both said `grant-oss.sh`. The work is App-JWT minting, SSM reads, a DynamoDB query, and an authenticated GitHub API chain — in bash that means hand-rolling JWT signing with `openssl` and parsing JSON with `jq`. `scripts/backfill-clear-stale-blocks.ts` already sets the `npx tsx` precedent and `@octokit/auth-app` is hoisted at the root, so TypeScript is both shorter and far less error-prone here. Docs, the plan, and E2E-83 were updated to match. Say the word if you'd rather have a thin `.sh` wrapper for muscle memory.

## Three safeguards before any write

1. **Refuses to run without `--stage`.** No default. It writes to a live table, and defaulting the environment is how a grant lands in the wrong one.
2. **Verifies the repo is public**, and surfaces last-push / open-issue counts so the human approving has the activity signal in hand.
3. **Prints the blast radius** — what the grant covers *and* what else in the same installation it does not.

That third one earned itself immediately. Dry run against prod:

```
✓ mergewatch/mergewatch.ai — public, last pushed 2026-08-13T01:19:11Z, 9 open issues

── GRANT · stage=prod · installation 141442688 ──
  Will sponsor 1 repo(s):
    • mergewatch/mergewatch.ai (id 1173050881)
  NOT covered in this installation:
    · mergewatch/documentation
    · mergewatch/fixtures
    · mergewatch/kitchensink
  Monthly cap  $5.00 (shared across the repos above)
```

## One thing worth knowing for review

**Two GitHub identities are required, and the order matters.** An App JWT resolves repo → installation (`GET /repos/{owner}/{repo}/installation`, which a user token cannot reach — the reason this isn't a `gh api` one-liner). But a JWT *cannot* read repository content endpoints, so an installation token then reads the repo for its id and visibility. My first implementation used one client for both and failed against the live API; the split is now documented at the call site.

## Verification

Exercised read-only against **prod**: SSM → JWT → installation `141442688` → installation token → repo read → DynamoDB read. Plus a full grant run aborted at the confirmation prompt (output above). **Nothing was written.**

Build ✅ typecheck ✅ full suite ✅.

## Risk

The script is additive — no runtime code changes. Grants only exist once someone runs it deliberately.

## Deferred

- **Stage 4** — dashboard OSS state + `/billing/status` fields + docs; graduates `docs/pending/oss-program.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)