### PR TITLE
docs: graduate shipped feature docs and sync RUNBOOK statuses

### DIFF
--- a/docs-site/configuration/mergewatch-yml.mdx
+++ b/docs-site/configuration/mergewatch-yml.mdx
@@ -126,7 +126,7 @@ ux:
 | `maxTokensPerAgent` | `number` | `4096` | Maximum output tokens per agent invocation. Increase for large PRs; decrease to reduce cost. |
 | `minSeverity` | `string` | `info` | Minimum severity level to report. One of `info`, `warning`, `critical`. Findings below this threshold are suppressed. |
 | `maxFindings` | `number` | `25` | Maximum number of findings posted per review. Prevents noisy reviews on large PRs. |
-| `postSummaryOnClean` | `boolean` | `true` | When `true`, MergeWatch posts a summary comment even when no findings are detected. Set to `false` to stay silent on clean PRs. |
+| `postSummaryOnClean` | `boolean` | `true` | When `true`, MergeWatch posts a summary comment even when no findings are detected. Set to `false` to stay silent on clean PRs. If an earlier review already posted a comment on the PR, it is still updated — a previously-flagged PR that comes back clean never keeps a stale review. |
 | `codebaseAwareness` | `boolean` | `true` | Enable agentic file fetching for cross-file context. When `true`, agents can request additional files from the repository. |
 | `maxFileRequestRounds` | `number` | `1` | Maximum rounds of file fetching per agent (1--2). Each round lets the agent request more files based on what it learned. |
 | `maxContextKB` | `number` | `256` | Maximum total context size in KB for fetched files per agent. Prevents runaway context expansion. |

--- a/docs/reviews-time-ordered-listing.md
+++ b/docs/reviews-time-ordered-listing.md
@@ -1,6 +1,6 @@
 # Time-ordered review listing (SaaS / DynamoDB)
 
