### PR TITLE
fix(model): let the committed .mergewatch.yml outrank the installation row

### DIFF
--- a/docs-site/configuration/mergewatch-yml.mdx
+++ b/docs-site/configuration/mergewatch-yml.mdx
@@ -300,9 +300,11 @@ pricing:
 
 `model:` is resolved against two other sources. Highest precedence first:
 
-1. **An installation-level override**, if one has been set on the repository's installation record.
-2. **`model:` in this file** — the per-repo setting documented above.
-3. **The deployment default.** On MergeWatch SaaS this is set per environment at deploy time. Self-hosted, it is the `LLM_MODEL` environment variable.
+1. **`model:` in this file** — the per-repo setting documented above. The committed `.mergewatch.yml` always wins, consistent with every other key on this page.
+2. **An installation-level override**, if one has been set on the repository's installation record.
+3. **The deployment default**, set per environment at deploy time.
+
+Self-hosted differs in one respect: the `LLM_MODEL` environment variable is an operator *pin* rather than a default, so it overrides everything above — including this file.
 
 Omitting `model:` therefore means "use whatever this deployment is configured with", not "use the value shown in the table above" — which is why the Default column reads *(deployment default)* rather than naming a model. The review log line records which source won:
 

--- a/packages/core/src/config/model-resolution.test.ts
+++ b/packages/core/src/config/model-resolution.test.ts
@@ -29,10 +29,33 @@ describe('resolveReviewModelId', () => {
     })).toEqual({ modelId: REPO, source: 'repo-config' });
   });
 
-  it('lets an installation override beat the repo config', () => {
+  it('lets the committed yml beat the installation-row override', () => {
+    // Aligned with the configuration contract #306 established for the rest of
+    // the config merge: "the .mergewatch.yml in the repository always wins".
+    // Before that alignment these two adjacent paths in review-agent.ts
+    // disagreed about which source outranked the other.
     expect(resolveReviewModelId({
       installationModelId: INSTALL,
       repoConfigModel: REPO,
+      deployDefault: DEPLOY,
+      fallback: FALLBACK,
+    })).toEqual({ modelId: REPO, source: 'repo-config' });
+  });
+
+  it('uses the installation-row override when the yml is silent', () => {
+    expect(resolveReviewModelId({
+      installationModelId: INSTALL,
+      deployDefault: DEPLOY,
+      fallback: FALLBACK,
+    })).toEqual({ modelId: INSTALL, source: 'installation' });
+  });
+
+  it('does not let an installation override resurrect a blank yml model', () => {
+    // A blank `model:` is "unset", not "defer to the row above me" — it should
+    // fall through the whole chain the same way an absent key does.
+    expect(resolveReviewModelId({
+      repoConfigModel: '   ',
+      installationModelId: INSTALL,
       deployDefault: DEPLOY,
       fallback: FALLBACK,
     })).toEqual({ modelId: INSTALL, source: 'installation' });
@@ -69,24 +92,31 @@ describe('resolveReviewModelId', () => {
     })).toEqual({ modelId: REPO, source: 'repo-config' });
   });
 
-  it('skips an empty installation override and uses the repo config', () => {
+  it('skips an empty installation override', () => {
     expect(resolveReviewModelId({
       installationModelId: '',
-      repoConfigModel: REPO,
       deployDefault: DEPLOY,
       fallback: FALLBACK,
-    })).toEqual({ modelId: REPO, source: 'repo-config' });
+    })).toEqual({ modelId: DEPLOY, source: 'deploy-default' });
+  });
+
+  it('the full chain degrades in order as each source is removed', () => {
+    const all = { repoConfigModel: REPO, installationModelId: INSTALL, deployDefault: DEPLOY, fallback: FALLBACK };
+    expect(resolveReviewModelId(all).modelId).toBe(REPO);
+    expect(resolveReviewModelId({ ...all, repoConfigModel: undefined }).modelId).toBe(INSTALL);
+    expect(resolveReviewModelId({ ...all, repoConfigModel: undefined, installationModelId: undefined }).modelId).toBe(DEPLOY);
+    expect(resolveReviewModelId({ fallback: FALLBACK }).modelId).toBe(FALLBACK);
   });
 
   it('reports the winning source so an unexpected model is traceable', () => {
     // The #264 investigation cost real time precisely because nothing said
     // where the running model came from.
     const sources = [
-      resolveReviewModelId({ installationModelId: INSTALL, fallback: FALLBACK }).source,
       resolveReviewModelId({ repoConfigModel: REPO, fallback: FALLBACK }).source,
+      resolveReviewModelId({ installationModelId: INSTALL, fallback: FALLBACK }).source,
       resolveReviewModelId({ deployDefault: DEPLOY, fallback: FALLBACK }).source,
       resolveReviewModelId({ fallback: FALLBACK }).source,
     ];
-    expect(sources).toEqual(['installation', 'repo-config', 'deploy-default', 'fallback']);
+    expect(sources).toEqual(['repo-config', 'installation', 'deploy-default', 'fallback']);
   });
 });

