### PR TITLE
fix(dashboard): remove the 500-review ceiling in analytics (#333, stage 2)

### DIFF
--- a/packages/dashboard/app/api/analytics/route.ts
+++ b/packages/dashboard/app/api/analytics/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { getDashboardStore } from "@/lib/store";
 import { aggregateReviews } from "@/lib/analytics-aggregate";
+import { collectAllReviews, ANALYTICS_PAGE_SIZE } from "@/lib/analytics-collect";
 import {
   fetchUserInstallations,
   fetchAccessibleRepoNames,
@@ -68,12 +69,30 @@ export async function GET(req: NextRequest) {
       ? allRepos.filter((r) => r === repoParam)
       : allRepos;
 
-    // Fetch up to 500 reviews for aggregation (with optional date filter)
-    const result = await store.reviews.listReviews(targetRepos, 500, undefined, undefined, startDate, endDate);
+    // Walk every page in the range. Aggregating a single page and calling the
+    // result a total is what #333 was: because the stores return newest-first,
+    // the dropped rows were the *oldest* in the range, so the trends lost
+    // their history while still being labelled with the full range.
+    const { reviews, truncated } = await collectAllReviews((cursor) =>
+      store.reviews.listReviews(
+        targetRepos,
+        ANALYTICS_PAGE_SIZE,
+        cursor,
+        undefined,
+        startDate,
+        endDate,
+      ),
+    );
 
-    const analytics = aggregateReviews(result.items);
+    const analytics = aggregateReviews(reviews);
 
-    return NextResponse.json({ analytics, availableRepos: allRepos });
+    return NextResponse.json({
+      analytics,
+      availableRepos: allRepos,
+      // Only ever true at the safety bound. The UI must label the figures as
+      // partial when it is — a capped aggregate shown as a total is the bug.
+      truncated,
+    });
   } catch (err) {
     if (err instanceof TokenExpiredError) {
       return NextResponse.json({ error: "Token expired" }, { status: 401 });

--- a/packages/dashboard/components/AnalyticsClient.tsx
+++ b/packages/dashboard/components/AnalyticsClient.tsx
@@ -336,6 +336,9 @@ export default function AnalyticsClient({ installationId }: AnalyticsClientProps
   );
 
   const [data, setData] = useState<AnalyticsData | null>(null);
+  // #333 — set when the API hit its safety bound and the figures below cover
+  // only part of the selected range.
+  const [truncated, setTruncated] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [timeRange, setTimeRange] = useState<TimeRangeKey>("7d");
@@ -396,6 +399,7 @@ export default function AnalyticsClient({ installationId }: AnalyticsClientProps
         const json = await res.json();
         if (!cancelled) {
           setData(json.analytics);
+          setTruncated(Boolean(json.truncated));
           if (json.availableRepos) {
             setAvailableRepos(json.availableRepos);
           }
@@ -588,11 +592,35 @@ export default function AnalyticsClient({ installationId }: AnalyticsClientProps
 
     return (
       <>
+        {/* #333 — never let a capped aggregate read as a total. */}
+        {truncated && (
+          <div
+            role="status"
+            className="mb-6 rounded-lg border border-yellow-500/30 bg-yellow-500/5 p-4"
+          >
+            <p className="text-sm font-medium text-fg-primary">
+              Showing a partial view of this range
+            </p>
+            <p className="mt-1 text-sm text-fg-secondary">
+              This range contains more reviews than a single query returns, so
+              the figures below cover only part of it. Narrow the date range for
+              exact numbers.
+            </p>
+          </div>
+        )}
+
         {/* Stat cards — Overview only */}
         {activeTab === "overview" && (
         <div className="grid grid-cols-2 gap-4 sm:grid-cols-4 mb-6">
-          <StatCard label="Total Reviews" value={data.totalReviews} />
-          <StatCard label="Total Findings" value={data.totalFindings} />
+          <StatCard
+            label={truncated ? "Reviews (partial)" : "Total Reviews"}
+            value={truncated ? `${data.totalReviews}+` : data.totalReviews}
+            subtext={truncated ? "Range exceeds the query limit" : undefined}
+          />
+          <StatCard
+            label={truncated ? "Findings (partial)" : "Total Findings"}
+            value={truncated ? `${data.totalFindings}+` : data.totalFindings}
+          />
           <StatCard
             label="Avg Merge Score"
             value={data.avgMergeScore > 0 ? `${data.avgMergeScore} / 5` : "N/A"}

--- a/packages/dashboard/lib/analytics-collect.test.ts
+++ b/packages/dashboard/lib/analytics-collect.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from "vitest";
+import {
+  collectAllReviews,
+  ANALYTICS_PAGE_SIZE,
+  ANALYTICS_MAX_REVIEWS,
+  type ReviewPage,
+} from "./analytics-collect";
+
+/**
+ * A fake store that serves `total` rows in pages of `pageSize`, recording the
+ * cursors it was called with so tests can assert the walk itself, not just the
+ * result.
+ */
+function fakeStore(total: number, pageSize = 3) {
+  const calls: Array<string | undefined> = [];
+
+  const fetchPage = async (cursor: string | undefined): Promise<ReviewPage<number>> => {
+    calls.push(cursor);
+    const offset = cursor ? Number(cursor) : 0;
+    const items = Array.from(
+      { length: Math.max(0, Math.min(pageSize, total - offset)) },
+      (_, i) => offset + i,
+    );
+    const nextOffset = offset + items.length;
+    return {
+      items,
+      nextCursor: nextOffset < total ? String(nextOffset) : null,
+    };
+  };
+
+  return { fetchPage, calls };
+}
+
+describe("collectAllReviews — exhausting the store", () => {
+  it("returns a single page and does not report truncation", async () => {
+    const { fetchPage, calls } = fakeStore(3, 3);
+    const r = await collectAllReviews(fetchPage);
+
+    expect(r.reviews).toEqual([0, 1, 2]);
+    expect(r.truncated).toBe(false);
+    expect(r.pagesFetched).toBe(1);
+    expect(calls).toEqual([undefined]);
+  });
+
+  it("follows the cursor across many pages and concatenates in order", async () => {
+    const { fetchPage, calls } = fakeStore(10, 3);
+    const r = await collectAllReviews(fetchPage);
+
+    expect(r.reviews).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    expect(r.truncated).toBe(false);
+    expect(r.pagesFetched).toBe(4);
+    // First call passes no cursor; each subsequent call passes the previous one.
+    expect(calls).toEqual([undefined, "3", "6", "9"]);
+  });
+
+  it("handles an empty store", async () => {
+    const { fetchPage } = fakeStore(0, 3);
+    const r = await collectAllReviews(fetchPage);
+
+    expect(r.reviews).toEqual([]);
+    expect(r.truncated).toBe(false);
+    expect(r.pagesFetched).toBe(1);
+  });
+
+  it("stops on a full final page that carries no cursor", async () => {
+    // total is an exact multiple of pageSize — the last page is full but the
+    // store still signals the end, so there must be no extra request.
+    const { fetchPage } = fakeStore(9, 3);
+    const r = await collectAllReviews(fetchPage);
+
+    expect(r.reviews).toHaveLength(9);
+    expect(r.pagesFetched).toBe(3);
+    expect(r.truncated).toBe(false);
+  });
+
+  it("collects well past the old 500-row cap", async () => {
+    const { fetchPage } = fakeStore(1234, 100);
+    const r = await collectAllReviews(fetchPage);
+
+    expect(r.reviews).toHaveLength(1234);
+    expect(r.truncated).toBe(false);
+  });
+});
+
+describe("collectAllReviews — safety bounds", () => {
+  it("stops at maxReviews and reports truncation", async () => {
+    const { fetchPage } = fakeStore(1000, 10);
+    const r = await collectAllReviews(fetchPage, { maxReviews: 50 });
+
+    expect(r.truncated).toBe(true);
+    expect(r.reviews).toHaveLength(50);
+  });
+
+  it("keeps the crossing page whole rather than slicing it", async () => {
+    // Soft bound: 7 rows per page, cap of 10 → stops after two pages at 14.
+    const { fetchPage } = fakeStore(1000, 7);
+    const r = await collectAllReviews(fetchPage, { maxReviews: 10 });
+
+    expect(r.reviews).toHaveLength(14);
+    expect(r.truncated).toBe(true);
+    // Overshoot is bounded by a single page.
+    expect(r.reviews.length).toBeLessThan(10 + 7);
+  });
+
+  it("does not report truncation when the store ends exactly at the cap", async () => {
+    const { fetchPage } = fakeStore(10, 5);
+    const r = await collectAllReviews(fetchPage, { maxReviews: 10 });
+
+    // The final page carried no cursor, so this is a clean exhaustion even
+    // though the cap was reached on the same iteration.
+    expect(r.reviews).toHaveLength(10);
+    expect(r.truncated).toBe(false);
+  });
+
+  it("stops when the store repeats a cursor instead of advancing", async () => {
+    let calls = 0;
+    const fetchPage = async (): Promise<ReviewPage<number>> => {
+      calls++;
+      return { items: [1], nextCursor: "stuck" };
+    };
+
+    const r = await collectAllReviews(fetchPage);
+
+    expect(r.truncated).toBe(true);
+    // First page yields "stuck"; the second sees it repeat and stops.
+    expect(calls).toBe(2);
+    expect(r.reviews).toEqual([1, 1]);
+  });
+
+  it("terminates when a store returns empty pages with a cursor forever", async () => {
+    // Pathological: never advances the row count, so maxReviews can never trip.
+    // Only the page ceiling stops this.
+    let n = 0;
+    const fetchPage = async (): Promise<ReviewPage<number>> => {
+      n++;
+      return { items: [], nextCursor: `cursor-${n}` };
+    };
+
+    const r = await collectAllReviews(fetchPage);
+
+    expect(r.truncated).toBe(true);
+    expect(r.reviews).toEqual([]);
+    // Bounded, not infinite — the point of the test.
+    expect(r.pagesFetched).toBeLessThanOrEqual(
+      Math.ceil(ANALYTICS_MAX_REVIEWS / ANALYTICS_PAGE_SIZE) + 5,
+    );
+  });
+
+  it("propagates a store error rather than returning a partial total", async () => {
+    // The route's catch handles this. Silently returning page 1 would be the
+    // 500-cap bug all over again, with no flag to show for it.
+    const fetchPage = async (cursor: string | undefined): Promise<ReviewPage<number>> => {
+      if (cursor) throw new Error("connection reset");
+      return { items: [1, 2], nextCursor: "next" };
+    };
+
+    await expect(collectAllReviews(fetchPage)).rejects.toThrow("connection reset");
+  });
+});
+
+describe("collectAllReviews — bounds are sane", () => {
+  it("defaults to a cap far above the old 500 limit", () => {
+    expect(ANALYTICS_MAX_REVIEWS).toBeGreaterThan(500);
+    expect(ANALYTICS_PAGE_SIZE).toBeGreaterThan(500);
+  });
+
+  it("reaches the default cap in a reasonable number of round trips", () => {
+    expect(ANALYTICS_MAX_REVIEWS / ANALYTICS_PAGE_SIZE).toBeLessThanOrEqual(20);
+  });
+});

--- a/packages/dashboard/lib/analytics-collect.ts
+++ b/packages/dashboard/lib/analytics-collect.ts
@@ -1,0 +1,115 @@
+/**
+ * Paginated collection for the analytics surface (#333).
+ *
+ * `/api/analytics` used to fetch a single 500-row page and discard
+ * `nextCursor`, then present the reduction of that page as a total. Because
+ * the stores return newest-first, the rows that got dropped were the *oldest*
+ * ones in the selected range — so the trend charts lost their history while
+ * still being labelled with the full range, and widening the date filter
+ * changed nothing.
+ *
+ * This module walks the cursor to exhaustion instead, and reports honestly
+ * when it had to stop early.
+ *
+ * The page fetcher is injected rather than imported so this is unit-testable
+ * without standing up next-auth, the store, or a Next.js request — there is no
+ * API-route test harness in this repo, and adding one to test a loop would be
+ * the wrong trade.
+ */
+
+/** One page as returned by `IDashboardReviewStore.listReviews`. */
+export interface ReviewPage<T> {
+  items: T[];
+  nextCursor: string | null;
+}
+
+/** Fetch one page. `cursor` is `undefined` for the first call. */
+export type FetchReviewPage<T> = (cursor: string | undefined) => Promise<ReviewPage<T>>;
+
+export interface CollectResult<T> {
+  reviews: T[];
+  /**
+   * True when collection stopped before the store ran out of rows — the
+   * aggregate below it is a partial view and must not be shown as a total.
+   */
+  truncated: boolean;
+  pagesFetched: number;
+}
+
+/**
+ * Rows per page. Larger than the old cap so typical installations finish in
+ * one or two round trips, small enough that a single page stays a reasonable
+ * query for both Postgres (offset pagination) and DynamoDB (1MB page limit).
+ */
+export const ANALYTICS_PAGE_SIZE = 1000;
+
+/**
+ * Upper bound on rows pulled into memory for one aggregation.
+ *
+ * This is a backstop against an unbounded request, not a product decision:
+ * 20k reviews is far past any current installation, and an instance that
+ * reaches it gets a truncation flag rather than silence. The real fix for
+ * that scale is aggregating in the database (see #333's fix direction) —
+ * which is also what #335 needs, since DynamoDB cannot page this efficiently.
+ */
+export const ANALYTICS_MAX_REVIEWS = 20_000;
+
+/**
+ * Hard ceiling on iterations. `maxReviews / pageSize` already bounds the loop
+ * for a well-behaved store; this catches a store that returns a cursor
+ * alongside an empty page forever, which would otherwise spin without ever
+ * growing `reviews`.
+ */
+const MAX_PAGES = Math.ceil(ANALYTICS_MAX_REVIEWS / ANALYTICS_PAGE_SIZE) + 5;
+
+/**
+ * Follow `nextCursor` until the store is exhausted or a safety bound trips.
+ *
+ * `maxReviews` is a **soft** bound: collection stops once the total reaches it,
+ * but the page that crossed the line is kept whole rather than sliced. Keeping
+ * partial pages would mean silently discarding rows we already paid to fetch,
+ * and the overshoot is bounded by one page.
+ *
+ * Ordering is irrelevant to the caller — aggregation is order-independent, and
+ * exhausting the range is precisely what makes it so. That also means this
+ * incidentally sidesteps #335's DynamoDB sort-order and pre-filter-`Limit`
+ * defects for the analytics path, though not for the paginated review list.
+ */
+export async function collectAllReviews<T>(
+  fetchPage: FetchReviewPage<T>,
+  options: { maxReviews?: number } = {},
+): Promise<CollectResult<T>> {
+  const maxReviews = options.maxReviews ?? ANALYTICS_MAX_REVIEWS;
+
+  const reviews: T[] = [];
+  const seenCursors = new Set<string>();
+  let cursor: string | undefined = undefined;
+  let pagesFetched = 0;
+  let exhausted = false;
+
+  while (pagesFetched < MAX_PAGES) {
+    const page: ReviewPage<T> = await fetchPage(cursor);
+    pagesFetched++;
+    reviews.push(...page.items);
+
+    const next = page.nextCursor;
+    if (!next) {
+      exhausted = true; // store ran out — the only clean exit
+      break;
+    }
+
+    if (reviews.length >= maxReviews) break;
+
+    // A repeated cursor means the store is not advancing. Stopping is right:
+    // we cannot claim completeness, and looping to MAX_PAGES would just burn
+    // queries to reach the same conclusion.
+    if (seenCursors.has(next)) break;
+
+    seenCursors.add(next);
+    cursor = next;
+  }
+
+  // Anything other than running the store dry leaves us with a partial view —
+  // including exiting on the final allowed page while still holding a cursor.
+  return { reviews, truncated: !exhausted, pagesFetched };
+}


### PR DESCRIPTION
Stage 2 of 2 for #333. **Stacked on #339** — base is `fix/analytics-extract-aggregator-stage1`, so review that first and merge it before this.

## The bug

```ts
const result = await store.reviews.listReviews(targetRepos, 500, …);
const reviews = result.items;   // nextCursor discarded
```

One page. `nextCursor` thrown away. Every aggregate then computed from it and returned as a total.

The count ceiling was the visible half. The damaging half is *which* rows survived: both stores return **newest-first**, so the truncation ate the **oldest** rows in the selected range. The trend charts lost their history while still being labelled with the full range, and widening the date filter changed nothing — it always returned the same newest 500. That is the "not true to the timelines" symptom in the report.

## The fix

`collectAllReviews()` walks `nextCursor` to exhaustion. The page fetcher is **injected** rather than imported, so the loop is unit-testable without standing up next-auth, the store, or a Next.js request — there is no API-route test harness in this repo (`find app/api -name '*.test.ts'` is empty), and adding one just to test a loop would be the wrong trade.

### Safety bounds, because an unbounded fetch is its own outage

| Guard | Catches |
|---|---|
| `ANALYTICS_MAX_REVIEWS` (20k) | A range far larger than any real installation |
| `MAX_PAGES` ceiling | A store returning a cursor with **empty** pages forever — `maxReviews` can never trip, so only the page count stops it |
| Repeated-cursor guard | A store that stops advancing |

Each has a test. `maxReviews` is a **soft** bound: the page that crosses it is kept whole rather than sliced, because discarding rows already paid for buys nothing and the overshoot is bounded by one page.

One bug worth naming: my first version set `truncated` from `pagesFetched >= MAX_PAGES`, which mislabels a **clean exhaustion that happens to land on the final allowed page**. Now tracked with an explicit `exhausted` flag — `truncated: !exhausted` — and pinned by the test *"does not report truncation when the store ends exactly at the cap"*.

## Truncation is reported, not hidden

The response carries `truncated`, and the UI renders a banner plus `Reviews (partial)` with a `1234+` value instead of captioning a capped number **"Total Reviews"**.

This is the part that actually matters. **Presenting a partial aggregate as a total was the defect** — raising the limit alone would only move where it lies.

## Tests — 13 added (46 across the stack)

Exhaustion across many pages with cursor-sequence assertions · single page · empty store · full final page with no cursor · 1234 rows past the old cap · cap reached → truncated · whole-page overshoot · **clean exhaustion exactly at the cap → not truncated** · repeated cursor · empty-pages-forever terminates · a store error propagates rather than silently returning a partial total.

## Acceptance criteria (#333)

- [x] Analytics over a >500-review range reports correct totals
- [x] Trend series cover the full selected range, with the oldest dates present
- [x] Widening the date range demonstrably adds older data points
- [x] If any cap remains, the response carries a truncation flag and the UI renders it
- [x] Regression test with >500 seeded reviews across a multi-month span (1234 rows / ~154 days, added in #339)

## Side effect worth knowing

Exhausting the range **incidentally neutralises #335's DynamoDB sort-order and pre-filter-`Limit` defects for the analytics path** — aggregation is order-independent, and fetching everything makes ordering irrelevant. #335 still matters for the paginated review list, which genuinely depends on order.

## Out of scope

#336 (p95 off-by-one) and #337 (date-only `end_date`) are untouched — separate tickets, separate reverts.

## Verification

`pnpm run build` ✅ · `pnpm run typecheck` ✅ · `pnpm run test` ✅ (46 new across the stack; core 834, server 97, lambda 64 all green)

Closes #333.