### PR TITLE
chore(config): remove the never-written installation.config and modelId surfaces (#310, phase 2)

### DIFF
--- a/packages/core/src/config/config-key-usage.test.ts
+++ b/packages/core/src/config/config-key-usage.test.ts
@@ -1,0 +1,101 @@
+/**
+ * #310 — config-key read tripwire.
+ *
+ * The #310 defect class: a `MergeWatchConfig` key that is documented, parsed
+ * (github/client.ts), typed and defaulted (config/defaults.ts), and merged by
+ * the runtimes — but never READ, so it silently does nothing. `minSeverity`
+ * shipped that way for months; `config.model` before it (#264/#268). Tests
+ * passed because they asserted the parse and the merge; only a grep for the
+ * read revealed the hole.
+ *
+ * This test is that grep, run on every build (same repo-walking shape as
+ * source-hygiene.test.ts from #307). For each top-level key of
+ * `MergeWatchConfig` it requires at least one dot-access read (`.key`) in
+ * package source OUTSIDE the three definition surfaces: the parser
+ * (github/client.ts), the type/defaults/merge module (config/defaults.ts),
+ * and test files. A key named only in those places parses and merges but is
+ * never consumed — exactly the #310 shape.
+ *
+ * The dot-access heuristic deliberately does not count object-literal
+ * property positions (`minSeverity: severityMap[...]` in a runtime's config
+ * assembly is a WRITE and would not have saved minSeverity). It can be
+ * satisfied by an unrelated object's same-named property — this is a
+ * tripwire against the fully-dead case, not a proof of correct use.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve, relative } from 'node:path';
+import { DEFAULT_CONFIG } from './defaults.js';
+
+const REPO_ROOT = resolve(process.cwd(), '..', '..');
+const PACKAGES_ROOT = join(REPO_ROOT, 'packages');
+
+const SKIP_DIRS = new Set([
+  'node_modules', '.git', 'dist', '.next', '.turbo', 'coverage', 'build', '.sam',
+]);
+
+/** The definition surfaces a key must be referenced OUTSIDE of. */
+const DEFINITION_FILES = new Set([
+  'packages/core/src/config/defaults.ts',
+  'packages/core/src/github/client.ts',
+]);
+
+/**
+ * Known-dead keys this tripwire flagged on its FIRST run — two more
+ * instances of the #310 class, found exactly as its remaining-key audit
+ * predicted. Tracked in #350; wiring each requires a product decision
+ * (comment-gating behavior / per-model token defaults), so they are
+ * allowlisted rather than scope-crept into #310's cleanup. Removing an
+ * entry here is the definition of done for wiring that key. Do NOT add to
+ * this list — wire or remove new keys instead.
+ */
+const KNOWN_DEAD_KEYS = new Set(['maxTokensPerAgent', 'postSummaryOnClean']); // #350
+
+function walk(dir: string, out: string[] = []): string[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    if (SKIP_DIRS.has(entry)) continue;
+    const full = join(dir, entry);
+    let isDir: boolean;
+    try {
+      isDir = statSync(full).isDirectory();
+    } catch {
+      continue;
+    }
+    if (isDir) walk(full, out);
+    else if (/\.(ts|tsx)$/.test(entry) && !/\.test\.tsx?$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+describe('MergeWatchConfig key usage (#310)', () => {
+  it('every config key has a read outside the parser, defaults, and tests', () => {
+    const sources = walk(PACKAGES_ROOT)
+      .map((file) => ({ rel: relative(REPO_ROOT, file), file }))
+      .filter(({ rel }) => !DEFINITION_FILES.has(rel));
+
+    const contents = sources.map(({ rel, file }) => ({ rel, text: readFileSync(file, 'utf8') }));
+
+    const dead: string[] = [];
+    for (const key of Object.keys(DEFAULT_CONFIG)) {
+      if (KNOWN_DEAD_KEYS.has(key)) continue; // #350 — tracked, not silently passed
+      // Dot-access read: `.key` at a property boundary. Writes in object
+      // literals (`key: value`) intentionally do not match.
+      const read = new RegExp(`\\.${key}\\b`);
+      const hit = contents.find(({ text }) => read.test(text));
+      if (!hit) dead.push(key);
+    }
+
+    expect(
+      dead,
+      'These MergeWatchConfig keys parse and merge but are never read — the '
+        + '#310 defect class. Wire each into the behavior its docs promise, '
+        + 'or remove it from the config surface (type, parser, docs).',
+    ).toEqual([]);
+  });
+});

--- a/packages/core/src/config/model-resolution.test.ts
+++ b/packages/core/src/config/model-resolution.test.ts
@@ -4,6 +4,10 @@
  * The regression these guard against: `.mergewatch.yml` `model:` documented as
  * functional but never read, and a merged-config value accidentally overriding
  * the deploy-time default for every repository at once.
+ *
+ * #310 removed the `installation.modelId` tier (nothing ever wrote it; 0 of
+ * 525 production rows carried it), so the chain is now
+ * repo-config → deploy-default → fallback.
  */
 import { describe, it, expect } from 'vitest';
 import { resolveReviewModelId } from './model-resolution';
@@ -11,7 +15,6 @@ import { resolveReviewModelId } from './model-resolution';
 const FALLBACK = 'us.anthropic.claude-opus-4-6-v1';
 const DEPLOY = 'us.anthropic.claude-sonnet-4-20250514-v1:0';
 const REPO = 'us.anthropic.claude-haiku-4-5-20251001-v1:0';
-const INSTALL = 'us.anthropic.claude-opus-4-8-v1';
 
 describe('resolveReviewModelId', () => {
   it('uses the deploy default when nothing else is set', () => {
@@ -27,38 +30,6 @@ describe('resolveReviewModelId', () => {
       deployDefault: DEPLOY,
       fallback: FALLBACK,
     })).toEqual({ modelId: REPO, source: 'repo-config' });
-  });
-
-  it('lets the committed yml beat the installation-row override', () => {
-    // Aligned with the configuration contract #306 established for the rest of
-    // the config merge: "the .mergewatch.yml in the repository always wins".
-    // Before that alignment these two adjacent paths in review-agent.ts
-    // disagreed about which source outranked the other.
-    expect(resolveReviewModelId({
-      installationModelId: INSTALL,
-      repoConfigModel: REPO,
-      deployDefault: DEPLOY,
-      fallback: FALLBACK,
-    })).toEqual({ modelId: REPO, source: 'repo-config' });
-  });
-
-  it('uses the installation-row override when the yml is silent', () => {
-    expect(resolveReviewModelId({
-      installationModelId: INSTALL,
-      deployDefault: DEPLOY,
-      fallback: FALLBACK,
-    })).toEqual({ modelId: INSTALL, source: 'installation' });
-  });
-
-  it('does not let an installation override resurrect a blank yml model', () => {
-    // A blank `model:` is "unset", not "defer to the row above me" — it should
-    // fall through the whole chain the same way an absent key does.
-    expect(resolveReviewModelId({
-      repoConfigModel: '   ',
-      installationModelId: INSTALL,
-      deployDefault: DEPLOY,
-      fallback: FALLBACK,
-    })).toEqual({ modelId: INSTALL, source: 'installation' });
   });
 
   it('falls back when the deploy default is unset', () => {
@@ -92,19 +63,10 @@ describe('resolveReviewModelId', () => {
     })).toEqual({ modelId: REPO, source: 'repo-config' });
   });
 
-  it('skips an empty installation override', () => {
-    expect(resolveReviewModelId({
-      installationModelId: '',
-      deployDefault: DEPLOY,
-      fallback: FALLBACK,
-    })).toEqual({ modelId: DEPLOY, source: 'deploy-default' });
-  });
-
   it('the full chain degrades in order as each source is removed', () => {
-    const all = { repoConfigModel: REPO, installationModelId: INSTALL, deployDefault: DEPLOY, fallback: FALLBACK };
+    const all = { repoConfigModel: REPO, deployDefault: DEPLOY, fallback: FALLBACK };
     expect(resolveReviewModelId(all).modelId).toBe(REPO);
-    expect(resolveReviewModelId({ ...all, repoConfigModel: undefined }).modelId).toBe(INSTALL);
-    expect(resolveReviewModelId({ ...all, repoConfigModel: undefined, installationModelId: undefined }).modelId).toBe(DEPLOY);
+    expect(resolveReviewModelId({ ...all, repoConfigModel: undefined }).modelId).toBe(DEPLOY);
     expect(resolveReviewModelId({ fallback: FALLBACK }).modelId).toBe(FALLBACK);
   });
 
@@ -113,10 +75,9 @@ describe('resolveReviewModelId', () => {
     // where the running model came from.
     const sources = [
       resolveReviewModelId({ repoConfigModel: REPO, fallback: FALLBACK }).source,
-      resolveReviewModelId({ installationModelId: INSTALL, fallback: FALLBACK }).source,
       resolveReviewModelId({ deployDefault: DEPLOY, fallback: FALLBACK }).source,
       resolveReviewModelId({ fallback: FALLBACK }).source,
     ];
-    expect(sources).toEqual(['repo-config', 'installation', 'deploy-default', 'fallback']);
+    expect(sources).toEqual(['repo-config', 'deploy-default', 'fallback']);
   });
 });

