### PR TITLE
chore: force textual diffs for source files (.gitattributes)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,33 @@
+# =============================================================================
+# Keep source files diffable (#307)
+# =============================================================================
+#
+# Git decides a blob is "binary" if it finds a NUL byte in the first 8000
+# bytes, and marks a diff binary when EITHER side is. One stray control
+# character therefore turns a source file into `Bin 45080 -> 45082 bytes` on
+# GitHub, in `git diff`, and to any reviewer that reads diffs — including
+# MergeWatch itself.
+#
+# That is not hypothetical: two literal NUL bytes in
+# packages/server/src/review-processor.ts (a 45KB file on the self-hosted
+# review path) made every change to it unreviewable, and an external
+# contributor's PR to that file was reviewed against an undiffable blob.
+#
+# Marking these types with the `diff` attribute forces a textual diff
+# regardless of content, so a file can never silently become unreviewable.
+# The complementary guard is packages/core/src/source-hygiene.test.ts, which
+# fails the build if a NUL byte is committed at all — this attribute keeps the
+# damage visible in the window before that test is consulted.
+
+*.ts    diff
+*.tsx   diff
+*.js    diff
+*.jsx   diff
+*.mjs   diff
+*.cjs   diff
+*.json  diff
+*.md    diff
+*.mdx   diff
+*.yml   diff
+*.yaml  diff
+*.sh    diff


### PR DESCRIPTION
Split out of #307 so that PR becomes reviewable.

## Why this has to be separate

`.gitattributes` is read from the **checkout**, not from the commits being diffed — so GitHub renders a pull request using the **base** branch's attributes. A `.gitattributes` living only on a feature branch cannot fix that branch's own rendering.

Verified locally:

```
attributes present in tree:   1   1   packages/server/src/review-processor.ts
attributes absent from tree:  -   -   packages/server/src/review-processor.ts
```

So #307 — the PR that removes the NUL bytes — will keep displaying as `Bin 45080 -> 45082 bytes` no matter what it contains, until this lands on `main`.

## What it does

Git marks a diff binary when **either** side has a NUL byte in its first 8000 bytes. Setting the `diff` attribute forces a textual diff regardless of content, so a stray control character can never silently make a file unreviewable.

Once merged, #307's one-line change renders as:

```
1  1  packages/server/src/review-processor.ts
```

## Risk

None to runtime — this affects diff rendering only. No code, config, or build change.

## Suggested order

Merge this first, then #307. The reverse order works too, but then the fix commit is reviewed as a blob, which is the exact problem being solved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)