### PR TITLE
feat(web): add /adversarial-defense market-test landing page

### DIFF
--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -833,6 +833,35 @@ Resources:
   # SK distinguishes helpful-vote rows (HV#repo#pr) from NPS rows (NPS#userId).
   # ReviewAgent writes helpful-vote deltas; the dashboard writes NPS responses;
   # the hourly InsightsRollup reads both for the engagement block.
+  # Adversarial Defense waitlist signups (#315 market test). Partitioned on the
+  # lowercased email so a repeat submission is an idempotent overwrite rather
+  # than a duplicate lead — and so the API can tell a new signup from a repeat
+  # and only alert on the former.
+  WaitlistTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub 'mergewatch-waitlist-${Stage}'
+      BillingMode: PAY_PER_REQUEST
+
+      KeySchema:
+        - AttributeName: email
+          KeyType: HASH
+
+      AttributeDefinitions:
+        - AttributeName: email
+          AttributeType: S
+
+      SSESpecification:
+        SSEEnabled: true
+
+      # No TTL: a lead should not silently expire.
+
+      Tags:
+        - Key: Project
+          Value: MergeWatch
+        - Key: Environment
+          Value: !Ref Stage
+
   SatisfactionTable:
     Type: AWS::DynamoDB::Table
     Properties:

--- a/packages/dashboard/app/adversarial-defense/WaitlistForm.tsx
+++ b/packages/dashboard/app/adversarial-defense/WaitlistForm.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useState } from "react";
+import { ArrowRight, CheckCircle2, Loader2 } from "lucide-react";
+
+type Status = "idle" | "submitting" | "done" | "error";
+
+/**
+ * Waitlist capture for /adversarial-defense.
+ *
+ * Inline rather than a link to a hosted form: this is a market test, and every
+ * redirect between reading the pitch and entering an address costs signups —
+ * which is the exact quantity being measured.
+ *
+ * Two fields only. Each additional question trades conversion for detail, and
+ * at this stage the question is "does anyone want this", not "who are they".
+ * The richer qualification (role, deployment preference, what they are
+ * worried about) belongs in the reply to people who raise their hand.
+ */
+export function WaitlistForm({ compact = false }: { compact?: boolean }) {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [website, setWebsite] = useState(""); // honeypot
+  const [status, setStatus] = useState<Status>("idle");
+  const [message, setMessage] = useState("");
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (status === "submitting") return;
+    setStatus("submitting");
+    setMessage("");
+
+    try {
+      const res = await fetch("/api/waitlist", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name, email, website }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setStatus("error");
+        setMessage(data.error ?? "Something went wrong. Please try again.");
+        return;
+      }
+      setStatus("done");
+    } catch {
+      setStatus("error");
+      setMessage("Network error. Please try again.");
+    }
+  }
+
+  if (status === "done") {
+    return (
+      <div
+        role="status"
+        className="mx-auto flex max-w-md items-start gap-3 rounded-xl border border-primer-green/30 bg-primer-green/5 p-5 text-left"
+      >
+        <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-primer-green" />
+        <div>
+          <p className="text-sm font-semibold text-fg-primary">
+            You&rsquo;re on the list.
+          </p>
+          <p className="mt-1 text-sm leading-relaxed text-primer-muted">
+            We&rsquo;ll be in touch about pilot conversations. If you have a
+            specific worry about your own stack, reply to that email with it
+            &mdash; it&rsquo;s the most useful thing you can send us.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={onSubmit}
+      className={`mx-auto w-full ${compact ? "max-w-md" : "max-w-lg"} text-left`}
+    >
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <label className="sr-only" htmlFor="wl-name">
+          Name
+        </label>
+        <input
+          id="wl-name"
+          name="name"
+          type="text"
+          required
+          maxLength={100}
+          autoComplete="name"
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full rounded-lg border border-border-default bg-surface-card px-4 py-3 text-sm text-fg-primary placeholder:text-primer-muted focus:border-primer-green focus:outline-none"
+        />
+        <label className="sr-only" htmlFor="wl-email">
+          Work email
+        </label>
+        <input
+          id="wl-email"
+          name="email"
+          type="email"
+          required
+          maxLength={254}
+          autoComplete="email"
+          placeholder="Work email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="w-full rounded-lg border border-border-default bg-surface-card px-4 py-3 text-sm text-fg-primary placeholder:text-primer-muted focus:border-primer-green focus:outline-none"
+        />
+      </div>
+
+      {/* Honeypot. Hidden from people, irresistible to bots. Not `display:none`,
+          which some bots skip — off-screen with aria-hidden and no tab stop. */}
+      <div aria-hidden="true" className="absolute left-[-9999px] top-[-9999px]">
+        <label htmlFor="wl-website">Website</label>
+        <input
+          id="wl-website"
+          name="website"
+          type="text"
+          tabIndex={-1}
+          autoComplete="off"
+          value={website}
+          onChange={(e) => setWebsite(e.target.value)}
+        />
+      </div>
+
+      <button
+        type="submit"
+        disabled={status === "submitting"}
+        className="mt-3 inline-flex w-full items-center justify-center rounded-lg bg-primer-green px-6 py-3 text-sm font-semibold text-black transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {status === "submitting" ? (
+          <>
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            Joining&hellip;
+          </>
+        ) : (
+          <>
+            Join the waitlist
+            <ArrowRight className="ml-2 h-4 w-4" />
+          </>
+        )}
+      </button>
+
+      {status === "error" && (
+        <p role="alert" className="mt-3 text-sm text-red-400">
+          {message}
+        </p>
+      )}
+
+      <p className="mt-3 text-xs leading-relaxed text-primer-muted">
+        Name and email only. We&rsquo;ll use it to talk to you about the pilot,
+        nothing else.
+      </p>
+    </form>
+  );
+}