-**Status:** 🚧 In review
+**Status:** ✅ Shipped
 **Issue:** [#335](https://github.com/mergewatch/mergewatch.ai/issues/335)
 
 Fix the three `listReviews` defects that made SaaS analytics numbers unreliable: candidate rows ordered by PR-number **string** (`"9#…" > "42#…" > "100#…"`), `Limit` applied per repo instead of to the result set, and `Limit` applied to items *read* before the date `FilterExpression` ran — silently losing matching rows the narrower the date range got.

--- a/docs/windowed-insight-rollups.md
+++ b/docs/windowed-insight-rollups.md
@@ -1,6 +1,6 @@
 # Time-bounded insight rollup windows
 
-**Status:** 🚧 In review
+**Status:** ✅ Shipped
 **Issue:** [#334](https://github.com/mergewatch/mergewatch.ai/issues/334)
 
 Make the 7d / 30d / 90d insight rollups mean what they say. The rollup previously selected records by window (`lastSeen` inside it) but summed **lifetime** counters, so one still-active long-lived finding injected its entire history into every window — all three windows converged toward all-time totals, and `disputeRate`, `perCategory`, `perSeverity`, `perRepo`, and the `topClusters` leverage ranking all inherited the distortion.

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -2983,7 +2983,7 @@ Tracked deliberately so they are decisions rather than oversights. Each is a can
 
 ### E2E-84: #334 — Time-bounded insight rollup windows
 
-**Status:** 🚧 In review (#334) — fixture not yet run.
+**Status:** ✅ SHIPPED (#334, PRs #341 + #343) — fixture not yet run.
 
 **Behavior:** every disposition-counter increment (surface, dispute, verified, unverified, silentDrop, agreement, resolve) also bumps a sparse per-UTC-day bucket (`periodCounts`, keyed `YYYY-MM-DD`) on the `FindingDispositionRecord`, atomically with the lifetime counter, on both backends. The nightly rollup then derives every windowed number from in-window activity: a record first seen inside the window contributes its lifetime counters (exact by definition); an older record contributes only the day buckets overlapping the window. `7d ≤ 30d ≤ 90d` holds by construction. Records written before #334 shipped have no buckets and contribute nothing to windows that predate their `firstSeen` — they ramp up within one window-length of deploy instead of injecting lifetime history.
 
@@ -3006,7 +3006,7 @@ Trigger the rollup manually (same paths as E2E-41), then read the three insight 
 
 ### E2E-85: #335 — Time-ordered DynamoDB review listing
 
-**Status:** 🚧 In review (#335) — fixture not yet run.
+**Status:** ✅ SHIPPED (#335, PRs #344 + #345) — fixture not yet run.
 
 **Behavior:** the SaaS dashboard's `listReviews` queries the `ByRepoCreatedAt` GSI (PK `repoFullName`, SK `createdAt`) descending — true reverse-chronological order regardless of PR numbers (the base sort key orders `"9#…" > "42#…" > "100#…"` as strings). Date-range bounds sit in the `KeyConditionExpression`, so `Limit` applies to matching items and a narrow range can no longer silently discard matching rows beyond the first unfiltered page. `limit` bounds the merged cross-repo result; v2 cursors resume each repo from the last *returned* item, so rows fetched but dropped by the global slice are re-fetched, never lost. On a stack without the GSI, the store logs one warning and degrades to the legacy base-table path (sticky per instance); v1 cursors finish their sequence on the legacy path.
 
@@ -3028,7 +3028,7 @@ Branch: `fixture/85-time-ordered-reviews`. Seed one repo with reviews for PR num
 
 ### E2E-86: #336 — p95 duration: nearest-rank + minimum sample
 
-**Status:** 🚧 In review (#336) — fixture not yet run.
+**Status:** ✅ SHIPPED (#336, PR #346) — fixture not yet run.
 
 **Behavior:** the analytics duration card computes p95 as the nearest-rank element (`⌈n × 0.95⌉`, clamped to a valid index) over completed reviews' durations. The old `floor(n × 0.95)` index returned the maximum for every n ≤ 20 — the slowest review wearing a percentile label, worst exactly when a new instance has little data. Below `MIN_P95_SAMPLE_SIZE` (20) completed reviews, `p95Ms` is `null` and the UI shows "—" with a "needs at least 20 completed reviews" tooltip and omits the P95 chart bar; Average and Completed still render.
 
@@ -3045,7 +3045,7 @@ Branch: `fixture/85-time-ordered-reviews`. Seed one repo with reviews for PR num
 
 ### E2E-87: #337 — Date-only range bounds include their whole day
 
-**Status:** 🚧 In review (#337) — fixture not yet run.
+**Status:** ✅ SHIPPED (#337, PR #347) — fixture not yet run.
 
 **Behavior:** the stores filter `createdAt` by string comparison against full ISO timestamps, so a date-only bound used to misbehave at one edge (`'2026-08-16T09:31:00.000Z' <= '2026-08-16'` is false → the entire final day silently excluded). `/api/analytics` now normalizes at the boundary: date-only `start_date` expands to `T00:00:00.000Z`, date-only `end_date` to `T23:59:59.999Z`; full timestamps pass through untouched (the dashboard UI sends exact viewer-local-derived instants that must not be re-widened). Both backends receive the same expanded instants — identical by construction. Timezone decision documented in the route: date-only params and trend-bucket labels are UTC calendar days; viewer-zone bucketing deliberately deferred until edge-day attribution matters.
 


### PR DESCRIPTION
Docs-only follow-through for the #333–#338 / #310 / #350 series — the graduation steps that were deferred until the merges landed:

- **`docs/pending` → `docs/`** for `windowed-insight-rollups.md` (#334) and `reviews-time-ordered-listing.md` (#335), status flipped to ✅ Shipped per the `docs/pending` README convention.
- **RUNBOOK E2E-84..E2E-87** statuses flip from 🚧 In review to ✅ SHIPPED with their PR references (fixtures still to be run), matching the E2E-83 convention.
- **`mergewatch-yml.mdx`**: the `postSummaryOnClean` entry now documents the update-existing nuance from #350 — an existing comment is still updated on a clean re-review, never left stale.

No code changes; full workspace build/test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)