--- a/packages/core/src/config/model-resolution.ts
+++ b/packages/core/src/config/model-resolution.ts
@@ -10,15 +10,12 @@
  * Precedence, highest first:
  *
  *   1. `.mergewatch.yml` `model:`      — the repository's committed intent
- *   2. `installation.modelId`          — per-repo override on the installation row
- *   3. `DEFAULT_BEDROCK_MODEL_ID`      — the deploy-time default
- *   4. hardcoded fallback
+ *   2. `DEFAULT_BEDROCK_MODEL_ID`      — the deploy-time default
+ *   3. hardcoded fallback
  *
- * The committed yml outranks stored installation state, matching the
- * configuration contract the rest of the config merge follows since #306
- * ("the .mergewatch.yml in the repository always wins") — see
- * `packages/server/src/review-processor.ts`. Before that alignment these two
- * adjacent code paths disagreed about which source won.
+ * (#310 removed the `installation.modelId` tier that sat between the yml and
+ * the deploy default — nothing ever wrote it and 0 of 525 production rows
+ * carried it. The supported per-repo model override is `model:` in the yml.)
  *
  * Note the deploy default sits at the BOTTOM here, unlike self-hosted's
  * `LLM_MODEL`, which overrides everything including the yml. That asymmetry is
@@ -38,12 +35,6 @@ export interface ModelResolutionInput {
    * everywhere — turning a per-repo opt-in into a global change.
    */
   repoConfigModel?: string;
-  /**
-   * Per-repo override stored on the installation row. Nothing writes this
-   * today (see `InstallationItem.modelId`); read so a hand-set row keeps
-   * working. Outranked by the committed yml.
-   */
-  installationModelId?: string;
   /** Deploy-time default (`DEFAULT_BEDROCK_MODEL_ID`). */
   deployDefault?: string;
   /** Last-resort fallback when the deploy default is unset. */
@@ -51,7 +42,6 @@ export interface ModelResolutionInput {
 }
 
 export type ModelSource =
-  | 'installation'
   | 'repo-config'
   | 'deploy-default'
   | 'fallback';
@@ -65,15 +55,13 @@ export interface ResolvedModel {
 /**
  * Resolve the model a review should run on.
  *
- * Precedence: `.mergewatch.yml` → installation override → deploy default →
- * hardcoded fallback. Empty and whitespace-only values are treated as unset,
- * so a `model:` key left blank in YAML falls through instead of resolving to
- * an empty model ID.
+ * Precedence: `.mergewatch.yml` → deploy default → hardcoded fallback.
+ * Empty and whitespace-only values are treated as unset, so a `model:` key
+ * left blank in YAML falls through instead of resolving to an empty model ID.
  */
 export function resolveReviewModelId(input: ModelResolutionInput): ResolvedModel {
   const candidates: Array<[ModelSource, string | undefined]> = [
     ['repo-config', input.repoConfigModel],
-    ['installation', input.installationModelId],
     ['deploy-default', input.deployDefault],
   ];
 

--- a/packages/core/src/types/db.ts
+++ b/packages/core/src/types/db.ts
@@ -104,32 +104,19 @@ export interface InstallationItem {
    */
   installedAt: string;
 
-  /**
-   * Parsed contents of the repository's `.mergewatch.yml` configuration file.
-   * This is fetched from the repo's default branch during installation and
-   * updated when the config file changes.
-   *
-   * Stored as a DynamoDB Map type. If the repo has no config file, this
-   * will be an empty object (defaults are applied at review time).
-   */
-  config: RepoConfig;
-
-  /**
-   * Amazon Bedrock model ID override for this specific repository.
-   *
-   * Precedence (#264): this wins over `.mergewatch.yml` `model:`, which in turn
-   * wins over the deploy-time `DEFAULT_BEDROCK_MODEL_ID`.
-   *
-   * NOTE: nothing in the codebase currently *writes* this field — there is no
-   * dashboard control or API that sets it, so in practice it is only ever
-   * present if someone edited the row by hand. The supported way to pick a
-   * per-repo model is `model:` in `.mergewatch.yml`. It is read (not removed)
-   * so any hand-set row keeps working; if a dashboard control is added later,
-   * this is where it should land.
-   *
-   * Example: "us.anthropic.claude-sonnet-4-20250514-v1:0"
-   */
-  modelId?: string;
+  // #310 — two fields removed from this interface rather than documented:
+  //   • `config` — typed as the parsed `.mergewatch.yml`, documented as
+  //     populated on installation, and merged into the effective config by
+  //     both runtimes. Nothing ever wrote it (both webhooks stored a literal
+  //     `{}`; 0 of 525 production rows had a non-empty map), so the
+  //     documented `storedConfig` precedence tier was always empty — and it
+  //     caused a wrong measurement when `config.model` was scanned to size
+  //     #268's impact. The committed `.mergewatch.yml` (fetched at review
+  //     time) and the dashboard settings are the real config surfaces.
+  //   • `modelId` — per-repo model override, read by the SaaS handler but
+  //     written by nothing (0 of 525 production rows). The supported way to
+  //     pick a per-repo model is `model:` in `.mergewatch.yml` (#264/#268).
+  // The underlying DB columns remain in place, inert, so no migration.
 
   /** Deprecated — retained for backward compatibility. The pipeline reviews all installed repos regardless of this flag. */
   monitored?: boolean;

--- a/packages/dashboard/app/api/repositories/route.ts
+++ b/packages/dashboard/app/api/repositories/route.ts
@@ -49,22 +49,6 @@ export async function GET(req: NextRequest) {
 
     const store = await getDashboardStore();
 
-    // Fetch config flags from store
-    const configMap = new Map<string, boolean>();
-
-    try {
-      const items = await store.installations.listByInstallation(installationIdParam);
-      for (const item of items) {
-        const cfg = item.config;
-        configMap.set(
-          item.repoFullName,
-          cfg != null && typeof cfg === "object" && Object.keys(cfg).length > 0,
-        );
-      }
-    } catch {
-      // Store error — defaults apply
-    }
-
     // Fetch review stats for this page's repos
     const repoNames = ghRepos.map((r) => r.repoFullName);
     const statsMap = await store.reviews.getRepoStats(repoNames);
@@ -80,7 +64,6 @@ export async function GET(req: NextRequest) {
         reviewCount: stats?.reviewCount ?? 0,
         issueCount: stats?.issueCount ?? 0,
         lastReviewedAt: stats?.lastReviewedAt ?? null,
-        hasConfig: configMap.get(r.repoFullName) ?? false,
         installationId: installationIdParam,
       };
     });

--- a/packages/dashboard/app/dashboard/repositories/RepositoriesClient.tsx
+++ b/packages/dashboard/app/dashboard/repositories/RepositoriesClient.tsx
@@ -6,7 +6,6 @@ import {
   Search,
   GitBranch,
   Clock,
-  Settings as SettingsIcon,
   Loader2,
 } from "lucide-react";
 import RelativeTime from "@/components/RelativeTime";
@@ -19,7 +18,6 @@ export interface RepositoryView {
   reviewCount: number;
   issueCount: number;
   lastReviewedAt: string | null;
-  hasConfig: boolean;
   installationId: string;
 }
 
@@ -345,14 +343,6 @@ function RepoCard({
 
       {/* Status */}
       <RepoStatus repo={repo} />
-
-      {/* Config badge */}
-      {repo.hasConfig && (
-        <div className="flex items-center gap-1.5 mt-3">
-          <SettingsIcon size={11} className="text-fg-muted" />
-          <span className="text-fg-muted text-xs font-mono">.mergewatch.yml</span>
-        </div>
-      )}
     </div>
   );
 }

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -612,13 +612,10 @@ export async function handler(
 
     // Model resolution (#264). Precedence, highest first:
     //   1. .mergewatch.yml `model:`  — the repository's committed intent
-    //   2. installation.modelId      — per-repo override on the installation row
-    //   3. DEFAULT_BEDROCK_MODEL_ID  — the deploy-time default
+    //   2. DEFAULT_BEDROCK_MODEL_ID  — the deploy-time default
     //
-    // The committed yml outranks stored installation state, matching the
-    // configuration contract the runtimeConfig merge above follows since #306
-    // ("the .mergewatch.yml in the repository always wins"). These two adjacent
-    // paths previously disagreed about which source won.
+    // (#310 removed the `installation.modelId` tier that sat between them —
+    // nothing ever wrote it, and 0 of 525 production rows carried it.)
     //
     // Read the RAW yamlConfig, never runtimeConfig.model: mergeConfig always
     // fills DEFAULT_CONFIG.model, so the merged value is truthy for every repo
@@ -629,7 +626,6 @@ export async function handler(
     // ignored `model:` entirely — while the very next line honored
     // `lightModel:`.
     const resolvedModel = resolveReviewModelId({
-      installationModelId: installation?.modelId,
       repoConfigModel: yamlConfig?.model,
       deployDefault: DEFAULT_BEDROCK_MODEL_ID,
       fallback: FALLBACK_BEDROCK_MODEL_ID,

--- a/packages/lambda/src/handlers/webhook.ts
+++ b/packages/lambda/src/handlers/webhook.ts
@@ -149,7 +149,6 @@ async function storeInstallation(event: InstallationEvent): Promise<void> {
           installationId: String(event.installation.id),
           repoFullName: event.installation.account.login,
           installedAt: event.installation.created_at,
-          config: {},
         },
       })
     );
@@ -164,7 +163,6 @@ async function storeInstallation(event: InstallationEvent): Promise<void> {
           installationId: String(event.installation.id),
           repoFullName: repo.full_name,
           installedAt: event.installation.created_at,
-          config: {},
         },
       })
     );

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -431,22 +431,20 @@ export async function processReviewJob(
       : [],
   };
 
-  // Merge config. Precedence: defaults < dashboard settings < stored
-  // installation config < the repo's committed .mergewatch.yml < LLM_MODEL env
-  // (global model pin for self-hosted). The committed yml wins over dashboard
-  // settings per the documented configuration contract ("the .mergewatch.yml
-  // in the repository always wins"); dashboard values apply only where the
-  // yml is silent.
+  // Merge config. Precedence: defaults < dashboard settings < the repo's
+  // committed .mergewatch.yml < LLM_MODEL env (global model pin for
+  // self-hosted). The committed yml wins over dashboard settings per the
+  // documented configuration contract ("the .mergewatch.yml in the
+  // repository always wins"); dashboard values apply only where the yml is
+  // silent. (#310 removed the `storedConfig` tier that used to sit between
+  // dashboard settings and the yml — nothing ever populated it.)
   // yamlConfig was fetched earlier for the smart-skip includePatterns override; reuse it here.
   const modelOverride = process.env.LLM_MODEL;
-  const storedConfig = (installation?.config || {}) as Partial<MergeWatchConfig>;
   const config = mergeConfig({
     ...settingsOverrides,
-    ...storedConfig,
     ...(yamlConfig ?? {}),
     agents: {
       ...settingsOverrides.agents,
-      ...(storedConfig.agents ?? {}),
       ...(yamlConfig?.agents ?? {}),
     },
     ...(modelOverride ? { model: modelOverride, lightModel: modelOverride } : {}),

--- a/packages/server/src/webhook-handler.ts
+++ b/packages/server/src/webhook-handler.ts
@@ -369,7 +369,6 @@ async function handleInstallation(payload: InstallationEvent, deps: WebhookDeps)
       installationId: String(installation.id),
       repoFullName: repo.full_name as string,
       installedAt: new Date().toISOString(),
-      config: {},
     });
   }
 }