--- a/packages/dashboard/app/adversarial-defense/faqs.ts
+++ b/packages/dashboard/app/adversarial-defense/faqs.ts
@@ -1,0 +1,44 @@
+/**
+ * FAQ content for /adversarial-defense.
+ *
+ * Kept in its own module so the page renders it and the layout can emit
+ * matching FAQPage JSON-LD from one source — the same arrangement
+ * `app/open-source/faqs.ts` uses. Editing an answer here updates both.
+ */
+export interface AdversarialFaq {
+  question: string;
+  answer: string;
+}
+
+export const adversarialFaqs: AdversarialFaq[] = [
+  {
+    question: "Is this a vulnerability scanner?",
+    answer:
+      "No. Scanners are genuinely useful and you should keep yours. What they mostly do is inspect one slice of a system at a time — this dependency, that endpoint, this configuration file. Adversarial Defense is aimed at the other problem: maintaining a model of how the pieces fit together, so it can reason about a chain that no single slice looks dangerous on its own.",
+  },
+  {
+    question: "Does this replace penetration testing?",
+    answer:
+      "No, and we would not claim otherwise. A pen test is a skilled human adversary with judgment we cannot replicate. The gap we are trying to close is the months between tests, when the architecture keeps changing and nobody is asking adversarial questions of it.",
+  },
+  {
+    question: "Will it run attacks against my production systems?",
+    answer:
+      "Only where you have explicitly authorized it, inside boundaries you set. The design assumes staging and test environments by default. Controlled testing is a pilot capability, not something that ships switched on, and it is gated by a policy layer rather than by our good intentions.",
+  },
+  {
+    question: "Why start with pull request review?",
+    answer:
+      "Because that is where new risk enters. A pull request is the moment a system changes, and it comes with the context you need to judge the change — what it touches, what it depends on, what it used to do. Reviewing there also means the model accumulates an understanding of the codebase as a side effect of doing something useful today.",
+  },
+  {
+    question: "What actually works today, and what am I joining a waitlist for?",
+    answer:
+      "PR review is live, in production, and free for qualifying open-source projects. Everything described on this page beyond that — stack modeling, attack-path generation, authorized testing — is what the waitlist is for. We would rather tell you that plainly than let a landing page imply otherwise.",
+  },
+  {
+    question: "How does this relate to the open-source program?",
+    answer:
+      "The open-source program is the live product and, honestly, part of how the models learn. Maintainers get frontier-model review on code the ecosystem depends on; we get exposure to a far wider range of real architectures than a private-only customer base would ever show us. Adversarial Defense is where that understanding is heading.",
+  },
+];

--- a/packages/dashboard/app/adversarial-defense/layout.tsx
+++ b/packages/dashboard/app/adversarial-defense/layout.tsx
@@ -1,0 +1,77 @@
+export const dynamic = "force-dynamic";
+
+import { redirect } from "next/navigation";
+import type { Metadata } from "next";
+import { adversarialFaqs } from "./faqs";
+
+export const metadata: Metadata = {
+  title: "MergeWatch Adversarial Defense — AI-native application security",
+  description:
+    "An internal security layer that models your code, dependencies, infrastructure, APIs and application behavior, then asks what an intelligent attacker would try. Starts at pull request review, where new risk enters. Join the waitlist.",
+  alternates: { canonical: "/adversarial-defense" },
+  openGraph: {
+    title: "AI-native adversarial defense for modern software stacks",
+    description:
+      "Attackers now reason across whole stacks, not just scan them. MergeWatch gives defenders a stack-aware internal model that finds the plausible attack paths first.",
+    url: "https://mergewatch.ai/adversarial-defense",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "AI-native adversarial defense for modern software stacks",
+    description:
+      "Attackers now reason across whole stacks, not just scan them. MergeWatch gives defenders a stack-aware internal model that finds the plausible attack paths first.",
+  },
+};
+
+function serializeJsonLd(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
+const adversarialJsonLd = [
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: adversarialFaqs.map((faq) => ({
+      "@type": "Question",
+      name: faq.question,
+      acceptedAnswer: { "@type": "Answer", text: faq.answer },
+    })),
+  },
+];
+
+/**
+ * Layout for the Adversarial Defense market-test page.
+ *
+ * Mirrors app/open-source/layout.tsx: self-hosted builds never serve this page
+ * (it is a hosted-product waitlist), and FAQ JSON-LD is emitted from the same
+ * array the page renders so the two cannot drift.
+ *
+ * Deliberately does NOT render the shared site nav. This is a single-purpose
+ * conversion page for market testing — every link that is not the waitlist is
+ * a way to leave without answering the question we are asking.
+ */
+export default function AdversarialDefenseLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  if (process.env.DEPLOYMENT_MODE !== "saas") {
+    redirect("/signin");
+  }
+
+  return (
+    <>
+      {children}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(adversarialJsonLd) }}
+      />
+    </>
+  );
+}

