### PR TITLE
fix(dashboard): nearest-rank p95 duration with a minimum sample size (#336)

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -212,6 +212,7 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-83](#e2e-83-oss-program--operator-grant-lifecycle) | `grant-oss.ts` grant/add/remove/revoke/inspect; `--stage` guard; private repo rejected | 5m | n/a | #266 |
 | [E2E-84](#e2e-84-334--time-bounded-insight-rollup-windows) | Counter increments write per-UTC-day `periodCounts` buckets alongside lifetime counters; rollup windows sum only in-window activity (7d ≤ 30d ≤ 90d guaranteed); pre-#334 long-lived records ramp up instead of injecting lifetime history; both backends (#334) | 3m | 90s | #334 |
 | [E2E-85](#e2e-85-335--time-ordered-dynamodb-review-listing) | SaaS `listReviews` queries the `ByRepoCreatedAt` GSI: reverse-chronological across any PR numbers, date bounds in the key condition (no pre-filter `Limit` loss), `limit` bounds the merged result with lossless v2 resume cursors; sticky legacy fallback when the GSI is absent (#335) | 3m | 60s | #335 |
+| [E2E-86](#e2e-86-336--p95-duration-nearest-rank--minimum-sample) | Analytics p95 duration uses nearest-rank (`⌈n × 0.95⌉`, clamped) instead of returning the maximum for n ≤ 20; below 20 completed reviews the UI shows "—" with an explanatory tooltip and no P95 bar (#336) | 2m | 30s | #336 |
 
 ---
 
@@ -3021,6 +3022,23 @@ Branch: `fixture/85-time-ordered-reviews`. Seed one repo with reviews for PR num
 - [ ] `limit` bounds the merged result; full pagination is loss-free and duplicate-free
 - [ ] GSI-absent stack degrades to legacy with a single warning, no hard failure
 - [ ] Read cost on a date-filtered query scales with matching rows, not with rows read-and-discarded
+
+---
+
+### E2E-86: #336 — p95 duration: nearest-rank + minimum sample
+
+**Status:** 🚧 In review (#336) — fixture not yet run.
+
+**Behavior:** the analytics duration card computes p95 as the nearest-rank element (`⌈n × 0.95⌉`, clamped to a valid index) over completed reviews' durations. The old `floor(n × 0.95)` index returned the maximum for every n ≤ 20 — the slowest review wearing a percentile label, worst exactly when a new instance has little data. Below `MIN_P95_SAMPLE_SIZE` (20) completed reviews, `p95Ms` is `null` and the UI shows "—" with a "needs at least 20 completed reviews" tooltip and omits the P95 chart bar; Average and Completed still render.
+
+**How to run.**
+1. On an instance with < 20 completed reviews (or a date filter narrowing to that), open `/dashboard/analytics` → Activity tab: the P95 stat shows "—" (hover for the tooltip), the duration chart has only the Average bar.
+2. With ≥ 20 completed reviews: P95 renders a number that is **not** the slowest review unless the distribution genuinely puts it there (seed 20 distinct durations: p95 must equal the second-highest, rank 19).
+
+**Expected outcomes.**
+- [ ] n ≤ 19 → "—" + tooltip, no P95 bar, no fabricated number
+- [ ] n = 20 with distinct durations → p95 = second-highest value (not the maximum)
+- [ ] Average / Completed unaffected in both states
 
 ---
 

--- a/packages/dashboard/components/AnalyticsClient.tsx
+++ b/packages/dashboard/components/AnalyticsClient.tsx
@@ -53,7 +53,8 @@ interface AnalyticsData {
   avgMergeScore: number;
   scoreTrend: ScoreTrendPoint[];
   severityBreakdown: Record<string, number>;
-  durationStats: { avgMs: number; p95Ms: number; count: number };
+  // #336 — p95Ms is null below the aggregator's minimum sample size.
+  durationStats: { avgMs: number; p95Ms: number | null; count: number };
   repoBreakdown: RepoBreakdownItem[];
   categoryBreakdown: Record<string, number>;
   statusCounts: Record<string, number>;
@@ -537,7 +538,10 @@ export default function AnalyticsClient({ installationId }: AnalyticsClientProps
 
   const durationData = [
     { name: "Average", value: Math.round(data.durationStats.avgMs / 1000), fill: CHART_COLORS.blue },
-    { name: "P95", value: Math.round(data.durationStats.p95Ms / 1000), fill: CHART_COLORS.purple },
+    // #336 — no P95 bar below the minimum sample size (p95Ms is null).
+    ...(data.durationStats.p95Ms != null
+      ? [{ name: "P95", value: Math.round(data.durationStats.p95Ms / 1000), fill: CHART_COLORS.purple }]
+      : []),
   ];
 
   // Review success rate
@@ -707,9 +711,20 @@ export default function AnalyticsClient({ installationId }: AnalyticsClientProps
               </div>
               <div>
                 <p className="text-xs text-fg-tertiary">P95</p>
-                <p className="text-lg font-semibold text-fg-primary">
-                  {formatDuration(data.durationStats.p95Ms)}
-                </p>
+                {/* #336 — a p95 over a handful of reviews is just the maximum
+                    wearing a percentile label; show insufficient-data instead. */}
+                {data.durationStats.p95Ms != null ? (
+                  <p className="text-lg font-semibold text-fg-primary">
+                    {formatDuration(data.durationStats.p95Ms)}
+                  </p>
+                ) : (
+                  <p
+                    className="text-lg font-semibold text-fg-tertiary"
+                    title="Needs at least 20 completed reviews for a meaningful p95"
+                  >
+                    —
+                  </p>
+                )}
               </div>
               <div>
                 <p className="text-xs text-fg-tertiary">Completed</p>

--- a/packages/dashboard/lib/analytics-aggregate.test.ts
+++ b/packages/dashboard/lib/analytics-aggregate.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   aggregateReviews,
+  MIN_P95_SAMPLE_SIZE,
   type AggregatableReview,
 } from "./analytics-aggregate";
 
@@ -25,7 +26,8 @@ describe("aggregateReviews — empty input", () => {
     expect(result.totalFindings).toBe(0);
     // Guards the division-by-zero paths: every average must be 0, not NaN.
     expect(result.avgMergeScore).toBe(0);
-    expect(result.durationStats).toEqual({ avgMs: 0, p95Ms: 0, count: 0 });
+    // #336 — p95Ms is null (insufficient data), never a fabricated 0.
+    expect(result.durationStats).toEqual({ avgMs: 0, p95Ms: null, count: 0 });
     expect(result.costStats).toEqual({ totalCostUsd: 0, avgCostUsd: 0, costCount: 0 });
     expect(result.scoreTrend).toEqual([]);
     expect(result.findingsPerReviewTrend).toEqual([]);
@@ -37,7 +39,14 @@ describe("aggregateReviews — empty input", () => {
   });
 
   it("has no NaN anywhere in the zero state", () => {
-    const json = JSON.stringify(aggregateReviews([]));
+    const result = aggregateReviews([]);
+    // p95Ms is the one field that is LEGITIMATELY null (#336 insufficient
+    // data); mask it so the stringify check below catches NaN → null
+    // conversions everywhere else.
+    const json = JSON.stringify({
+      ...result,
+      durationStats: { ...result.durationStats, p95Ms: 0 },
+    });
     // JSON.stringify turns NaN into null — either would be a bug here.
     expect(json).not.toContain("null");
     expect(json).not.toContain("NaN");
@@ -294,29 +303,40 @@ describe("aggregateReviews — missing and malformed optional fields", () => {
   });
 });
 
-describe("aggregateReviews — percentile behavior (see #336)", () => {
-  // These assertions pin the CURRENT, KNOWN-WRONG behavior so the #333
-  // extraction is provably a no-op. #336 fixes the index and must update them.
-  it("currently returns the maximum for small samples (off-by-one)", () => {
+describe("aggregateReviews — percentile behavior (#336 fixed)", () => {
+  // #333 pinned the old off-by-one behavior here so the extraction was
+  // provably a no-op; #336 fixed the index, and these now assert the fix.
+  it("returns nearest-rank p95, not the maximum, at the sample threshold", () => {
     const durations = Array.from({ length: 20 }, (_, i) =>
       review({ durationMs: (i + 1) * 100 }),
     );
     const r = aggregateReviews(durations);
 
-    // Correct nearest-rank p95 of 1..20 hundreds would be 1900; index 19 gives 2000.
-    expect(r.durationStats.p95Ms).toBe(2000);
+    // Nearest-rank p95 of 1..20 hundreds = rank 19 = 1900. The old
+    // floor(20 × 0.95) = index 19 returned 2000 — the maximum.
+    expect(r.durationStats.p95Ms).toBe(1900);
   });
 
   it("sorts durations numerically, not lexicographically", () => {
-    // A default .sort() would order [1000, 200, 30] and corrupt every percentile.
-    const r = aggregateReviews([
+    // A default .sort() would order [1000, 200, 30] and corrupt every
+    // percentile. Below the #336 sample threshold p95 is withheld, so the
+    // numeric-sort guarantee is asserted through avgMs + a threshold-size run.
+    const small = aggregateReviews([
       review({ durationMs: 1000 }),
       review({ durationMs: 200 }),
       review({ durationMs: 30 }),
     ]);
+    expect(small.durationStats.avgMs).toBe(410);
+    expect(small.durationStats.p95Ms).toBeNull();
 
-    expect(r.durationStats.avgMs).toBe(410);
-    expect(r.durationStats.p95Ms).toBe(1000);
+    // 100..1900 plus a duplicate 1000: lexicographic order would misplace
+    // "1000" before "200" and surface the wrong rank. Sorted numerically the
+    // 20 values are 100..900, 1000, 1000, 1100..1900 → rank 19 = 1800.
+    const atThreshold = aggregateReviews([
+      ...Array.from({ length: 19 }, (_, i) => review({ durationMs: (i + 1) * 100 })),
+      review({ durationMs: 1000 }),
+    ]);
+    expect(atThreshold.durationStats.p95Ms).toBe(1800);
   });
 });
 
@@ -388,5 +408,61 @@ describe("aggregateReviews — no ceiling (#333 regression)", () => {
     const r = aggregateReviews(many);
     expect(r.costStats.costCount).toBe(COUNT);
     expect(r.costStats.totalCostUsd).toBeCloseTo(COUNT * 0.01, 4);
+  });
+});
+
+// ─── #336 — p95 nearest-rank + minimum sample size ──────────────────────────
+
+describe("aggregateReviews — p95 duration (#336)", () => {
+  /** n completed reviews with durations 1000, 2000, …, n×1000 ms (shuffled). */
+  function withDurations(n: number): AggregatableReview[] {
+    const ms = Array.from({ length: n }, (_, i) => (i + 1) * 1000);
+    // Deterministic shuffle — p95 must not depend on input order.
+    ms.sort((a, b) => (a * 7919) % 104729 - (b * 7919) % 104729);
+    return ms.map((durationMs) => review({ durationMs }));
+  }
+
+  /** Nearest-rank expectation over 1000..n×1000: rank ⌈n × 0.95⌉. */
+  function nearestRank95(n: number): number {
+    return Math.ceil(n * 0.95) * 1000;
+  }
+
+  it(`withholds p95 below MIN_P95_SAMPLE_SIZE (${MIN_P95_SAMPLE_SIZE})`, () => {
+    for (const n of [1, 5, 19]) {
+      const r = aggregateReviews(withDurations(n));
+      expect(r.durationStats.p95Ms, `n=${n}`).toBeNull();
+      expect(r.durationStats.count, `n=${n}`).toBe(n);
+    }
+  });
+
+  it("returns the nearest-rank element for n = 20, 21, 100", () => {
+    // n=20 → rank 19 → 19000: the SECOND-highest, where the old floor()
+    // index returned 20000 (the maximum wearing a percentile label).
+    expect(aggregateReviews(withDurations(20)).durationStats.p95Ms).toBe(19_000);
+    expect(nearestRank95(20)).toBe(19_000);
+    // n=21 → rank ⌈19.95⌉ = 20 → 20000 (old index: also 20000 — one rank
+    // high relative to nearest-rank only at some n; equal here).
+    expect(aggregateReviews(withDurations(21)).durationStats.p95Ms).toBe(nearestRank95(21));
+    // n=100 → rank 95 → 95000 (old index: 96000, one rank high).
+    expect(aggregateReviews(withDurations(100)).durationStats.p95Ms).toBe(95_000);
+  });
+
+  it("never exceeds the maximum and stays a valid element", () => {
+    for (const n of [20, 33, 47, 100]) {
+      const p95 = aggregateReviews(withDurations(n)).durationStats.p95Ms!;
+      expect(p95).toBeLessThanOrEqual(n * 1000);
+      expect(p95 % 1000).toBe(0); // an actual sample, not an interpolation
+    }
+  });
+
+  it("counts only completed reviews with a duration toward the sample size", () => {
+    // 19 complete + 5 failed-with-duration must stay below the threshold.
+    const rows = [
+      ...withDurations(19),
+      ...Array.from({ length: 5 }, () => review({ status: "failed", durationMs: 99_000 })),
+    ];
+    const r = aggregateReviews(rows);
+    expect(r.durationStats.count).toBe(19);
+    expect(r.durationStats.p95Ms).toBeNull();
   });
 });

--- a/packages/dashboard/lib/analytics-aggregate.ts
+++ b/packages/dashboard/lib/analytics-aggregate.ts
@@ -54,7 +54,12 @@ export interface AnalyticsAggregate {
   avgMergeScore: number;
   scoreTrend: ScoreTrendPoint[];
   severityBreakdown: Record<string, number>;
-  durationStats: { avgMs: number; p95Ms: number; count: number };
+  /**
+   * #336 — `p95Ms` is `null` when there are fewer than
+   * {@link MIN_P95_SAMPLE_SIZE} completed reviews with a duration; the UI
+   * renders an insufficient-data state instead of a number.
+   */
+  durationStats: { avgMs: number; p95Ms: number | null; count: number };
   repoBreakdown: Array<{ repo: string; count: number }>;
   categoryBreakdown: Record<string, number>;
   statusCounts: Record<string, number>;
@@ -62,6 +67,14 @@ export interface AnalyticsAggregate {
   mergeScoreDistribution: Record<number, number>;
   costStats: { totalCostUsd: number; avgCostUsd: number; costCount: number };
 }
+
+/**
+ * #336 — minimum completed-review count before a p95 is reported. 20 is the
+ * smallest n where nearest-rank p95 stops degenerating to the maximum
+ * (⌈20 × 0.95⌉ = rank 19 of 20 — the second-highest value); below it the
+ * "percentile" would just be the slowest review wearing a percentile label.
+ */
+export const MIN_P95_SAMPLE_SIZE = 20;
 
 /**
  * Reduce a set of reviews into the analytics payload.
@@ -173,11 +186,15 @@ export function aggregateReviews(
   const avgDuration = durations.length > 0
     ? Math.round(durations.reduce((s, d) => s + d, 0) / durations.length)
     : 0;
-  // NOTE: this index is off by one and returns the maximum for n <= 20.
-  // Preserved as-is by the #333 extraction; fixed under #336.
-  const p95Duration = durations.length > 0
-    ? durations[Math.floor(durations.length * 0.95)]
-    : 0;
+  // #336 — nearest-rank p95 (rank ⌈n × 0.95⌉, clamped to a valid index).
+  // The old `floor(n × 0.95)` index returned the MAXIMUM for every n ≤ 20
+  // and sat one rank high beyond that. Below the sample threshold the
+  // figure is withheld entirely: a "p95" that still equals the maximum is
+  // not a percentile, and it is most misleading on exactly the small
+  // datasets a new instance starts with.
+  const p95Duration = durations.length >= MIN_P95_SAMPLE_SIZE
+    ? durations[Math.min(durations.length - 1, Math.max(0, Math.ceil(durations.length * 0.95) - 1))]
+    : null;
 
   return {
     totalReviews: reviews.length,


### PR DESCRIPTION
Closes #336.

## What

`durations[Math.floor(n × 0.95)]` returns the **maximum** for every n ≤ 20 (`floor(20 × 0.95) = 19`, the last index) and sits one rank high beyond that. The stat was most wrong exactly when a user first evaluates the product — few reviews, narrow filters.

- **p95** is now nearest-rank: `min(n − 1, max(0, ceil(n × 0.95) − 1))` (the issue's suggested fix, applied in `lib/analytics-aggregate.ts` where #333 stage 1 moved the computation).
- **Minimum sample size**: below `MIN_P95_SAMPLE_SIZE = 20`, `p95Ms` is `null`. 20 is documented in code as the smallest n where nearest-rank p95 stops degenerating to the maximum (`⌈20 × 0.95⌉` = rank 19 of 20 = second-highest). The UI renders "—" with a "needs at least 20 completed reviews" tooltip and omits the P95 chart bar; Average/Completed are unaffected.

## Acceptance criteria (from #336)

- ✅ Correct nearest-rank element for n = 1, 5, 20, 21, 100 — tested (1/5 fall under the threshold → `null` by design; 20 → second-highest, 21 → rank 20, 100 → rank 95)
- ✅ Below a documented minimum sample size the UI shows insufficient-data, not a number
- ✅ Boundary unit tests, including order-independence (shuffled input), the exact n=20 threshold edge, duplicate values, and completed-reviews-only sample counting

Also updates the two #333-era tests that deliberately pinned the old off-by-one behavior ("#336 fixes the index and must update them" — done), and adds RUNBOOK scenario E2E-86. Full workspace build / typecheck / test green (37 aggregate tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)