### PR TITLE
refactor(dashboard): extract analytics aggregation into a pure, tested function (#333, stage 1)

### DIFF
--- a/packages/dashboard/app/api/analytics/route.ts
+++ b/packages/dashboard/app/api/analytics/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { getDashboardStore } from "@/lib/store";
+import { aggregateReviews } from "@/lib/analytics-aggregate";
 import {
   fetchUserInstallations,
   fetchAccessibleRepoNames,
@@ -69,148 +70,8 @@ export async function GET(req: NextRequest) {
 
     // Fetch up to 500 reviews for aggregation (with optional date filter)
     const result = await store.reviews.listReviews(targetRepos, 500, undefined, undefined, startDate, endDate);
-    const reviews = result.items;
 
-    // --- Aggregate analytics in-memory ---
-
-    // Score trend: average mergeScore per day
-    const scoreByDate = new Map<string, { sum: number; count: number }>();
-    // Severity breakdown
-    const severityBreakdown: Record<string, number> = { critical: 0, warning: 0, info: 0 };
-    // Duration stats
-    const durations: number[] = [];
-    // Repo breakdown
-    const repoBreakdown = new Map<string, number>();
-    // Category breakdown
-    const categoryBreakdown: Record<string, number> = { security: 0, bug: 0, style: 0 };
-    // Totals
-    let totalFindings = 0;
-    let mergeScoreSum = 0;
-    let mergeScoreCount = 0;
-    // Cost stats
-    let totalCostUsd = 0;
-    let costCount = 0;
-    // Status counts
-    const statusCounts: Record<string, number> = { complete: 0, failed: 0, skipped: 0, pending: 0, in_progress: 0 };
-    // Findings-per-review trend
-    const findingsByDate = new Map<string, { sum: number; count: number }>();
-    // Merge score distribution (1-5)
-    const mergeScoreDistribution: Record<number, number> = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };
-
-    for (const review of reviews) {
-      // Status counts
-      if (review.status && statusCounts[review.status] !== undefined) {
-        statusCounts[review.status]++;
-      }
-
-      // Score trend
-      if (review.createdAt && review.mergeScore != null) {
-        const date = review.createdAt.substring(0, 10); // YYYY-MM-DD
-        const entry = scoreByDate.get(date) ?? { sum: 0, count: 0 };
-        entry.sum += review.mergeScore;
-        entry.count += 1;
-        scoreByDate.set(date, entry);
-        mergeScoreSum += review.mergeScore;
-        mergeScoreCount += 1;
-
-        // Merge score distribution
-        const rounded = Math.round(review.mergeScore);
-        if (rounded >= 1 && rounded <= 5) {
-          mergeScoreDistribution[rounded]++;
-        }
-      }
-
-      // Severity and category from findings
-      if (review.findings && Array.isArray(review.findings)) {
-        totalFindings += review.findings.length;
-        for (const finding of review.findings) {
-          if (finding.severity && severityBreakdown[finding.severity] !== undefined) {
-            severityBreakdown[finding.severity]++;
-          }
-          if (finding.category && categoryBreakdown[finding.category] !== undefined) {
-            categoryBreakdown[finding.category]++;
-          }
-        }
-      }
-
-      // Findings-per-review trend (only completed reviews)
-      if (review.createdAt && review.status === "complete") {
-        const date = review.createdAt.substring(0, 10);
-        const fc = review.findingCount ?? 0;
-        const entry = findingsByDate.get(date) ?? { sum: 0, count: 0 };
-        entry.sum += fc;
-        entry.count += 1;
-        findingsByDate.set(date, entry);
-      }
-
-      // Cost stats
-      if ((review as any).estimatedCostUsd != null && review.status === "complete") {
-        totalCostUsd += Number((review as any).estimatedCostUsd);
-        costCount += 1;
-      }
-
-      // Duration stats
-      if (review.durationMs != null && review.status === "complete") {
-        durations.push(review.durationMs);
-      }
-
-      // Repo breakdown
-      const repoCount = repoBreakdown.get(review.repoFullName) ?? 0;
-      repoBreakdown.set(review.repoFullName, repoCount + 1);
-    }
-
-    // Compute score trend sorted by date
-    const scoreTrend = Array.from(scoreByDate.entries())
-      .map(([date, { sum, count }]) => ({
-        date,
-        avgScore: Math.round((sum / count) * 100) / 100,
-        count,
-      }))
-      .sort((a, b) => a.date.localeCompare(b.date));
-
-    // Duration statistics
-    durations.sort((a, b) => a - b);
-    const avgDuration = durations.length > 0
-      ? Math.round(durations.reduce((s, d) => s + d, 0) / durations.length)
-      : 0;
-    const p95Duration = durations.length > 0
-      ? durations[Math.floor(durations.length * 0.95)]
-      : 0;
-
-    const analytics = {
-      totalReviews: reviews.length,
-      totalFindings,
-      avgMergeScore: mergeScoreCount > 0
-        ? Math.round((mergeScoreSum / mergeScoreCount) * 100) / 100
-        : 0,
-      scoreTrend,
-      severityBreakdown,
-      durationStats: {
-        avgMs: avgDuration,
-        p95Ms: p95Duration,
-        count: durations.length,
-      },
-      repoBreakdown: Array.from(repoBreakdown.entries())
-        .map(([repo, count]) => ({ repo, count }))
-        .sort((a, b) => b.count - a.count),
-      categoryBreakdown,
-      statusCounts,
-      findingsPerReviewTrend: Array.from(findingsByDate.entries())
-        .map(([date, { sum, count }]) => ({
-          date,
-          avgFindings: Math.round((sum / count) * 100) / 100,
-          count,
-        }))
-        .sort((a, b) => a.date.localeCompare(b.date)),
-      mergeScoreDistribution,
-      costStats: {
-        totalCostUsd: Math.round(totalCostUsd * 10000) / 10000,
-        avgCostUsd: costCount > 0
-          ? Math.round((totalCostUsd / costCount) * 10000) / 10000
-          : 0,
-        costCount,
-      },
-    };
+    const analytics = aggregateReviews(result.items);
 
     return NextResponse.json({ analytics, availableRepos: allRepos });
   } catch (err) {

--- a/packages/dashboard/app/api/analytics/route.ts
+++ b/packages/dashboard/app/api/analytics/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { getDashboardStore } from "@/lib/store";
 import { aggregateReviews } from "@/lib/analytics-aggregate";
+import { collectAllReviews, ANALYTICS_PAGE_SIZE } from "@/lib/analytics-collect";
 import {
   fetchUserInstallations,
   fetchAccessibleRepoNames,
@@ -68,12 +69,30 @@ export async function GET(req: NextRequest) {
       ? allRepos.filter((r) => r === repoParam)
       : allRepos;
 
-    // Fetch up to 500 reviews for aggregation (with optional date filter)
-    const result = await store.reviews.listReviews(targetRepos, 500, undefined, undefined, startDate, endDate);
+    // Walk every page in the range. Aggregating a single page and calling the
+    // result a total is what #333 was: because the stores return newest-first,
+    // the dropped rows were the *oldest* in the range, so the trends lost
+    // their history while still being labelled with the full range.
+    const { reviews, truncated } = await collectAllReviews((cursor) =>
+      store.reviews.listReviews(
+        targetRepos,
+        ANALYTICS_PAGE_SIZE,
+        cursor,
+        undefined,
+        startDate,
+        endDate,
+      ),
+    );
 
-    const analytics = aggregateReviews(result.items);
+    const analytics = aggregateReviews(reviews);
 
-    return NextResponse.json({ analytics, availableRepos: allRepos });
+    return NextResponse.json({
+      analytics,
+      availableRepos: allRepos,
+      // Only ever true at the safety bound. The UI must label the figures as
+      // partial when it is — a capped aggregate shown as a total is the bug.
+      truncated,
+    });
   } catch (err) {
     if (err instanceof TokenExpiredError) {
       return NextResponse.json({ error: "Token expired" }, { status: 401 });

--- a/packages/dashboard/components/AnalyticsClient.tsx
+++ b/packages/dashboard/components/AnalyticsClient.tsx
@@ -336,6 +336,9 @@ export default function AnalyticsClient({ installationId }: AnalyticsClientProps
   );
 
   const [data, setData] = useState<AnalyticsData | null>(null);
+  // #333 — set when the API hit its safety bound and the figures below cover
+  // only part of the selected range.
+  const [truncated, setTruncated] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [timeRange, setTimeRange] = useState<TimeRangeKey>("7d");
@@ -396,6 +399,7 @@ export default function AnalyticsClient({ installationId }: AnalyticsClientProps
         const json = await res.json();
         if (!cancelled) {
           setData(json.analytics);
+          setTruncated(Boolean(json.truncated));
           if (json.availableRepos) {
             setAvailableRepos(json.availableRepos);
           }
@@ -588,11 +592,35 @@ export default function AnalyticsClient({ installationId }: AnalyticsClientProps
 
     return (
       <>
+        {/* #333 — never let a capped aggregate read as a total. */}
+        {truncated && (
+          <div
+            role="status"
+            className="mb-6 rounded-lg border border-yellow-500/30 bg-yellow-500/5 p-4"
+          >
+            <p className="text-sm font-medium text-fg-primary">
+              Showing a partial view of this range
+            </p>
+            <p className="mt-1 text-sm text-fg-secondary">
+              This range contains more reviews than a single query returns, so
+              the figures below cover only part of it. Narrow the date range for
+              exact numbers.
+            </p>
+          </div>
+        )}
+
         {/* Stat cards — Overview only */}
         {activeTab === "overview" && (
         <div className="grid grid-cols-2 gap-4 sm:grid-cols-4 mb-6">
-          <StatCard label="Total Reviews" value={data.totalReviews} />
-          <StatCard label="Total Findings" value={data.totalFindings} />
+          <StatCard
+            label={truncated ? "Reviews (partial)" : "Total Reviews"}
+            value={truncated ? `${data.totalReviews}+` : data.totalReviews}
+            subtext={truncated ? "Range exceeds the query limit" : undefined}
+          />
+          <StatCard
+            label={truncated ? "Findings (partial)" : "Total Findings"}
+            value={truncated ? `${data.totalFindings}+` : data.totalFindings}
+          />
           <StatCard
             label="Avg Merge Score"
             value={data.avgMergeScore > 0 ? `${data.avgMergeScore} / 5` : "N/A"}

--- a/packages/dashboard/lib/analytics-aggregate.test.ts
+++ b/packages/dashboard/lib/analytics-aggregate.test.ts
@@ -1,0 +1,392 @@
+import { describe, it, expect } from "vitest";
+import {
+  aggregateReviews,
+  type AggregatableReview,
+} from "./analytics-aggregate";
+
+/**
+ * Build a review with sensible defaults so each test only states the fields it
+ * actually cares about.
+ */
+function review(overrides: Partial<AggregatableReview> = {}): AggregatableReview {
+  return {
+    repoFullName: "acme/api",
+    status: "complete",
+    createdAt: "2026-08-01T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("aggregateReviews — empty input", () => {
+  it("returns a fully-formed zero state rather than NaN or undefined", () => {
+    const result = aggregateReviews([]);
+
+    expect(result.totalReviews).toBe(0);
+    expect(result.totalFindings).toBe(0);
+    // Guards the division-by-zero paths: every average must be 0, not NaN.
+    expect(result.avgMergeScore).toBe(0);
+    expect(result.durationStats).toEqual({ avgMs: 0, p95Ms: 0, count: 0 });
+    expect(result.costStats).toEqual({ totalCostUsd: 0, avgCostUsd: 0, costCount: 0 });
+    expect(result.scoreTrend).toEqual([]);
+    expect(result.findingsPerReviewTrend).toEqual([]);
+    expect(result.repoBreakdown).toEqual([]);
+    // Buckets are always seeded so the UI never has to null-check them.
+    expect(result.severityBreakdown).toEqual({ critical: 0, warning: 0, info: 0 });
+    expect(result.categoryBreakdown).toEqual({ security: 0, bug: 0, style: 0 });
+    expect(result.mergeScoreDistribution).toEqual({ 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 });
+  });
+
+  it("has no NaN anywhere in the zero state", () => {
+    const json = JSON.stringify(aggregateReviews([]));
+    // JSON.stringify turns NaN into null — either would be a bug here.
+    expect(json).not.toContain("null");
+    expect(json).not.toContain("NaN");
+  });
+});
+
+describe("aggregateReviews — totals against a hand-computed fixture", () => {
+  const fixture: AggregatableReview[] = [
+    review({
+      createdAt: "2026-08-01T09:00:00.000Z",
+      mergeScore: 4,
+      findingCount: 2,
+      durationMs: 1000,
+      estimatedCostUsd: 0.01,
+      findings: [
+        { severity: "critical", category: "security" },
+        { severity: "info", category: "style" },
+      ],
+    }),
+    review({
+      createdAt: "2026-08-01T15:00:00.000Z",
+      mergeScore: 2,
+      findingCount: 1,
+      durationMs: 3000,
+      estimatedCostUsd: 0.03,
+      findings: [{ severity: "warning", category: "bug" }],
+    }),
+    review({
+      repoFullName: "acme/web",
+      createdAt: "2026-08-02T09:00:00.000Z",
+      mergeScore: 5,
+      findingCount: 0,
+      durationMs: 2000,
+      estimatedCostUsd: 0.02,
+      findings: [],
+    }),
+  ];
+
+  it("counts reviews and findings", () => {
+    const r = aggregateReviews(fixture);
+    expect(r.totalReviews).toBe(3);
+    expect(r.totalFindings).toBe(3);
+  });
+
+  it("averages merge score across reviews that have one", () => {
+    // (4 + 2 + 5) / 3 = 3.666… → 3.67
+    expect(aggregateReviews(fixture).avgMergeScore).toBe(3.67);
+  });
+
+  it("buckets severity and category", () => {
+    const r = aggregateReviews(fixture);
+    expect(r.severityBreakdown).toEqual({ critical: 1, warning: 1, info: 1 });
+    expect(r.categoryBreakdown).toEqual({ security: 1, bug: 1, style: 1 });
+  });
+
+  it("distributes merge scores into integer buckets", () => {
+    expect(aggregateReviews(fixture).mergeScoreDistribution).toEqual({
+      1: 0, 2: 1, 3: 0, 4: 1, 5: 1,
+    });
+  });
+
+  it("sums and averages cost", () => {
+    const r = aggregateReviews(fixture);
+    expect(r.costStats.totalCostUsd).toBe(0.06);
+    expect(r.costStats.avgCostUsd).toBe(0.02);
+    expect(r.costStats.costCount).toBe(3);
+  });
+
+  it("ranks repo breakdown by count descending", () => {
+    expect(aggregateReviews(fixture).repoBreakdown).toEqual([
+      { repo: "acme/api", count: 2 },
+      { repo: "acme/web", count: 1 },
+    ]);
+  });
+
+  it("averages duration", () => {
+    // (1000 + 3000 + 2000) / 3 = 2000
+    expect(aggregateReviews(fixture).durationStats.avgMs).toBe(2000);
+    expect(aggregateReviews(fixture).durationStats.count).toBe(3);
+  });
+});
+
+describe("aggregateReviews — trend series", () => {
+  it("buckets by day and sorts ascending regardless of input order", () => {
+    const r = aggregateReviews([
+      review({ createdAt: "2026-08-03T10:00:00.000Z", mergeScore: 5 }),
+      review({ createdAt: "2026-08-01T10:00:00.000Z", mergeScore: 1 }),
+      review({ createdAt: "2026-08-02T10:00:00.000Z", mergeScore: 3 }),
+    ]);
+
+    expect(r.scoreTrend.map((p) => p.date)).toEqual([
+      "2026-08-01",
+      "2026-08-02",
+      "2026-08-03",
+    ]);
+  });
+
+  it("averages within a day and reports the day's review count", () => {
+    const r = aggregateReviews([
+      review({ createdAt: "2026-08-01T01:00:00.000Z", mergeScore: 2 }),
+      review({ createdAt: "2026-08-01T23:00:00.000Z", mergeScore: 5 }),
+    ]);
+
+    expect(r.scoreTrend).toEqual([{ date: "2026-08-01", avgScore: 3.5, count: 2 }]);
+  });
+
+  it("omits days with no data rather than emitting zero-filled points", () => {
+    // A gap must stay a gap — a synthesized 0 would render as a score crash.
+    const r = aggregateReviews([
+      review({ createdAt: "2026-08-01T10:00:00.000Z", mergeScore: 4 }),
+      review({ createdAt: "2026-08-05T10:00:00.000Z", mergeScore: 4 }),
+    ]);
+
+    expect(r.scoreTrend.map((p) => p.date)).toEqual(["2026-08-01", "2026-08-05"]);
+  });
+
+  it("counts only completed reviews in the findings-per-review trend", () => {
+    const r = aggregateReviews([
+      review({ createdAt: "2026-08-01T10:00:00.000Z", status: "complete", findingCount: 4 }),
+      review({ createdAt: "2026-08-01T11:00:00.000Z", status: "failed", findingCount: 99 }),
+    ]);
+
+    expect(r.findingsPerReviewTrend).toEqual([
+      { date: "2026-08-01", avgFindings: 4, count: 1 },
+    ]);
+  });
+
+  it("treats a missing findingCount on a completed review as zero", () => {
+    const r = aggregateReviews([
+      review({ createdAt: "2026-08-01T10:00:00.000Z", findingCount: 2 }),
+      review({ createdAt: "2026-08-01T11:00:00.000Z", findingCount: undefined }),
+    ]);
+
+    expect(r.findingsPerReviewTrend).toEqual([
+      { date: "2026-08-01", avgFindings: 1, count: 2 },
+    ]);
+  });
+});
+
+describe("aggregateReviews — status handling", () => {
+  it("counts each known status", () => {
+    const r = aggregateReviews([
+      review({ status: "complete" }),
+      review({ status: "failed" }),
+      review({ status: "skipped" }),
+      review({ status: "pending" }),
+      review({ status: "in_progress" }),
+      review({ status: "complete" }),
+    ]);
+
+    expect(r.statusCounts).toEqual({
+      complete: 2, failed: 1, skipped: 1, pending: 1, in_progress: 1,
+    });
+  });
+
+  it("ignores an unrecognized status instead of creating a bucket for it", () => {
+    const r = aggregateReviews([review({ status: "quantum_superposition" })]);
+
+    expect(Object.keys(r.statusCounts).sort()).toEqual([
+      "complete", "failed", "in_progress", "pending", "skipped",
+    ]);
+    // Still counted as a review and still attributed to its repo.
+    expect(r.totalReviews).toBe(1);
+    expect(r.repoBreakdown).toEqual([{ repo: "acme/api", count: 1 }]);
+  });
+
+  it("excludes non-complete reviews from duration and cost", () => {
+    const r = aggregateReviews([
+      review({ status: "complete", durationMs: 1000, estimatedCostUsd: 0.05 }),
+      review({ status: "failed", durationMs: 9999, estimatedCostUsd: 9.99 }),
+      review({ status: "pending", durationMs: 8888, estimatedCostUsd: 8.88 }),
+    ]);
+
+    expect(r.durationStats.count).toBe(1);
+    expect(r.durationStats.avgMs).toBe(1000);
+    expect(r.costStats.costCount).toBe(1);
+    expect(r.costStats.totalCostUsd).toBe(0.05);
+  });
+});
+
+describe("aggregateReviews — missing and malformed optional fields", () => {
+  it("skips reviews with no mergeScore without disturbing the average", () => {
+    const r = aggregateReviews([
+      review({ mergeScore: 4 }),
+      review({ mergeScore: undefined }),
+      review({ mergeScore: null }),
+    ]);
+
+    expect(r.avgMergeScore).toBe(4);
+    expect(r.totalReviews).toBe(3);
+  });
+
+  it("counts a mergeScore of 0 as present, not missing", () => {
+    // `!= null` rather than falsy — a 0 score is real data.
+    const r = aggregateReviews([review({ mergeScore: 0 }), review({ mergeScore: 4 })]);
+    expect(r.avgMergeScore).toBe(2);
+    // 0 rounds outside the 1-5 distribution and is dropped from it.
+    expect(r.mergeScoreDistribution[4]).toBe(1);
+  });
+
+  it("handles null and absent findings arrays", () => {
+    const r = aggregateReviews([
+      review({ findings: null }),
+      review({ findings: undefined }),
+      review({ findings: [{ severity: "critical", category: "security" }] }),
+    ]);
+
+    expect(r.totalFindings).toBe(1);
+    expect(r.severityBreakdown.critical).toBe(1);
+  });
+
+  it("ignores findings with unknown or missing severity and category", () => {
+    const r = aggregateReviews([
+      review({
+        findings: [
+          { severity: "apocalyptic", category: "vibes" },
+          { severity: undefined, category: undefined },
+          { severity: "info", category: "style" },
+        ],
+      }),
+    ]);
+
+    // All three count toward the total; only the known one buckets.
+    expect(r.totalFindings).toBe(3);
+    expect(r.severityBreakdown).toEqual({ critical: 0, warning: 0, info: 1 });
+    expect(r.categoryBreakdown).toEqual({ security: 0, bug: 0, style: 1 });
+  });
+
+  it("coerces a string cost, as the DynamoDB path can return one", () => {
+    const r = aggregateReviews([
+      review({ estimatedCostUsd: "0.25" }),
+      review({ estimatedCostUsd: 0.25 }),
+    ]);
+
+    expect(r.costStats.totalCostUsd).toBe(0.5);
+    expect(r.costStats.costCount).toBe(2);
+  });
+
+  it("counts a zero cost as priced rather than missing", () => {
+    const r = aggregateReviews([review({ estimatedCostUsd: 0 })]);
+    expect(r.costStats.costCount).toBe(1);
+    expect(r.costStats.totalCostUsd).toBe(0);
+  });
+
+  it("skips reviews with no createdAt in the trends but still counts them", () => {
+    const r = aggregateReviews([
+      review({ createdAt: undefined, mergeScore: 4, findingCount: 3 }),
+      review({ createdAt: "2026-08-01T10:00:00.000Z", mergeScore: 2, findingCount: 1 }),
+    ]);
+
+    expect(r.totalReviews).toBe(2);
+    expect(r.scoreTrend).toEqual([{ date: "2026-08-01", avgScore: 2, count: 1 }]);
+    expect(r.findingsPerReviewTrend).toHaveLength(1);
+  });
+});
+
+describe("aggregateReviews — percentile behavior (see #336)", () => {
+  // These assertions pin the CURRENT, KNOWN-WRONG behavior so the #333
+  // extraction is provably a no-op. #336 fixes the index and must update them.
+  it("currently returns the maximum for small samples (off-by-one)", () => {
+    const durations = Array.from({ length: 20 }, (_, i) =>
+      review({ durationMs: (i + 1) * 100 }),
+    );
+    const r = aggregateReviews(durations);
+
+    // Correct nearest-rank p95 of 1..20 hundreds would be 1900; index 19 gives 2000.
+    expect(r.durationStats.p95Ms).toBe(2000);
+  });
+
+  it("sorts durations numerically, not lexicographically", () => {
+    // A default .sort() would order [1000, 200, 30] and corrupt every percentile.
+    const r = aggregateReviews([
+      review({ durationMs: 1000 }),
+      review({ durationMs: 200 }),
+      review({ durationMs: 30 }),
+    ]);
+
+    expect(r.durationStats.avgMs).toBe(410);
+    expect(r.durationStats.p95Ms).toBe(1000);
+  });
+});
+
+describe("aggregateReviews — no ceiling (#333 regression)", () => {
+  /**
+   * The bug this extraction exists to make testable: the route capped its fetch
+   * at 500 rows and presented the result as a total. The aggregator itself must
+   * have no such limit, so a fixture comfortably past the old cap and spanning
+   * several months has to come back complete and fully time-covered.
+   */
+  const COUNT = 1234;
+  const START = Date.UTC(2026, 2, 1); // 2026-03-01, ~5 months before the fixture epoch
+  const DAY_MS = 24 * 60 * 60 * 1000;
+
+  const many: AggregatableReview[] = Array.from({ length: COUNT }, (_, i) => ({
+    repoFullName: i % 2 === 0 ? "acme/api" : "acme/web",
+    status: "complete",
+    // One review every 3 hours, walking forward across ~154 days.
+    createdAt: new Date(START + i * 3 * 60 * 60 * 1000).toISOString(),
+    mergeScore: (i % 5) + 1,
+    findingCount: i % 4,
+    durationMs: 1000 + i,
+    estimatedCostUsd: 0.01,
+    findings: [{ severity: "warning", category: "bug" }],
+  }));
+
+  it("counts every review past the old 500 cap", () => {
+    expect(aggregateReviews(many).totalReviews).toBe(COUNT);
+  });
+
+  it("counts every finding past the old cap", () => {
+    expect(aggregateReviews(many).totalFindings).toBe(COUNT);
+    expect(aggregateReviews(many).severityBreakdown.warning).toBe(COUNT);
+  });
+
+  it("covers the full time span, oldest day included", () => {
+    const r = aggregateReviews(many);
+    const first = r.scoreTrend[0].date;
+    const last = r.scoreTrend[r.scoreTrend.length - 1].date;
+
+    expect(first).toBe("2026-03-01");
+    // The oldest data is the part the truncation bug destroyed — the trend must
+    // start at the beginning of the range, not 500 reviews back from the end.
+    expect(new Date(last).getTime() - new Date(first).getTime()).toBeGreaterThan(
+      150 * DAY_MS,
+    );
+  });
+
+  it("produces a trend point for every distinct day in the span", () => {
+    const r = aggregateReviews(many);
+    const distinctDays = new Set(many.map((rv) => rv.createdAt!.substring(0, 10)));
+
+    expect(r.scoreTrend).toHaveLength(distinctDays.size);
+    expect(r.findingsPerReviewTrend).toHaveLength(distinctDays.size);
+  });
+
+  it("keeps the trend sorted ascending across the whole span", () => {
+    const dates = aggregateReviews(many).scoreTrend.map((p) => p.date);
+    expect(dates).toEqual([...dates].sort());
+  });
+
+  it("attributes every review to a repo", () => {
+    const r = aggregateReviews(many);
+    const total = r.repoBreakdown.reduce((s, x) => s + x.count, 0);
+    expect(total).toBe(COUNT);
+  });
+
+  it("prices every completed review", () => {
+    const r = aggregateReviews(many);
+    expect(r.costStats.costCount).toBe(COUNT);
+    expect(r.costStats.totalCostUsd).toBeCloseTo(COUNT * 0.01, 4);
+  });
+});

--- a/packages/dashboard/lib/analytics-aggregate.ts
+++ b/packages/dashboard/lib/analytics-aggregate.ts
@@ -1,0 +1,216 @@
+/**
+ * Pure aggregation for the analytics surface (#333).
+ *
+ * Lifted verbatim out of `app/api/analytics/route.ts`, where ~110 lines of
+ * reduction sat inline in the request handler with no test coverage — which is
+ * how a 500-row truncation, an off-by-one percentile (#336) and a date-boundary
+ * bug (#337) all shipped unnoticed.
+ *
+ * Kept dependency-free (no React, no Next, no store) so it can be exercised
+ * against a hand-built fixture, the way `cost-insight.ts` is and the way
+ * `buildInsightFromDispositions` is in `@mergewatch/core`.
+ *
+ * **This module deliberately preserves the existing behavior, bugs included.**
+ * The percentile index and the UTC day bucketing below are wrong, and are fixed
+ * under their own issues — reproducing them exactly here is what makes the
+ * extraction reviewable as a no-op.
+ */
+
+/**
+ * The fields of a review this aggregation actually reads.
+ *
+ * A structural subset rather than an import of `ReviewItem`: it keeps the
+ * module dependency-free, lets tests build fixtures without satisfying two
+ * dozen irrelevant required fields, and gives `estimatedCostUsd` a real type
+ * instead of the `(review as any)` cast the route was using.
+ */
+export interface AggregatableReview {
+  repoFullName: string;
+  status?: string;
+  createdAt?: string;
+  mergeScore?: number | null;
+  findingCount?: number | null;
+  durationMs?: number | null;
+  estimatedCostUsd?: number | string | null;
+  findings?: Array<{ severity?: string; category?: string }> | null;
+}
+
+export interface TrendPoint {
+  date: string;
+  count: number;
+}
+
+export interface ScoreTrendPoint extends TrendPoint {
+  avgScore: number;
+}
+
+export interface FindingsPerReviewPoint extends TrendPoint {
+  avgFindings: number;
+}
+
+export interface AnalyticsAggregate {
+  totalReviews: number;
+  totalFindings: number;
+  avgMergeScore: number;
+  scoreTrend: ScoreTrendPoint[];
+  severityBreakdown: Record<string, number>;
+  durationStats: { avgMs: number; p95Ms: number; count: number };
+  repoBreakdown: Array<{ repo: string; count: number }>;
+  categoryBreakdown: Record<string, number>;
+  statusCounts: Record<string, number>;
+  findingsPerReviewTrend: FindingsPerReviewPoint[];
+  mergeScoreDistribution: Record<number, number>;
+  costStats: { totalCostUsd: number; avgCostUsd: number; costCount: number };
+}
+
+/**
+ * Reduce a set of reviews into the analytics payload.
+ *
+ * Only the severities, categories and statuses seeded below are counted —
+ * an unrecognized value is ignored rather than creating a new bucket, so a
+ * future status cannot silently appear in the UI as an unlabelled slice.
+ */
+export function aggregateReviews(
+  reviews: readonly AggregatableReview[],
+): AnalyticsAggregate {
+  // Score trend: average mergeScore per day
+  const scoreByDate = new Map<string, { sum: number; count: number }>();
+  // Severity breakdown
+  const severityBreakdown: Record<string, number> = { critical: 0, warning: 0, info: 0 };
+  // Duration stats
+  const durations: number[] = [];
+  // Repo breakdown
+  const repoBreakdown = new Map<string, number>();
+  // Category breakdown
+  const categoryBreakdown: Record<string, number> = { security: 0, bug: 0, style: 0 };
+  // Totals
+  let totalFindings = 0;
+  let mergeScoreSum = 0;
+  let mergeScoreCount = 0;
+  // Cost stats
+  let totalCostUsd = 0;
+  let costCount = 0;
+  // Status counts
+  const statusCounts: Record<string, number> = { complete: 0, failed: 0, skipped: 0, pending: 0, in_progress: 0 };
+  // Findings-per-review trend
+  const findingsByDate = new Map<string, { sum: number; count: number }>();
+  // Merge score distribution (1-5)
+  const mergeScoreDistribution: Record<number, number> = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };
+
+  for (const review of reviews) {
+    // Status counts
+    if (review.status && statusCounts[review.status] !== undefined) {
+      statusCounts[review.status]++;
+    }
+
+    // Score trend
+    if (review.createdAt && review.mergeScore != null) {
+      const date = review.createdAt.substring(0, 10); // YYYY-MM-DD
+      const entry = scoreByDate.get(date) ?? { sum: 0, count: 0 };
+      entry.sum += review.mergeScore;
+      entry.count += 1;
+      scoreByDate.set(date, entry);
+      mergeScoreSum += review.mergeScore;
+      mergeScoreCount += 1;
+
+      // Merge score distribution
+      const rounded = Math.round(review.mergeScore);
+      if (rounded >= 1 && rounded <= 5) {
+        mergeScoreDistribution[rounded]++;
+      }
+    }
+
+    // Severity and category from findings
+    if (review.findings && Array.isArray(review.findings)) {
+      totalFindings += review.findings.length;
+      for (const finding of review.findings) {
+        if (finding.severity && severityBreakdown[finding.severity] !== undefined) {
+          severityBreakdown[finding.severity]++;
+        }
+        if (finding.category && categoryBreakdown[finding.category] !== undefined) {
+          categoryBreakdown[finding.category]++;
+        }
+      }
+    }
+
+    // Findings-per-review trend (only completed reviews)
+    if (review.createdAt && review.status === "complete") {
+      const date = review.createdAt.substring(0, 10);
+      const fc = review.findingCount ?? 0;
+      const entry = findingsByDate.get(date) ?? { sum: 0, count: 0 };
+      entry.sum += fc;
+      entry.count += 1;
+      findingsByDate.set(date, entry);
+    }
+
+    // Cost stats
+    if (review.estimatedCostUsd != null && review.status === "complete") {
+      totalCostUsd += Number(review.estimatedCostUsd);
+      costCount += 1;
+    }
+
+    // Duration stats
+    if (review.durationMs != null && review.status === "complete") {
+      durations.push(review.durationMs);
+    }
+
+    // Repo breakdown
+    const repoCount = repoBreakdown.get(review.repoFullName) ?? 0;
+    repoBreakdown.set(review.repoFullName, repoCount + 1);
+  }
+
+  // Compute score trend sorted by date
+  const scoreTrend = Array.from(scoreByDate.entries())
+    .map(([date, { sum, count }]) => ({
+      date,
+      avgScore: Math.round((sum / count) * 100) / 100,
+      count,
+    }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+
+  // Duration statistics
+  durations.sort((a, b) => a - b);
+  const avgDuration = durations.length > 0
+    ? Math.round(durations.reduce((s, d) => s + d, 0) / durations.length)
+    : 0;
+  // NOTE: this index is off by one and returns the maximum for n <= 20.
+  // Preserved as-is by the #333 extraction; fixed under #336.
+  const p95Duration = durations.length > 0
+    ? durations[Math.floor(durations.length * 0.95)]
+    : 0;
+
+  return {
+    totalReviews: reviews.length,
+    totalFindings,
+    avgMergeScore: mergeScoreCount > 0
+      ? Math.round((mergeScoreSum / mergeScoreCount) * 100) / 100
+      : 0,
+    scoreTrend,
+    severityBreakdown,
+    durationStats: {
+      avgMs: avgDuration,
+      p95Ms: p95Duration,
+      count: durations.length,
+    },
+    repoBreakdown: Array.from(repoBreakdown.entries())
+      .map(([repo, count]) => ({ repo, count }))
+      .sort((a, b) => b.count - a.count),
+    categoryBreakdown,
+    statusCounts,
+    findingsPerReviewTrend: Array.from(findingsByDate.entries())
+      .map(([date, { sum, count }]) => ({
+        date,
+        avgFindings: Math.round((sum / count) * 100) / 100,
+        count,
+      }))
+      .sort((a, b) => a.date.localeCompare(b.date)),
+    mergeScoreDistribution,
+    costStats: {
+      totalCostUsd: Math.round(totalCostUsd * 10000) / 10000,
+      avgCostUsd: costCount > 0
+        ? Math.round((totalCostUsd / costCount) * 10000) / 10000
+        : 0,
+      costCount,
+    },
+  };
+}

--- a/packages/dashboard/lib/analytics-collect.test.ts
+++ b/packages/dashboard/lib/analytics-collect.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from "vitest";
+import {
+  collectAllReviews,
+  ANALYTICS_PAGE_SIZE,
+  ANALYTICS_MAX_REVIEWS,
+  type ReviewPage,
+} from "./analytics-collect";
+
+/**
+ * A fake store that serves `total` rows in pages of `pageSize`, recording the
+ * cursors it was called with so tests can assert the walk itself, not just the
+ * result.
+ */
+function fakeStore(total: number, pageSize = 3) {
+  const calls: Array<string | undefined> = [];
+
+  const fetchPage = async (cursor: string | undefined): Promise<ReviewPage<number>> => {
+    calls.push(cursor);
+    const offset = cursor ? Number(cursor) : 0;
+    const items = Array.from(
+      { length: Math.max(0, Math.min(pageSize, total - offset)) },
+      (_, i) => offset + i,
+    );
+    const nextOffset = offset + items.length;
+    return {
+      items,
+      nextCursor: nextOffset < total ? String(nextOffset) : null,
+    };
+  };
+
+  return { fetchPage, calls };
+}
+
+describe("collectAllReviews — exhausting the store", () => {
+  it("returns a single page and does not report truncation", async () => {
+    const { fetchPage, calls } = fakeStore(3, 3);
+    const r = await collectAllReviews(fetchPage);
+
+    expect(r.reviews).toEqual([0, 1, 2]);
+    expect(r.truncated).toBe(false);
+    expect(r.pagesFetched).toBe(1);
+    expect(calls).toEqual([undefined]);
+  });
+
+  it("follows the cursor across many pages and concatenates in order", async () => {
+    const { fetchPage, calls } = fakeStore(10, 3);
+    const r = await collectAllReviews(fetchPage);
+
+    expect(r.reviews).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    expect(r.truncated).toBe(false);
+    expect(r.pagesFetched).toBe(4);
+    // First call passes no cursor; each subsequent call passes the previous one.
+    expect(calls).toEqual([undefined, "3", "6", "9"]);
+  });
+
+  it("handles an empty store", async () => {
+    const { fetchPage } = fakeStore(0, 3);
+    const r = await collectAllReviews(fetchPage);
+
+    expect(r.reviews).toEqual([]);
+    expect(r.truncated).toBe(false);
+    expect(r.pagesFetched).toBe(1);
+  });
+
+  it("stops on a full final page that carries no cursor", async () => {
+    // total is an exact multiple of pageSize — the last page is full but the
+    // store still signals the end, so there must be no extra request.
+    const { fetchPage } = fakeStore(9, 3);
+    const r = await collectAllReviews(fetchPage);
+
+    expect(r.reviews).toHaveLength(9);
+    expect(r.pagesFetched).toBe(3);
+    expect(r.truncated).toBe(false);
+  });
+
+  it("collects well past the old 500-row cap", async () => {
+    const { fetchPage } = fakeStore(1234, 100);
+    const r = await collectAllReviews(fetchPage);
+
+    expect(r.reviews).toHaveLength(1234);
+    expect(r.truncated).toBe(false);
+  });
+});
+
+describe("collectAllReviews — safety bounds", () => {
+  it("stops at maxReviews and reports truncation", async () => {
+    const { fetchPage } = fakeStore(1000, 10);
+    const r = await collectAllReviews(fetchPage, { maxReviews: 50 });
+
+    expect(r.truncated).toBe(true);
+    expect(r.reviews).toHaveLength(50);
+  });
+
+  it("keeps the crossing page whole rather than slicing it", async () => {
+    // Soft bound: 7 rows per page, cap of 10 → stops after two pages at 14.
+    const { fetchPage } = fakeStore(1000, 7);
+    const r = await collectAllReviews(fetchPage, { maxReviews: 10 });
+
+    expect(r.reviews).toHaveLength(14);
+    expect(r.truncated).toBe(true);
+    // Overshoot is bounded by a single page.
+    expect(r.reviews.length).toBeLessThan(10 + 7);
+  });
+
+  it("does not report truncation when the store ends exactly at the cap", async () => {
+    const { fetchPage } = fakeStore(10, 5);
+    const r = await collectAllReviews(fetchPage, { maxReviews: 10 });
+
+    // The final page carried no cursor, so this is a clean exhaustion even
+    // though the cap was reached on the same iteration.
+    expect(r.reviews).toHaveLength(10);
+    expect(r.truncated).toBe(false);
+  });
+
+  it("stops when the store repeats a cursor instead of advancing", async () => {
+    let calls = 0;
+    const fetchPage = async (): Promise<ReviewPage<number>> => {
+      calls++;
+      return { items: [1], nextCursor: "stuck" };
+    };
+
+    const r = await collectAllReviews(fetchPage);
+
+    expect(r.truncated).toBe(true);
+    // First page yields "stuck"; the second sees it repeat and stops.
+    expect(calls).toBe(2);
+    expect(r.reviews).toEqual([1, 1]);
+  });
+
+  it("terminates when a store returns empty pages with a cursor forever", async () => {
+    // Pathological: never advances the row count, so maxReviews can never trip.
+    // Only the page ceiling stops this.
+    let n = 0;
+    const fetchPage = async (): Promise<ReviewPage<number>> => {
+      n++;
+      return { items: [], nextCursor: `cursor-${n}` };
+    };
+
+    const r = await collectAllReviews(fetchPage);
+
+    expect(r.truncated).toBe(true);
+    expect(r.reviews).toEqual([]);
+    // Bounded, not infinite — the point of the test.
+    expect(r.pagesFetched).toBeLessThanOrEqual(
+      Math.ceil(ANALYTICS_MAX_REVIEWS / ANALYTICS_PAGE_SIZE) + 5,
+    );
+  });
+
+  it("propagates a store error rather than returning a partial total", async () => {
+    // The route's catch handles this. Silently returning page 1 would be the
+    // 500-cap bug all over again, with no flag to show for it.
+    const fetchPage = async (cursor: string | undefined): Promise<ReviewPage<number>> => {
+      if (cursor) throw new Error("connection reset");
+      return { items: [1, 2], nextCursor: "next" };
+    };
+
+    await expect(collectAllReviews(fetchPage)).rejects.toThrow("connection reset");
+  });
+});
+
+describe("collectAllReviews — bounds are sane", () => {
+  it("defaults to a cap far above the old 500 limit", () => {
+    expect(ANALYTICS_MAX_REVIEWS).toBeGreaterThan(500);
+    expect(ANALYTICS_PAGE_SIZE).toBeGreaterThan(500);
+  });
+
+  it("reaches the default cap in a reasonable number of round trips", () => {
+    expect(ANALYTICS_MAX_REVIEWS / ANALYTICS_PAGE_SIZE).toBeLessThanOrEqual(20);
+  });
+});

--- a/packages/dashboard/lib/analytics-collect.ts
+++ b/packages/dashboard/lib/analytics-collect.ts
@@ -1,0 +1,115 @@
+/**
+ * Paginated collection for the analytics surface (#333).
+ *
+ * `/api/analytics` used to fetch a single 500-row page and discard
+ * `nextCursor`, then present the reduction of that page as a total. Because
+ * the stores return newest-first, the rows that got dropped were the *oldest*
+ * ones in the selected range — so the trend charts lost their history while
+ * still being labelled with the full range, and widening the date filter
+ * changed nothing.
+ *
+ * This module walks the cursor to exhaustion instead, and reports honestly
+ * when it had to stop early.
+ *
+ * The page fetcher is injected rather than imported so this is unit-testable
+ * without standing up next-auth, the store, or a Next.js request — there is no
+ * API-route test harness in this repo, and adding one to test a loop would be
+ * the wrong trade.
+ */
+
+/** One page as returned by `IDashboardReviewStore.listReviews`. */
+export interface ReviewPage<T> {
+  items: T[];
+  nextCursor: string | null;
+}
+
+/** Fetch one page. `cursor` is `undefined` for the first call. */
+export type FetchReviewPage<T> = (cursor: string | undefined) => Promise<ReviewPage<T>>;
+
+export interface CollectResult<T> {
+  reviews: T[];
+  /**
+   * True when collection stopped before the store ran out of rows — the
+   * aggregate below it is a partial view and must not be shown as a total.
+   */
+  truncated: boolean;
+  pagesFetched: number;
+}
+
+/**
+ * Rows per page. Larger than the old cap so typical installations finish in
+ * one or two round trips, small enough that a single page stays a reasonable
+ * query for both Postgres (offset pagination) and DynamoDB (1MB page limit).
+ */
+export const ANALYTICS_PAGE_SIZE = 1000;
+
+/**
+ * Upper bound on rows pulled into memory for one aggregation.
+ *
+ * This is a backstop against an unbounded request, not a product decision:
+ * 20k reviews is far past any current installation, and an instance that
+ * reaches it gets a truncation flag rather than silence. The real fix for
+ * that scale is aggregating in the database (see #333's fix direction) —
+ * which is also what #335 needs, since DynamoDB cannot page this efficiently.
+ */
+export const ANALYTICS_MAX_REVIEWS = 20_000;
+
+/**
+ * Hard ceiling on iterations. `maxReviews / pageSize` already bounds the loop
+ * for a well-behaved store; this catches a store that returns a cursor
+ * alongside an empty page forever, which would otherwise spin without ever
+ * growing `reviews`.
+ */
+const MAX_PAGES = Math.ceil(ANALYTICS_MAX_REVIEWS / ANALYTICS_PAGE_SIZE) + 5;
+
+/**
+ * Follow `nextCursor` until the store is exhausted or a safety bound trips.
+ *
+ * `maxReviews` is a **soft** bound: collection stops once the total reaches it,
+ * but the page that crossed the line is kept whole rather than sliced. Keeping
+ * partial pages would mean silently discarding rows we already paid to fetch,
+ * and the overshoot is bounded by one page.
+ *
+ * Ordering is irrelevant to the caller — aggregation is order-independent, and
+ * exhausting the range is precisely what makes it so. That also means this
+ * incidentally sidesteps #335's DynamoDB sort-order and pre-filter-`Limit`
+ * defects for the analytics path, though not for the paginated review list.
+ */
+export async function collectAllReviews<T>(
+  fetchPage: FetchReviewPage<T>,
+  options: { maxReviews?: number } = {},
+): Promise<CollectResult<T>> {
+  const maxReviews = options.maxReviews ?? ANALYTICS_MAX_REVIEWS;
+
+  const reviews: T[] = [];
+  const seenCursors = new Set<string>();
+  let cursor: string | undefined = undefined;
+  let pagesFetched = 0;
+  let exhausted = false;
+
+  while (pagesFetched < MAX_PAGES) {
+    const page: ReviewPage<T> = await fetchPage(cursor);
+    pagesFetched++;
+    reviews.push(...page.items);
+
+    const next = page.nextCursor;
+    if (!next) {
+      exhausted = true; // store ran out — the only clean exit
+      break;
+    }
+
+    if (reviews.length >= maxReviews) break;
+
+    // A repeated cursor means the store is not advancing. Stopping is right:
+    // we cannot claim completeness, and looping to MAX_PAGES would just burn
+    // queries to reach the same conclusion.
+    if (seenCursors.has(next)) break;
+
+    seenCursors.add(next);
+    cursor = next;
+  }
+
+  // Anything other than running the store dry leaves us with a partial view —
+  // including exiting on the final allowed page while still holding a cursor.
+  return { reviews, truncated: !exhausted, pagesFetched };
+}


### PR DESCRIPTION
Stage 1 of 2 for #333. **No behavior change** — this PR exists to make stage 2's fix testable.

## Why

`/api/analytics` reduced reviews into ~15 aggregates inside the request handler, and there is **no API-route test harness anywhere in this repo** (`find app/api -name '*.test.ts'` returns nothing). So the logic was untestable where it lived, and three separate defects shipped through it: the 500-row truncation (#333), an off-by-one percentile (#336), and a date-boundary bug (#337).

Rather than invent a next-auth/Next.js mocking layer, the aggregation moves to `lib/` as a pure function — the convention `cost-insight.ts` already follows ("kept dependency-free so the logic is unit-testable without React") and the same shape as `buildInsightFromDispositions` in core.

## The extraction is provably a no-op

Only three deltas, all semantically identical:

| Before | After | Why |
|---|---|---|
| `(review as any).estimatedCostUsd` | `review.estimatedCostUsd` | The input is now structurally typed, so the cast is unnecessary |
| `const analytics = { … }` | `return { … }` | It's a function now |
| — | a `NOTE:` comment on the p95 index | Flags the known bug for #336 |

**The known-wrong p95 is preserved deliberately and pinned by a test.** Fixing it here would make "no behavior change" untrue and would mean this PR and #336 both touch the same line. The test asserts the current wrong value (`2000` for n=20, where nearest-rank p95 is `1900`), so #336 has an explicit assertion to flip rather than a silent behavior change.

## Input typing

`AggregatableReview` is a structural subset of `ReviewItem` rather than an import of it. That keeps the module dependency-free, lets fixtures state only the fields under test instead of satisfying two dozen irrelevant required ones, and gives `estimatedCostUsd` a real type — it's declared `number | string | null` because the DynamoDB path can return a string, which is why the original code wrapped it in `Number()`.

## Tests — 33 added

- **Zero state** — every average is `0`, not `NaN`; all buckets pre-seeded so the UI never null-checks
- **Hand-computed fixture** — totals, averages, severity/category buckets, score distribution, cost, repo ranking
- **Trends** — ascending sort regardless of input order, intra-day averaging, and **gaps stay gaps** (a synthesized zero would render as a score crash)
- **Status** — each known status counted; an unknown status ignored rather than creating a bucket; non-complete excluded from duration and cost
- **Missing/malformed fields** — `null` vs `undefined` vs absent; `mergeScore: 0` and `estimatedCostUsd: 0` counted as present, not missing (the `!= null` distinction); unknown severities counted in the total but not bucketed; string cost coerced
- **Numeric duration sort** — a default `.sort()` would order `[1000, 200, 30]` and corrupt every percentile
- **#333 regression** — a **1234-review fixture spanning ~154 days** asserting full counts, complete day coverage, ascending order across the whole span, and correct repo/cost attribution. This is the test stage 2's fix has to satisfy.

## Verification

`pnpm run build` ✅ · `pnpm run typecheck` ✅ · `pnpm run test` ✅ (33 new, full suite green)

## Next

Stage 2 removes the hardcoded `500`, paginates `nextCursor` to exhaustion, and surfaces a truncation flag in the UI. It will carry `Closes #333`.

Part of #333.