--- a/packages/storage-postgres/src/installation-store.ts
+++ b/packages/storage-postgres/src/installation-store.ts
@@ -22,8 +22,9 @@ export class PostgresInstallationStore implements IInstallationStore {
       installationId: row.installationId,
       repoFullName: row.repoFullName,
       installedAt: row.installedAt,
-      config: row.config as any,
-      ...(row.modelId ? { modelId: row.modelId } : {}),
+      // #310 — the config/model_id columns still exist but are no longer
+      // surfaced: nothing ever wrote config, and modelId's read tier was
+      // removed with it.
       monitored: row.monitored,
     };
   }
@@ -53,16 +54,12 @@ export class PostgresInstallationStore implements IInstallationStore {
         installationId: item.installationId,
         repoFullName: item.repoFullName,
         installedAt: item.installedAt,
-        config: item.config as any,
-        modelId: item.modelId ?? null,
         monitored: item.monitored ?? true,
       })
       .onConflictDoUpdate({
         target: [installations.installationId, installations.repoFullName],
         set: {
           installedAt: item.installedAt,
-          config: item.config as any,
-          modelId: item.modelId ?? null,
           monitored: item.monitored ?? true,
         },
       });


### PR DESCRIPTION
Phase 2 of 2 — follows #349 (merged: `minSeverity` wired). Closes #310.

