### PR TITLE
feat(core): wire minSeverity into the review pipeline (#310, phase 1)

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -2730,7 +2730,7 @@ curl -s "$MCP_URL" \
 
 ### E2E-78: Output shaping — `minSeverity`, `maxFindings`, `postSummaryOnClean`
 
-**Status:** ⬜ NOT YET COVERED.
+**Status:** ⬜ NOT YET COVERED. (`minSeverity` was documented-but-unwired until #310 — the filter now exists; fixture still to be run.)
 
 **Behavior:** Three independent knobs on what reaches the PR: `minSeverity` (`info` | `warning` | `critical`) drops lower-severity findings; `maxFindings` caps how many are posted; `postSummaryOnClean` decides whether a clean PR gets a comment at all.
 

--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -1141,6 +1141,94 @@ describe('runReviewPipeline', () => {
     expect(result.mergeScoreReason).toContain('no new criticals');
   });
 
+  // ─── #310 — minSeverity threshold filter ─────────────────────────────────
+
+  /**
+   * Orchestrator returns one finding per severity tier, all on a changed line
+   * (line 3 of sampleDiff) with distinct titles/descriptions so the W10
+   * clustering step cannot merge them. Shared by the threshold tests below.
+   */
+  function mixedSeverityResponses(): string[] {
+    const mixedFindings = [
+      { file: 'foo.ts', line: 3, severity: 'info',     category: 'style',    title: 'Rename variable',     description: 'Cosmetic naming.',    suggestion: '…' },
+      { file: 'foo.ts', line: 3, severity: 'warning',  category: 'bug',      title: 'Possible race',       description: 'Concurrent access.',  suggestion: '…' },
+      { file: 'foo.ts', line: 3, severity: 'critical', category: 'security', title: 'Credential exposure', description: 'Secret in payload.',  suggestion: '…' },
+    ];
+    const emptyAgent = JSON.stringify({ findings: [] });
+    const summaryResponse = JSON.stringify({ summary: 'Refactor.' });
+    const diagramResponse = '%% overview\nflowchart TD\n  A-->B';
+    const orchestratorResponse = JSON.stringify({
+      findings: mixedFindings,
+      mergeScore: 2,
+      mergeScoreReason: 'Critical present.',
+    });
+    return [
+      // The security agent emits the raw findings so `totalRawFindings` is
+      // non-zero and the suppression math can register the dropped tiers.
+      JSON.stringify({ findings: mixedFindings }),
+      emptyAgent, emptyAgent, emptyAgent, emptyAgent, emptyAgent,
+      summaryResponse, diagramResponse, orchestratorResponse,
+    ];
+  }
+
+  function pipelineOptions(minSeverity?: 'info' | 'warning' | 'critical'): ReviewPipelineOptions {
+    return {
+      diff: sampleDiff,
+      context: sampleContext,
+      modelId: 'heavy-model',
+      lightModelId: 'light-model',
+      maxFindings: 25,
+      enabledAgents: allAgentsEnabled,
+      // Forces the orchestrator to run even though the agent responses are
+      // empty — same trick as the mergeScore-reconciliation tests above.
+      previousFindings: [
+        { file: 'foo.ts', line: 100, title: 'Prior note', severity: 'info' as const, category: 'style' },
+      ],
+      ...(minSeverity ? { minSeverity } : {}),
+    };
+  }
+
+  it('#310: minSeverity warning drops info findings and counts them as suppressed', async () => {
+    const llm = createMockLLM(mixedSeverityResponses());
+    const result = await runReviewPipeline(pipelineOptions('warning'), { llm });
+
+    expect(result.findings.map((f) => f.severity).sort()).toEqual(['critical', 'warning']);
+    expect(result.findings.some((f) => f.severity === 'info')).toBe(false);
+    expect(result.suppressedCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('#310: minSeverity critical keeps only critical findings', async () => {
+    const llm = createMockLLM(mixedSeverityResponses());
+    const result = await runReviewPipeline(pipelineOptions('critical'), { llm });
+
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].severity).toBe('critical');
+  });
+
+  it('#310: the info default reports every tier (no filtering)', async () => {
+    const llm = createMockLLM(mixedSeverityResponses());
+    const result = await runReviewPipeline(pipelineOptions(), { llm });
+
+    expect(result.findings.map((f) => f.severity).sort()).toEqual(['critical', 'info', 'warning']);
+    expect(result.suppressedCount).toBe(0);
+  });
+
+  it('#310: a finding without a recognized severity is kept under a threshold (no surprise suppression)', async () => {
+    const responses = mixedSeverityResponses();
+    responses[8] = JSON.stringify({
+      findings: [
+        { file: 'foo.ts', line: 3, severity: 'bogus', category: 'bug', title: 'Odd tier', description: 'Unknown severity.', suggestion: '…' },
+      ],
+      mergeScore: 3,
+      mergeScoreReason: 'One finding.',
+    });
+    const llm = createMockLLM(responses);
+    const result = await runReviewPipeline(pipelineOptions('critical'), { llm });
+
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].title).toBe('Odd tier');
+  });
+
   it('forces mergeScore >= 3 (yellow) when net improvement: more resolved than new criticals', async () => {
     // Net improvement: 3 prior criticals resolved, but the LLM flagged 1 new
     // critical on the fix code (could be a real concern or an over-eager

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -1046,6 +1046,14 @@ export interface ReviewPipelineOptions {
   lightModelId: string;
   customStyleRules?: string[];
   maxFindings: number;
+  /**
+   * #310 — minimum severity a finding needs to be reported. Findings below
+   * the threshold are dropped by a deterministic post-orchestrator filter
+   * (rolling into `suppressedCount`). Fed from `.mergewatch.yml`
+   * `minSeverity:` merged with the dashboard's severity-threshold setting.
+   * Defaults to 'info' (report everything) when absent.
+   */
+  minSeverity?: 'info' | 'warning' | 'critical';
   enabledAgents: {
     security: boolean;
     bugs: boolean;
@@ -2068,6 +2076,7 @@ export async function runReviewPipeline(
     lightModelId,
     customStyleRules = [],
     maxFindings,
+    minSeverity = 'info',
     enabledAgents,
     fileFetchOptions,
     groundingFetch,
@@ -2212,6 +2221,30 @@ export async function runReviewPipeline(
         dropped,
         dropped === 1 ? '' : 's',
         CONFIDENCE_FLOOR,
+      );
+    }
+  }
+
+  // #310 — minSeverity threshold filter. The key was documented, parsed,
+  // merged, and fed by the dashboard's severity-threshold control for months
+  // without anything reading it; this is the read. Same deterministic-post-
+  // orchestrator shape as the confidence floor above. A finding with no
+  // severity is kept (no surprise suppression), mirroring the confidence
+  // default. Drops roll into `suppressedCount` downstream.
+  if (minSeverity !== 'info') {
+    const severityRank: Record<string, number> = { info: 0, warning: 1, critical: 2 };
+    const threshold = severityRank[minSeverity];
+    const before = orchestratorResult.findings.length;
+    orchestratorResult.findings = orchestratorResult.findings.filter(
+      (f) => (severityRank[f.severity] ?? threshold) >= threshold,
+    );
+    const dropped = before - orchestratorResult.findings.length;
+    if (dropped > 0) {
+      console.warn(
+        '[min-severity] dropped %d finding%s below the %s threshold',
+        dropped,
+        dropped === 1 ? '' : 's',
+        minSeverity,
       );
     }
   }

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -805,6 +805,8 @@ export async function handler(
       lightModelId,
       customStyleRules: runtimeConfig.customStyleRules,
       maxFindings: runtimeConfig.maxFindings,
+      // #310 — merged from yml `minSeverity:` + dashboard severityThreshold.
+      minSeverity: runtimeConfig.minSeverity,
       enabledAgents: mode === 'summary'
         ? { security: false, bugs: false, style: false, summary: true, diagram: false, errorHandling: false, testCoverage: false, commentAccuracy: false }
         : { ...runtimeConfig.agents, diagram: instSettings.summary.diagram },

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -665,6 +665,8 @@ export async function processReviewJob(
         lightModelId: config.lightModel || config.model,
         customStyleRules: config.customStyleRules,
         maxFindings: config.maxFindings,
+        // #310 — merged from yml `minSeverity:` + dashboard severityThreshold.
+        minSeverity: config.minSeverity,
         enabledAgents: {
           ...config.agents,
           diagram: instSettings.summary?.diagram !== false,


### PR DESCRIPTION
Part of #310 — phase 1 of 2, per the decision on the ticket (wire `minSeverity`; phase 2 removes `installation.config`/`modelId` and adds the config-key guard test, which requires this to land first or it would flag `minSeverity` as unread).

## What

`minSeverity` was documented, parsed with validation, typed, defaulted, merged in both runtimes, and fed by the dashboard's severity-threshold control — and never read (#310 defect 1). This PR is the read:

- **`reviewer.ts`**: `minSeverity` on `ReviewPipelineOptions` + a deterministic post-orchestrator filter in the same chain as the FP-A confidence floor. Drops roll into `suppressedCount` (it's computed as raw-minus-final downstream). A finding with an unrecognized severity is kept — no surprise suppression, mirroring the confidence-floor default.
- **Both runtimes** pass `config.minSeverity` — already merged from yml `minSeverity:` + the dashboard `severityThreshold` — so **both advertised surfaces activate at once** (the issue explicitly asked for that to be a conscious choice; it is the documented decision).
- `info` default = no-op, so behavior is unchanged for every config that never set it.

## Tests

4 new pipeline tests: `warning` drops info (and registers in `suppressedCount`), `critical` keeps only criticals, the `info` default reports every tier, and an unrecognized severity survives a threshold. 195/195 in the reviewer suite; full workspace build/typecheck/test green.

## Docs

`mergewatch-yml.mdx` already described exactly this behavior — it is now true as written. E2E-78's status line notes the wiring (fixture still to be run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)