### PR TITLE
fix(insights): bound the 7d/30d/90d rollup windows to in-window activity (#334, stage 2)

### DIFF
--- a/docs/pending/windowed-insight-rollups.md
+++ b/docs/pending/windowed-insight-rollups.md
@@ -1,0 +1,55 @@
+# Time-bounded insight rollup windows
+
+**Status:** 🚧 In review
+**Issue:** [#334](https://github.com/mergewatch/mergewatch.ai/issues/334)
+
+Make the 7d / 30d / 90d insight rollups mean what they say. The rollup previously selected records by window (`lastSeen` inside it) but summed **lifetime** counters, so one still-active long-lived finding injected its entire history into every window — all three windows converged toward all-time totals, and `disputeRate`, `perCategory`, `perSeverity`, `perRepo`, and the `topClusters` leverage ranking all inherited the distortion.
+
+## Architecture
+
+```
+capture (per event)                       aggregation (nightly)
+─────────────────────                     ─────────────────────
+counter increment  ─► lifetime counter    buildInsightFromDispositions()
+                       + periodCounts       per-record windowed contribution:
+                       day bucket             firstSeen in window → lifetime counters (exact)
+                       (YYYY-MM-DD, UTC)      older → Σ day buckets overlapping the window
+```
+
+Windowed counts require per-period data — a lifetime counter cannot be retroactively sliced. Every counter increment now also bumps a sparse per-UTC-day bucket (`periodCounts`) on the `FindingDispositionRecord`, written atomically with the lifetime counter on both backends:
+
+- **Postgres** — `period_counts` jsonb column; single-statement `jsonb_set` merge (no read-modify-write, concurrent writers can't lose increments). Migration `0015` is `ADD COLUMN IF NOT EXISTS`.
+- **DynamoDB** — flattened `pc#<day>#<counter>` numeric attributes (Dynamo can't atomically create-and-increment a two-level nested map path in one UpdateExpression); folded back into the typed `periodCounts` map on read. No table or infra change.
+
+## Window semantics after the change
+
+A record's contribution to a window is:
+
+- **`firstSeen` inside the window** — its lifetime counters, verbatim. Every event in its lifetime is in-window by definition, so this is exact — and complete even for activity that predates the buckets shipping. Recent findings never wait for buckets to accumulate.
+- **`firstSeen` before the window** — the sum of its day buckets overlapping the window. Buckets are whole UTC days; the bucket on the window's start day is included wholesale (bounded overcount of < 1 day of activity).
+- Inclusion follows **activity**, not `lastSeen` — a dispute or reaction landing after a finding's last surfacing now counts in the window it happened in.
+
+This guarantees **7d ≤ 30d ≤ 90d** on any dataset.
+
+## Migration / backfill plan
+
+There is no backfill: per-period data was never recorded, so it cannot be reconstructed. Consequences, in the honest direction (undercount, never overcount):
+
+- Buckets accumulate from the moment stage 1 deploys.
+- Pre-existing **long-lived** records (first seen before the window) contribute only their post-deploy bucketed activity — they ramp up and are fully accurate within one window-length of deploy (7d windows heal within a week, 90d within a quarter).
+- Records **born after** deploy (and any record first seen inside the window) are exact immediately.
+- Rollup rows written before the change keep their old lifetime-summed semantics until the next nightly run overwrites them (`upsert` per `(installationId, window)`).
+
+## What changed
+
+- `packages/core/src/types/db.ts` — `PeriodCounterBucket`, `periodCounts` on `FindingDispositionRecord`, shared `periodDayKey()` helper.
+- `packages/core/src/storage/types.ts` — optional `nowIso` on the `IFindingDispositionStore.increment*` methods (stores default to now; existing callers unchanged).
+- `packages/storage-postgres` / `packages/storage-dynamo` disposition stores — atomic bucket writes + read-back mapping.
+- `packages/core/src/insights/rollup.ts` — per-record windowed contribution substituted before totals / buckets / clusters, so every derived number is window-bounded.
+
+## Edge cases
+
+- **Legacy record, no buckets, `firstSeen` predates window** — contributes nothing (ramp-up above), rather than injecting lifetime history.
+- **Record first seen after `windowEnd`** (rollup anchored in the past) — contributes nothing.
+- **Dispute with zero in-window surfacings** — counted in `totalDisputes`; `disputeRate` keeps its divide-by-zero guard (rate 0).
+- **Unbounded bucket growth** — buckets are sparse (a key exists only for days with activity), so growth is bounded by a record's active days. Pruning buckets older than 90 days is a possible follow-up if record sizes ever warrant it.

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -210,6 +210,7 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-81](#e2e-81-codebase-awareness--file-request-budget) | `codebaseAwareness` fetches out-of-diff files; `maxFileRequestRounds` / `maxContextKB` enforced; hitting the budget degrades gracefully | 3m | 60s | core |
 | [E2E-82](#e2e-82-oss-program--sponsored-review-on-a-granted-public-repo) | OSS grant sponsors a named public repo; unnamed/private/expired all fall back correctly; rename keeps the grant | 5m | 60s | #263, #265 |
 | [E2E-83](#e2e-83-oss-program--operator-grant-lifecycle) | `grant-oss.ts` grant/add/remove/revoke/inspect; `--stage` guard; private repo rejected | 5m | n/a | #266 |
+| [E2E-84](#e2e-84-334--time-bounded-insight-rollup-windows) | Counter increments write per-UTC-day `periodCounts` buckets alongside lifetime counters; rollup windows sum only in-window activity (7d ≤ 30d ≤ 90d guaranteed); pre-#334 long-lived records ramp up instead of injecting lifetime history; both backends (#334) | 3m | 90s | #334 |
 
 ---
 
@@ -2974,6 +2975,29 @@ Tracked deliberately so they are decisions rather than oversights. Each is a can
      1. "autoReview: false posts a user-actionable check run" — the code goes fully silent (review-agent.ts:396, skip-logic.ts:151). E2E-04 is correct; the published docs are wrong.
      2. "Repository is paused in the dashboard" as a skip reason — there is no pause feature; the only "paused" in the codebase is billing-driven (block-notify.ts). E2E-73 covers the real behavior.
      Both are documentation defects, tracked outside this runbook. -->
+
+---
+
+### E2E-84: #334 — Time-bounded insight rollup windows
+
+**Status:** 🚧 In review (#334) — fixture not yet run.
+
+**Behavior:** every disposition-counter increment (surface, dispute, verified, unverified, silentDrop, agreement, resolve) also bumps a sparse per-UTC-day bucket (`periodCounts`, keyed `YYYY-MM-DD`) on the `FindingDispositionRecord`, atomically with the lifetime counter, on both backends. The nightly rollup then derives every windowed number from in-window activity: a record first seen inside the window contributes its lifetime counters (exact by definition); an older record contributes only the day buckets overlapping the window. `7d ≤ 30d ≤ 90d` holds by construction. Records written before #334 shipped have no buckets and contribute nothing to windows that predate their `firstSeen` — they ramp up within one window-length of deploy instead of injecting lifetime history.
+
+**How to run.**
+Branch: `fixture/84-windowed-rollups`. Pre-seed an installation with:
+1. A "long-lived" record: `firstSeen` ~180 days back, `surfaceCount: 200`, `disputeCount: 30`, plus a `periodCounts` bucket for yesterday (`{ surface: 1 }`).
+2. A "recent" record: `firstSeen` 2 days back, `surfaceCount: 3`, `disputeCount: 1`, no buckets needed.
+3. A "legacy" record: `firstSeen` ~180 days back, large lifetime counters, **no** `periodCounts`.
+Trigger the rollup manually (same paths as E2E-41), then read the three insight rows back.
+
+**Expected outcomes.**
+- [ ] 7d `totalFindingsSurfaced` = 4 (yesterday's bucket + the recent record) — NOT 200+
+- [ ] 7d `totalDisputes` = 1 — the long-lived record's 30 lifetime disputes do not appear
+- [ ] The legacy record contributes 0 to every window (honest ramp-up)
+- [ ] `7d ≤ 30d ≤ 90d` for `totalFindingsSurfaced` and `totalDisputes`
+- [ ] `perCategory` / `perSeverity` / `perRepo` / `topClusters` reflect windowed counts (spot-check the long-lived record's category bucket shows 1, not 200)
+- [ ] New reviews after deploy write `periodCounts` buckets on both backends (inspect a row: Postgres `period_counts` jsonb / Dynamo `pc#<day>#<counter>` attributes)
 
 ---
 

--- a/packages/core/src/insights/rollup.test.ts
+++ b/packages/core/src/insights/rollup.test.ts
@@ -35,11 +35,13 @@ function record(over: Partial<FindingDispositionRecord> = {}): FindingDispositio
 // ─── Window filtering ───────────────────────────────────────────────────────
 
 describe('buildInsightFromDispositions — window filtering', () => {
-  it('includes only records whose lastSeen falls inside the window', () => {
+  it('includes only activity that happened inside the window (#334)', () => {
+    // Each record's whole lifetime sits at a distinct age, so its lifetime
+    // counters equal its in-window activity for windows that contain it.
     const records = [
-      record({ lastSeen: isoOffset(1), surfaceCount: 5 }),
-      record({ lastSeen: isoOffset(10), surfaceCount: 3 }),
-      record({ lastSeen: isoOffset(45), surfaceCount: 7 }),
+      record({ firstSeen: isoOffset(1),  lastSeen: isoOffset(1),  surfaceCount: 5 }),
+      record({ firstSeen: isoOffset(10), lastSeen: isoOffset(10), surfaceCount: 3 }),
+      record({ firstSeen: isoOffset(45), lastSeen: isoOffset(45), surfaceCount: 7 }),
     ];
     const r7  = buildInsightFromDispositions('42', '7d',  WINDOW_END, records);
     const r30 = buildInsightFromDispositions('42', '30d', WINDOW_END, records);
@@ -62,6 +64,121 @@ describe('buildInsightFromDispositions — window filtering', () => {
     expect(r.topClusters).toEqual([]);
     expect(r.perCategory).toEqual({});
     expect(r.perRepo).toEqual({});
+  });
+});
+
+// ─── #334 — time-bounded windows ────────────────────────────────────────────
+
+/** The `periodCounts` day key `daysBack` days before the window end. */
+function dayOffset(daysBack: number): string {
+  return isoOffset(daysBack).slice(0, 10);
+}
+
+describe('buildInsightFromDispositions — #334 windowed counters', () => {
+  it('a record whose activity predates the window does not contribute pre-window counts', () => {
+    const records = [
+      // Long-lived: first seen ~6 months ago, surfaced 200× / disputed 30×
+      // over its lifetime, surfaced exactly once yesterday.
+      record({
+        firstSeen: isoOffset(180),
+        lastSeen: isoOffset(1),
+        surfaceCount: 200,
+        disputeCount: 30,
+        periodCounts: { [dayOffset(1)]: { surface: 1 } },
+      }),
+      // Recent: born 2 days ago, everything in-window.
+      record({ firstSeen: isoOffset(2), lastSeen: isoOffset(1), surfaceCount: 3, disputeCount: 1 }),
+    ];
+    const r7 = buildInsightFromDispositions('42', '7d', WINDOW_END, records);
+    // The long-lived record contributes ONLY yesterday's surfacing.
+    expect(r7.totalFindingsSurfaced).toBe(1 + 3);
+    expect(r7.totalDisputes).toBe(0 + 1);
+    expect(r7.disputeRate).toBeCloseTo(1 / 4);
+  });
+
+  it('7d ≤ 30d ≤ 90d holds for a dataset that previously violated it', () => {
+    const records = [
+      record({
+        firstSeen: isoOffset(180),
+        lastSeen: isoOffset(1),
+        surfaceCount: 200,
+        disputeCount: 30,
+        periodCounts: {
+          [dayOffset(60)]: { surface: 4, dispute: 2 },
+          [dayOffset(20)]: { surface: 2, dispute: 1 },
+          [dayOffset(1)]:  { surface: 1 },
+        },
+      }),
+      record({ firstSeen: isoOffset(15), lastSeen: isoOffset(15), surfaceCount: 5, disputeCount: 2 }),
+    ];
+    const windows = (['7d', '30d', '90d'] as const).map(
+      (w) => buildInsightFromDispositions('42', w, WINDOW_END, records),
+    );
+    const [r7, r30, r90] = windows;
+    expect(r7.totalFindingsSurfaced).toBe(1);              // yesterday's bucket only
+    expect(r30.totalFindingsSurfaced).toBe(1 + 2 + 5);     // + 20d bucket + 15d-old record
+    expect(r90.totalFindingsSurfaced).toBe(1 + 2 + 4 + 5); // + 60d bucket
+    expect(r7.totalFindingsSurfaced).toBeLessThanOrEqual(r30.totalFindingsSurfaced);
+    expect(r30.totalFindingsSurfaced).toBeLessThanOrEqual(r90.totalFindingsSurfaced);
+    expect(r7.totalDisputes).toBeLessThanOrEqual(r30.totalDisputes);
+    expect(r30.totalDisputes).toBeLessThanOrEqual(r90.totalDisputes);
+  });
+
+  it('per-category / per-severity / per-repo / clusters all derive from windowed counts', () => {
+    const records = [
+      record({
+        firstSeen: isoOffset(180),
+        lastSeen: isoOffset(1),
+        surfaceCount: 100,
+        disputeCount: 50,
+        category: 'security',
+        severity: 'critical',
+        repoFullName: 'org/api',
+        sigTokens: ['token'],
+        periodCounts: { [dayOffset(2)]: { surface: 2, dispute: 1 } },
+      }),
+    ];
+    const r = buildInsightFromDispositions('42', '7d', WINDOW_END, records);
+    expect(r.perCategory.security).toEqual({ surfaced: 2, disputed: 1, rate: 0.5 });
+    expect(r.perSeverity!.critical).toEqual({ surfaced: 2, disputed: 1, rate: 0.5 });
+    expect(r.perRepo['org/api']).toEqual({ surfaced: 2, disputed: 1, rate: 0.5 });
+    expect(r.topClusters[0].surfaceCount).toBe(2);
+    expect(r.topClusters[0].disputeCount).toBe(1);
+  });
+
+  it('legacy long-lived record (no periodCounts) contributes nothing — honest ramp-up, not lifetime injection', () => {
+    const records = [
+      record({ firstSeen: isoOffset(180), lastSeen: isoOffset(1), surfaceCount: 200, disputeCount: 30, periodCounts: undefined }),
+    ];
+    const r = buildInsightFromDispositions('42', '7d', WINDOW_END, records);
+    expect(r.totalFindingsSurfaced).toBe(0);
+    expect(r.totalDisputes).toBe(0);
+    expect(r.perCategory).toEqual({});
+    expect(r.topClusters).toEqual([]);
+  });
+
+  it('counts a dispute that lands after the finding\'s last surfacing (inclusion follows activity, not lastSeen)', () => {
+    const records = [
+      record({
+        firstSeen: isoOffset(60),
+        lastSeen: isoOffset(20), // last SURFACED 20 days ago…
+        surfaceCount: 10,
+        disputeCount: 3,
+        periodCounts: { [dayOffset(1)]: { dispute: 1 } }, // …but disputed yesterday
+      }),
+    ];
+    const r = buildInsightFromDispositions('42', '7d', WINDOW_END, records);
+    expect(r.totalDisputes).toBe(1);
+    expect(r.totalFindingsSurfaced).toBe(0);
+    expect(r.disputeRate).toBe(0); // divide-by-zero guard unchanged
+  });
+
+  it('ignores a record first seen after the window end', () => {
+    const records = [
+      record({ firstSeen: isoOffset(-2), lastSeen: isoOffset(-2), surfaceCount: 9 }),
+    ];
+    const r = buildInsightFromDispositions('42', '7d', WINDOW_END, records);
+    expect(r.totalFindingsSurfaced).toBe(0);
   });
 });
 

--- a/packages/core/src/insights/rollup.ts
+++ b/packages/core/src/insights/rollup.ts
@@ -9,6 +9,7 @@
  */
 
 import type { FindingDispositionRecord, InstallationFPInsight } from '../types/db.js';
+import { periodDayKey } from '../types/db.js';
 
 /** Rolling window definitions: ISO 8601 duration → milliseconds. */
 export const WINDOW_LENGTH_MS: Record<InstallationFPInsight['window'], number> = {
@@ -24,7 +25,8 @@ const TOP_CLUSTERS_LIMIT = 10;
 /**
  * Compute one rolling-window insight from a set of disposition records.
  *
- *   1. Filter records to those whose `lastSeen` falls inside the window.
+ *   1. Compute each record's IN-WINDOW contribution (#334) and keep only
+ *      records with any in-window activity.
  *   2. Sum the global counters.
  *   3. Bucket by `category` and by `repoFullName`.
  *   4. Cluster by shared significant tokens (union-find on sigToken
@@ -32,6 +34,13 @@ const TOP_CLUSTERS_LIMIT = 10;
  *
  * Defensive defaults — rates are 0 when surfaceCount is 0; missing
  * sigTokens skip the cluster step but still feed the totals.
+ *
+ * #334 — the window bounds not just WHICH records count but HOW MUCH of
+ * each record counts. The previous version filtered by `lastSeen` and then
+ * summed lifetime counters, so one still-active long-lived finding injected
+ * its entire history into every window and all three windows converged
+ * toward all-time totals. Per-record windowing now guarantees
+ * 7d ≤ 30d ≤ 90d on any dataset.
  */
 export function buildInsightFromDispositions(
   installationId: string,
@@ -43,14 +52,26 @@ export function buildInsightFromDispositions(
   const windowStartMs = windowEndMs - WINDOW_LENGTH_MS[window];
   const windowStartIso = new Date(windowStartMs).toISOString();
 
-  // Filter to "active in window" — lastSeen inside [windowStart, windowEnd].
-  // We deliberately use lastSeen (most-recent surfacing) rather than
-  // firstSeen so a long-running finding contributes to its currently-
-  // active window rather than its first-discovered one.
-  const inWindow = records.filter((r) => {
-    const t = new Date(r.lastSeen).getTime();
-    return t >= windowStartMs && t <= windowEndMs;
-  });
+  // #334 — windowed view: substitute each record's counters with its
+  // in-window contribution and keep only records that actually had activity
+  // inside the window. Downstream (totals, per-* buckets, clusters) reads
+  // the substituted counters, so every derived number is window-bounded.
+  // Inclusion follows activity rather than `lastSeen`, which also captures
+  // a dispute/agreement landing after the finding's last surfacing.
+  const inWindow: FindingDispositionRecord[] = [];
+  for (const r of records) {
+    const w = windowedCounts(r, windowStartMs, windowEndMs);
+    if (w.surfaced + w.disputes + w.silentDrops + w.agreements === 0) continue;
+    // Only the four counters the insight derives from are substituted; the
+    // remaining lifetime fields ride along unread.
+    inWindow.push({
+      ...r,
+      surfaceCount: w.surfaced,
+      disputeCount: w.disputes,
+      silentDropCount: w.silentDrops,
+      agreementCount: w.agreements,
+    });
+  }
 
   // Global counters.
   let totalFindingsSurfaced = 0;
@@ -119,6 +140,64 @@ export function buildInsightFromDispositions(
     perRepo,
     topClusters,
   };
+}
+
+// ─── Internal: #334 per-record windowing ────────────────────────────────────
+
+/** One record's contribution to a window — the four counters the insight derives from. */
+interface WindowedCounts {
+  surfaced: number;
+  disputes: number;
+  silentDrops: number;
+  agreements: number;
+}
+
+/**
+ * How much of `r`'s activity falls inside [windowStart, windowEnd].
+ *
+ * Two regimes:
+ *   • `firstSeen` inside the window — the record's whole lifetime is
+ *     in-window, so the lifetime counters are exact. This also keeps recent
+ *     findings fully counted even when they predate the period buckets
+ *     shipping (#334 stage 1).
+ *   • `firstSeen` before the window — only the per-day buckets overlapping
+ *     the window count. Records written before buckets existed contribute
+ *     nothing here (an honest undercount that self-heals within one
+ *     window-length of stage 1 deploying — see the #334 backfill plan).
+ *
+ * Buckets are whole UTC days; a bucket on the window's start day is included
+ * wholesale (bounded overcount of < 1 day of activity, in exchange for never
+ * splitting a day the data can't split). Day keys are `YYYY-MM-DD`, so plain
+ * string comparison is chronological.
+ */
+function windowedCounts(
+  r: FindingDispositionRecord,
+  windowStartMs: number,
+  windowEndMs: number,
+): WindowedCounts {
+  const counts: WindowedCounts = { surfaced: 0, disputes: 0, silentDrops: 0, agreements: 0 };
+  const firstSeenMs = new Date(r.firstSeen).getTime();
+  if (firstSeenMs > windowEndMs) return counts;
+
+  if (firstSeenMs >= windowStartMs) {
+    counts.surfaced    = r.surfaceCount;
+    counts.disputes    = r.disputeCount;
+    counts.silentDrops = r.silentDropCount;
+    counts.agreements  = r.agreementCount;
+    return counts;
+  }
+
+  if (!r.periodCounts) return counts;
+  const startDay = periodDayKey(new Date(windowStartMs).toISOString());
+  const endDay   = periodDayKey(new Date(windowEndMs).toISOString());
+  for (const [day, bucket] of Object.entries(r.periodCounts)) {
+    if (day < startDay || day > endDay) continue;
+    counts.surfaced    += bucket.surface    ?? 0;
+    counts.disputes    += bucket.dispute    ?? 0;
+    counts.silentDrops += bucket.silentDrop ?? 0;
+    counts.agreements  += bucket.agreement  ?? 0;
+  }
+  return counts;
 }
 
 // ─── Internal: clustering ────────────────────────────────────────────────────


### PR DESCRIPTION
Stage 2 of 2 — follows #341 (write path, merged). Supersedes #342, which GitHub auto-closed when #341's branch was deleted (a closed PR can be neither retargeted nor reopened once its base branch is gone). Branch rebased onto `main`; content identical, MergeWatch reviewed it 🟢 5/5 on #342. Closes #334.

## What

`buildInsightFromDispositions` filtered records by `lastSeen` and then summed **lifetime** counters, so a long-lived finding surfaced once yesterday injected its entire history (e.g. 200 surfaces / 30 disputes) into the 7-day total, and all three windows converged toward all-time totals.

Each record now contributes its **in-window** activity:

- **`firstSeen` inside the window** → lifetime counters, verbatim. Exact by definition (the record's whole lifetime is in-window), and complete even for activity predating the stage-1 buckets — recent findings never wait for buckets to accumulate.
- **`firstSeen` before the window** → the sum of `periodCounts` day buckets overlapping the window. Pre-#334 records without buckets contribute nothing — an honest ramp-up (undercount) rather than lifetime injection (overcount), self-healing within one window-length of stage 1 deploying.

Inclusion follows activity rather than `lastSeen`, so a dispute or reaction landing after a finding's last surfacing counts in the window it happened in.

## Acceptance criteria (from #334)

- ✅ A record whose activity predates the window does not contribute pre-window counts — tested
- ✅ 7d ≤ 30d ≤ 90d holds by construction — tested on a dataset that previously violated it
- ✅ `disputeRate`, `perCategory`, `perSeverity`, `perRepo`, `topClusters` all derive from windowed counts (substituted before aggregation) — tested
- ✅ Test: long-lived + recent record, 7d total excludes the long-lived record's history
- ✅ Migration/backfill plan: `docs/pending/windowed-insight-rollups.md` + the tracking comment on #334

## Tests / docs

7 new rollup tests (40 total in the insights suite, all green); the one legacy test asserting lastSeen-based inclusion was rewritten to the new semantics with coherent fixtures. `e2e/RUNBOOK.md` gains scenario E2E-84. Full workspace build / typecheck / test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)