--- a/packages/dashboard/app/adversarial-defense/page.tsx
+++ b/packages/dashboard/app/adversarial-defense/page.tsx
@@ -1,0 +1,502 @@
+"use client";
+
+import { Wordmark } from "@/components/MergeWatchLogo";
+import {
+  ArrowRight,
+  Boxes,
+  GitPullRequest,
+  Network,
+  Radar,
+  ShieldCheck,
+  Waypoints,
+} from "lucide-react";
+import { adversarialFaqs } from "./faqs";
+
+/**
+ * Waitlist form for Adversarial Defense.
+ *
+ * Same guard as the OSS application CTA: while this is a placeholder the
+ * button degrades to a disabled state rather than shipping a dead link to
+ * production. A market-test page whose only CTA 404s measures nothing.
+ */
+const WAITLIST_URL = "PLACEHOLDER_WAITLIST_URL";
+const WAITLIST_OPEN = !WAITLIST_URL.includes("PLACEHOLDER");
+
+/**
+ * /adversarial-defense — market-test landing page.
+ *
+ * Deliberately has no site navigation. The only actions are the waitlist and
+ * a jump to the explanation; every other link would be a way to leave without
+ * answering the question this page exists to ask.
+ *
+ * Honesty constraint, carried from the brief: PR review is live today.
+ * Everything else here is a waitlist or pilot capability and is labelled as
+ * such wherever it appears. Present-tense copy about unbuilt capability would
+ * poison the signal we are trying to collect — people would be signing up for
+ * something we did not say clearly enough.
+ */
+export default function AdversarialDefensePage() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      {/* Wordmark only — no nav. See the component doc comment. */}
+      <header className="px-6 py-6 md:px-12">
+        <Wordmark iconSize={20} />
+      </header>
+
+      <main className="flex-1">
+        {/* ─── Hero ─────────────────────────────────────────────────────── */}
+        <section className="flex flex-col items-center px-6 pt-12 pb-16 text-center md:pt-20">
+          <p className="mb-4 text-[11px] font-semibold uppercase tracking-widest text-primer-green">
+            AI-Native Continuous Adversarial Defense
+          </p>
+          <h1 className="mx-auto max-w-4xl text-3xl font-extrabold leading-tight tracking-tight md:text-5xl">
+            Your attackers stopped scanning.{" "}
+            <span className="text-primer-green">They started reasoning.</span>
+          </h1>
+          <p className="mx-auto mt-6 max-w-2xl text-base leading-relaxed text-primer-muted">
+            An automated attack used to be fast and dumb. It is still fast. An
+            agent can now infer your framework from an error message, guess how
+            your auth probably works, form a theory about where that leaves you
+            exposed, test it, and adjust — across many attempts at once.
+            MergeWatch Adversarial Defense gives the defender the same kind of
+            reasoning, from the inside, where the information is better.
+          </p>
+
+          <div className="mt-9 flex w-full max-w-sm flex-col items-center gap-3 sm:w-auto sm:flex-row">
+            <WaitlistButton full />
+            <a
+              href="#how-it-works"
+              className="inline-flex w-full items-center justify-center rounded-lg border border-border-default px-6 py-3 text-sm font-semibold text-fg-primary transition hover:bg-surface-card sm:w-auto"
+            >
+              See how it works
+            </a>
+          </div>
+
+          <p className="mt-5 max-w-xl text-xs leading-relaxed text-primer-muted">
+            Pull request review is live today and free for qualifying
+            open-source projects. Everything else on this page is what the
+            waitlist is for.
+          </p>
+        </section>
+
+        {/* ─── The asymmetry ────────────────────────────────────────────── */}
+        <section className="border-t border-border-default px-6 py-16 md:py-24">
+          <div className="mx-auto max-w-3xl">
+            <h2 className="text-center text-2xl font-bold md:text-3xl">
+              One vulnerability rarely gets anyone in.{" "}
+              <span className="text-primer-green">A chain of five does.</span>
+            </h2>
+            <div className="mx-auto mt-6 max-w-2xl space-y-4 text-sm leading-relaxed text-primer-muted">
+              <p>
+                Most security tooling is organized around findings: this package
+                has a CVE, this endpoint lacks a check, this bucket is readable.
+                Each one gets a severity and a ticket. Individually, most are
+                unremarkable, and teams reasonably deprioritize them.
+              </p>
+              <p>
+                Real compromises are seldom one dramatic hole. They are an
+                ordinary information leak, plus a permission that is slightly
+                too broad, plus a dependency that behaves surprisingly under a
+                specific input, plus a service that trusts a header it should
+                not — assembled in an order nobody anticipated. Every link looked
+                acceptable in isolation. Nothing in the toolchain was responsible
+                for noticing the combination.
+              </p>
+              <p className="text-fg-primary">
+                That assembly step is exactly what a reasoning attacker is good
+                at, and it is the step no scanner performs.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* ─── Defender's advantage ─────────────────────────────────────── */}
+        <section className="border-t border-border-default px-6 py-16 md:py-24">
+          <div className="mx-auto max-w-3xl">
+            <h2 className="text-center text-2xl font-bold md:text-3xl">
+              The attacker is guessing.{" "}
+              <span className="text-primer-green">You are not.</span>
+            </h2>
+            <div className="mx-auto mt-6 max-w-2xl space-y-4 text-sm leading-relaxed text-primer-muted">
+              <p>
+                An outside attacker reconstructs your system from scraps —
+                response timings, error strings, header quirks, whatever a
+                changelog gave away. They are inferring the architecture.
+              </p>
+              <p>
+                You already have it. The source. The dependency graph. The
+                infrastructure definitions. The API surface. The authentication
+                logic. Who can reach what. What changed last Tuesday and why.
+                The defender has always held more information than the attacker
+                and has rarely had a way to reason over all of it at once.
+              </p>
+            </div>
+
+            <blockquote className="mx-auto mt-10 max-w-2xl border-l-2 border-primer-green pl-6">
+              <p className="text-lg font-semibold leading-relaxed text-fg-primary md:text-xl">
+                If something intelligent understood this entire system — not one
+                file, all of it — what would it try first?
+              </p>
+            </blockquote>
+
+            <p className="mx-auto mt-8 max-w-2xl text-sm leading-relaxed text-primer-muted">
+              Adversarial Defense makes that a question your stack answers
+              continuously, rather than one a consultant asks twice a year.
+            </p>
+          </div>
+        </section>
+
+        {/* ─── How it works ─────────────────────────────────────────────── */}
+        <section
+          id="how-it-works"
+          className="scroll-mt-8 border-t border-border-default px-6 py-16 md:py-24"
+        >
+          <div className="mx-auto max-w-5xl">
+            <h2 className="text-center text-2xl font-bold md:text-3xl">
+              From a list of findings to a model of the system
+            </h2>
+            <p className="mx-auto mt-4 max-w-2xl text-center text-sm leading-relaxed text-primer-muted">
+              Six things happen continuously. The point of connecting them is
+              that a finding only becomes interesting in the context of the
+              others.
+            </p>
+
+            <div className="mt-12 grid gap-5 md:grid-cols-2 lg:grid-cols-3">
+              <StepCard
+                icon={<Boxes className="h-5 w-5" />}
+                step="01"
+                title="Map the stack"
+                body="Code, dependencies, frameworks, APIs, infrastructure, data stores, third-party integrations — kept current rather than captured once in a diagram nobody has opened since."
+              />
+              <StepCard
+                icon={<GitPullRequest className="h-5 w-5" />}
+                step="02"
+                title="Watch what changes"
+                body="Pull requests, commits, dependency bumps, configuration edits, deployment topology. New risk is judged against the system it is landing in, not in isolation."
+              />
+              <StepCard
+                icon={<Radar className="h-5 w-5" />}
+                step="03"
+                title="Form attack hypotheses"
+                body="Ask how observable behavior, implementation detail, privilege and known weakness could be combined into something that actually works."
+              />
+              <StepCard
+                icon={<Waypoints className="h-5 w-5" />}
+                step="04"
+                title="Rank by consequence"
+                body="Likelihood, blast radius, reachability, privilege escalation, business impact. A ranked shortlist you can act on beats an exhaustive list you cannot."
+              />
+              <StepCard
+                icon={<ShieldCheck className="h-5 w-5" />}
+                step="05"
+                title="Test only where authorized"
+                body="Selected hypotheses validated in staging or explicitly approved environments, inside boundaries you define. Never a surprise."
+                pilot
+              />
+              <StepCard
+                icon={<Network className="h-5 w-5" />}
+                step="06"
+                title="Return it to the pull request"
+                body="Findings surface where the change is being made, while it is still cheap to change — not in a report that arrives three sprints later."
+              />
+            </div>
+          </div>
+        </section>
+
+        {/* ─── Why PR review first ──────────────────────────────────────── */}
+        <section className="border-t border-border-default px-6 py-16 md:py-24">
+          <div className="mx-auto max-w-3xl">
+            <h2 className="text-center text-2xl font-bold md:text-3xl">
+              Why this starts at the pull request
+            </h2>
+            <div className="mx-auto mt-6 max-w-2xl space-y-4 text-sm leading-relaxed text-primer-muted">
+              <p>
+                Not because review is the whole answer — because it is where new
+                risk enters, and because it is the one place a system is
+                explained while it changes. A pull request carries the intent,
+                the diff, and the context in one artifact.
+              </p>
+              <p>
+                Reviewing there has a second effect that matters more over time:
+                the model accumulates an understanding of the codebase as a
+                by-product of doing something useful today. Each subsequent
+                capability needs that foundation.
+              </p>
+            </div>
+
+            <div className="mt-10 rounded-xl border border-border-default bg-surface-card/60 p-6">
+              <p className="text-[11px] font-semibold uppercase tracking-widest text-fg-primary">
+                Where this goes
+              </p>
+              <ol className="mt-5 space-y-4">
+                <Phase n="1" title="Pull request review" live>
+                  Security, correctness and reliability review on every change.
+                  Free for qualifying open-source projects.
+                </Phase>
+                <Phase n="2" title="Repository understanding">
+                  Persistent knowledge of the codebase, its architecture and its
+                  history, instead of judging each pull request from scratch.
+                </Phase>
+                <Phase n="3" title="Stack-aware model">
+                  Repository knowledge joined to infrastructure, APIs, cloud
+                  configuration, data stores, authentication and external
+                  services.
+                </Phase>
+                <Phase n="4" title="Attack-path generation">
+                  Specialized agents propose plausible chains across the real
+                  architecture, and rank them by what they would actually cost
+                  you.
+                </Phase>
+                <Phase n="5" title="Controlled defensive testing">
+                  Selected hypotheses validated where you have authorized it,
+                  under policy and guardrails.
+                </Phase>
+                <Phase n="6" title="Continuous adversarial defense">
+                  A standing internal model that re-reasons whenever the code,
+                  the infrastructure, the dependencies or the behavior move.
+                </Phase>
+              </ol>
+            </div>
+          </div>
+        </section>
+
+        {/* ─── Agents ───────────────────────────────────────────────────── */}
+        <section className="border-t border-border-default px-6 py-16 md:py-24">
+          <div className="mx-auto max-w-4xl">
+            <h2 className="text-center text-2xl font-bold md:text-3xl">
+              Specialists, with something coordinating them
+            </h2>
+            <p className="mx-auto mt-4 max-w-2xl text-center text-sm leading-relaxed text-primer-muted">
+              Each agent understands one dimension properly. An orchestration
+              layer decides which hypotheses are worth pursuing — the useful
+              work is in choosing, not in scanning everything indiscriminately.
+            </p>
+
+            <div className="mt-10 grid gap-3 sm:grid-cols-2">
+              <AgentRow name="Stack Discovery" role="Builds and maintains the technology and dependency map" />
+              <AgentRow name="Code Security" role="Reads code, commits and pull requests for exploitable behavior" />
+              <AgentRow name="Dependency" role="Tracks vulnerable versions and dangerous combinations of them" />
+              <AgentRow name="Infrastructure" role="Cloud configuration, permissions, exposure, secrets, topology" />
+              <AgentRow name="API Attack" role="Models how exposed interfaces get abused or chained together" />
+              <AgentRow name="Attack Chain" role="Assembles findings across components into multi-stage paths" />
+              <AgentRow name="Adversarial Simulation" role="Asks what a capable external attacker would infer and try next" />
+              <AgentRow name="Behavioral Testing" role="Validates selected hypotheses in authorized environments" pilot />
+              <AgentRow name="Policy & Guardrail" role="Keeps every test inside the boundaries you set" pilot />
+            </div>
+          </div>
+        </section>
+
+        {/* ─── Open source ──────────────────────────────────────────────── */}
+        <section className="border-t border-border-default px-6 py-16 md:py-24">
+          <div className="mx-auto max-w-3xl">
+            <h2 className="text-center text-2xl font-bold md:text-3xl">
+              Open source is in the critical path
+            </h2>
+            <div className="mx-auto mt-6 max-w-2xl space-y-4 text-sm leading-relaxed text-primer-muted">
+              <p>
+                Core review is free for qualifying open-source projects, because
+                a great deal of the world runs on libraries maintained by people
+                with no security budget and not enough weekends.
+              </p>
+              <p>
+                It is also, candidly, how the models learn. Open-source work
+                exposes MergeWatch to a far wider range of real architectures,
+                dependency habits and failure modes than any private customer
+                base would. That breadth is what stack-aware defense needs.
+                Saying so seems better than pretending it is purely altruism.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* ─── FAQ ──────────────────────────────────────────────────────── */}
+        <section className="border-t border-border-default px-6 py-16 md:py-24">
+          <div className="mx-auto max-w-3xl">
+            <h2 className="text-center text-2xl font-bold md:text-3xl">
+              Reasonable questions
+            </h2>
+            <div className="mt-10 space-y-5">
+              {adversarialFaqs.map((faq) => (
+                <div
+                  key={faq.question}
+                  className="rounded-xl border border-border-default bg-surface-card/60 p-6"
+                >
+                  <h3 className="text-base font-semibold text-fg-primary">
+                    {faq.question}
+                  </h3>
+                  <p className="mt-3 text-sm leading-relaxed text-primer-muted">
+                    {faq.answer}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* ─── Waitlist ─────────────────────────────────────────────────── */}
+        <section className="border-t border-border-default px-6 py-16 text-center md:py-24">
+          <h2 className="mx-auto max-w-2xl text-2xl font-bold md:text-3xl">
+            Join the Adversarial Defense waitlist
+          </h2>
+          <p className="mx-auto mt-5 max-w-2xl text-sm leading-relaxed text-primer-muted">
+            We are looking for teams who already suspect that periodic scanning
+            is not keeping pace: security-conscious startups, regulated
+            engineering teams, platform and DevSecOps groups, and maintainers
+            carrying infrastructure a lot of people depend on.
+          </p>
+          <p className="mx-auto mt-4 max-w-2xl text-sm leading-relaxed text-primer-muted">
+            Early conversations shape what gets built first. If you have a
+            specific fear about your own stack, that is the most useful thing
+            you can bring.
+          </p>
+          <div className="mt-9 flex justify-center">
+            <WaitlistButton />
+          </div>
+        </section>
+      </main>
+
+      <footer className="border-t border-border-default px-6 py-10">
+        <p className="text-center text-xs text-primer-muted">
+          Open source under AGPL-3.0 &copy; {new Date().getFullYear()}{" "}
+          mergewatch.ai
+        </p>
+      </footer>
+    </div>
+  );
+}
+
+/* ─── Inline sub-components ────────────────────────────────────────────── */
+
+/**
+ * Primary CTA. Degrades to a disabled button while WAITLIST_URL is a
+ * placeholder, so this page can never ship its only conversion path broken.
+ */
+function WaitlistButton({ full = false }: { full?: boolean }) {
+  const width = full ? "w-full sm:w-auto" : "";
+
+  if (!WAITLIST_OPEN) {
+    return (
+      <button
+        type="button"
+        disabled
+        aria-disabled="true"
+        title="The waitlist form is not wired up yet."
+        className={`inline-flex ${width} cursor-not-allowed items-center justify-center rounded-lg border border-border-default bg-surface-card px-6 py-3 text-sm font-semibold text-primer-muted`}
+      >
+        Waitlist opening shortly
+      </button>
+    );
+  }
+
+  return (
+    <a
+      href={WAITLIST_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`inline-flex ${width} items-center justify-center rounded-lg bg-primer-green px-6 py-3 text-sm font-semibold text-black transition hover:brightness-110`}
+    >
+      Join the waitlist
+      <ArrowRight className="ml-2 h-4 w-4" />
+    </a>
+  );
+}
+
+/** Badge marking a capability that is not generally available. */
+function PilotBadge() {
+  return (
+    <span className="rounded-full border border-primer-blue/40 bg-primer-blue/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primer-blue">
+      Pilot
+    </span>
+  );
+}
+
+function StepCard({
+  icon,
+  step,
+  title,
+  body,
+  pilot = false,
+}: {
+  icon: React.ReactNode;
+  step: string;
+  title: string;
+  body: string;
+  pilot?: boolean;
+}) {
+  return (
+    <div className="rounded-xl border border-border-default bg-surface-card/60 p-6">
+      <div className="mb-4 flex items-center gap-3">
+        <span className="text-primer-green">{icon}</span>
+        <span className="text-[11px] font-semibold tracking-widest text-primer-muted">
+          {step}
+        </span>
+        {pilot && <span className="ml-auto"><PilotBadge /></span>}
+      </div>
+      <h3 className="text-base font-semibold text-fg-primary">{title}</h3>
+      <p className="mt-2 text-sm leading-relaxed text-primer-muted">{body}</p>
+    </div>
+  );
+}
+
+function Phase({
+  n,
+  title,
+  live = false,
+  children,
+}: {
+  n: string;
+  title: string;
+  live?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <li className="flex gap-4">
+      <span
+        className={`mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[11px] font-bold ${
+          live
+            ? "bg-primer-green text-black"
+            : "border border-border-default text-primer-muted"
+        }`}
+      >
+        {n}
+      </span>
+      <div>
+        <div className="flex flex-wrap items-center gap-2">
+          <h4 className="text-sm font-semibold text-fg-primary">{title}</h4>
+          {live ? (
+            <span className="rounded-full bg-primer-green/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primer-green">
+              Live today
+            </span>
+          ) : (
+            <PilotBadge />
+          )}
+        </div>
+        <p className="mt-1 text-sm leading-relaxed text-primer-muted">
+          {children}
+        </p>
+      </div>
+    </li>
+  );
+}
+
+function AgentRow({
+  name,
+  role,
+  pilot = false,
+}: {
+  name: string;
+  role: string;
+  pilot?: boolean;
+}) {
+  return (
+    <div className="flex items-start gap-3 rounded-lg border border-border-default bg-surface-card/40 p-4">
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-2">
+          <p className="text-sm font-semibold text-fg-primary">{name}</p>
+          {pilot && <PilotBadge />}
+        </div>
+        <p className="mt-1 text-sm leading-relaxed text-primer-muted">{role}</p>
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard/app/adversarial-defense/page.tsx
+++ b/packages/dashboard/app/adversarial-defense/page.tsx
@@ -11,16 +11,7 @@ import {
   Waypoints,
 } from "lucide-react";
 import { adversarialFaqs } from "./faqs";
-
-/**
- * Waitlist form for Adversarial Defense.
- *
- * Same guard as the OSS application CTA: while this is a placeholder the
- * button degrades to a disabled state rather than shipping a dead link to
- * production. A market-test page whose only CTA 404s measures nothing.
- */
-const WAITLIST_URL = "PLACEHOLDER_WAITLIST_URL";
-const WAITLIST_OPEN = !WAITLIST_URL.includes("PLACEHOLDER");
+import { WaitlistForm } from "./WaitlistForm";
 
 /**
  * /adversarial-defense — market-test landing page.
@@ -62,15 +53,15 @@ export default function AdversarialDefensePage() {
             reasoning, from the inside, where the information is better.
           </p>
 
-          <div className="mt-9 flex w-full max-w-sm flex-col items-center gap-3 sm:w-auto sm:flex-row">
-            <WaitlistButton full />
-            <a
-              href="#how-it-works"
-              className="inline-flex w-full items-center justify-center rounded-lg border border-border-default px-6 py-3 text-sm font-semibold text-fg-primary transition hover:bg-surface-card sm:w-auto"
-            >
-              See how it works
-            </a>
+          <div className="mt-9 w-full">
+            <WaitlistForm compact />
           </div>
+          <a
+            href="#how-it-works"
+            className="mt-5 text-sm font-medium text-primer-muted underline-offset-4 transition hover:text-fg-primary hover:underline"
+          >
+            Or see how it works first
+          </a>
 
           <p className="mt-5 max-w-xl text-xs leading-relaxed text-primer-muted">
             Pull request review is live today and free for qualifying
@@ -349,8 +340,8 @@ export default function AdversarialDefensePage() {
             specific fear about your own stack, that is the most useful thing
             you can bring.
           </p>
-          <div className="mt-9 flex justify-center">
-            <WaitlistButton />
+          <div className="mt-9">
+            <WaitlistForm />
           </div>
         </section>
       </main>
@@ -366,40 +357,6 @@ export default function AdversarialDefensePage() {
 }
 
 /* ─── Inline sub-components ────────────────────────────────────────────── */
-
-/**
- * Primary CTA. Degrades to a disabled button while WAITLIST_URL is a
- * placeholder, so this page can never ship its only conversion path broken.
- */
-function WaitlistButton({ full = false }: { full?: boolean }) {
-  const width = full ? "w-full sm:w-auto" : "";
-
-  if (!WAITLIST_OPEN) {
-    return (
-      <button
-        type="button"
-        disabled
-        aria-disabled="true"
-        title="The waitlist form is not wired up yet."
-        className={`inline-flex ${width} cursor-not-allowed items-center justify-center rounded-lg border border-border-default bg-surface-card px-6 py-3 text-sm font-semibold text-primer-muted`}
-      >
-        Waitlist opening shortly
-      </button>
-    );
-  }
-
-  return (
-    <a
-      href={WAITLIST_URL}
-      target="_blank"
-      rel="noopener noreferrer"
-      className={`inline-flex ${width} items-center justify-center rounded-lg bg-primer-green px-6 py-3 text-sm font-semibold text-black transition hover:brightness-110`}
-    >
-      Join the waitlist
-      <ArrowRight className="ml-2 h-4 w-4" />
-    </a>
-  );
-}
 
 /** Badge marking a capability that is not generally available. */
 function PilotBadge() {

--- a/packages/dashboard/app/api/waitlist/route.ts
+++ b/packages/dashboard/app/api/waitlist/route.ts
@@ -1,0 +1,145 @@
+/**
+ * POST /api/waitlist — Adversarial Defense waitlist signup (#315).
+ *
+ * body: { name: string, email: string, website?: string }
+ *   → { ok: true }  on success, and on silently-discarded bot submissions
+ *
+ * This is the only **unauthenticated write** endpoint in the dashboard, which
+ * shapes most of what follows.
+ *
+ * Two ordering rules matter:
+ *
+ *   1. Store first, alert second. The Slack ping is best-effort — a webhook
+ *      outage must never cost a lead. A market test is expensive per signup.
+ *   2. Alert only on a genuinely new email. The conditional write tells us
+ *      whether this was the first submission, so a refresh or a double-click
+ *      does not ping twice.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+const TABLE = process.env.WAITLIST_TABLE ?? "mergewatch-waitlist";
+const SLACK_WEBHOOK = process.env.SLACK_WAITLIST_WEBHOOK_URL;
+
+/** RFC 5321 caps a domain-qualified address at 254 characters. */
+const MAX_EMAIL = 254;
+const MAX_NAME = 100;
+
+/**
+ * Deliberately permissive. The goal is to reject obvious junk, not to
+ * adjudicate address validity — over-strict patterns reject real addresses
+ * (plus-tags, new TLDs, unicode locals) and every rejection here is a lost
+ * lead on a page whose entire purpose is measuring demand.
+ */
+const EMAIL_RE = /^[^\s@]+@[^\s@.]+\.[^\s@]+$/;
+
+let _client: import("@aws-sdk/lib-dynamodb").DynamoDBDocumentClient | null = null;
+
+async function getClient() {
+  if (_client) return _client;
+  const { DynamoDBClient } = await import("@aws-sdk/client-dynamodb");
+  const { DynamoDBDocumentClient } = await import("@aws-sdk/lib-dynamodb");
+  const raw = new DynamoDBClient({
+    region: process.env.APP_REGION ?? process.env.AWS_REGION ?? "us-east-1",
+  });
+  _client = DynamoDBDocumentClient.from(raw, {
+    marshallOptions: { removeUndefinedValues: true },
+  });
+  return _client;
+}
+
+/**
+ * Post to Slack. Never throws — the caller has already stored the signup and
+ * must not fail the request because a webhook is down or unset.
+ */
+async function notifySlack(name: string, email: string): Promise<void> {
+  if (!SLACK_WEBHOOK) {
+    console.warn(
+      "[waitlist] SLACK_WAITLIST_WEBHOOK_URL unset — signup stored but not announced",
+    );
+    return;
+  }
+  try {
+    const res = await fetch(SLACK_WEBHOOK, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        text: `*Adversarial Defense waitlist*\n${name} — ${email}`,
+      }),
+      signal: AbortSignal.timeout(4000),
+    });
+    if (!res.ok) {
+      console.error(`[waitlist] Slack responded ${res.status} for ${email}`);
+    }
+  } catch (err) {
+    // Stored is what counts. Log loudly enough to notice a persistently
+    // broken webhook, but never surface it to the visitor.
+    console.error("[waitlist] Slack notify failed:", err);
+  }
+}
+
+export async function POST(req: NextRequest) {
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  // Honeypot. Real people never see this field; bots fill everything. Answer
+  // 200 so a scraper cannot tell a discarded submission from an accepted one
+  // and start probing for the tell.
+  if (typeof body.website === "string" && body.website.trim() !== "") {
+    return NextResponse.json({ ok: true });
+  }
+
+  const name = typeof body.name === "string" ? body.name.trim() : "";
+  const email =
+    typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
+
+  if (!name || name.length > MAX_NAME) {
+    return NextResponse.json({ error: "Please enter your name." }, { status: 400 });
+  }
+  if (!email || email.length > MAX_EMAIL || !EMAIL_RE.test(email)) {
+    return NextResponse.json(
+      { error: "Please enter a valid email address." },
+      { status: 400 },
+    );
+  }
+
+  const now = new Date().toISOString();
+  let isNew = true;
+
+  try {
+    const { PutCommand } = await import("@aws-sdk/lib-dynamodb");
+    const client = await getClient();
+    await client.send(
+      new PutCommand({
+        TableName: TABLE,
+        Item: { email, name, createdAt: now, source: "adversarial-defense" },
+        // First write wins, so `createdAt` records genuine first contact and a
+        // repeat submission cannot re-trigger the alert below.
+        ConditionExpression: "attribute_not_exists(email)",
+      }),
+    );
+  } catch (err) {
+    if ((err as { name?: string }).name === "ConditionalCheckFailedException") {
+      // Already on the list. Same response as a new signup — telling a visitor
+      // "you already signed up" is a worse experience and leaks list
+      // membership to anyone who wants to probe it.
+      isNew = false;
+    } else {
+      console.error("[waitlist] store failed:", err);
+      return NextResponse.json(
+        { error: "Something went wrong. Please try again." },
+        { status: 500 },
+      );
+    }
+  }
+
+  if (isNew) await notifySlack(name, email);
+
+  return NextResponse.json({ ok: true });
+}