## Removals (both measured at 0 of 525 production rows)

- **`installation.config` / `storedConfig` tier** — typed as the parsed `.mergewatch.yml`, documented as populated on installation, merged by the self-hosted runtime; but both webhooks wrote a literal `{}` and nothing else ever wrote it. Removed: the field, the merge tier, the webhook writes, the store mappings, and the dashboard's `hasConfig` badge plumbing (a repo-card `.mergewatch.yml` badge gated on a flag that was provably always false). The `db.ts` doc comment describing nonexistent behavior is replaced with the removal rationale. DB columns stay in place, inert — no migration.
- **`installation.modelId`** — read by the SaaS handler, written by nothing. The `installationModelId` tier is removed from `resolveReviewModelId`; precedence is now `repo-config → deploy-default → fallback`, and the supported per-repo model override remains `model:` in `.mergewatch.yml` (#264/#268). Model-resolution tests updated to the two-tier chain.

## Guard test + remaining-key audit (the issue's last two checkboxes)

New `config-key-usage.test.ts` (same repo-walking shape as `source-hygiene.test.ts` from #307): every `MergeWatchConfig` key must have a dot-access read outside the parser (`github/client.ts`) and the type/defaults module — the #310 defect class is now a **build failure**. The heuristic deliberately doesn't count object-literal property positions, which is exactly why it would have caught `minSeverity` (its only runtime mentions were writes).

**The audit found more, immediately**: on its first run the guard flagged `maxTokensPerAgent` and `postSummaryOnClean` — both documented in `mergewatch-yml.mdx`, parsed with validation, and never read. Wiring each needs a product decision (per-model token defaults / clean-PR comment gating), so they are filed as #350 and allowlisted with that reference; removing an allowlist entry is the definition of done for wiring a key, and the guard hard-fails on any new dead key.

Full workspace build / typecheck / test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)