### PR TITLE
fix(dashboard): date-only range bounds include their whole day (#337)

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -213,6 +213,7 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-84](#e2e-84-334--time-bounded-insight-rollup-windows) | Counter increments write per-UTC-day `periodCounts` buckets alongside lifetime counters; rollup windows sum only in-window activity (7d ≤ 30d ≤ 90d guaranteed); pre-#334 long-lived records ramp up instead of injecting lifetime history; both backends (#334) | 3m | 90s | #334 |
 | [E2E-85](#e2e-85-335--time-ordered-dynamodb-review-listing) | SaaS `listReviews` queries the `ByRepoCreatedAt` GSI: reverse-chronological across any PR numbers, date bounds in the key condition (no pre-filter `Limit` loss), `limit` bounds the merged result with lossless v2 resume cursors; sticky legacy fallback when the GSI is absent (#335) | 3m | 60s | #335 |
 | [E2E-86](#e2e-86-336--p95-duration-nearest-rank--minimum-sample) | Analytics p95 duration uses nearest-rank (`⌈n × 0.95⌉`, clamped) instead of returning the maximum for n ≤ 20; below 20 completed reviews the UI shows "—" with an explanatory tooltip and no P95 bar (#336) | 2m | 30s | #336 |
+| [E2E-87](#e2e-87-337--date-only-range-bounds-include-their-whole-day) | `/api/analytics` date-only `start_date`/`end_date` expand to the UTC day's edge instants at the boundary (`end_date=2026-08-16` includes the whole 16th); full timestamps pass through untouched; identical on both backends; UTC bucketing documented in the route (#337) | 2m | 30s | #337 |
 
 ---
 
@@ -3039,6 +3040,26 @@ Branch: `fixture/85-time-ordered-reviews`. Seed one repo with reviews for PR num
 - [ ] n ≤ 19 → "—" + tooltip, no P95 bar, no fabricated number
 - [ ] n = 20 with distinct durations → p95 = second-highest value (not the maximum)
 - [ ] Average / Completed unaffected in both states
+
+---
+
+### E2E-87: #337 — Date-only range bounds include their whole day
+
+**Status:** 🚧 In review (#337) — fixture not yet run.
+
+**Behavior:** the stores filter `createdAt` by string comparison against full ISO timestamps, so a date-only bound used to misbehave at one edge (`'2026-08-16T09:31:00.000Z' <= '2026-08-16'` is false → the entire final day silently excluded). `/api/analytics` now normalizes at the boundary: date-only `start_date` expands to `T00:00:00.000Z`, date-only `end_date` to `T23:59:59.999Z`; full timestamps pass through untouched (the dashboard UI sends exact viewer-local-derived instants that must not be re-widened). Both backends receive the same expanded instants — identical by construction. Timezone decision documented in the route: date-only params and trend-bucket labels are UTC calendar days; viewer-zone bucketing deliberately deferred until edge-day attribution matters.
+
+**How to run.**
+1. Seed reviews across three consecutive days, including one mid-morning on the last day. Call `/api/analytics?end_date=<last-day>` (date-only): the last day's reviews are included in totals and trends.
+2. Same call with `end_date=<last-day>T00:00:00.000Z`: last day excluded except midnight — full timestamps are honored verbatim.
+3. `start_date=<first-day>` date-only: the whole first day is included.
+4. Repeat 1 on self-hosted (Postgres): identical totals.
+
+**Expected outcomes.**
+- [ ] Date-only `end_date` includes the whole final day; date-only `start_date` the whole first day
+- [ ] Full-timestamp bounds honored exactly, never re-widened
+- [ ] Postgres and DynamoDB return identical results for the same parameters
+- [ ] Invalid date forms are ignored (no 500, no partial filter)
 
 ---
 

--- a/packages/dashboard/app/api/analytics/route.ts
+++ b/packages/dashboard/app/api/analytics/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from "@/lib/auth";
 import { getDashboardStore } from "@/lib/store";
 import { aggregateReviews } from "@/lib/analytics-aggregate";
 import { collectAllReviews, ANALYTICS_PAGE_SIZE } from "@/lib/analytics-collect";
+import { normalizeDateParam } from "@/lib/date-range";
 import {
   fetchUserInstallations,
   fetchAccessibleRepoNames,
@@ -32,12 +33,23 @@ export async function GET(req: NextRequest) {
   const installationIdParam = sp.get("installation_id");
   const repoParam = sp.get("repo") ?? undefined;
 
-  // Validate date parameters
-  const isoDateRegex = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d{3})?Z)?$/;
-  const rawStart = sp.get("start_date");
-  const rawEnd = sp.get("end_date");
-  const startDate = rawStart && isoDateRegex.test(rawStart) ? rawStart : undefined;
-  const endDate = rawEnd && isoDateRegex.test(rawEnd) ? rawEnd : undefined;
+  // #337 — validate + normalize date parameters. The stores compare
+  // `createdAt` as strings against full ISO timestamps, so a date-only bound
+  // is expanded to the edge instant of that UTC day here at the boundary
+  // (`end_date=2026-08-16` → `…T23:59:59.999Z`); previously it silently
+  // excluded the whole final day. Both backends receive the same expanded
+  // instants, so behavior is identical by construction.
+  //
+  // Timezone decision (#337): date-only parameters mean UTC calendar days,
+  // and the trend buckets computed downstream (aggregateReviews' substring
+  // day-keys) are likewise UTC days labeled by UTC date. The dashboard UI
+  // never sends date-only values — it converts the viewer's local day range
+  // to exact instants, so its FILTER honors local days while bucket labels
+  // remain UTC. Bucketing in the viewer's zone would need a tz parameter
+  // threaded through the API; deliberately not done until edge-day
+  // attribution proves to matter in practice.
+  const startDate = normalizeDateParam(sp.get("start_date"), "start");
+  const endDate = normalizeDateParam(sp.get("end_date"), "end");
 
   try {
     const userInstallations = await fetchUserInstallations(accessToken);

--- a/packages/dashboard/lib/date-range.test.ts
+++ b/packages/dashboard/lib/date-range.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { normalizeDateParam } from "./date-range";
+
+describe("normalizeDateParam (#337)", () => {
+  it("expands a date-only start to the first instant of the UTC day", () => {
+    expect(normalizeDateParam("2026-08-16", "start")).toBe("2026-08-16T00:00:00.000Z");
+  });
+
+  it("expands a date-only end to the last instant of the UTC day", () => {
+    expect(normalizeDateParam("2026-08-16", "end")).toBe("2026-08-16T23:59:59.999Z");
+  });
+
+  it("passes full timestamps through untouched, with and without millis", () => {
+    // The dashboard UI sends exact instants derived from viewer-local day
+    // boundaries — re-widening them would change the selected range.
+    expect(normalizeDateParam("2026-08-16T09:31:00.000Z", "end")).toBe("2026-08-16T09:31:00.000Z");
+    expect(normalizeDateParam("2026-08-16T09:31:00Z", "start")).toBe("2026-08-16T09:31:00Z");
+  });
+
+  it("returns undefined for absent input", () => {
+    expect(normalizeDateParam(null, "start")).toBeUndefined();
+    expect(normalizeDateParam("", "end")).toBeUndefined();
+  });
+
+  it("rejects invalid forms rather than passing them to the store", () => {
+    for (const bad of [
+      "2026-8-16",              // unpadded
+      "16-08-2026",             // wrong order
+      "2026-08-16T09:31Z",      // missing seconds
+      "2026-08-16T09:31:00",    // missing Z
+      "2026-08-16T09:31:00+02:00", // offset form not accepted
+      "2026-08-16T09:31:00.1Z", // millis must be exactly 3 digits
+      "not-a-date",
+      "2026-08-16 09:31:00Z",   // space separator
+    ]) {
+      expect(normalizeDateParam(bad, "end"), bad).toBeUndefined();
+    }
+  });
+
+  it("string-compares correctly: the expanded end bound includes every stored timestamp on that day", () => {
+    // The #337 defect: '2026-08-16T09:31:00.000Z' <= '2026-08-16' is FALSE,
+    // excluding the whole final day. After expansion the comparison holds
+    // for any toISOString()-format value on the day, and still excludes the
+    // next day.
+    const end = normalizeDateParam("2026-08-16", "end")!;
+    expect("2026-08-16T09:31:00.000Z" <= end).toBe(true);
+    expect("2026-08-16T23:59:59.998Z" <= end).toBe(true);
+    expect("2026-08-16T00:00:00.000Z" <= end).toBe(true);
+    expect("2026-08-17T00:00:00.000Z" <= end).toBe(false);
+
+    const start = normalizeDateParam("2026-08-16", "start")!;
+    expect("2026-08-16T00:00:00.000Z" >= start).toBe(true);
+    expect("2026-08-15T23:59:59.999Z" >= start).toBe(false);
+  });
+});

--- a/packages/dashboard/lib/date-range.ts
+++ b/packages/dashboard/lib/date-range.ts
@@ -1,0 +1,38 @@
+/**
+ * #337 — date-parameter normalization for the analytics query surface.
+ *
+ * The stores filter `createdAt` by STRING comparison against full ISO
+ * timestamps. A date-only bound therefore misbehaves at one edge:
+ * `'2026-08-16T09:31:00.000Z' <= '2026-08-16'` is false, so a date-only
+ * `end_date` silently excluded the entire final day of the range. The fix is
+ * to normalize at the API boundary — expand date-only values to the edge
+ * instant of that UTC day — so both backends receive the same exact instants
+ * and behave identically by construction.
+ */
+
+/**
+ * Accepted forms: `YYYY-MM-DD`, or a full UTC timestamp
+ * `YYYY-MM-DDTHH:MM:SS[.mmm]Z`. Anything else is rejected (treated as
+ * absent, matching the route's long-standing invalid-input behavior).
+ */
+const ISO_DATE_OR_TIMESTAMP_REGEX = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d{3})?Z)?$/;
+
+/**
+ * Validate a `start_date` / `end_date` query parameter and expand a
+ * date-only value to the edge instant of that UTC day:
+ *
+ *   - `edge: 'start'` → `T00:00:00.000Z` (whole first day included)
+ *   - `edge: 'end'`   → `T23:59:59.999Z` (whole final day included)
+ *
+ * Full timestamps pass through untouched — the dashboard UI already sends
+ * exact instants derived from the viewer's local day boundaries, and those
+ * must not be re-widened. Returns `undefined` for absent or invalid input.
+ */
+export function normalizeDateParam(
+  raw: string | null,
+  edge: 'start' | 'end',
+): string | undefined {
+  if (!raw || !ISO_DATE_OR_TIMESTAMP_REGEX.test(raw)) return undefined;
+  if (raw.includes('T')) return raw;
+  return edge === 'start' ? `${raw}T00:00:00.000Z` : `${raw}T23:59:59.999Z`;
+}


### PR DESCRIPTION
Closes #337.

## What

`'2026-08-16T09:31:00.000Z' <= '2026-08-16'` is false under the stores' string comparison, so a date-only `end_date` silently excluded the entire final day of the range. Latent (the dashboard UI always sends full instants), but `/api/analytics` is a documented query surface where `?end_date=2026-08-16` is the obvious thing to pass.

- **`lib/date-range.ts`** — pure `normalizeDateParam(raw, edge)`: validates the same forms the route accepted before, expands date-only values to the UTC day's edge instants (`start` → `T00:00:00.000Z`, `end` → `T23:59:59.999Z`), passes full timestamps through untouched, rejects invalid input as before. Extracted rather than inlined because the routes have no test harness (same pattern as #333).
- **Route** — uses the helper for both params. Normalization happens **above** the store, so Postgres and DynamoDB receive identical expanded instants — backend parity by construction (AC 2).
- **Timezone decision (AC 3), documented in the route**: date-only params and trend-bucket labels mean **UTC calendar days**; the dashboard UI's filter honors viewer-local days because it converts them to exact instants; bucketing in the viewer's zone is deliberately deferred (needs a `tz` parameter threaded through the API) until edge-day attribution proves to matter.

## Acceptance criteria (from #337)

- ✅ Date-only `end_date` includes the whole final day; date-only `start_date` the whole first day — tested, including the string-comparison inclusion property against same-day timestamps
- ✅ Identical on Postgres and DynamoDB — normalization precedes the store call
- ✅ Timezone bucketing decision made and documented in the route
- ✅ Tests for date-only and full-timestamp forms (with/without millis) + invalid-form rejection

6 new unit tests; RUNBOOK scenario E2E-87; full workspace build / typecheck / test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)