### PR TITLE
feat(infra): add ByRepoCreatedAt GSI to the reviews table (#335, phase 1)

### DIFF
--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -543,6 +543,28 @@ Resources:
           AttributeType: S
         - AttributeName: prNumberCommitSha
           AttributeType: S
+        - AttributeName: createdAt
+          AttributeType: S
+
+      # #335 — time-ordered per-repo review listing. The base sort key
+      # (prNumberCommitSha) orders by PR-number STRING, so "newest N" walks
+      # lexicographic PR numbers ("9#…" > "42#…" > "100#…"), not time. The
+      # dashboard's listReviews queries this index descending on createdAt,
+      # and puts date-range bounds in the key condition so `Limit` applies
+      # to matching items (the base-table path filtered AFTER the read).
+      # Every review row carries createdAt (required on ReviewItem), so the
+      # index covers the full table. IAM index access is already granted
+      # (`${ReviewsTable.Arn}/index/*` below; Amplify policy covers
+      # `table/mergewatch-*/index/*`).
+      GlobalSecondaryIndexes:
+        - IndexName: ByRepoCreatedAt
+          KeySchema:
+            - AttributeName: repoFullName
+              KeyType: HASH
+            - AttributeName: createdAt
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
 
       PointInTimeRecoverySpecification:
         PointInTimeRecoveryEnabled: true


### PR DESCRIPTION
Part of #335 — phase 1 of 2 (infra). Independent of phase 2 (the store rewrite carries a legacy fallback until this index exists, so merge order is safe — this lands first by intent).

## What

Adds a `ByRepoCreatedAt` GSI (PK `repoFullName`, SK `createdAt`, projection ALL) to the reviews table. The base sort key (`prNumberCommitSha`) orders by PR-number **string**, so a descending query walks `"9#…" > "42#…" > "100#…"` — defect 1 of #335. Time-ordered retrieval needs a time-keyed index; it also lets date-range bounds move into the key condition, which is what fixes the `Limit`-before-`FilterExpression` data loss (defect 3) in phase 2.

## Notes

- Every review row carries `createdAt` (required on `ReviewItem` and written on every upsert), so the index covers the full table; CFN backfills online on the existing (Retain) table.
- IAM needs no change: the Lambda role already grants `${ReviewsTable.Arn}/index/*`, and the prod Amplify SSR inline policy already covers `table/mergewatch-*/index/*` (verified against the live role).
- Template validated with `aws cloudformation validate-template`.
- Read-cost datapoint motivating the pair (measured on dev): a 7-day date-filtered `listReviews` query read **31 items / 16 RCU and returned 0 matches** — the filter runs after the read, so narrow ranges waste the entire read. Post-GSI the same query reads only matching items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)