### PR TITLE
docs: point every image reference at a tag that actually exists (#254)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Dashboard at **http://localhost:3001**. Sign in with GitHub and install the app 
 
 | Service | Port | Image |
 |---------|------|-------|
-| **mergewatch** (server) | 3000 | `ghcr.io/mergewatch/mergewatch:0.1.0` |
-| **dashboard** (Next.js) | 3001 | `ghcr.io/mergewatch/mergewatch-dashboard:0.1.0` |
+| **mergewatch** (server) | 3000 | `ghcr.io/mergewatch/mergewatch:latest` |
+| **dashboard** (Next.js) | 3001 | `ghcr.io/mergewatch/mergewatch-dashboard:latest` |
 | **db** (PostgreSQL 16) | 5432 | `postgres:16-alpine` |
 
 Pre-built images are published to GHCR on pushes to `main` that change relevant source files, and on every GitHub Release. Upgrade with `docker compose pull && docker compose up -d`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   mergewatch:
-    image: ghcr.io/mergewatch/mergewatch:0.1.0
+    image: ghcr.io/mergewatch/mergewatch:latest
     build: .
     restart: unless-stopped
     environment:
@@ -35,7 +35,7 @@ services:
       start_period: 30s
 
   dashboard:
-    image: ghcr.io/mergewatch/mergewatch-dashboard:0.1.0
+    image: ghcr.io/mergewatch/mergewatch-dashboard:latest
     build:
       context: .
       dockerfile: Dockerfile.dashboard

--- a/docs-site/dashboard/deployment.mdx
+++ b/docs-site/dashboard/deployment.mdx
@@ -21,7 +21,7 @@ The MergeWatch dashboard is a Next.js application that provides a web UI for man
 
     ```yaml docker-compose.yml
     dashboard:
-      image: ghcr.io/santthosh/mergewatch-dashboard:0.1.0
+      image: ghcr.io/mergewatch/mergewatch-dashboard:latest
       restart: unless-stopped
       environment:
         DEPLOYMENT_MODE: self-hosted

--- a/docs-site/overview/how-it-works.mdx
+++ b/docs-site/overview/how-it-works.mdx
@@ -217,7 +217,7 @@ Codebase awareness is enabled by default. To revert to diff-only analysis (faste
 
 <CardGroup cols={2}>
   <Card title="Express Server (Docker)">
-    - **Image:** `ghcr.io/santthosh/mergewatch:latest`
+    - **Image:** `ghcr.io/mergewatch/mergewatch:latest`
     - **Port:** 3000
     - **Webhook endpoint:** `/webhook`
     - **Role:** Validate signature, fetch diff, invoke agents, run orchestrator, post results

--- a/docs-site/reference/troubleshooting.mdx
+++ b/docs-site/reference/troubleshooting.mdx
@@ -46,7 +46,7 @@ description: "Fixes for reviews not posting, webhooks not arriving, Docker conta
 </Accordion>
 
 <Accordion title="Cannot pull Docker images">
-  The images `ghcr.io/santthosh/mergewatch:latest` and `ghcr.io/santthosh/mergewatch-dashboard:latest` are hosted on GitHub Container Registry.
+  The images `ghcr.io/mergewatch/mergewatch:latest` and `ghcr.io/mergewatch/mergewatch-dashboard:latest` are hosted on GitHub Container Registry.
 
   **Fix:** Authenticate with GHCR if pulling from a private registry:
 

--- a/docs-site/self-hosting/llm-providers/litellm.mdx
+++ b/docs-site/self-hosting/llm-providers/litellm.mdx
@@ -41,7 +41,7 @@ Run LiteLLM as a sidecar alongside MergeWatch:
 ```yaml docker-compose.yml
 services:
   mergewatch:
-    image: ghcr.io/santthosh/mergewatch:latest
+    image: ghcr.io/mergewatch/mergewatch:latest
     ports:
       - "3000:3000"
     env_file: .env

--- a/docs-site/self-hosting/llm-providers/ollama.mdx
+++ b/docs-site/self-hosting/llm-providers/ollama.mdx
@@ -56,7 +56,7 @@ Run Ollama as a sidecar alongside MergeWatch:
 ```yaml docker-compose.yml
 services:
   mergewatch:
-    image: ghcr.io/santthosh/mergewatch:latest
+    image: ghcr.io/mergewatch/mergewatch:latest
     ports:
       - "3000:3000"
     env_file: .env

--- a/docs-site/self-hosting/manual-install.mdx
+++ b/docs-site/self-hosting/manual-install.mdx
@@ -71,7 +71,7 @@ For most users, the recommended path is Docker Compose. See the [install guide](
       -e LLM_PROVIDER=anthropic \
       -e ANTHROPIC_API_KEY=sk-ant-your-key \
       -p 3000:3000 \
-      ghcr.io/santthosh/mergewatch:latest
+      ghcr.io/mergewatch/mergewatch:latest
     ```
 
     <Warning>
@@ -119,7 +119,7 @@ For most users, the recommended path is Docker Compose. See the [install guide](
       -e NEXTAUTH_SECRET=$(openssl rand -base64 32) \
       -e NEXTAUTH_URL=http://localhost:3001 \
       -p 3001:3001 \
-      ghcr.io/santthosh/mergewatch-dashboard:0.1.0
+      ghcr.io/mergewatch/mergewatch-dashboard:latest
     ```
 
     The dashboard reads directly from the MergeWatch Postgres database, so no `NEXT_PUBLIC_API_URL` is required.
@@ -164,12 +164,12 @@ For most users, the recommended path is Docker Compose. See the [install guide](
 | Restart server | `docker restart mergewatch` |
 | Stop all | `docker stop mergewatch dashboard postgres` |
 | Remove all | `docker rm mergewatch dashboard postgres` |
-| Pull latest images | `docker pull ghcr.io/santthosh/mergewatch:latest && docker pull ghcr.io/santthosh/mergewatch-dashboard:latest` |
+| Pull latest images | `docker pull ghcr.io/mergewatch/mergewatch:latest && docker pull ghcr.io/mergewatch/mergewatch-dashboard:latest` |
 
 To upgrade, pull the latest images and recreate the containers:
 
 ```bash
-docker pull ghcr.io/santthosh/mergewatch:latest
+docker pull ghcr.io/mergewatch/mergewatch:latest
 docker stop mergewatch && docker rm mergewatch
 # Re-run the docker run command from Step 3
 ```

--- a/docs-site/self-hosting/overview.mdx
+++ b/docs-site/self-hosting/overview.mdx
@@ -37,7 +37,7 @@ flowchart LR
     style PG fill:#0d1117,stroke:#00ff88,color:#fff
 ```
 
-The Docker image (`ghcr.io/santthosh/mergewatch:latest`) runs an Express server that:
+The Docker image (`ghcr.io/mergewatch/mergewatch:latest`) runs an Express server that:
 
 1. Receives GitHub webhooks on `/webhook` (port 3000)
 2. Validates the HMAC-SHA256 signature

--- a/docs-site/self-hosting/platforms/air-gapped.mdx
+++ b/docs-site/self-hosting/platforms/air-gapped.mdx
@@ -67,7 +67,7 @@ In an air-gapped environment, your GitHub Enterprise Server instance must be rea
 <Step title="Pull the required container images">
 
 ```bash
-docker pull ghcr.io/santthosh/mergewatch:latest
+docker pull ghcr.io/mergewatch/mergewatch:latest
 docker pull ollama/ollama:latest
 docker pull postgres:15-alpine
 ```
@@ -91,7 +91,7 @@ docker run --rm -v ollama-models:/root/.ollama ollama/ollama pull qwen2.5-coder:
 <Step title="Save images to tar files">
 
 ```bash
-docker save ghcr.io/santthosh/mergewatch:latest -o mergewatch.tar
+docker save ghcr.io/mergewatch/mergewatch:latest -o mergewatch.tar
 docker save ollama/ollama:latest -o ollama.tar
 docker save postgres:15-alpine -o postgres.tar
 ```
@@ -151,7 +151,7 @@ version: "3.8"
 
 services:
   mergewatch:
-    image: ghcr.io/santthosh/mergewatch:latest
+    image: ghcr.io/mergewatch/mergewatch:latest
     container_name: mergewatch
     restart: unless-stopped
     ports:

--- a/docs-site/self-hosting/platforms/aws-ecs-fargate.mdx
+++ b/docs-site/self-hosting/platforms/aws-ecs-fargate.mdx
@@ -96,7 +96,7 @@ Create a file called `task-definition.json`:
   "containerDefinitions": [
     {
       "name": "mergewatch",
-      "image": "ghcr.io/santthosh/mergewatch:latest",
+      "image": "ghcr.io/mergewatch/mergewatch:latest",
       "portMappings": [
         { "containerPort": 3000, "protocol": "tcp" }
       ],

--- a/docs-site/self-hosting/platforms/azure-container-apps.mdx
+++ b/docs-site/self-hosting/platforms/azure-container-apps.mdx
@@ -70,7 +70,7 @@ az containerapp create \
   --name mergewatch \
   --resource-group mergewatch-rg \
   --environment mergewatch-env \
-  --image ghcr.io/santthosh/mergewatch:latest \
+  --image ghcr.io/mergewatch/mergewatch:latest \
   --target-port 3000 \
   --ingress external \
   --min-replicas 0 \

--- a/docs-site/self-hosting/platforms/fly-io.mdx
+++ b/docs-site/self-hosting/platforms/fly-io.mdx
@@ -49,7 +49,7 @@ Set `LLM_PROVIDER` to your preferred provider. For the default Anthropic provide
 From a directory containing a `Dockerfile` (or use the MergeWatch image directly), run:
 
 ```bash
-fly launch --image ghcr.io/santthosh/mergewatch:latest \
+fly launch --image ghcr.io/mergewatch/mergewatch:latest \
   --name mergewatch \
   --region iad \
   --no-deploy

--- a/docs-site/self-hosting/platforms/google-cloud-run.mdx
+++ b/docs-site/self-hosting/platforms/google-cloud-run.mdx
@@ -64,7 +64,7 @@ Deploy the MergeWatch container image with all required environment variables.
 
 ```bash Single command
 gcloud run deploy mergewatch \
-  --image ghcr.io/santthosh/mergewatch:latest \
+  --image ghcr.io/mergewatch/mergewatch:latest \
   --region us-central1 \
   --port 3000 \
   --allow-unauthenticated \
@@ -84,7 +84,7 @@ echo -n "YOUR_ANTHROPIC_KEY" | gcloud secrets create mergewatch-anthropic-key --
 
 # Deploy with secret references
 gcloud run deploy mergewatch \
-  --image ghcr.io/santthosh/mergewatch:latest \
+  --image ghcr.io/mergewatch/mergewatch:latest \
   --region us-central1 \
   --port 3000 \
   --allow-unauthenticated \

--- a/docs-site/self-hosting/platforms/railway-render.mdx
+++ b/docs-site/self-hosting/platforms/railway-render.mdx
@@ -45,7 +45,7 @@ Set `LLM_PROVIDER` to your preferred provider. For the default Anthropic provide
 
 1. Go to [railway.app/new](https://railway.app/new)
 2. Select **Deploy from Docker Image**
-3. Enter the image: `ghcr.io/santthosh/mergewatch:latest`
+3. Enter the image: `ghcr.io/mergewatch/mergewatch:latest`
 
 </Step>
 
@@ -100,7 +100,7 @@ https://mergewatch-production-abc1.up.railway.app
 1. Go to [dashboard.render.com](https://dashboard.render.com)
 2. Click **New > Web Service**
 3. Select **Deploy an existing image from a registry**
-4. Enter: `ghcr.io/santthosh/mergewatch:latest`
+4. Enter: `ghcr.io/mergewatch/mergewatch:latest`
 
 </Step>
 

--- a/docs-site/self-hosting/platforms/vps-bare-metal.mdx
+++ b/docs-site/self-hosting/platforms/vps-bare-metal.mdx
@@ -83,7 +83,7 @@ version: "3.8"
 
 services:
   mergewatch:
-    image: ghcr.io/santthosh/mergewatch:latest
+    image: ghcr.io/mergewatch/mergewatch:latest
     container_name: mergewatch
     restart: unless-stopped
     ports:

--- a/docs-site/self-hosting/upgrading.mdx
+++ b/docs-site/self-hosting/upgrading.mdx
@@ -11,7 +11,7 @@ Upgrading MergeWatch is a single command:
 docker compose pull && docker compose up -d
 ```
 
-This pulls the latest image (`ghcr.io/santthosh/mergewatch:latest`) and restarts the container. The Postgres sidecar is unaffected.
+This pulls the latest image (`ghcr.io/mergewatch/mergewatch:latest`) and restarts the container. The Postgres sidecar is unaffected.
 
 ## Database migrations
 
@@ -33,12 +33,22 @@ For true zero-downtime upgrades in production, consider running MergeWatch behin
 
 ## Rollback
 
-To roll back to a specific version, pin the image tag:
+To roll back, pin the image tag to a known-good build.
+
+Published tags today are `latest` plus the commit SHA of each build on `main`
+(for example `e24f5fa`). Semantic-version tags such as `0.1.0` are produced
+only when a `v*` git tag is pushed, so pin to a SHA unless a release tag exists:
 
 ```bash
-docker compose pull ghcr.io/santthosh/mergewatch:v0.1.0
+# Pin to a specific build by commit SHA
+docker compose pull ghcr.io/mergewatch/mergewatch:e24f5fa
 docker compose up -d
 ```
+
+<Tip>
+Browse the available tags at
+[ghcr.io/mergewatch/mergewatch](https://github.com/mergewatch/mergewatch.ai/pkgs/container/mergewatch).
+</Tip>
 
 <Warning>
 Rolling back to a version with an older database schema may cause issues if newer migrations have already run. Test rollbacks in a staging environment first.


### PR DESCRIPTION
Closes the last P0 in #254, now that the org packages are public.

## Two independent breakages

**1. Owner drift — 25 references across 15 files.** They still pointed at `ghcr.io/santthosh/*` from before the org transfer. That image is public and pullable, which made this worse rather than better: anyone following the docs got *working* commands that installed the wrong software. It was last built **2026-05-27** — three months and a rename ago.

**2. A tag that has never existed.** `docker-compose.yml`, the README table and two docs pages pinned `:0.1.0`. The publish workflow only emits semver on `v*` git tags, and the repo has **zero** of those — so `0.1.0` has never been built under either owner, and no future push to `main` would create it.

```
mergewatch/mergewatch:0.1.0   -> 404
mergewatch/mergewatch:latest  -> 200
```

## Also fixed: the rollback docs described a scheme the pipeline doesn't produce

`upgrading.mdx` told users to pin `ghcr.io/santthosh/mergewatch:v0.1.0` — wrong owner, wrong tag, *and* wrong tag format (the workflow would emit `0.1.0`, never `v0.1.0`).

Rewritten to describe what is actually published — `latest` plus a per-commit SHA — with a real SHA as the example and a link to the package page.

## Verified, not assumed

Every `ghcr.io` reference in every **tracked** file was resolved against the registry with an anonymous pull token:

```
[OK] ghcr.io/berriai/litellm:main-latest              (1 file)
[OK] ghcr.io/mergewatch/mergewatch-dashboard:latest   (5 files)
[OK] ghcr.io/mergewatch/mergewatch:e24f5fa            (1 file)
[OK] ghcr.io/mergewatch/mergewatch:latest             (16 files)

unresolvable references: 0
```

That check also caught my own earlier miscount — I reported "23 references" from a narrower grep; the real number is 25 across 15 files. The remaining `santthosh` hits on disk are all in `.claude/worktrees/`, which is untracked.

## One deliberate trade-off

I repointed the pins to `:latest` rather than keeping a version pin. A quick start that tracks `main` will drift, and pinning is the better long-term property — but **a pin to a nonexistent tag is strictly worse than no pin**, so `:latest` is the correct state until a release exists.

The clean follow-up is to cut a `v0.1.0` tag, which makes the workflow build `0.1.0` and `0.1` and lets `docker-compose.yml` go back to a real pin. That's a publishing action, so I've left it to you rather than doing it unilaterally — happy to run it on a word.

## Scope

Docs and compose only. No code, no workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)