### PR TITLE
feat(core): wire maxTokensPerAgent and postSummaryOnClean (#350)

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -2730,7 +2730,7 @@ curl -s "$MCP_URL" \
 
 ### E2E-78: Output shaping — `minSeverity`, `maxFindings`, `postSummaryOnClean`
 
-**Status:** ⬜ NOT YET COVERED. (`minSeverity` was documented-but-unwired until #310 — the filter now exists; fixture still to be run.)
+**Status:** ⬜ NOT YET COVERED. (All three knobs were documented-but-unwired at various points: `minSeverity` until #310, `maxTokensPerAgent` and `postSummaryOnClean` until #350 — all three now exist; fixture still to be run.)
 
 **Behavior:** Three independent knobs on what reaches the PR: `minSeverity` (`info` | `warning` | `critical`) drops lower-severity findings; `maxFindings` caps how many are posted; `postSummaryOnClean` decides whether a clean PR gets a comment at all.
 

--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -1229,6 +1229,59 @@ describe('runReviewPipeline', () => {
     expect(result.findings[0].title).toBe('Odd tier');
   });
 
+  // ─── #350 — maxTokensPerAgent output cap ─────────────────────────────────
+
+  it('#350: maxTokensPerAgent becomes the default output cap for every pipeline invocation', async () => {
+    const maxTokensSeen: Array<number | undefined> = [];
+    const responses = makeResponses(9);
+    let idx = 0;
+    const llm: ILLMProvider = {
+      async invoke(_modelId: string, _prompt: string, maxTokens?: number) {
+        maxTokensSeen.push(maxTokens);
+        return responses[idx++] ?? responses[responses.length - 1];
+      },
+    };
+    await runReviewPipeline(
+      {
+        diff: sampleDiff,
+        context: sampleContext,
+        modelId: 'heavy-model',
+        lightModelId: 'light-model',
+        maxFindings: 25,
+        maxTokensPerAgent: 2048,
+        enabledAgents: allAgentsEnabled,
+      },
+      { llm },
+    );
+    expect(maxTokensSeen.length).toBeGreaterThan(0);
+    // Every invocation that passed no explicit cap inherited the configured one.
+    expect(maxTokensSeen.every((t) => t === 2048)).toBe(true);
+  });
+
+  it('#350: without maxTokensPerAgent, invocations keep the provider default (undefined)', async () => {
+    const maxTokensSeen: Array<number | undefined> = [];
+    const responses = makeResponses(9);
+    let idx = 0;
+    const llm: ILLMProvider = {
+      async invoke(_modelId: string, _prompt: string, maxTokens?: number) {
+        maxTokensSeen.push(maxTokens);
+        return responses[idx++] ?? responses[responses.length - 1];
+      },
+    };
+    await runReviewPipeline(
+      {
+        diff: sampleDiff,
+        context: sampleContext,
+        modelId: 'heavy-model',
+        lightModelId: 'light-model',
+        maxFindings: 25,
+        enabledAgents: allAgentsEnabled,
+      },
+      { llm },
+    );
+    expect(maxTokensSeen.every((t) => t === undefined)).toBe(true);
+  });
+
   it('forces mergeScore >= 3 (yellow) when net improvement: more resolved than new criticals', async () => {
     // Net improvement: 3 prior criticals resolved, but the LLM flagged 1 new
     // critical on the fix code (could be a real concern or an over-eager

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -1054,6 +1054,15 @@ export interface ReviewPipelineOptions {
    * Defaults to 'info' (report everything) when absent.
    */
   minSeverity?: 'info' | 'warning' | 'critical';
+  /**
+   * #350 — output-token cap applied to every LLM invocation this pipeline
+   * makes (agents, summary, diagram, orchestrator, verification). A call
+   * site that passes an explicit maxTokens keeps it; everything else
+   * defaults to this value instead of the provider's built-in 4096. Fed
+   * from `.mergewatch.yml` `maxTokensPerAgent:` (default 4096 — identical
+   * to the provider default, so unset configs see no change).
+   */
+  maxTokensPerAgent?: number;
   enabledAgents: {
     security: boolean;
     bugs: boolean;
@@ -2077,6 +2086,7 @@ export async function runReviewPipeline(
     customStyleRules = [],
     maxFindings,
     minSeverity = 'info',
+    maxTokensPerAgent,
     enabledAgents,
     fileFetchOptions,
     groundingFetch,
@@ -2093,7 +2103,14 @@ export async function runReviewPipeline(
 
   // Wrap the LLM provider to track token usage across all agents
   const accumulator = new TokenAccumulator();
-  const llm = new TrackingLLMProvider(deps.llm, accumulator);
+  const trackedLlm = new TrackingLLMProvider(deps.llm, accumulator);
+  // #350 — maxTokensPerAgent becomes the default output cap for every
+  // invocation in this pipeline (same decorator pattern as the tracking
+  // wrapper above). Call sites that pass an explicit maxTokens keep it;
+  // when unset, providers fall back to their built-in 4096 as before.
+  const llm: ILLMProvider = maxTokensPerAgent
+    ? { invoke: (m, p, t, s) => trackedLlm.invoke(m, p, t ?? maxTokensPerAgent, s) }
+    : trackedLlm;
 
   // Extract the changed-file set once, up front. Used for:
   //   - FP-D diagram path validation (passed into runDiagramAgent below).

--- a/packages/core/src/config/config-key-usage.test.ts
+++ b/packages/core/src/config/config-key-usage.test.ts
@@ -41,15 +41,12 @@ const DEFINITION_FILES = new Set([
 ]);
 
 /**
- * Known-dead keys this tripwire flagged on its FIRST run — two more
- * instances of the #310 class, found exactly as its remaining-key audit
- * predicted. Tracked in #350; wiring each requires a product decision
- * (comment-gating behavior / per-model token defaults), so they are
- * allowlisted rather than scope-crept into #310's cleanup. Removing an
- * entry here is the definition of done for wiring that key. Do NOT add to
- * this list — wire or remove new keys instead.
+ * Keys with a tracked wiring decision pending. This list held
+ * `maxTokensPerAgent` and `postSummaryOnClean` between the tripwire's first
+ * run (#310) and their wiring (#350); it is now empty and should stay that
+ * way — wire or remove new keys instead of adding entries.
  */
-const KNOWN_DEAD_KEYS = new Set(['maxTokensPerAgent', 'postSummaryOnClean']); // #350
+const KNOWN_DEAD_KEYS = new Set<string>();
 
 function walk(dir: string, out: string[] = []): string[] {
   let entries: string[];

--- a/packages/core/src/llm/token-accumulator.test.ts
+++ b/packages/core/src/llm/token-accumulator.test.ts
@@ -132,3 +132,25 @@ describe('TrackingLLMProvider', () => {
     expect(acc.totalOutputTokens).toBe(75);
   });
 });
+
+describe('TrackingLLMProvider — argument forwarding (#350)', () => {
+  it('forwards maxTokens AND sampling to the inner provider', async () => {
+    // Found while wiring #350: the wrapper previously declared only 3 params
+    // and silently dropped the sampling argument, so pipeline calls that set
+    // a temperature ran at the provider default.
+    const calls: unknown[][] = [];
+    const inner = {
+      async invoke(...args: unknown[]) {
+        calls.push(args);
+        return 'ok';
+      },
+    } as any;
+    const tracking = new TrackingLLMProvider(inner, new TokenAccumulator());
+
+    await tracking.invoke('model-x', 'prompt', 2048, { temperature: 0.2 });
+    expect(calls[0]).toEqual(['model-x', 'prompt', 2048, { temperature: 0.2 }]);
+
+    await tracking.invoke('model-x', 'prompt');
+    expect(calls[1]).toEqual(['model-x', 'prompt', undefined, undefined]);
+  });
+});

--- a/packages/core/src/llm/token-accumulator.ts
+++ b/packages/core/src/llm/token-accumulator.ts
@@ -6,7 +6,7 @@
  * The wrapped provider is transparent to callers — agents still receive strings.
  */
 
-import type { ILLMProvider, TokenUsage, LLMInvokeResult } from './types.js';
+import type { ILLMProvider, TokenUsage, LLMInvokeResult, LLMSamplingConfig } from './types.js';
 import { normalizeLLMResult } from './types.js';
 import { estimateCost } from './pricing.js';
 
@@ -82,8 +82,18 @@ export class TrackingLLMProvider implements ILLMProvider {
     private accumulator: TokenAccumulator,
   ) {}
 
-  async invoke(modelId: string, prompt: string, maxTokens?: number): Promise<string> {
-    const raw = await this.inner.invoke(modelId, prompt, maxTokens);
+  // The full 4-param ILLMProvider signature. Found while wiring #350: this
+  // wrapper previously declared only 3 params and silently DROPPED the
+  // sampling argument, so every pipeline call that passed a temperature
+  // (diagram, summary, delta caption, verification) ran at the provider
+  // default instead.
+  async invoke(
+    modelId: string,
+    prompt: string,
+    maxTokens?: number,
+    sampling?: LLMSamplingConfig,
+  ): Promise<string> {
+    const raw = await this.inner.invoke(modelId, prompt, maxTokens, sampling);
     const result = normalizeLLMResult(raw);
     this.accumulator.add(modelId, result.usage);
     return result.text;

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -803,6 +803,8 @@ export async function handler(
       maxFindings: runtimeConfig.maxFindings,
       // #310 — merged from yml `minSeverity:` + dashboard severityThreshold.
       minSeverity: runtimeConfig.minSeverity,
+      // #350 — per-invocation output-token cap from yml `maxTokensPerAgent:`.
+      maxTokensPerAgent: runtimeConfig.maxTokensPerAgent,
       enabledAgents: mode === 'summary'
         ? { security: false, bugs: false, style: false, summary: true, diagram: false, errorHandling: false, testCoverage: false, commentAccuracy: false }
         : { ...runtimeConfig.agents, diagram: instSettings.summary.diagram },
@@ -921,14 +923,22 @@ export async function handler(
       targetCommentId = (await findExistingBotComment(octokit, owner, repo, prNumber)) ?? undefined;
     }
 
-    if (targetCommentId) {
+    // #350 — postSummaryOnClean: false means a clean PR gets no comment. Only
+    // the INITIAL post is gated: an existing MergeWatch comment is always
+    // updated, so a previously-dirty PR that comes back clean never keeps a
+    // stale review claiming old findings.
+    const stayingSilent =
+      result.findings.length === 0 && runtimeConfig.postSummaryOnClean === false && !targetCommentId;
+    if (stayingSilent) {
+      console.log(`[post-summary] clean PR and postSummaryOnClean=false — staying silent on ${repoFullName}#${prNumber}`);
+    } else if (targetCommentId) {
       await updateReviewComment(octokit, owner, repo, targetCommentId, commentBody);
       commentId = targetCommentId;
     } else {
       commentId = await postReviewComment(octokit, owner, repo, prNumber, commentBody);
     }
 
-    if (!commentId) {
+    if (!commentId && !stayingSilent) {
       throw new Error('Failed to create or update issue comment');
     }
 

--- a/packages/server/src/review-processor.test.ts
+++ b/packages/server/src/review-processor.test.ts
@@ -55,6 +55,7 @@ import {
   runReviewPipeline, postReplyComment, fetchRepoConfig, handleInlineReply,
   addPRReaction, removePRReaction, submitPRReview, mergeScoreToReviewEvent,
   fetchTriageComments, computeDisputedKeys,
+  postReviewComment, updateReviewComment, findExistingBotComment,
 } from '@mergewatch/core';
 import { processReviewJob } from './review-processor.js';
 
@@ -1043,5 +1044,65 @@ describe('processReviewJob — org custom agents (#235)', () => {
     // No org-block override → event comes from the (mocked) score mapping.
     const reviewEvent = (submitPRReview as any).mock.calls[0][5];
     expect(reviewEvent).toBe('APPROVE');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #350 — postSummaryOnClean gates the clean-PR comment
+// ---------------------------------------------------------------------------
+
+describe('processReviewJob — postSummaryOnClean (#350)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getPRContext as any).mockResolvedValue(basePRContext);
+    (getPRDiff as any).mockResolvedValue('diff content');
+    (shouldSkipPR as any).mockReturnValue(null);
+    (shouldSkipByRules as any).mockReturnValue(null);
+    (runReviewPipeline as any).mockResolvedValue(basePipelineResult); // zero findings
+    (fetchRepoConfig as any).mockResolvedValue(null);
+    (findExistingBotComment as any).mockResolvedValue(null);
+    (postReviewComment as any).mockResolvedValue(100);
+  });
+
+  it('stays silent on a clean PR when postSummaryOnClean is false and no prior comment exists', async () => {
+    (fetchRepoConfig as any).mockResolvedValue({ postSummaryOnClean: false });
+    const deps = makeDeps();
+    await processReviewJob(makeJob(), deps);
+
+    expect(postReviewComment).not.toHaveBeenCalled();
+    expect(updateReviewComment).not.toHaveBeenCalled();
+    // The review itself still completes — only the comment is withheld.
+    expect((deps.reviewStore.updateStatus as any).mock.calls.some(
+      (c: any[]) => c[2] === 'complete',
+    )).toBe(true);
+  });
+
+  it('still updates an existing comment on a clean PR (never leaves a stale review)', async () => {
+    (fetchRepoConfig as any).mockResolvedValue({ postSummaryOnClean: false });
+    (findExistingBotComment as any).mockResolvedValue(42);
+    const deps = makeDeps();
+    await processReviewJob(makeJob(), deps);
+
+    expect(updateReviewComment).toHaveBeenCalledWith(mockOctokit, 'test', 'repo', 42, 'formatted comment');
+    expect(postReviewComment).not.toHaveBeenCalled();
+  });
+
+  it('posts normally on a dirty PR even when postSummaryOnClean is false', async () => {
+    (fetchRepoConfig as any).mockResolvedValue({ postSummaryOnClean: false });
+    (runReviewPipeline as any).mockResolvedValue({
+      ...basePipelineResult,
+      findings: [{ file: 'src/index.ts', line: 1, severity: 'warning', category: 'bug', title: 'T', description: 'D', suggestion: 'S' }],
+    });
+    const deps = makeDeps();
+    await processReviewJob(makeJob(), deps);
+
+    expect(postReviewComment).toHaveBeenCalled();
+  });
+
+  it('posts on a clean PR under the default (postSummaryOnClean: true)', async () => {
+    const deps = makeDeps();
+    await processReviewJob(makeJob(), deps);
+
+    expect(postReviewComment).toHaveBeenCalled();
   });
 });

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -665,6 +665,8 @@ export async function processReviewJob(
         maxFindings: config.maxFindings,
         // #310 — merged from yml `minSeverity:` + dashboard severityThreshold.
         minSeverity: config.minSeverity,
+        // #350 — per-invocation output-token cap from yml `maxTokensPerAgent:`.
+        maxTokensPerAgent: config.maxTokensPerAgent,
         enabledAgents: {
           ...config.agents,
           diagram: instSettings.summary?.diagram !== false,
@@ -791,14 +793,22 @@ export async function processReviewJob(
       || (prevReviewsResult.find((r) => r.commentId && r.prNumberCommitSha !== prNumberCommitSha)?.commentId as number | undefined)
       || (await findExistingBotComment(octokit, owner, repo, prNumber)) || undefined;
 
-    if (targetCommentId) {
+    // #350 — postSummaryOnClean: false means a clean PR gets no comment. Only
+    // the INITIAL post is gated: an existing MergeWatch comment is always
+    // updated, so a previously-dirty PR that comes back clean never keeps a
+    // stale review claiming old findings.
+    const stayingSilent =
+      result.findings.length === 0 && config.postSummaryOnClean === false && !targetCommentId;
+    if (stayingSilent) {
+      console.log('[post-summary] clean PR and postSummaryOnClean=false — staying silent on %s#%d', repoFullName, prNumber);
+    } else if (targetCommentId) {
       await updateReviewComment(octokit, owner, repo, targetCommentId, comment);
       commentId = targetCommentId;
     } else {
       commentId = await postReviewComment(octokit, owner, repo, prNumber, comment);
     }
 
-    if (!commentId) {
+    if (!commentId && !stayingSilent) {
       throw new Error('Failed to create or update issue comment');
     }
 


### PR DESCRIPTION
Closes #350 — wires the two config keys the #310 guard test flagged on its first run, and empties the guard's allowlist (this issue's definition of done).

## `maxTokensPerAgent`

Threaded via a pipeline-level LLM wrapper composing with the existing `TrackingLLMProvider` decorator: every invocation the pipeline makes (agents, summary, diagram, orchestrator, verification) defaults to the configured cap, and a call site passing an explicit `maxTokens` keeps it. One change point instead of threading a parameter through eight agent signatures. Behavior-neutral for unset configs — the config default (4096) equals the provider default.

## `postSummaryOnClean`

Both runtimes stay silent on a clean PR (zero post-filter findings) when `false` **and no prior MergeWatch comment exists**. An existing comment is always updated — a previously-dirty PR that comes back clean must never keep a stale review claiming old findings. The "failed to create comment" guard is bypassed only in the deliberate-silence case.

## Drive-by fix, found while wiring

`TrackingLLMProvider.invoke` declared only 3 of the interface's 4 params and **silently dropped the `sampling` argument** — every pipeline call that set a temperature (diagram 0.2, summary 0.3, delta caption 0.2, verification 0) actually ran at the provider default. TypeScript allowed it because the wrapper met the interface with fewer params. Fixed to forward all four, with a regression test pinning the forwarding.

## Tests

- Core: wrapper cap applied to every invocation / absent by default (2), sampling+maxTokens forwarding (1) — 197/197 reviewer suite, 16/16 accumulator suite.
- Server: clean-PR silence, clean-PR-with-prior-comment update, dirty-PR unaffected, default posts (4) — 52/52 suite.
- Lambda: the gate is line-for-line the same logic as the server's; `review-agent.ts` has no direct unit harness (none exists today), so the server suite pins the behavior for both.
- `config-key-usage.test.ts`: `KNOWN_DEAD_KEYS` is now empty; the guard passes with both keys read and hard-fails on any new dead key.

Full workspace build / typecheck / test green. RUNBOOK E2E-78 status updated (all three output-shaping knobs now exist; fixture still to be run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)