### PR TITLE
fix(storage-dynamo): time-ordered listReviews via the ByRepoCreatedAt GSI (#335, phase 2)

### DIFF
--- a/docs/pending/reviews-time-ordered-listing.md
+++ b/docs/pending/reviews-time-ordered-listing.md
@@ -1,0 +1,40 @@
+# Time-ordered review listing (SaaS / DynamoDB)
+
+**Status:** 🚧 In review
+**Issue:** [#335](https://github.com/mergewatch/mergewatch.ai/issues/335)
+
+Fix the three `listReviews` defects that made SaaS analytics numbers unreliable: candidate rows ordered by PR-number **string** (`"9#…" > "42#…" > "100#…"`), `Limit` applied per repo instead of to the result set, and `Limit` applied to items *read* before the date `FilterExpression` ran — silently losing matching rows the narrower the date range got.
+
+## Architecture
+
+```
+before                                   after
+──────                                   ─────
+Query base table per repo                Query ByRepoCreatedAt GSI per repo (parallel)
+  sort key: prNumberCommitSha              keys: (repoFullName, createdAt)
+  order: PR-number string ❌                order: reverse chronological ✅
+  dates: FilterExpression (post-read) ❌    dates: KeyConditionExpression (pre-read) ✅
+  Limit: per repo, pre-filter ❌            Limit: merged result; status filter pages ✅
+```
+
+- **Infra**: `ByRepoCreatedAt` GSI (PK `repoFullName`, SK `createdAt`, projection ALL) on the reviews table. Every review row carries `createdAt`, so the index covers the full table; CFN backfills it online. IAM needed no change (index ARNs were already granted on both the Lambda role and the Amplify SSR policy).
+- **Store**: `listReviews` queries the GSI descending on `createdAt`. Date bounds live in the key condition (`BETWEEN` / `>=` / `<=`), so `Limit` counts **matching** items. Only the status filter remains a `FilterExpression`; a bounded per-repo paging loop (≤ 10 pages) keeps reading until the target count or the stream runs dry.
+- **Pagination (v2 cursors)**: the per-repo resume position is the GSI key of the last item the page *returned* for that repo — not the raw `LastEvaluatedKey`, which has already advanced past rows that were fetched but dropped by the global limit slice. Dropped rows are re-fetched next page; nothing is lost or duplicated across a full pagination walk (tested).
+- **Fallback**: on a stack without the GSI, the first index-missing error flips a sticky flag and the store degrades to the legacy base-table path (its defects intact — still better than a hard failure) with a one-time warning. v1 cursors (from clients mid-pagination at deploy time) also finish their sequence on the legacy path; new sequences start on the GSI.
+
+## Read-cost impact
+
+Measured on the dev table (`mergewatch-reviews-dev`, repo `santthosh/mergewatch-kitchensink`, 31 rows) with `ReturnConsumedCapacity`:
+
+- **Before** — 7-day date-filtered query, base table: read all **31 items, 16 RCU, returned 0 matches**. The filter runs after the read, so 100% of the read cost was wasted; on a large repo the waste is bounded only by `Limit: 500` per repo, and the matching rows can sit unread past `LastEvaluatedKey` (the actual data loss).
+- **After** — the same bounds in the GSI key condition read only matching items: an empty result consumes ~0.5 RCU (one key lookup), and a k-match result reads k items. The per-repo fan-out (`limit` candidates per repo, worst case) is unchanged in shape but now reads only in-range rows; post-deploy measurement on dev to be appended to the #335 tracker.
+
+The long-term shape for aggregates remains a scheduled rollup (the insights pipeline precedent) rather than live per-repo fan-out; #335's fix makes the live path correct, not free.
+
+## Edge cases
+
+- **Repo with zero matches / empty repo list** — exhausted immediately; cursor null when all repos are done.
+- **Status filter removing an entire read page** — the loop continues from `LastEvaluatedKey` (bounded), and the cursor stores the raw read position when nothing matched, so progress is never lost.
+- **All of a repo's fetched rows dropped by the global slice** — the incoming resume position is carried forward unchanged; the rows are re-fetched next page.
+- **Unparseable cursor** — starts a fresh sequence (existing behavior).
+- **Non-index query errors** (throttling, auth) — rethrown, never masked by the fallback.

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -211,6 +211,7 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-82](#e2e-82-oss-program--sponsored-review-on-a-granted-public-repo) | OSS grant sponsors a named public repo; unnamed/private/expired all fall back correctly; rename keeps the grant | 5m | 60s | #263, #265 |
 | [E2E-83](#e2e-83-oss-program--operator-grant-lifecycle) | `grant-oss.ts` grant/add/remove/revoke/inspect; `--stage` guard; private repo rejected | 5m | n/a | #266 |
 | [E2E-84](#e2e-84-334--time-bounded-insight-rollup-windows) | Counter increments write per-UTC-day `periodCounts` buckets alongside lifetime counters; rollup windows sum only in-window activity (7d ≤ 30d ≤ 90d guaranteed); pre-#334 long-lived records ramp up instead of injecting lifetime history; both backends (#334) | 3m | 90s | #334 |
+| [E2E-85](#e2e-85-335--time-ordered-dynamodb-review-listing) | SaaS `listReviews` queries the `ByRepoCreatedAt` GSI: reverse-chronological across any PR numbers, date bounds in the key condition (no pre-filter `Limit` loss), `limit` bounds the merged result with lossless v2 resume cursors; sticky legacy fallback when the GSI is absent (#335) | 3m | 60s | #335 |
 
 ---
 
@@ -2998,6 +2999,28 @@ Trigger the rollup manually (same paths as E2E-41), then read the three insight 
 - [ ] `7d ≤ 30d ≤ 90d` for `totalFindingsSurfaced` and `totalDisputes`
 - [ ] `perCategory` / `perSeverity` / `perRepo` / `topClusters` reflect windowed counts (spot-check the long-lived record's category bucket shows 1, not 200)
 - [ ] New reviews after deploy write `periodCounts` buckets on both backends (inspect a row: Postgres `period_counts` jsonb / Dynamo `pc#<day>#<counter>` attributes)
+
+---
+
+### E2E-85: #335 — Time-ordered DynamoDB review listing
+
+**Status:** 🚧 In review (#335) — fixture not yet run.
+
+**Behavior:** the SaaS dashboard's `listReviews` queries the `ByRepoCreatedAt` GSI (PK `repoFullName`, SK `createdAt`) descending — true reverse-chronological order regardless of PR numbers (the base sort key orders `"9#…" > "42#…" > "100#…"` as strings). Date-range bounds sit in the `KeyConditionExpression`, so `Limit` applies to matching items and a narrow range can no longer silently discard matching rows beyond the first unfiltered page. `limit` bounds the merged cross-repo result; v2 cursors resume each repo from the last *returned* item, so rows fetched but dropped by the global slice are re-fetched, never lost. On a stack without the GSI, the store logs one warning and degrades to the legacy base-table path (sticky per instance); v1 cursors finish their sequence on the legacy path.
+
+**How to run.**
+Branch: `fixture/85-time-ordered-reviews`. Seed one repo with reviews for PR numbers 9, 42, 100, and 1000 whose `createdAt` order deliberately disagrees with PR-number order (e.g. 100 newest, then 1000, 42, 9), plus a second repo with interleaved timestamps and a batch of rows older than 30 days.
+1. `/dashboard/reviews` (SaaS): confirm the list renders in `createdAt` order — 100, 1000, 42, 9 — not 9, 42, 1000, 100.
+2. Apply a "last 7 days" date filter on `/dashboard/analytics`: confirm the totals equal the seeded in-range row count exactly (previously: whatever survived the first unfiltered 500-item read).
+3. Page through `/api/reviews?limit=4` across both repos to exhaustion: confirm every seeded row appears exactly once.
+4. On a stack without the GSI (dev before infra deploy): confirm the one-time `ByRepoCreatedAt index not found` warning and that the list still renders (legacy order).
+
+**Expected outcomes.**
+- [ ] Time order across PR numbers 9 / 42 / 100 / 1000 (never PR-number-string order)
+- [ ] Date-filtered totals count all matching rows, independent of how many out-of-range rows precede them
+- [ ] `limit` bounds the merged result; full pagination is loss-free and duplicate-free
+- [ ] GSI-absent stack degrades to legacy with a single warning, no hard failure
+- [ ] Read cost on a date-filtered query scales with matching rows, not with rows read-and-discarded
 
 ---
 

--- a/packages/storage-dynamo/src/dashboard-store.test.ts
+++ b/packages/storage-dynamo/src/dashboard-store.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { DynamoDashboardReviewStore, REVIEWS_BY_CREATED_AT_INDEX } from './dashboard-store.js';
+
+/** Build a review item; createdAt is the field under test everywhere here. */
+function review(repoFullName: string, prNumber: number, createdAt: string, over: Record<string, unknown> = {}) {
+  return {
+    repoFullName,
+    prNumberCommitSha: `${prNumber}#sha${prNumber}`,
+    prNumber,
+    createdAt,
+    status: 'complete',
+    ...over,
+  };
+}
+
+/**
+ * Mock DynamoDB client for the GSI path: serves time-descending pages per
+ * repo, honoring KeyConditionExpression date bounds, FilterExpression status,
+ * Limit, and ExclusiveStartKey — the pieces listReviews relies on. Rejects
+ * with `indexError` instead when set (fallback tests).
+ */
+function makeGsiClient(itemsByRepo: Record<string, Record<string, unknown>[]>, opts: { indexError?: Error; pageSize?: number } = {}) {
+  const send = vi.fn(async (cmd: any) => {
+    if (!(cmd instanceof QueryCommand)) throw new Error('unexpected command');
+    const input = cmd.input as any;
+    if (input.IndexName === REVIEWS_BY_CREATED_AT_INDEX && opts.indexError) throw opts.indexError;
+
+    const repo = input.ExpressionAttributeValues[':repo'];
+    let rows = [...(itemsByRepo[repo] ?? [])].sort((a, b) =>
+      String(b.createdAt).localeCompare(String(a.createdAt)));
+
+    // Key-condition date bounds (GSI path only — legacy sends them as FilterExpression).
+    const start = input.ExpressionAttributeValues[':startDate'];
+    const end = input.ExpressionAttributeValues[':endDate'];
+    const kc = String(input.KeyConditionExpression);
+    if (kc.includes('createdAt')) {
+      if (start) rows = rows.filter((r) => String(r.createdAt) >= start);
+      if (end) rows = rows.filter((r) => String(r.createdAt) <= end);
+    }
+
+    // ExclusiveStartKey: resume strictly after the given position.
+    const esk = input.ExclusiveStartKey;
+    if (esk) {
+      const idx = rows.findIndex((r) =>
+        String(r.createdAt) === String(esk.createdAt) &&
+        String(r.prNumberCommitSha) === String(esk.prNumberCommitSha));
+      rows = idx >= 0 ? rows.slice(idx + 1) : rows;
+    }
+
+    // Limit applies to items READ; FilterExpression applies after.
+    const pageSize = Math.min(input.Limit ?? Infinity, opts.pageSize ?? Infinity);
+    const read = rows.slice(0, pageSize);
+    const hasMore = rows.length > read.length;
+    let items = read;
+    if (input.FilterExpression && input.ExpressionAttributeValues[':status']) {
+      items = read.filter((r) => r.status === input.ExpressionAttributeValues[':status']);
+    }
+    const last = read[read.length - 1];
+    return {
+      Items: items,
+      ...(hasMore && last
+        ? { LastEvaluatedKey: { repoFullName: last.repoFullName, createdAt: last.createdAt, prNumberCommitSha: last.prNumberCommitSha } }
+        : {}),
+    };
+  });
+  return { send };
+}
+
+function makeStore(client: { send: unknown }) {
+  return new DynamoDashboardReviewStore(client as any, 'test-reviews');
+}
+
+/** Every GSI QueryCommand the store issued. */
+function gsiQueries(client: any) {
+  return client.send.mock.calls
+    .map((c: any[]) => c[0].input)
+    .filter((i: any) => i.IndexName === REVIEWS_BY_CREATED_AT_INDEX);
+}
+
+describe('DynamoDashboardReviewStore.listReviews — #335 GSI path', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('AC: orders by time across PR numbers 9 / 42 / 100 / 1000, not by PR-number string', async () => {
+    // Lexicographic PR-string order would yield 9 > 42 > 1000 > 100.
+    const client = makeGsiClient({
+      'octo/repo': [
+        review('octo/repo', 9,    '2026-08-01T00:00:00Z'),
+        review('octo/repo', 42,   '2026-08-04T00:00:00Z'),
+        review('octo/repo', 100,  '2026-08-16T00:00:00Z'),
+        review('octo/repo', 1000, '2026-08-10T00:00:00Z'),
+      ],
+    });
+    const reviews = makeStore(client);
+    const { items } = await reviews.listReviews(['octo/repo'], 10);
+    expect(items.map((i: any) => i.prNumber)).toEqual([100, 1000, 42, 9]);
+    expect(gsiQueries(client)[0].ScanIndexForward).toBe(false);
+  });
+
+  it('puts date bounds in the key condition, never in a FilterExpression', async () => {
+    const client = makeGsiClient({ 'octo/repo': [review('octo/repo', 1, '2026-08-10T00:00:00Z')] });
+    const reviews = makeStore(client);
+    await reviews.listReviews(['octo/repo'], 10, undefined, undefined, '2026-08-01T00:00:00Z', '2026-08-16T00:00:00Z');
+    const q = gsiQueries(client)[0];
+    expect(q.KeyConditionExpression).toBe('repoFullName = :repo AND createdAt BETWEEN :startDate AND :endDate');
+    expect(q.FilterExpression).toBeUndefined();
+  });
+
+  it('date-filtered queries return matches beyond the first unfiltered page (defect 3 fixture)', async () => {
+    // 30 old rows would previously fill the read Limit and be filtered to
+    // nothing; the 5 in-range rows sat unread past LastEvaluatedKey.
+    const old = Array.from({ length: 30 }, (_, i) =>
+      review('octo/repo', i + 1, `2026-01-${String(i + 1).padStart(2, '0')}T00:00:00Z`));
+    const recent = Array.from({ length: 5 }, (_, i) =>
+      review('octo/repo', 100 + i, `2026-08-1${i}T00:00:00Z`));
+    const client = makeGsiClient({ 'octo/repo': [...old, ...recent] });
+    const reviews = makeStore(client);
+    const { items } = await reviews.listReviews(['octo/repo'], 10, undefined, undefined, '2026-08-01T00:00:00Z');
+    expect(items).toHaveLength(5);
+    expect((items as any[]).every((i) => i.createdAt >= '2026-08-01')).toBe(true);
+  });
+
+  it('limit bounds the merged result across repos, and dropped rows are re-fetched next page (defect 2)', async () => {
+    const client = makeGsiClient({
+      'octo/api': [
+        review('octo/api', 1, '2026-08-16T00:00:00Z'),
+        review('octo/api', 2, '2026-08-14T00:00:00Z'),
+        review('octo/api', 3, '2026-08-12T00:00:00Z'),
+      ],
+      'octo/web': [
+        review('octo/web', 7, '2026-08-15T00:00:00Z'),
+        review('octo/web', 8, '2026-08-13T00:00:00Z'),
+        review('octo/web', 9, '2026-08-11T00:00:00Z'),
+      ],
+    });
+    const reviews = makeStore(client);
+
+    const page1 = await reviews.listReviews(['octo/api', 'octo/web'], 4);
+    expect(page1.items).toHaveLength(4);
+    expect(page1.items.map((i: any) => i.createdAt)).toEqual([
+      '2026-08-16T00:00:00Z', '2026-08-15T00:00:00Z', '2026-08-14T00:00:00Z', '2026-08-13T00:00:00Z',
+    ]);
+    expect(page1.nextCursor).not.toBeNull();
+
+    // Page 2 must produce the two rows page 1 fetched-but-dropped.
+    const page2 = await reviews.listReviews(['octo/api', 'octo/web'], 4, page1.nextCursor!);
+    expect(page2.items.map((i: any) => i.createdAt)).toEqual([
+      '2026-08-12T00:00:00Z', '2026-08-11T00:00:00Z',
+    ]);
+    expect(page2.nextCursor).toBeNull();
+  });
+
+  it('full pagination never loses or duplicates a row (6 repos × 5 rows, page size 4)', async () => {
+    const itemsByRepo: Record<string, ReturnType<typeof review>[]> = {};
+    for (let r = 0; r < 6; r++) {
+      const repo = `octo/repo${r}`;
+      itemsByRepo[repo] = Array.from({ length: 5 }, (_, i) =>
+        review(repo, i + 1, `2026-08-${String(2 + ((r * 5 + i) % 27)).padStart(2, '0')}T0${r}:0${i}:00Z`));
+    }
+    const client = makeGsiClient(itemsByRepo);
+    const reviews = makeStore(client);
+
+    const seen: string[] = [];
+    let cursor: string | undefined;
+    for (let page = 0; page < 20; page++) {
+      const res = await reviews.listReviews(Object.keys(itemsByRepo), 4, cursor);
+      seen.push(...res.items.map((i: any) => `${i.repoFullName}:${i.prNumberCommitSha}`));
+      if (!res.nextCursor) break;
+      cursor = res.nextCursor;
+    }
+    expect(seen).toHaveLength(30);
+    expect(new Set(seen).size).toBe(30);
+  });
+
+  it('status filter pages past filtered-out reads instead of returning a short page', async () => {
+    // 12 rows, only the 3 oldest are complete; page size forces multiple
+    // reads before the matches surface.
+    const rows = Array.from({ length: 12 }, (_, i) =>
+      review('octo/repo', i + 1, `2026-08-${String(i + 1).padStart(2, '0')}T00:00:00Z`, {
+        status: i < 3 ? 'complete' : 'failed',
+      }));
+    const client = makeGsiClient({ 'octo/repo': rows }, { pageSize: 4 });
+    const reviews = makeStore(client);
+    const { items } = await reviews.listReviews(['octo/repo'], 3, undefined, 'completed');
+    expect(items).toHaveLength(3);
+    expect((items as any[]).every((i) => i.status === 'complete')).toBe(true);
+    // Multiple sequential GSI queries were needed to get there.
+    expect(gsiQueries(client).length).toBeGreaterThan(1);
+  });
+
+  it("maps the caller's 'completed' to the stored 'complete'", async () => {
+    const client = makeGsiClient({ 'octo/repo': [review('octo/repo', 1, '2026-08-10T00:00:00Z')] });
+    const reviews = makeStore(client);
+    await reviews.listReviews(['octo/repo'], 10, undefined, 'completed');
+    const q = gsiQueries(client)[0];
+    expect(q.ExpressionAttributeValues[':status']).toBe('complete');
+    expect(q.FilterExpression).toBe('#s = :status');
+  });
+
+  it('returns a null cursor when every repo is exhausted', async () => {
+    const client = makeGsiClient({
+      'octo/api': [review('octo/api', 1, '2026-08-16T00:00:00Z')],
+      'octo/web': [],
+    });
+    const reviews = makeStore(client);
+    const { items, nextCursor } = await reviews.listReviews(['octo/api', 'octo/web'], 10);
+    expect(items).toHaveLength(1);
+    expect(nextCursor).toBeNull();
+  });
+
+  it('handles an empty repo list', async () => {
+    const client = makeGsiClient({});
+    const reviews = makeStore(client);
+    const { items, nextCursor } = await reviews.listReviews([], 10);
+    expect(items).toEqual([]);
+    expect(nextCursor).toBeNull();
+  });
+});
+
+describe('DynamoDashboardReviewStore.listReviews — legacy fallback', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('falls back to the base table when the GSI does not exist, and stays there (sticky)', async () => {
+    const err = Object.assign(new Error('The table does not have the specified index: ByRepoCreatedAt'), {
+      name: 'ValidationException',
+    });
+    const client = makeGsiClient({ 'octo/repo': [review('octo/repo', 1, '2026-08-10T00:00:00Z')] }, { indexError: err });
+    const reviews = makeStore(client);
+
+    const first = await reviews.listReviews(['octo/repo'], 10);
+    expect(first.items).toHaveLength(1);
+
+    await reviews.listReviews(['octo/repo'], 10);
+    // One failed GSI attempt total — the flag prevents a second.
+    expect(gsiQueries(client)).toHaveLength(1);
+    // Every successful query hit the base table (no IndexName).
+    const baseQueries = client.send.mock.calls
+      .map((c: any[]) => c[0].input)
+      .filter((i: any) => !i.IndexName);
+    expect(baseQueries.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('rethrows non-index query errors instead of masking them with the legacy path', async () => {
+    const err = Object.assign(new Error('Throughput exceeded'), { name: 'ProvisionedThroughputExceededException' });
+    const client = makeGsiClient({}, { indexError: err });
+    const reviews = makeStore(client);
+    await expect(reviews.listReviews(['octo/repo'], 10)).rejects.toThrow('Throughput exceeded');
+  });
+
+  it('routes a v1 cursor to the legacy path for pagination continuity', async () => {
+    const client = makeGsiClient({ 'octo/repo': [review('octo/repo', 1, '2026-08-10T00:00:00Z')] });
+    const reviews = makeStore(client);
+    const v1Cursor = Buffer.from(JSON.stringify({ keys: {}, exhausted: [] })).toString('base64url');
+    await reviews.listReviews(['octo/repo'], 10, v1Cursor);
+    expect(gsiQueries(client)).toHaveLength(0);
+    const q = client.send.mock.calls[0][0].input;
+    expect(q.IndexName).toBeUndefined();
+    // Legacy keeps dates in the FilterExpression — assert its shape survives untouched.
+    expect(q.KeyConditionExpression).toBe('repoFullName = :repo');
+  });
+
+  it('starts fresh on an unparseable cursor (GSI path)', async () => {
+    const client = makeGsiClient({ 'octo/repo': [review('octo/repo', 1, '2026-08-10T00:00:00Z')] });
+    const reviews = makeStore(client);
+    const { items } = await reviews.listReviews(['octo/repo'], 10, 'not-base64-json');
+    expect(items).toHaveLength(1);
+    expect(gsiQueries(client)).toHaveLength(1);
+  });
+});

--- a/packages/storage-dynamo/src/dashboard-store.ts
+++ b/packages/storage-dynamo/src/dashboard-store.ts
@@ -116,7 +116,55 @@ class DynamoDashboardInstallationStore implements IDashboardInstallationStore {
 
 // ─── Review store ───────────────────────────────────────────────────────────
 
-class DynamoDashboardReviewStore implements IDashboardReviewStore {
+/**
+ * #335 — GSI on the reviews table: PK repoFullName, SK createdAt
+ * (infra/template.yaml). The base table's sort key (prNumberCommitSha,
+ * "42#abc123") orders by PR-number STRING, so a descending base-table query
+ * walks "9#…" > "42#…" > "100#…" — not time. This index is what makes
+ * time-ordered listing possible.
+ */
+export const REVIEWS_BY_CREATED_AT_INDEX = 'ByRepoCreatedAt';
+
+/**
+ * Safety bound on the per-repo status-filter paging loop below. Only the
+ * status filter can force extra pages (dates live in the key condition), so
+ * in practice one page suffices; this caps a pathological repo where nearly
+ * every read item is filtered out.
+ */
+const MAX_QUERY_PAGES_PER_REPO = 10;
+
+/**
+ * v2 cursor (#335): per-repo resume position = the GSI key of the last item
+ * this page RETURNED for that repo (repoFullName + createdAt + the base-table
+ * key, which is what a GSI ExclusiveStartKey requires). Anchoring the cursor
+ * on returned — not fetched — items means rows that were read but dropped by
+ * the global limit are re-fetched on the next page instead of silently lost
+ * (the v1 cursor stored the raw LastEvaluatedKey, which had already advanced
+ * past them). `exhausted` lists repos whose streams ran dry with every
+ * fetched row returned.
+ */
+interface ListReviewsCursorV2 {
+  v: 2;
+  keys: Record<string, Record<string, unknown>>;
+  exhausted: string[];
+}
+
+/** What one repo's in-flight query contributed to a `listReviews` page. */
+interface RepoFetchResult {
+  repoFullName: string;
+  items: Record<string, unknown>[];
+  /** Raw LastEvaluatedKey when the query stopped with more index left. */
+  lastEvaluatedKey?: Record<string, unknown>;
+}
+
+export class DynamoDashboardReviewStore implements IDashboardReviewStore {
+  /**
+   * Sticky flag — set on the first "index does not exist" error so a stack
+   * deployed without the #335 GSI (phase 2 code ahead of phase 1 infra)
+   * degrades to the legacy base-table path once, not on every request.
+   */
+  private gsiUnavailable = false;
+
   constructor(
     private readonly client: DynamoDBDocumentClient,
     private readonly tableName: string,
@@ -130,19 +178,218 @@ class DynamoDashboardReviewStore implements IDashboardReviewStore {
     startDate?: string,
     endDate?: string,
   ): Promise<PaginatedResult<ReviewItem>> {
-    // Decode cursor: { keys: { [repo]: LastEvaluatedKey }, exhausted: string[] }
-    let cursorState: {
-      keys: Record<string, Record<string, unknown>>;
-      exhausted: string[];
-    } = { keys: {}, exhausted: [] };
-
+    let decoded: Record<string, unknown> | undefined;
     if (cursor) {
       try {
-        cursorState = JSON.parse(Buffer.from(cursor, 'base64url').toString());
+        decoded = JSON.parse(Buffer.from(cursor, 'base64url').toString());
       } catch {
         // Invalid cursor — start fresh
       }
     }
+
+    // A v1 cursor is mid-flight through the legacy path — finish the
+    // pagination sequence there (its keys are base-table positions that the
+    // GSI cannot resume from). New sequences start on the GSI.
+    if (this.gsiUnavailable || (decoded && decoded.v !== 2)) {
+      return this.listReviewsLegacy(repos, limit, decoded as never, status, startDate, endDate);
+    }
+
+    const cursorState: ListReviewsCursorV2 =
+      decoded && decoded.v === 2
+        ? (decoded as unknown as ListReviewsCursorV2)
+        : { v: 2, keys: {}, exhausted: [] };
+
+    try {
+      return await this.listReviewsByCreatedAt(repos, limit, cursorState, status, startDate, endDate);
+    } catch (err: unknown) {
+      // "index does not exist" → the stack predates the #335 GSI. Degrade to
+      // the legacy path (known #335 defects and all — still better than a
+      // hard 500) and stop retrying the index. Anything else is a real error.
+      const name = err && typeof err === 'object' && 'name' in err ? String(err.name) : '';
+      const message = err instanceof Error ? err.message : String(err);
+      const indexMissing =
+        (name === 'ValidationException' || name === 'ResourceNotFoundException') &&
+        /index/i.test(message);
+      if (!indexMissing) throw err;
+      this.gsiUnavailable = true;
+      console.warn(
+        '[dashboard-store] %s index not found on %s — falling back to base-table listReviews (deploy the #335 GSI to restore time-ordered listing)',
+        REVIEWS_BY_CREATED_AT_INDEX, this.tableName,
+      );
+      // Restart the sequence: a v2 cursor cannot resume a base-table query.
+      return this.listReviewsLegacy(repos, limit, undefined, status, startDate, endDate);
+    }
+  }
+
+  /**
+   * #335 — time-ordered listing over the ByRepoCreatedAt GSI.
+   *
+   *   • Ordering: ScanIndexForward=false over createdAt — true reverse
+   *     chronological, independent of PR numbers (defect 1).
+   *   • Dates: bounds live in the KeyConditionExpression, so `Limit` applies
+   *     to MATCHING items — a narrow range can no longer discard matching
+   *     rows that sat beyond the first unfiltered page (defect 3).
+   *   • Limit: bounds the merged result; each repo reads at most `limit`
+   *     matching items per page (the price of per-repo partitions — computing
+   *     the global newest-N needs up to N candidates per repo), and the v2
+   *     cursor re-fetches anything the global slice dropped (defect 2).
+   *
+   * Repos fan out in parallel (same shape as getReviewStats below).
+   */
+  private async listReviewsByCreatedAt(
+    repos: string[],
+    limit: number,
+    cursorState: ListReviewsCursorV2,
+    status?: string,
+    startDate?: string,
+    endDate?: string,
+  ): Promise<PaginatedResult<ReviewItem>> {
+    const results = await Promise.all(
+      repos
+        .filter((repoFullName) => !cursorState.exhausted.includes(repoFullName))
+        .map((repoFullName) =>
+          this.queryRepoByCreatedAt(repoFullName, limit, cursorState.keys[repoFullName], status, startDate, endDate),
+        ),
+    );
+
+    // Merge and order the candidate streams. createdAt is the real sort key;
+    // the base-table key breaks ties deterministically.
+    const allReviews = results.flatMap((r) => r.items);
+    allReviews.sort((a, b) =>
+      String(b.createdAt ?? '').localeCompare(String(a.createdAt ?? '')) ||
+      String(b.prNumberCommitSha ?? '').localeCompare(String(a.prNumberCommitSha ?? '')),
+    );
+    const paged = allReviews.slice(0, limit) as unknown as ReviewItem[];
+
+    // Per-repo resume positions anchored on RETURNED items (see the v2
+    // cursor contract above).
+    const returnedCount = new Map<string, number>();
+    const lastReturned = new Map<string, Record<string, unknown>>();
+    for (const item of paged as unknown as Record<string, unknown>[]) {
+      const repo = String(item.repoFullName);
+      returnedCount.set(repo, (returnedCount.get(repo) ?? 0) + 1);
+      lastReturned.set(repo, item);
+    }
+
+    const nextCursorState: ListReviewsCursorV2 = {
+      v: 2,
+      keys: {},
+      exhausted: [...cursorState.exhausted],
+    };
+    for (const r of results) {
+      const returned = returnedCount.get(r.repoFullName) ?? 0;
+      const dropped = r.items.length - returned;
+      if (dropped === 0 && !r.lastEvaluatedKey) {
+        // Stream ran dry and everything it produced went out this page.
+        nextCursorState.exhausted.push(r.repoFullName);
+        continue;
+      }
+      const anchor = lastReturned.get(r.repoFullName);
+      if (anchor) {
+        // Resume strictly after the last returned item. A GSI
+        // ExclusiveStartKey carries the index keys plus the base-table key.
+        nextCursorState.keys[r.repoFullName] = {
+          repoFullName: anchor.repoFullName,
+          createdAt: anchor.createdAt,
+          prNumberCommitSha: anchor.prNumberCommitSha,
+        };
+      } else if (r.lastEvaluatedKey && dropped === 0) {
+        // Nothing fetched survived the status filter this page — continue
+        // from where the query stopped reading.
+        nextCursorState.keys[r.repoFullName] = r.lastEvaluatedKey;
+      } else {
+        // Items were fetched but none returned (all dropped by the global
+        // slice) — keep the incoming position so they're re-fetched.
+        const incoming = cursorState.keys[r.repoFullName];
+        if (incoming) nextCursorState.keys[r.repoFullName] = incoming;
+        // No incoming key means this repo restarts from the top next page —
+        // correct, since none of its rows have been returned yet.
+      }
+    }
+
+    const hasMore = nextCursorState.exhausted.length < repos.length;
+    const nextCursor = hasMore
+      ? Buffer.from(JSON.stringify(nextCursorState)).toString('base64url')
+      : null;
+
+    return { items: paged, nextCursor };
+  }
+
+  /** One repo's page: query the GSI, paging past status-filter losses until
+   *  `limit` matching items, the stream runs dry, or the page cap trips. */
+  private async queryRepoByCreatedAt(
+    repoFullName: string,
+    limit: number,
+    exclusiveStartKey: Record<string, unknown> | undefined,
+    status?: string,
+    startDate?: string,
+    endDate?: string,
+  ): Promise<RepoFetchResult> {
+    const values: Record<string, unknown> = { ':repo': repoFullName };
+    let keyCondition = 'repoFullName = :repo';
+    if (startDate && endDate) {
+      keyCondition += ' AND createdAt BETWEEN :startDate AND :endDate';
+      values[':startDate'] = startDate;
+      values[':endDate'] = endDate;
+    } else if (startDate) {
+      keyCondition += ' AND createdAt >= :startDate';
+      values[':startDate'] = startDate;
+    } else if (endDate) {
+      keyCondition += ' AND createdAt <= :endDate';
+      values[':endDate'] = endDate;
+    }
+
+    const params: Record<string, unknown> = {
+      TableName: this.tableName,
+      IndexName: REVIEWS_BY_CREATED_AT_INDEX,
+      KeyConditionExpression: keyCondition,
+      ExpressionAttributeValues: values,
+      ScanIndexForward: false,
+      Limit: limit,
+    };
+    if (status) {
+      params.FilterExpression = '#s = :status';
+      params.ExpressionAttributeNames = { '#s': 'status' };
+      values[':status'] = status === 'completed' ? 'complete' : status;
+    }
+
+    const items: Record<string, unknown>[] = [];
+    let startKey = exclusiveStartKey;
+    let lastEvaluatedKey: Record<string, unknown> | undefined;
+    for (let page = 0; page < MAX_QUERY_PAGES_PER_REPO; page++) {
+      const result = await this.client.send(new QueryCommand({
+        ...params,
+        ...(startKey ? { ExclusiveStartKey: startKey } : {}),
+      } as any));
+      items.push(...(result.Items ?? []));
+      lastEvaluatedKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+      if (!lastEvaluatedKey || items.length >= limit) break;
+      startKey = lastEvaluatedKey;
+    }
+    return { repoFullName, items, ...(lastEvaluatedKey ? { lastEvaluatedKey } : {}) };
+  }
+
+  /**
+   * Pre-#335 base-table implementation, kept verbatim as the fallback for
+   * stacks where the ByRepoCreatedAt GSI is not deployed yet and for
+   * finishing pagination sequences started on v1 cursors. Known defects
+   * (#335): PR-number-string candidate order, per-repo Limit, Limit applied
+   * before FilterExpression.
+   */
+  private async listReviewsLegacy(
+    repos: string[],
+    limit: number,
+    decodedCursor?: { keys: Record<string, Record<string, unknown>>; exhausted: string[] },
+    status?: string,
+    startDate?: string,
+    endDate?: string,
+  ): Promise<PaginatedResult<ReviewItem>> {
+    const cursorState: {
+      keys: Record<string, Record<string, unknown>>;
+      exhausted: string[];
+    } = decodedCursor && decodedCursor.keys && decodedCursor.exhausted
+      ? { keys: decodedCursor.keys, exhausted: decodedCursor.exhausted }
+      : { keys: {}, exhausted: [] };
 
     const allReviews: Record<string, unknown>[] = [];
     const nextCursorState: typeof cursorState = {


### PR DESCRIPTION
Phase 2 of 2 — pairs with #344 (infra GSI). Safe to merge in either order: the store degrades to the legacy base-table path (sticky, one warning) until the index exists. Closes #335.

## What

Rewrites the DynamoDB `listReviews` to fix all three #335 defects:

1. **Ordering** — queries the `ByRepoCreatedAt` GSI descending on `createdAt`: true reverse-chronological, independent of PR-number lexicographics.
2. **Per-repo `Limit`** — `limit` now bounds the **merged** result. v2 cursors anchor each repo's resume position on the last item actually *returned*, so rows fetched-but-dropped by the global slice are re-fetched next page (the old cursor stored the already-advanced `LastEvaluatedKey`, losing them). A 6-repo × 5-row × page-size-4 walk is loss-free and duplicate-free (tested).
3. **Pre-filter `Limit` loss** — date bounds move into the `KeyConditionExpression` (`BETWEEN`/`>=`/`<=`), so `Limit` counts matching items. Only the status filter remains a `FilterExpression`, with a bounded (≤10 page) per-repo loop.

Repos fan out in parallel (same shape as `getReviewStats`).

## Back-compat

- GSI absent (stack not yet on #344): first index-missing error flips a sticky flag → legacy path + one-time warning. Non-index errors rethrow, never masked.
- v1 cursors (clients mid-pagination at deploy time) finish on the legacy path; new sequences start on the GSI.

## Acceptance criteria (from #335)

- ✅ Time-ordered retrieval independent of PR-number order — tested with PR numbers **9 / 42 / 100 / 1000**
- ✅ Date-filtered queries return all matching rows (defect-3 fixture: 5 in-range rows behind 30 out-of-range rows, all 5 returned)
- ✅ `limit` bounds the result set, not the per-repo read
- ✅ Read cost measured before (dev table: 7-day filter read **31 items / 16 RCU, 0 matches**); after-measurement needs the deployed GSI — flagged on the tracker for post-merge verification

## Tests / docs

13 new unit tests (`dashboard-store.test.ts`) with a mock that faithfully models `Limit`-before-`FilterExpression`, key-condition bounds, and `ExclusiveStartKey` resume. `docs/pending/reviews-time-ordered-listing.md` + RUNBOOK scenario E2E-85. Full workspace build / typecheck / test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)