### PR TITLE
feat(analytics): record per-day counter buckets on finding dispositions (#334, stage 1)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -277,6 +277,7 @@ export type {
   CreateReviewInput,
   UpdateReviewInput,
   FindingDispositionRecord,
+  PeriodCounterBucket,
   InstallationFPInsight,
   CycleTimePercentiles,
   PRLifecycleRecord,
@@ -290,7 +291,7 @@ export type {
 
 export { resolveReviewModelId } from './config/model-resolution.js';
 export type { ModelResolutionInput, ModelSource, ResolvedModel } from './config/model-resolution.js';
-export { DEFAULT_INSTALLATION_SETTINGS, ORG_CUSTOM_AGENT_SOFT_CAP } from './types/db.js';
+export { DEFAULT_INSTALLATION_SETTINGS, ORG_CUSTOM_AGENT_SOFT_CAP, periodDayKey } from './types/db.js';
 export {
   sanitizeOrgCustomAgents,
   agentAppliesToRepo,

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -137,23 +137,29 @@ export interface IFindingDispositionStore {
     attribution?: FindingDispositionAttribution,
   ): Promise<void>;
 
-  /** Increment disputeCount by 1. No-op if no record exists yet (we don't backfill — a dispute without prior surfacing is a write-ordering bug we'd want to see logged separately). */
-  incrementDispute(installationId: string, repoFullName: string, findingMatchKey: string): Promise<void>;
+  /**
+   * Increment disputeCount by 1. No-op if no record exists yet (we don't backfill — a dispute without prior surfacing is a write-ordering bug we'd want to see logged separately).
+   *
+   * #334 — every increment also bumps the matching per-day bucket in
+   * `periodCounts`. `nowIso` names the event day (UTC); implementations
+   * default it to the current time, so existing callers stay correct.
+   */
+  incrementDispute(installationId: string, repoFullName: string, findingMatchKey: string, nowIso?: string): Promise<void>;
 
   /** Increment verifiedCount by 1. */
-  incrementVerified(installationId: string, repoFullName: string, findingMatchKey: string): Promise<void>;
+  incrementVerified(installationId: string, repoFullName: string, findingMatchKey: string, nowIso?: string): Promise<void>;
 
   /** Increment unverifiedCount by 1. */
-  incrementUnverified(installationId: string, repoFullName: string, findingMatchKey: string): Promise<void>;
+  incrementUnverified(installationId: string, repoFullName: string, findingMatchKey: string, nowIso?: string): Promise<void>;
 
   /** FB-B — increment silentDropCount by 1. */
-  incrementSilentDrop(installationId: string, repoFullName: string, findingMatchKey: string): Promise<void>;
+  incrementSilentDrop(installationId: string, repoFullName: string, findingMatchKey: string, nowIso?: string): Promise<void>;
 
   /** FB-C — increment agreementCount by 1. */
-  incrementAgreement(installationId: string, repoFullName: string, findingMatchKey: string): Promise<void>;
+  incrementAgreement(installationId: string, repoFullName: string, findingMatchKey: string, nowIso?: string): Promise<void>;
 
   /** #195 — increment resolveCount by 1 (a `/resolve` command on the bot's inline thread). */
-  incrementResolve(installationId: string, repoFullName: string, findingMatchKey: string): Promise<void>;
+  incrementResolve(installationId: string, repoFullName: string, findingMatchKey: string, nowIso?: string): Promise<void>;
 
   /** FB-D — append a rejectReason entry. Idempotent at the record level; appends always extend. */
   appendRejectReason(

--- a/packages/core/src/types/db.ts
+++ b/packages/core/src/types/db.ts
@@ -588,6 +588,31 @@ export type CreateReviewInput = Omit<ReviewItem, 'completedAt' | 'commentId'>;
  * review pipeline. Counters are monotonic — we never decrement (avoids the
  * need for an event-source table to reconcile reaction removals).
  */
+/**
+ * #334 — one UTC day's slice of the disposition counters. Every field is the
+ * count of that event on that day; a field is simply absent when the day saw
+ * none. Field names mirror the lifetime counters on the record (minus the
+ * `Count` suffix) so the mapping stays greppable.
+ */
+export interface PeriodCounterBucket {
+  surface?: number;
+  dispute?: number;
+  verified?: number;
+  unverified?: number;
+  silentDrop?: number;
+  agreement?: number;
+  resolve?: number;
+}
+
+/**
+ * #334 — the `periodCounts` day key for an ISO timestamp: the UTC calendar
+ * date, `YYYY-MM-DD`. Both storage backends and the rollup use this one
+ * helper so the bucket keys can never drift between writer and reader.
+ */
+export function periodDayKey(iso: string): string {
+  return iso.slice(0, 10);
+}
+
 export interface FindingDispositionRecord {
   installationId: string;
   repoFullName: string;
@@ -619,6 +644,17 @@ export interface FindingDispositionRecord {
    * Defaults to 0 on records written before this counter existed.
    */
   resolveCount: number;
+
+  /**
+   * #334 — sparse per-UTC-day counter buckets, keyed `YYYY-MM-DD`. Written
+   * alongside every lifetime-counter increment; a day key exists only when
+   * that day saw activity. This is what lets the FB-E rollup bound a window
+   * to the activity that actually happened inside it — the lifetime counters
+   * above cannot be retroactively sliced. Absent on records written before
+   * the buckets shipped; rollups treat missing buckets as zero in-window
+   * activity for records whose `firstSeen` predates the window.
+   */
+  periodCounts?: Record<string, PeriodCounterBucket>;
 
   /** Last-seen finding category for this key (the few seen are stable; we keep the most recent). */
   category?: 'security' | 'bug' | 'style' | 'errorHandling' | 'testCoverage' | 'commentAccuracy' | 'custom';

--- a/packages/storage-dynamo/src/finding-disposition-store.test.ts
+++ b/packages/storage-dynamo/src/finding-disposition-store.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { UpdateCommand, ScanCommand } from '@aws-sdk/lib-dynamodb';
+import { DynamoFindingDispositionStore } from './finding-disposition-store.js';
+
+const TABLE = 'test-finding-dispositions';
+
+function makeClient(response: unknown = {}) {
+  return { send: vi.fn().mockResolvedValue(response) } as any;
+}
+
+/** Pull every UpdateCommand the store issued. */
+function updates(client: any): UpdateCommand[] {
+  return client.send.mock.calls
+    .map((c: any[]) => c[0])
+    .filter((cmd: any) => cmd instanceof UpdateCommand);
+}
+
+describe('DynamoFindingDispositionStore #334 period buckets', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('upsertSurface bumps the flattened per-day surface bucket in the same call', async () => {
+    const client = makeClient();
+    const store = new DynamoFindingDispositionStore(client, TABLE);
+    await store.upsertSurface('42', 'octo/repo', 'src/a.ts::T::title', '2026-08-16T14:30:00Z');
+    const cmd = updates(client)[0];
+    expect(cmd.input.Key).toEqual({ pk: '42#octo/repo', sk: 'src/a.ts::T::title' });
+    // Lifetime counter and bucket bump live in ONE expression.
+    expect(cmd.input.UpdateExpression).toContain('surfaceCount = if_not_exists(surfaceCount, :zero) + :one');
+    expect(cmd.input.UpdateExpression).toContain('#pcSurface = if_not_exists(#pcSurface, :zero) + :one');
+    // Day key is the UTC calendar date of nowIso.
+    expect(cmd.input.ExpressionAttributeNames?.['#pcSurface']).toBe('pc#2026-08-16#surface');
+  });
+
+  it('increment* bumps the lifetime counter and its day bucket atomically', async () => {
+    const client = makeClient();
+    const store = new DynamoFindingDispositionStore(client, TABLE);
+    await store.incrementDispute('42', 'octo/repo', 'k', '2026-08-15T23:59:59Z');
+    const cmd = updates(client)[0];
+    expect(cmd.input.UpdateExpression).toBe(
+      'SET #c = if_not_exists(#c, :zero) + :one, #p = if_not_exists(#p, :zero) + :one',
+    );
+    expect(cmd.input.ExpressionAttributeNames).toEqual({
+      '#c': 'disputeCount',
+      '#p': 'pc#2026-08-15#dispute',
+    });
+  });
+
+  it('increment* defaults the bucket day to today when nowIso is omitted (back-compat callers)', async () => {
+    const client = makeClient();
+    const store = new DynamoFindingDispositionStore(client, TABLE);
+    await store.incrementResolve('42', 'octo/repo', 'k');
+    const cmd = updates(client)[0];
+    const attr = cmd.input.ExpressionAttributeNames?.['#p'] as string;
+    expect(attr).toMatch(/^pc#\d{4}-\d{2}-\d{2}#resolve$/);
+  });
+
+  it('every counter maps to its matching bucket key', async () => {
+    const client = makeClient();
+    const store = new DynamoFindingDispositionStore(client, TABLE);
+    const now = '2026-08-16T00:00:00Z';
+    await store.incrementVerified('1', 'o/r', 'k', now);
+    await store.incrementUnverified('1', 'o/r', 'k', now);
+    await store.incrementSilentDrop('1', 'o/r', 'k', now);
+    await store.incrementAgreement('1', 'o/r', 'k', now);
+    const names = updates(client).map((c) => c.input.ExpressionAttributeNames?.['#p']);
+    expect(names).toEqual([
+      'pc#2026-08-16#verified',
+      'pc#2026-08-16#unverified',
+      'pc#2026-08-16#silentDrop',
+      'pc#2026-08-16#agreement',
+    ]);
+  });
+
+  it('listByInstallation folds pc# attributes back into the typed periodCounts map', async () => {
+    const client = makeClient({
+      Items: [{
+        pk: '42#octo/repo',
+        sk: 'k1',
+        firstSeen: '2026-08-01T00:00:00Z',
+        lastSeen: '2026-08-16T00:00:00Z',
+        surfaceCount: 3,
+        'pc#2026-08-01#surface': 1,
+        'pc#2026-08-16#surface': 2,
+        'pc#2026-08-16#dispute': 1,
+      }],
+    });
+    const store = new DynamoFindingDispositionStore(client, TABLE);
+    const { items } = await store.listByInstallation('42');
+    expect(client.send.mock.calls[0][0]).toBeInstanceOf(ScanCommand);
+    expect(items[0].periodCounts).toEqual({
+      '2026-08-01': { surface: 1 },
+      '2026-08-16': { surface: 2, dispute: 1 },
+    });
+  });
+
+  it('leaves periodCounts absent on legacy items and skips malformed pc# attributes', async () => {
+    const client = makeClient({
+      Items: [
+        { pk: '42#octo/repo', sk: 'legacy', firstSeen: 'a', lastSeen: 'b', surfaceCount: 5 },
+        { pk: '42#octo/repo', sk: 'weird', firstSeen: 'a', lastSeen: 'b', surfaceCount: 1, 'pc#nonsense': 'NaN-ish', 'pc#2026-08-16#surface': 1 },
+      ],
+    });
+    const store = new DynamoFindingDispositionStore(client, TABLE);
+    const { items } = await store.listByInstallation('42');
+    expect(items[0].periodCounts).toBeUndefined();
+    expect(items[1].periodCounts).toEqual({ '2026-08-16': { surface: 1 } });
+  });
+});

--- a/packages/storage-dynamo/src/finding-disposition-store.ts
+++ b/packages/storage-dynamo/src/finding-disposition-store.ts
@@ -23,9 +23,28 @@ import type {
   IFindingDispositionStore,
   FindingDispositionAttribution,
   FindingDispositionRecord,
+  PeriodCounterBucket,
 } from '@mergewatch/core';
+import { periodDayKey } from '@mergewatch/core';
 
 export const DEFAULT_FINDING_DISPOSITIONS_TABLE = 'mergewatch-finding-dispositions';
+
+/**
+ * #334 — per-day counter buckets are stored FLATTENED as top-level numeric
+ * attributes named `pc#<YYYY-MM-DD>#<counter>` (e.g. `pc#2026-08-16#dispute`)
+ * rather than a nested `periodCounts` map. Rationale: DynamoDB cannot
+ * atomically create-and-increment a two-level nested map path in one
+ * UpdateExpression (intermediate path segments must already exist), which
+ * would force a read-or-retry dance on the review hot path. A flat attribute
+ * keeps every bucket bump the same single-call
+ * `if_not_exists(#a, :zero) + :one` idiom the lifetime counters use.
+ * `itemToRecord` folds them back into the typed `periodCounts` map on read.
+ */
+const PERIOD_ATTR_PREFIX = 'pc#';
+
+function periodAttr(day: string, counter: keyof PeriodCounterBucket): string {
+  return `${PERIOD_ATTR_PREFIX}${day}#${counter}`;
+}
 
 /** Compose the partition key from installation + repo. */
 function pk(installationId: string, repoFullName: string): string {
@@ -66,6 +85,8 @@ export class DynamoFindingDispositionStore implements IFindingDispositionStore {
       'firstSeen = if_not_exists(firstSeen, :now)',
       'lastSeen = :now',
       'surfaceCount = if_not_exists(surfaceCount, :zero) + :one',
+      // #334 — bump today's flattened surface bucket in the same call.
+      '#pcSurface = if_not_exists(#pcSurface, :zero) + :one',
       // Counter defaults so subsequent increment* calls don't have to
       // bootstrap. DynamoDB rejects ADD on a non-existent attribute when
       // the target type is unset; pre-seeding to 0 sidesteps that.
@@ -80,6 +101,9 @@ export class DynamoFindingDispositionStore implements IFindingDispositionStore {
       ':now': nowIso,
       ':zero': 0,
       ':one': 1,
+    };
+    const exprNames: Record<string, string> = {
+      '#pcSurface': periodAttr(periodDayKey(nowIso), 'surface'),
     };
     if (attribution?.category !== undefined) {
       setExprs.push('category = :category');
@@ -104,6 +128,7 @@ export class DynamoFindingDispositionStore implements IFindingDispositionStore {
         TableName: this.tableName,
         Key: { pk: pk(installationId, repoFullName), sk: findingMatchKey },
         UpdateExpression: 'SET ' + setExprs.join(', '),
+        ExpressionAttributeNames: exprNames,
         ExpressionAttributeValues: exprValues,
       }));
     } catch (err) {
@@ -116,13 +141,18 @@ export class DynamoFindingDispositionStore implements IFindingDispositionStore {
     repoFullName: string,
     findingMatchKey: string,
     attrName: 'disputeCount' | 'verifiedCount' | 'unverifiedCount' | 'silentDropCount' | 'agreementCount' | 'resolveCount',
+    periodKey: keyof PeriodCounterBucket,
+    nowIso?: string,
   ): Promise<void> {
     try {
+      const day = periodDayKey(nowIso ?? new Date().toISOString());
       await this.client.send(new UpdateCommand({
         TableName: this.tableName,
+        // #334 — the lifetime counter and its per-day bucket bump in ONE
+        // expression so they can never drift apart.
+        UpdateExpression: `SET #c = if_not_exists(#c, :zero) + :one, #p = if_not_exists(#p, :zero) + :one`,
         Key: { pk: pk(installationId, repoFullName), sk: findingMatchKey },
-        UpdateExpression: `SET #c = if_not_exists(#c, :zero) + :one`,
-        ExpressionAttributeNames: { '#c': attrName },
+        ExpressionAttributeNames: { '#c': attrName, '#p': periodAttr(day, periodKey) },
         ExpressionAttributeValues: { ':zero': 0, ':one': 1 },
       }));
     } catch (err) {
@@ -130,12 +160,12 @@ export class DynamoFindingDispositionStore implements IFindingDispositionStore {
     }
   }
 
-  incrementDispute(i: string, r: string, k: string)     { return this.incrementCounter(i, r, k, 'disputeCount'); }
-  incrementVerified(i: string, r: string, k: string)    { return this.incrementCounter(i, r, k, 'verifiedCount'); }
-  incrementUnverified(i: string, r: string, k: string)  { return this.incrementCounter(i, r, k, 'unverifiedCount'); }
-  incrementSilentDrop(i: string, r: string, k: string)  { return this.incrementCounter(i, r, k, 'silentDropCount'); }
-  incrementAgreement(i: string, r: string, k: string)   { return this.incrementCounter(i, r, k, 'agreementCount'); }
-  incrementResolve(i: string, r: string, k: string)     { return this.incrementCounter(i, r, k, 'resolveCount'); }
+  incrementDispute(i: string, r: string, k: string, nowIso?: string)     { return this.incrementCounter(i, r, k, 'disputeCount', 'dispute', nowIso); }
+  incrementVerified(i: string, r: string, k: string, nowIso?: string)    { return this.incrementCounter(i, r, k, 'verifiedCount', 'verified', nowIso); }
+  incrementUnverified(i: string, r: string, k: string, nowIso?: string)  { return this.incrementCounter(i, r, k, 'unverifiedCount', 'unverified', nowIso); }
+  incrementSilentDrop(i: string, r: string, k: string, nowIso?: string)  { return this.incrementCounter(i, r, k, 'silentDropCount', 'silentDrop', nowIso); }
+  incrementAgreement(i: string, r: string, k: string, nowIso?: string)   { return this.incrementCounter(i, r, k, 'agreementCount', 'agreement', nowIso); }
+  incrementResolve(i: string, r: string, k: string, nowIso?: string)     { return this.incrementCounter(i, r, k, 'resolveCount', 'resolve', nowIso); }
 
   async appendRejectReason(
     installationId: string,
@@ -210,5 +240,20 @@ function itemToRecord(it: Record<string, unknown>): FindingDispositionRecord {
   if (it.severity) r.severity = it.severity as FindingDispositionRecord['severity'];
   if (Array.isArray(it.sigTokens)) r.sigTokens = it.sigTokens as string[];
   if (Array.isArray(it.rejectReasons)) r.rejectReasons = it.rejectReasons as FindingDispositionRecord['rejectReasons'];
+
+  // #334 — fold the flattened `pc#<day>#<counter>` attributes back into the
+  // typed periodCounts map. Attributes that don't parse cleanly are skipped
+  // (defensive: a malformed name should not poison the whole record).
+  let periodCounts: FindingDispositionRecord['periodCounts'];
+  for (const [attr, value] of Object.entries(it)) {
+    if (!attr.startsWith(PERIOD_ATTR_PREFIX)) continue;
+    const [day, counter] = attr.slice(PERIOD_ATTR_PREFIX.length).split('#');
+    if (!day || !counter) continue;
+    const n = Number(value);
+    if (!Number.isFinite(n)) continue;
+    periodCounts ??= {};
+    (periodCounts[day] ??= {})[counter as keyof PeriodCounterBucket] = n;
+  }
+  if (periodCounts) r.periodCounts = periodCounts;
   return r;
 }

--- a/packages/storage-postgres/drizzle/0015_useful_tony_stark.sql
+++ b/packages/storage-postgres/drizzle/0015_useful_tony_stark.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "finding_dispositions" ADD COLUMN IF NOT EXISTS "period_counts" jsonb;

--- a/packages/storage-postgres/drizzle/meta/0015_snapshot.json
+++ b/packages/storage-postgres/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,1161 @@
+{
+  "id": "bbeb7fe9-2289-4abe-bcc7-6bc30aada776",
+  "prevId": "516160b1-d6a9-45cc-a6d5-e465a1f4aee3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_installation_idx": {
+          "name": "api_keys_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.finding_dispositions": {
+      "name": "finding_dispositions",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finding_match_key": {
+          "name": "finding_match_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_count": {
+          "name": "surface_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dispute_count": {
+          "name": "dispute_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verified_count": {
+          "name": "verified_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unverified_count": {
+          "name": "unverified_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "silent_drop_count": {
+          "name": "silent_drop_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "agreement_count": {
+          "name": "agreement_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resolve_count": {
+          "name": "resolve_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_agent": {
+          "name": "top_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sig_tokens": {
+          "name": "sig_tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reject_reasons": {
+          "name": "reject_reasons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_counts": {
+          "name": "period_counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "finding_dispositions_installation_idx": {
+          "name": "finding_dispositions_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "finding_dispositions_installation_id_repo_full_name_finding_match_key_pk": {
+          "name": "finding_dispositions_installation_id_repo_full_name_finding_match_key_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name",
+            "finding_match_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.helpful_votes": {
+      "name": "helpful_votes",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "up": {
+          "name": "up",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "down": {
+          "name": "down",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_vote_at": {
+          "name": "last_vote_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "helpful_votes_installation_idx": {
+          "name": "helpful_votes_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "helpful_votes_installation_id_repo_full_name_pr_number_pk": {
+          "name": "helpful_votes_installation_id_repo_full_name_pr_number_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name",
+            "pr_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installation_fp_insights": {
+      "name": "installation_fp_insights",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window": {
+          "name": "window",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_end": {
+          "name": "window_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_findings_surfaced": {
+          "name": "total_findings_surfaced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_disputes": {
+          "name": "total_disputes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dispute_rate": {
+          "name": "dispute_rate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_silent_drops": {
+          "name": "total_silent_drops",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_agreements": {
+          "name": "total_agreements",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "per_category": {
+          "name": "per_category",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "per_severity": {
+          "name": "per_severity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "per_repo": {
+          "name": "per_repo",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "top_clusters": {
+          "name": "top_clusters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "cycle_time": {
+          "name": "cycle_time",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "engagement": {
+          "name": "engagement",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "installation_fp_insights_installation_id_window_pk": {
+          "name": "installation_fp_insights_installation_id_window_pk",
+          "columns": [
+            "installation_id",
+            "window"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installation_settings": {
+      "name": "installation_settings",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "severity_threshold": {
+          "name": "severity_threshold",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Low'"
+        },
+        "comment_types": {
+          "name": "comment_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"syntax\":true,\"logic\":true,\"style\":true}'::jsonb"
+        },
+        "max_comments": {
+          "name": "max_comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 25
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"prSummary\":true,\"confidenceScore\":true,\"issuesTable\":true,\"diagram\":true}'::jsonb"
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "comment_header": {
+          "name": "comment_header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "custom_agents": {
+          "name": "custom_agents",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installations": {
+      "name": "installations",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monitored": {
+          "name": "monitored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "installations_installation_id_repo_full_name_pk": {
+          "name": "installations_installation_id_repo_full_name_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_sessions": {
+      "name": "mcp_sessions",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_billed_at": {
+          "name": "first_billed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_billed_cents": {
+          "name": "max_billed_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iteration": {
+          "name": "iteration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nps_responses": {
+      "name": "nps_responses",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_user_id": {
+          "name": "github_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nps_responses_installation_idx": {
+          "name": "nps_responses_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "nps_responses_installation_id_github_user_id_pk": {
+          "name": "nps_responses_installation_id_github_user_id_pk",
+          "columns": [
+            "installation_id",
+            "github_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pr_lifecycle": {
+      "name": "pr_lifecycle",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_created_at": {
+          "name": "pr_created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_review_at": {
+          "name": "first_review_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "reviewed": {
+          "name": "reviewed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "skipped": {
+          "name": "skipped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "total_pushes": {
+          "name": "total_pushes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pushes_after_first_review": {
+          "name": "pushes_after_first_review",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pr_lifecycle_installation_idx": {
+          "name": "pr_lifecycle_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "pr_lifecycle_installation_id_repo_full_name_pr_number_pk": {
+          "name": "pr_lifecycle_installation_id_repo_full_name_pr_number_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name",
+            "pr_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_costs": {
+      "name": "review_costs",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "review_costs_installation_idx": {
+          "name": "review_costs_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "review_costs_installation_id_repo_full_name_pr_number_commit_sha_pk": {
+          "name": "review_costs_installation_id_repo_full_name_pr_number_commit_sha_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name",
+            "pr_number",
+            "commit_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number_commit_sha": {
+          "name": "pr_number_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_title": {
+          "name": "pr_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_author": {
+          "name": "pr_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_author_avatar": {
+          "name": "pr_author_avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_branch": {
+          "name": "head_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_severity": {
+          "name": "top_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_text": {
+          "name": "summary_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagram_text": {
+          "name": "diagram_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_score": {
+          "name": "merge_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_score_reason": {
+          "name": "merge_score_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "findings": {
+          "name": "findings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reactions": {
+          "name": "reactions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_used": {
+          "name": "settings_used",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_cost_usd": {
+          "name": "estimated_cost_usd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inline_resolved_keys": {
+          "name": "inline_resolved_keys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "inline_reactions_snapshot": {
+          "name": "inline_reactions_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "reviews_installation_idx": {
+          "name": "reviews_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_pr_idx": {
+          "name": "reviews_pr_idx",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "reviews_repo_full_name_pr_number_commit_sha_pk": {
+          "name": "reviews_repo_full_name_pr_number_commit_sha_pk",
+          "columns": [
+            "repo_full_name",
+            "pr_number_commit_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/storage-postgres/drizzle/meta/_journal.json
+++ b/packages/storage-postgres/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1782430462808,
       "tag": "0014_abnormal_venom",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1786901819294,
+      "tag": "0015_useful_tony_stark",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/storage-postgres/src/finding-disposition-store.test.ts
+++ b/packages/storage-postgres/src/finding-disposition-store.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PostgresFindingDispositionStore } from './finding-disposition-store';
+import { findingDispositions } from './schema';
+
+/** Drizzle chain mock (mirrors review-cost-store.test). */
+function chain(result: any) {
+  const p: any = {
+    select: vi.fn(() => p),
+    from: vi.fn(() => p),
+    where: vi.fn(() => p),
+    limit: vi.fn(() => Promise.resolve(result)),
+    insert: vi.fn(() => p),
+    values: vi.fn(() => p),
+    onConflictDoUpdate: vi.fn(() => Promise.resolve(result)),
+    update: vi.fn(() => p),
+    set: vi.fn(() => p),
+    then: (resolve: any) => Promise.resolve(result).then(resolve),
+  };
+  return p;
+}
+
+describe('PostgresFindingDispositionStore #334 period buckets', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('upsertSurface seeds periodCounts with today\'s surface bucket on insert', async () => {
+    const db: any = chain(undefined);
+    const store = new PostgresFindingDispositionStore(db);
+    await store.upsertSurface('42', 'octo/repo', 'k', '2026-08-16T14:30:00Z');
+    expect(db.insert).toHaveBeenCalledWith(findingDispositions);
+    expect(db.values).toHaveBeenCalledWith(expect.objectContaining({
+      periodCounts: { '2026-08-16': { surface: 1 } },
+    }));
+    // Conflict path bumps the bucket too (SQL expression — assert presence).
+    const conflictSet = db.onConflictDoUpdate.mock.calls[0][0].set;
+    expect(conflictSet.periodCounts).toBeDefined();
+  });
+
+  it('increment* writes the lifetime column and the periodCounts bucket in one UPDATE', async () => {
+    const db: any = chain(undefined);
+    const store = new PostgresFindingDispositionStore(db);
+    await store.incrementDispute('42', 'octo/repo', 'k', '2026-08-15T23:59:59Z');
+    expect(db.update).toHaveBeenCalledWith(findingDispositions);
+    const setArg = db.set.mock.calls[0][0];
+    expect(setArg.disputeCount).toBeDefined();
+    expect(setArg.periodCounts).toBeDefined();
+    // The bucket-bump SQL targets the UTC day of nowIso and the short
+    // counter key. Drizzle SQL params carry the bound values.
+    const params = collectSqlParams(setArg.periodCounts);
+    expect(params).toContain('2026-08-15');
+    expect(params).toContain('dispute');
+  });
+
+  it('increment* defaults the bucket day to today when nowIso is omitted', async () => {
+    const db: any = chain(undefined);
+    const store = new PostgresFindingDispositionStore(db);
+    await store.incrementResolve('42', 'octo/repo', 'k');
+    const params = collectSqlParams(db.set.mock.calls[0][0].periodCounts);
+    const today = new Date().toISOString().slice(0, 10);
+    expect(params).toContain(today);
+    expect(params).toContain('resolve');
+  });
+
+  it('hydrates periodCounts from period_counts and leaves it absent on legacy rows', async () => {
+    const db: any = chain([
+      row({ periodCounts: { '2026-08-16': { surface: 2, dispute: 1 } } }),
+      row({ periodCounts: null }),
+    ]);
+    const store = new PostgresFindingDispositionStore(db);
+    const { items } = await store.listByInstallation('42');
+    expect(items[0].periodCounts).toEqual({ '2026-08-16': { surface: 2, dispute: 1 } });
+    expect(items[1].periodCounts).toBeUndefined();
+  });
+});
+
+/** Minimal DB row shape for hydration tests. */
+function row(over: Record<string, unknown> = {}) {
+  return {
+    installationId: '42',
+    repoFullName: 'octo/repo',
+    findingMatchKey: 'k',
+    firstSeen: '2026-08-01T00:00:00Z',
+    lastSeen: '2026-08-16T00:00:00Z',
+    surfaceCount: 1,
+    disputeCount: 0,
+    verifiedCount: 0,
+    unverifiedCount: 0,
+    silentDropCount: 0,
+    agreementCount: 0,
+    resolveCount: 0,
+    category: null,
+    topAgent: null,
+    severity: null,
+    sigTokens: null,
+    rejectReasons: null,
+    periodCounts: null,
+    ...over,
+  };
+}
+
+/** Walk a drizzle SQL template and collect its bound string params. */
+function collectSqlParams(sqlObj: any): string[] {
+  const out: string[] = [];
+  const visit = (node: any) => {
+    if (node == null) return;
+    if (typeof node === 'string') { out.push(node); return; }
+    if (Array.isArray(node)) { node.forEach(visit); return; }
+    if (typeof node === 'object') {
+      if ('value' in node) visit(node.value);
+      if ('queryChunks' in node) visit(node.queryChunks);
+    }
+  };
+  visit(sqlObj);
+  return out;
+}

--- a/packages/storage-postgres/src/finding-disposition-store.ts
+++ b/packages/storage-postgres/src/finding-disposition-store.ts
@@ -18,8 +18,27 @@ import type {
   IFindingDispositionStore,
   FindingDispositionAttribution,
   FindingDispositionRecord,
+  PeriodCounterBucket,
 } from '@mergewatch/core';
+import { periodDayKey } from '@mergewatch/core';
 import { findingDispositions } from './schema.js';
+
+/**
+ * #334 — atomic single-statement bump of `period_counts[day][counter]`.
+ * The outer jsonb_set (create_missing = true) materialises the day object,
+ * the `||` merge overwrites just the one counter inside it — no
+ * read-modify-write loop, so concurrent writers can't lose increments.
+ */
+function bumpPeriodCountSql(day: string, counter: keyof PeriodCounterBucket) {
+  const col = findingDispositions.periodCounts;
+  return sql`jsonb_set(
+    COALESCE(${col}, '{}'::jsonb),
+    ARRAY[${day}]::text[],
+    COALESCE(${col} -> ${day}, '{}'::jsonb)
+      || jsonb_build_object(${counter}::text, COALESCE((${col} -> ${day} ->> ${counter})::int, 0) + 1),
+    true
+  )`;
+}
 
 export class PostgresFindingDispositionStore implements IFindingDispositionStore {
   constructor(private db: PostgresJsDatabase) {}
@@ -41,6 +60,7 @@ export class PostgresFindingDispositionStore implements IFindingDispositionStore
           firstSeen: nowIso,
           lastSeen: nowIso,
           surfaceCount: 1,
+          periodCounts: { [periodDayKey(nowIso)]: { surface: 1 } },
           category: attribution?.category ?? null,
           topAgent: attribution?.topAgent ?? null,
           severity: attribution?.severity ?? null,
@@ -57,6 +77,7 @@ export class PostgresFindingDispositionStore implements IFindingDispositionStore
           set: {
             lastSeen: nowIso,
             surfaceCount: sql`${findingDispositions.surfaceCount} + 1`,
+            periodCounts: bumpPeriodCountSql(periodDayKey(nowIso), 'surface'),
             // COALESCE keeps the prior value when this caller doesn't carry
             // attribution data (e.g. a 👎 reaction handler) — otherwise the
             // last writer would clear category/topAgent/sigTokens to null.
@@ -85,20 +106,27 @@ export class PostgresFindingDispositionStore implements IFindingDispositionStore
     repoFullName: string,
     findingMatchKey: string,
     column: 'disputeCount' | 'verifiedCount' | 'unverifiedCount' | 'silentDropCount' | 'agreementCount' | 'resolveCount',
+    nowIso?: string,
   ): Promise<void> {
     try {
+      // Lifetime column + its #334 per-day bucket key, kept in one map so a
+      // counter can never bump one without the other.
       const colMap = {
-        disputeCount:    findingDispositions.disputeCount,
-        verifiedCount:   findingDispositions.verifiedCount,
-        unverifiedCount: findingDispositions.unverifiedCount,
-        silentDropCount: findingDispositions.silentDropCount,
-        agreementCount:  findingDispositions.agreementCount,
-        resolveCount:    findingDispositions.resolveCount,
+        disputeCount:    { col: findingDispositions.disputeCount,    period: 'dispute' },
+        verifiedCount:   { col: findingDispositions.verifiedCount,   period: 'verified' },
+        unverifiedCount: { col: findingDispositions.unverifiedCount, period: 'unverified' },
+        silentDropCount: { col: findingDispositions.silentDropCount, period: 'silentDrop' },
+        agreementCount:  { col: findingDispositions.agreementCount,  period: 'agreement' },
+        resolveCount:    { col: findingDispositions.resolveCount,    period: 'resolve' },
       } as const;
-      const dbCol = colMap[column];
+      const { col: dbCol, period } = colMap[column];
+      const day = periodDayKey(nowIso ?? new Date().toISOString());
       await this.db
         .update(findingDispositions)
-        .set({ [column]: sql`${dbCol} + 1` } as Record<string, unknown>)
+        .set({
+          [column]: sql`${dbCol} + 1`,
+          periodCounts: bumpPeriodCountSql(day, period),
+        } as Record<string, unknown>)
         .where(and(
           eq(findingDispositions.installationId, installationId),
           eq(findingDispositions.repoFullName, repoFullName),
@@ -109,12 +137,12 @@ export class PostgresFindingDispositionStore implements IFindingDispositionStore
     }
   }
 
-  incrementDispute(i: string, r: string, k: string)     { return this.incrementCounter(i, r, k, 'disputeCount'); }
-  incrementVerified(i: string, r: string, k: string)    { return this.incrementCounter(i, r, k, 'verifiedCount'); }
-  incrementUnverified(i: string, r: string, k: string)  { return this.incrementCounter(i, r, k, 'unverifiedCount'); }
-  incrementSilentDrop(i: string, r: string, k: string)  { return this.incrementCounter(i, r, k, 'silentDropCount'); }
-  incrementAgreement(i: string, r: string, k: string)   { return this.incrementCounter(i, r, k, 'agreementCount'); }
-  incrementResolve(i: string, r: string, k: string)     { return this.incrementCounter(i, r, k, 'resolveCount'); }
+  incrementDispute(i: string, r: string, k: string, nowIso?: string)     { return this.incrementCounter(i, r, k, 'disputeCount', nowIso); }
+  incrementVerified(i: string, r: string, k: string, nowIso?: string)    { return this.incrementCounter(i, r, k, 'verifiedCount', nowIso); }
+  incrementUnverified(i: string, r: string, k: string, nowIso?: string)  { return this.incrementCounter(i, r, k, 'unverifiedCount', nowIso); }
+  incrementSilentDrop(i: string, r: string, k: string, nowIso?: string)  { return this.incrementCounter(i, r, k, 'silentDropCount', nowIso); }
+  incrementAgreement(i: string, r: string, k: string, nowIso?: string)   { return this.incrementCounter(i, r, k, 'agreementCount', nowIso); }
+  incrementResolve(i: string, r: string, k: string, nowIso?: string)     { return this.incrementCounter(i, r, k, 'resolveCount', nowIso); }
 
   async appendRejectReason(
     installationId: string,
@@ -171,6 +199,9 @@ export class PostgresFindingDispositionStore implements IFindingDispositionStore
       ...(r.severity ? { severity: r.severity as FindingDispositionRecord['severity'] } : {}),
       ...(Array.isArray(r.sigTokens) ? { sigTokens: r.sigTokens as string[] } : {}),
       ...(Array.isArray(r.rejectReasons) ? { rejectReasons: r.rejectReasons as FindingDispositionRecord['rejectReasons'] } : {}),
+      ...(r.periodCounts && typeof r.periodCounts === 'object' && !Array.isArray(r.periodCounts)
+        ? { periodCounts: r.periodCounts as FindingDispositionRecord['periodCounts'] }
+        : {}),
     }));
     // Single-page for now — FB-E rollup can extend to cursor paging if any
     // installation exceeds the 1000-row cap.

--- a/packages/storage-postgres/src/schema.ts
+++ b/packages/storage-postgres/src/schema.ts
@@ -153,6 +153,10 @@ export const findingDispositions = pgTable('finding_dispositions', {
   severity: text('severity'),
   sigTokens: jsonb('sig_tokens'),
   rejectReasons: jsonb('reject_reasons'),
+  // #334 — sparse per-UTC-day counter buckets ({ 'YYYY-MM-DD': { surface: n,
+  // dispute: n, … } }). Nullable so pre-#334 rows need no backfill; the
+  // rollup treats a missing map as zero in-window activity.
+  periodCounts: jsonb('period_counts'),
 }, (t) => ({
   pk: primaryKey({ columns: [t.installationId, t.repoFullName, t.findingMatchKey] }),
   installationIdx: index('finding_dispositions_installation_idx').on(t.installationId),


### PR DESCRIPTION
Part of #334 — stage 1 of 2 (write path).

## What

The 7d/30d/90d insight rollups sum lifetime counters, so windowed numbers converge toward all-time totals (#334). Windowed counts require per-period data — a lifetime counter cannot be retroactively sliced. This PR adds sparse **per-UTC-day counter buckets** (`periodCounts`, keyed `YYYY-MM-DD`) to `FindingDispositionRecord`, written atomically alongside every lifetime-counter increment. The read path (`rollup.ts`) is deliberately untouched: buckets start accumulating the moment this deploys, and stage 2 makes the rollup consume them.

## How

- **Core**: `PeriodCounterBucket` + `periodCounts` on the record type; `periodDayKey()` shared helper so writer and reader can never disagree on the key format; optional `nowIso` on the `increment*` interface methods (stores default to now — existing callers unchanged).
- **Postgres**: `period_counts` jsonb column (idempotent `ADD COLUMN IF NOT EXISTS` migration, `migrations:check` green). Bucket bumps are a single-statement `jsonb_set` merge — no read-modify-write, concurrent writers can't lose increments.
- **DynamoDB**: buckets stored as flattened `pc#<day>#<counter>` numeric attributes because Dynamo cannot atomically create-and-increment a two-level nested map path in one UpdateExpression; a nested map would force a read-or-retry dance on the review hot path. `itemToRecord` folds them back into the typed map on read. Lifetime counter + bucket bump share one UpdateExpression so they can never drift.

## Tests

10 new unit tests across both stores (command/SQL construction + read-back folding + legacy rows without buckets), matching the neighboring store-test style. Full workspace build / typecheck / test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)