### PR TITLE
feat(dashboard): OSS Program state on the billing page + docs (#261, stage 4)

### DIFF
--- a/docs-site/saas/billing.mdx
+++ b/docs-site/saas/billing.mdx
@@ -21,6 +21,20 @@ MergeWatch offers **free frontier-model review to open-source maintainers**, bey
 Applications are reviewed individually — tell us about the project and how you'd use MergeWatch.
 </Card>
 
+### How an approved grant behaves
+
+Once a project is approved, reviews on the covered repositories are **sponsored**: no charge, and they don't consume your free reviews or credit balance. Your **Dashboard → Billing** page shows an Open Source Program panel with the covered repositories, what's been sponsored this month, and your fair-use headroom.
+
+Specifics worth knowing:
+
+- **Only the repositories named in the grant are covered.** Approval is per project, not per organization — other repositories in the same installation bill normally. Ask us to add a repository and we will.
+- **Coverage requires the repository to be public at review time.** If a covered repository is made private, its next review is billed normally rather than sponsored.
+- **Renaming or transferring a covered repository is safe.** Grants track the repository itself, not its name.
+- **Fair use is a monthly ceiling**, shared across the repositories in your grant. Going over it doesn't block anything — reviews simply fall back to your free tier and balance for the rest of the month.
+- **Grants are time-limited** and renewed on request. When one expires, reviews fall back to the standard free tier and balance — they are never cut off outright.
+
+If a grant lapses or a project outgrows the fair-use limit, MergeWatch will say so on the pull request and point you at renewal or at [self-hosting](/self-hosting/overview), which is free and unlimited. You will not be asked for a card.
+
 Self-hosting is always free regardless, and remains the right choice if you would rather run the whole pipeline yourself. See [Self-hosted is always free](#self-hosted-is-always-free).
 
 ## Per-review pricing

--- a/docs/feat/20260812-01-oss-program-entitlement.plan.md
+++ b/docs/feat/20260812-01-oss-program-entitlement.plan.md
@@ -1,6 +1,6 @@
 # OSS Program — Sponsored-Review Entitlement
 
-**Status:** In progress
+**Status:** Shipped
 **Tracking issue:** [#261](https://github.com/mergewatch/mergewatch.ai/issues/261)
 
 ## Summary
@@ -117,10 +117,10 @@ Ships dark — nothing writes the fields yet, so this is a no-op in prod and saf
 
 ### Phase 4 — Dashboard + docs (capstone)
 
-- [ ] OSS fields in the `/billing/status` response (`packages/lambda/src/handlers/billing.ts:254`).
-- [ ] OSS Program state in `BillingClient.tsx` — covered repos, sponsored this month, fair-use headroom — replacing the balance/top-up prompt.
-- [ ] Update `docs-site/saas/billing.mdx` to describe actual grant behavior.
-- [ ] Graduate `docs/pending/oss-program.md` → `docs/oss-program.md`.
+- [x] OSS fields in the `/billing/status` response (`packages/lambda/src/handlers/billing.ts:254`).
+- [x] OSS Program state in `BillingClient.tsx` — covered repos, sponsored this month, fair-use headroom. Rendered *alongside* the balance card rather than replacing it: a granted installation can still hold private or unnamed repos that bill normally, so both states are simultaneously true.
+- [x] Update `docs-site/saas/billing.mdx` to describe actual grant behavior.
+- [x] Graduate `docs/pending/oss-program.md` → `docs/oss-program.md`.
 
 ## Out of scope / deferred
 

--- a/docs/oss-program.md
+++ b/docs/oss-program.md
@@ -1,6 +1,6 @@
 # MergeWatch for Open Source — sponsored reviews
 
-**Status:** 🚧 In progress (#261)
+**Status:** ✅ Shipped (#261)
 
 Approved open-source repositories have their PR reviews sponsored: no balance, no payment method, and no consumption of the standard 5-review free tier. This is the runtime behind the promise on [mergewatch.ai/open-source](https://mergewatch.ai/open-source).
 

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -2833,9 +2833,9 @@ curl -s "$MCP_URL" \
 
 ### E2E-82: OSS Program — sponsored review on a granted public repo
 
-**Status:** ⬜ NOT YET COVERED.
+**Status:** ✅ SHIPPED (#263, #265) — fixture not yet run.
 
-**Behavior:** A repository named in an active OSS grant (#261) is reviewed with no balance, no payment method, and no free-tier consumption. Being named is necessary but not sufficient — the repo must also be public at review time, the grant must not have expired, and the month must be under its fair-use cap. See `docs/pending/oss-program.md`.
+**Behavior:** A repository named in an active OSS grant (#261) is reviewed with no balance, no payment method, and no free-tier consumption. Being named is necessary but not sufficient — the repo must also be public at review time, the grant must not have expired, and the month must be under its fair-use cap. See `docs/oss-program.md`.
 
 **Setup**
 
@@ -2873,7 +2873,7 @@ Prerequisites on the fixtures installation:
 
 ### E2E-83: OSS Program — operator grant lifecycle
 
-**Status:** ⬜ NOT YET COVERED.
+**Status:** ✅ SHIPPED (#266) — fixture not yet run.
 
 **Behavior:** `scripts/grant-oss.ts` is the only way a grant is written. It resolves a repo to its installation via an App JWT, verifies the repo is public, shows the blast radius, and refuses to run without an explicit `--stage`.
 

--- a/packages/dashboard/app/dashboard/billing/BillingClient.tsx
+++ b/packages/dashboard/app/dashboard/billing/BillingClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { CreditCard, Zap, TrendingUp, AlertCircle, CheckCircle2, Loader2, RefreshCw } from "lucide-react";
+import { CreditCard, Zap, TrendingUp, AlertCircle, CheckCircle2, Loader2, RefreshCw, HeartHandshake } from "lucide-react";
 
 interface BillingStatus {
   freeReviewsUsed: number;
@@ -16,6 +16,21 @@ interface BillingStatus {
   totalBilledCents: number;
   prCount: number;
   prTimestamps: string[];
+  /**
+   * OSS Program (#261). Null for every installation without a grant.
+   * `active` is computed server-side so this panel can't drift from the
+   * billing gate's own notion of an active grant.
+   */
+  oss: {
+    active: boolean;
+    repos: string[];
+    expiresAt: string;
+    grantedAt: string | null;
+    note: string | null;
+    monthlyCapCents: number | null;
+    sponsoredThisPeriodCents: number;
+    sponsoredLifetimeCents: number;
+  } | null;
 }
 
 interface BillingClientProps {
@@ -210,6 +225,101 @@ export default function BillingClient({ installationId, accountLogin, setupCompl
             >
               Dismiss
             </button>
+          </div>
+        )}
+
+        {/* OSS Program (#261) — sponsored reviews.
+            Rendered alongside the credit balance rather than replacing it:
+            a granted installation can still contain private or unnamed repos
+            that bill normally, so both states are true at once. */}
+        {status.oss && (
+          <div className="rounded-lg border border-border-default bg-surface-card p-5 sm:p-6">
+            <div className="flex items-center gap-2 mb-4">
+              <HeartHandshake className="h-4 w-4 text-accent-green" />
+              <h2 className="text-[11px] font-semibold uppercase tracking-widest text-fg-muted">
+                Open Source Program
+              </h2>
+              {!status.oss.active && (
+                <span className="ml-auto rounded-full border border-yellow-500/30 bg-yellow-500/5 px-2 py-0.5 text-[10px] font-medium text-yellow-300">
+                  Expired
+                </span>
+              )}
+            </div>
+
+            {status.oss.active ? (
+              <p className="text-sm text-fg-secondary">
+                Reviews on the repositories below are sponsored by MergeWatch — no charge, and
+                they don&rsquo;t use your free reviews or balance.
+              </p>
+            ) : (
+              <p className="text-sm text-fg-secondary">
+                This grant expired on {new Date(status.oss.expiresAt).toLocaleDateString()}. Reviews
+                now fall back to your free tier and balance. Get in touch at{" "}
+                <a
+                  href="https://mergewatch.ai/open-source"
+                  className="text-accent-green hover:underline"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  mergewatch.ai/open-source
+                </a>{" "}
+                to renew it — there&rsquo;s no charge.
+              </p>
+            )}
+
+            <div className="mt-5 grid gap-5 sm:grid-cols-3">
+              <div>
+                <div className="text-2xl font-bold text-fg-primary tabular-nums">
+                  ${(status.oss.sponsoredThisPeriodCents / 100).toFixed(2)}
+                </div>
+                <p className="mt-1 text-xs text-fg-tertiary">Sponsored this month</p>
+                {status.oss.monthlyCapCents !== null && (
+                  <>
+                    <div className="mt-2 h-2 rounded-full bg-surface-card-hover">
+                      <div
+                        className="h-2 rounded-full bg-accent-green transition-all"
+                        style={{
+                          width: `${Math.min(100, (status.oss.sponsoredThisPeriodCents / status.oss.monthlyCapCents) * 100)}%`,
+                        }}
+                      />
+                    </div>
+                    <p className="mt-1 text-[11px] text-fg-muted">
+                      of ${(status.oss.monthlyCapCents / 100).toFixed(2)} fair-use limit
+                    </p>
+                  </>
+                )}
+              </div>
+
+              <div>
+                <div className="text-2xl font-bold text-fg-primary tabular-nums">
+                  ${(status.oss.sponsoredLifetimeCents / 100).toFixed(2)}
+                </div>
+                <p className="mt-1 text-xs text-fg-tertiary">Sponsored to date</p>
+              </div>
+
+              <div>
+                <div className="text-2xl font-bold text-fg-primary tabular-nums">
+                  {status.oss.repos.length}
+                </div>
+                <p className="mt-1 text-xs text-fg-tertiary">
+                  {status.oss.repos.length === 1 ? "Covered repository" : "Covered repositories"}
+                </p>
+              </div>
+            </div>
+
+            <div className="mt-5 pt-4 border-t border-border-default">
+              <p className="text-xs text-fg-tertiary mb-2">Covered repositories</p>
+              <ul className="space-y-1">
+                {status.oss.repos.map((r) => (
+                  <li key={r} className="text-sm text-fg-secondary">{r}</li>
+                ))}
+              </ul>
+              <p className="mt-3 text-[11px] text-fg-muted">
+                Only these repositories are sponsored, and only while they are public. Anything
+                else in this installation bills normally.
+                {status.oss.active && ` Grant runs until ${new Date(status.oss.expiresAt).toLocaleDateString()}.`}
+              </p>
+            </div>
           </div>
         )}
 

--- a/packages/dashboard/app/dashboard/billing/BillingClient.tsx
+++ b/packages/dashboard/app/dashboard/billing/BillingClient.tsx
@@ -279,7 +279,12 @@ export default function BillingClient({ installationId, accountLogin, setupCompl
                       <div
                         className="h-2 rounded-full bg-accent-green transition-all"
                         style={{
-                          width: `${Math.min(100, (status.oss.sponsoredThisPeriodCents / status.oss.monthlyCapCents) * 100)}%`,
+                          // A zero cap means no allowance at all, so the bar is
+                          // full. Guarding the divide matters: 0/0 is NaN, which
+                          // renders as `width: "NaN%"` and silently drops the bar.
+                          width: `${status.oss.monthlyCapCents > 0
+                            ? Math.min(100, (status.oss.sponsoredThisPeriodCents / status.oss.monthlyCapCents) * 100)
+                            : 100}%`,
                         }}
                       />
                     </div>

--- a/packages/lambda/src/handlers/billing.ts
+++ b/packages/lambda/src/handlers/billing.ts
@@ -227,6 +227,37 @@ async function handleWebhook(event: APIGatewayProxyEventV2): Promise<APIGatewayP
   return json(200, { received: true });
 }
 
+/**
+ * #261 — OSS Program status for the dashboard, or null when the installation
+ * has no grant.
+ *
+ * `active` is computed here rather than left to the client so the dashboard
+ * can't drift from the gate's own notion of "active" (`evaluateOssGrant`).
+ * Period spend is reported as 0 once `ossPeriod` goes stale, matching how the
+ * cap is actually applied — last month's spend never eats this month's
+ * allowance.
+ */
+function ossStatus(fields: Awaited<ReturnType<typeof getBillingFields>>) {
+  const repos = fields.ossGrantRepos ?? [];
+  if (!fields.ossGrantExpiresAt || repos.length === 0) return null;
+
+  const expiresAt = Date.parse(fields.ossGrantExpiresAt);
+  const period = new Date().toISOString().slice(0, 7);
+
+  return {
+    active: Number.isFinite(expiresAt) && expiresAt > Date.now(),
+    repos: repos.map((r) => r.fullName),
+    expiresAt: fields.ossGrantExpiresAt,
+    grantedAt: fields.ossGrantedAt ?? null,
+    note: fields.ossGrantNote ?? null,
+    monthlyCapCents: fields.ossMonthlyCapCents ?? null,
+    sponsoredThisPeriodCents: fields.ossPeriod === period
+      ? (fields.ossSponsoredCentsThisPeriod ?? 0)
+      : 0,
+    sponsoredLifetimeCents: fields.ossSponsoredCentsLifetime ?? 0,
+  };
+}
+
 async function handleStatus(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyResultV2> {
   const installationId = event.queryStringParameters?.installationId;
   if (!installationId) {
@@ -264,6 +295,11 @@ async function handleStatus(event: APIGatewayProxyEventV2): Promise<APIGatewayPr
     totalBilledCents: fields.totalBilledCents ?? 0,
     prCount: fields.prCount ?? 0,
     prTimestamps: fields.prTimestamps ?? [],
+
+    // OSS Program (#261). `oss` is null for every installation without a
+    // grant, which is what the dashboard keys off to decide whether to show
+    // the program panel instead of the balance/top-up one.
+    oss: ossStatus(fields),
   });
 }
 

--- a/scripts/grant-oss.ts
+++ b/scripts/grant-oss.ts
@@ -99,12 +99,24 @@ function parseArgs(argv: string[]): Args {
     if (!/^[^/\s]+\/[^/\s]+$/.test(r)) fail(`Not an owner/repo: ${r}`);
   }
 
+  const capCents = Number(flag(argv, '--cap') ?? DEFAULT_CAP_CENTS);
+  const months = Number(flag(argv, '--months') ?? DEFAULT_TERM_MONTHS);
+  // A zero or negative cap is almost certainly a typo, and it produces a grant
+  // that is active but sponsors nothing — the most confusing possible state for
+  // a maintainer. Reject it here rather than letting it reach the row.
+  if (!Number.isFinite(capCents) || capCents <= 0) {
+    fail(`--cap must be a positive number of cents (got ${flag(argv, '--cap')}). Use --revoke to end a grant.`);
+  }
+  if (!Number.isFinite(months) || months <= 0) {
+    fail(`--months must be a positive number (got ${flag(argv, '--months')}).`);
+  }
+
   return {
     repos,
     stage: stage!,
     mode,
-    capCents: Number(flag(argv, '--cap') ?? DEFAULT_CAP_CENTS),
-    months: Number(flag(argv, '--months') ?? DEFAULT_TERM_MONTHS),
+    capCents,
+    months,
     note: flag(argv, '--note'),
     yes: argv.includes('--yes'),
   };


### PR DESCRIPTION
**Stage 4 of 4** — the capstone for #261. **Stacks on #266 → #265 → #263.**

## What this ships

- `/billing/status` returns an `oss` object — `null` for any installation without a grant.
- The billing page shows covered repositories, sponsored-this-month against the fair-use bar, and sponsored-to-date. An expired grant renders explicitly with a renewal link, not a payment prompt.
- `docs-site/saas/billing.mdx` describes how a grant actually behaves.
- `docs/pending/oss-program.md` graduates to `docs/oss-program.md`; E2E-82/83 marked shipped.

## Two deliberate departures from the plan

**1. The OSS panel sits *alongside* the credit-balance card, not replacing it.** The plan said "replacing the balance/top-up prompt", and that's wrong for the data model: a granted installation can still hold private or unnamed repos that bill normally, so both states are simultaneously true. Showing only the OSS panel would imply the whole installation is free. The panel says so explicitly — *"Only these repositories are sponsored, and only while they are public. Anything else in this installation bills normally."*

**2. `active` is computed server-side.** It would have been easy to ship `expiresAt` and let the client compare dates, but then the dashboard has its own second opinion about what "active" means and can drift from `evaluateOssGrant`. Same reason `sponsoredThisPeriodCents` reports 0 once `ossPeriod` goes stale — it mirrors how the cap is actually applied rather than showing a figure the gate ignores.

## Docs correction

The previous `billing.mdx` text implied a blanket free tier for OSS projects. The new section states the real constraints: named repos only, public-at-review-time, rename-safe, fair use as a soft ceiling, and expiry falling back to the free tier rather than cutting off. It also promises the thing the code now guarantees — a lapsed grant never asks a maintainer for a card.

## Verification

Build ✅ typecheck ✅ full suite ✅. Dashboard production build passes.

## Merge order

#263 → #265 → #266 → this. Each is independently reviewable; the stack must merge bottom-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)