--- a/packages/core/src/config/model-resolution.ts
+++ b/packages/core/src/config/model-resolution.ts
@@ -1,23 +1,36 @@
 /**
- * #264 — Review model resolution.
+ * Review model resolution (#264).
  *
  * Extracted from the Lambda handler so the precedence is pinned by tests rather
- * than buried in a thousand-line function. The bug this fixes was invisible
+ * than buried in a thousand-line function. The original bug was invisible
  * precisely because nothing asserted the behavior: `.mergewatch.yml`'s
  * documented `model:` key was silently ignored on SaaS while the adjacent line
  * honored `lightModel:`.
+ *
+ * Precedence, highest first:
+ *
+ *   1. `.mergewatch.yml` `model:`      — the repository's committed intent
+ *   2. `installation.modelId`          — per-repo override on the installation row
+ *   3. `DEFAULT_BEDROCK_MODEL_ID`      — the deploy-time default
+ *   4. hardcoded fallback
+ *
+ * The committed yml outranks stored installation state, matching the
+ * configuration contract the rest of the config merge follows since #306
+ * ("the .mergewatch.yml in the repository always wins") — see
+ * `packages/server/src/review-processor.ts`. Before that alignment these two
+ * adjacent code paths disagreed about which source won.
+ *
+ * Note the deploy default sits at the BOTTOM here, unlike self-hosted's
+ * `LLM_MODEL`, which overrides everything including the yml. That asymmetry is
+ * intentional and follows the names: `LLM_MODEL` is an operator pin ("run
+ * everything on this"), while `DEFAULT_BEDROCK_MODEL_ID` is a default a
+ * repository is entitled to override.
  */
 
