### PR TITLE
test(dashboard): close the #338 analytics-coverage checklist

### DIFF
--- a/packages/dashboard/lib/analytics-aggregate.test.ts
+++ b/packages/dashboard/lib/analytics-aggregate.test.ts
@@ -291,6 +291,26 @@ describe("aggregateReviews — missing and malformed optional fields", () => {
     expect(r.costStats.totalCostUsd).toBe(0);
   });
 
+  it("excludes a complete review with no durationMs from the duration stats (#338)", () => {
+    const r = aggregateReviews([
+      review({ durationMs: 4000 }),
+      review({ durationMs: undefined }),
+    ]);
+    expect(r.durationStats.count).toBe(1);
+    expect(r.durationStats.avgMs).toBe(4000);
+    expect(r.totalReviews).toBe(2); // still counted everywhere else
+  });
+
+  it("excludes a complete review with no estimatedCostUsd from the cost stats (#338)", () => {
+    const r = aggregateReviews([
+      review({ estimatedCostUsd: 0.05 }),
+      review({ estimatedCostUsd: undefined }),
+    ]);
+    expect(r.costStats.costCount).toBe(1);
+    expect(r.costStats.totalCostUsd).toBe(0.05);
+    expect(r.totalReviews).toBe(2);
+  });
+
   it("skips reviews with no createdAt in the trends but still counts them", () => {
     const r = aggregateReviews([
       review({ createdAt: undefined, mergeScore: 4, findingCount: 3 }),


### PR DESCRIPTION
Closes #338.

## Context

#338 asked for the analytics aggregation to be a pure, independently-testable function with a suite that would have caught #333/#336/#337. That work shipped incrementally with the fixes themselves — this PR audits the checklist, fills the two residual gaps, and performs the explicit fails-against-pre-fix verification the issue demands.

## Checklist → where it shipped

| #338 requirement | Where |
|---|---|
| Pure exported aggregation function | `lib/analytics-aggregate.ts` (#339, mirroring `buildInsightFromDispositions`) |
| Totals/breakdowns vs hand-computed fixture | #339 |
| Trend ordering, day bucketing, gap handling | #339 (days with no data omitted, ascending order, out-of-order input) |
| Percentile boundaries n = 1, 5, 20, 21, 100 | #346 (+ `MIN_P95_SAMPLE_SIZE` threshold) |
| Missing `mergeScore` / `findings` / `createdAt` | #339 |
| Missing `durationMs` / `estimatedCostUsd` | **this PR** (explicit exclusion tests) |
| Non-complete statuses excluded | #339 |
| Empty input | #339 |
| >500-review multi-month fixture | #339 — 1,234 reviews across ~154 days, no truncation, full trend coverage |

## AC 3 — suite fails against the pre-fix code (verified explicitly)

**Pre-#336 p95 index** (scratch-reverted `ceil`-rank to `durations[Math.floor(n * 0.95)]`):
```
Tests  5 failed | 32 passed (37)
  × percentile behavior (#336 fixed) > returns nearest-rank p95, not the maximum, at the sample threshold
  × percentile behavior (#336 fixed) > sorts durations numerically, not lexicographically
  × p95 duration (#336) > withholds p95 below MIN_P95_SAMPLE_SIZE (20)
  × p95 duration (#336) > returns the nearest-rank element for n = 20, 21, 100
  × p95 duration (#336) > counts only completed reviews with a duration toward the sample size
```

**#333-shaped truncation** (newest-first 500-slice simulated inside the aggregator):
```
Tests  6 failed | 31 passed (37)
  × no ceiling (#333 regression) > counts every review past the old 500 cap
  × no ceiling (#333 regression) > counts every finding past the old cap
  × no ceiling (#333 regression) > covers the full time span, oldest day included
  × no ceiling (#333 regression) > produces a trend point for every distinct day in the span
  × no ceiling (#333 regression) > attributes every review to a repo
  × no ceiling (#333 regression) > prices every completed review
```

Both scratch edits were reverted; the committed suite is green at **39/39**, full workspace build / typecheck / test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)