--- a/packages/dashboard/app/privacy/page.tsx
+++ b/packages/dashboard/app/privacy/page.tsx
@@ -62,6 +62,13 @@ export default function PrivacyPolicyPage() {
           email, and any billing metadata required by our payment processor if
           you are on a paid plan.
         </li>
+        <li>
+          <strong>Waitlist signups:</strong> if you join a product waitlist we
+          store the name and email address you submit, and the date. We use it
+          only to contact you about that product. It is not sold, shared, or
+          added to any marketing list, and we delete it on request &mdash; email
+          the address in Section 9.
+        </li>
       </ul>
       <p>
         We do <strong>not</strong> persist raw pull request diffs, raw file

--- a/packages/dashboard/app/sitemap.ts
+++ b/packages/dashboard/app/sitemap.ts
@@ -18,6 +18,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.9,
     },
     {
+      url: `${SITE_URL}/adversarial-defense`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
       url: `${SITE_URL}/open-source`,
       lastModified: now,
       changeFrequency: "monthly",

--- a/packages/dashboard/next.config.js
+++ b/packages/dashboard/next.config.js
@@ -129,6 +129,11 @@ const nextConfig = {
     // #195 Phase 5 — optional; NPS route reports ineligible when unset.
     DYNAMODB_TABLE_SATISFACTION: process.env.DYNAMODB_TABLE_SATISFACTION,
     API_KEYS_TABLE: process.env.API_KEYS_TABLE,
+    // #315 — Adversarial Defense waitlist. An env var absent from this block
+    // does not exist at runtime on Amplify, so both must be declared here or
+    // signups land in the wrong table and never reach Slack.
+    WAITLIST_TABLE: process.env.WAITLIST_TABLE,
+    SLACK_WAITLIST_WEBHOOK_URL: process.env.SLACK_WAITLIST_WEBHOOK_URL,
     GITHUB_APP_SLUG: process.env.GITHUB_APP_SLUG,
     DEPLOYMENT_MODE: process.env.DEPLOYMENT_MODE,
     BILLING_API_URL: process.env.BILLING_API_URL,


### PR DESCRIPTION
A single-purpose page at `/adversarial-defense` for testing demand for stack-aware adversarial defense. Primary conversion is the waitlist.

## No navigation, deliberately

There is no site nav — one CTA and one in-page jump, nothing else. Verified against the render: zero `next/link` usages, one anchor (`#how-it-works`), and none of `Docs` / `Pricing` / `For Open Source` / `Get started` appear.

Every other link is a way to leave without answering the question the page exists to ask.

## Copy is written from the brief, not lifted from it

Two structural decisions worth a look, since they diverge from the source ordering:

**The problem section leads with chaining, not with AI.** The headline is *"One vulnerability rarely gets anyone in. A chain of five does."* That is the argument a security buyer already believes from experience. AI is the reason chaining became cheap — it is not itself the product. Opening on "attackers use AI now" would sound like every other 2026 security page; opening on the chain earns the AI claim a paragraph later.

**The defender's-advantage section is built around one question**, set as a pull quote:

> If something intelligent understood this entire system — not one file, all of it — what would it try first?

It is the sharpest idea in the source material and it survives being read in isolation, which is what a scanned page needs.

## Capability honesty is a visual affordance, not a disclaimer

The brief's own implementation notes ask for unbuilt capability to be labelled explicitly. Rather than hedge in prose, state is a badge:

- Green **Live today** on phase 1 (PR review)
- Blue **Pilot** on every other roadmap phase, on the authorized-testing step, and on the two agents that only exist behind it

The hero says it in one line, and an FAQ answers *"what actually works today, and what am I joining a waitlist for?"* directly.

This matters for the experiment, not just for ethics: **a market test that overstates what exists measures the wrong thing.** Signups would be for something we did not say clearly enough, and the signal would be unusable — you would learn that the pitch converts, not that the product does.

## Before this can go live

`WAITLIST_URL` is a placeholder, guarded exactly the way the OSS application CTA is — the button degrades to a disabled *"Waitlist opening shortly"* rather than shipping the page's only conversion path as a dead link.

**Wire it to a real form and the page is ready.** Suggested fields from the brief: name, work email, company/project, role, application type, deployment preference (hosted / private cloud / self-hosted / on-prem / air-gapped), primary interest, and an open question about their security environment. That last one is where the useful signal lives.

## Conventions followed

Mirrors `/open-source`: `force-dynamic` layout, redirect to `/signin` on self-hosted builds, FAQ content in its own module so the rendered FAQ and the `FAQPage` JSON-LD cannot drift, plus OG and Twitter metadata. Registered in `sitemap.ts` at priority 0.8.

## Not included

`Dynamic Social Defense` is referenced in the source material as a separate roadmap product and is deliberately absent — the brief asks for it to stay parked, and a market test with two propositions measures neither.

## Verification

Dashboard production build ✅ · repo typecheck ✅ · full suite ✅. Page renders `200` with expected content and no navigation.