-/** Inputs to model resolution, most specific first. */
+/** Inputs to model resolution. Field order does not imply precedence. */
 export interface ModelResolutionInput {
   /**
-   * Per-repo override stored on the installation row. Nothing writes this
-   * today (see `InstallationItem.modelId`); read so a hand-set row keeps
-   * working.
-   */
-  installationModelId?: string;
-  /**
-   * `model:` as authored in `.mergewatch.yml`.
+   * `model:` as authored in `.mergewatch.yml`. Highest precedence.
    *
    * This must be the **raw** parsed value, never a merged config's `model`.
    * `mergeConfig` always fills `DEFAULT_CONFIG.model`, so a merged value is
@@ -25,6 +38,12 @@ export interface ModelResolutionInput {
    * everywhere — turning a per-repo opt-in into a global change.
    */
   repoConfigModel?: string;
+  /**
+   * Per-repo override stored on the installation row. Nothing writes this
+   * today (see `InstallationItem.modelId`); read so a hand-set row keeps
+   * working. Outranked by the committed yml.
+   */
+  installationModelId?: string;
   /** Deploy-time default (`DEFAULT_BEDROCK_MODEL_ID`). */
   deployDefault?: string;
   /** Last-resort fallback when the deploy default is unset. */
@@ -46,15 +65,15 @@ export interface ResolvedModel {
 /**
  * Resolve the model a review should run on.
  *
- * Precedence: installation override → `.mergewatch.yml` → deploy default →
+ * Precedence: `.mergewatch.yml` → installation override → deploy default →
  * hardcoded fallback. Empty and whitespace-only values are treated as unset,
  * so a `model:` key left blank in YAML falls through instead of resolving to
  * an empty model ID.
  */
 export function resolveReviewModelId(input: ModelResolutionInput): ResolvedModel {
   const candidates: Array<[ModelSource, string | undefined]> = [
-    ['installation', input.installationModelId],
     ['repo-config', input.repoConfigModel],
+    ['installation', input.installationModelId],
     ['deploy-default', input.deployDefault],
   ];
 

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -610,10 +610,15 @@ export async function handler(
       console.log(`Excluded ${excludedFiles.length} file(s) from diff: ${excludedFiles.join(', ')}`);
     }
 
-    // Model resolution (#264). Precedence, most specific first:
-    //   1. installation.modelId — per-repo admin override on the installation row
-    //   2. .mergewatch.yml `model:` — the documented per-repo key
-    //   3. DEFAULT_BEDROCK_MODEL_ID — the deploy-time default
+    // Model resolution (#264). Precedence, highest first:
+    //   1. .mergewatch.yml `model:`  — the repository's committed intent
+    //   2. installation.modelId      — per-repo override on the installation row
+    //   3. DEFAULT_BEDROCK_MODEL_ID  — the deploy-time default
+    //
+    // The committed yml outranks stored installation state, matching the
+    // configuration contract the runtimeConfig merge above follows since #306
+    // ("the .mergewatch.yml in the repository always wins"). These two adjacent
+    // paths previously disagreed about which source won.
     //
     // Read the RAW yamlConfig, never runtimeConfig.model: mergeConfig always
     // fills DEFAULT_CONFIG.model, so the merged value is truthy for every repo
@@ -622,8 +627,7 @@ export async function handler(
     //
     // Until #264 this line read `installation?.modelId ?? DEFAULT_...`, which
     // ignored `model:` entirely — while the very next line honored
-    // `lightModel:`. Self-hosted (review-processor.ts) already resolved both
-    // from config, so the two runtimes disagreed about a documented setting.
+    // `lightModel:`.
     const resolvedModel = resolveReviewModelId({
       installationModelId: installation?.modelId,
       repoConfigModel: yamlConfig?.model,


### PR DESCRIPTION
Two adjacent paths in `review-agent.ts` disagree about which config source wins. This makes them agree.

## The inconsistency

**#306** established the contract for the config merge — `defaults < dashboard settings < stored installation config < committed .mergewatch.yml` — on the grounds that the docs promise *"the .mergewatch.yml in the repository always wins"*.

**#264/#268** landed model resolution separately, and went the other way: `installation.modelId` beat `yamlConfig.model`.

Both merged. So `review-agent.ts` now contains a merge that puts the yml *above* stored installation state and, forty lines later, a resolver that puts it *below*.

## Why fix it if nothing is broken

**Nothing is broken today.** Nothing writes `installation.modelId`, and all 525 installation rows have it unset — so the two rules never actually collide at runtime.

This is about the next person to touch either path not having to work out which of two contradictory rules was intended. That cost is real: reconciling these two took a diff, a scan of the installations table, and a read of both PRs' rationale.

## The change

Resolver precedence becomes:

```
.mergewatch.yml model:  →  installation.modelId  →  deploy default  →  fallback
```

And documents an asymmetry worth naming, because it looks like a bug until you see the reasoning:

| | Position | Why |
|---|---|---|
| `DEFAULT_BEDROCK_MODEL_ID` (SaaS) | **bottom** | a *default* a repository is entitled to override |
| `LLM_MODEL` (self-hosted) | **top**, above the yml | an operator *pin* — "run everything on this" |

The names carry the intent; the code now says so out loud.

## Tests

Updated rather than deleted — the old assertion encoded the old rule, so silently flipping it would lose the coverage. Three new cases:

- the yml wins over the installation row
- the row still applies when the yml is silent
- a blank `model:` does **not** resurrect the row — it falls through the whole chain exactly like an absent key

12 model-resolution cases total.

## Docs

`docs-site/configuration/mergewatch-yml.mdx` corrected to match, including the self-hosted `LLM_MODEL` asymmetry, which it previously described in the wrong order.

## Verification

Build ✅ typecheck ✅ full suite ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)