### PR TITLE
fix(core): unverified-only criticals keep the check advisory and the comment coherent (#240)

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -1060,6 +1060,8 @@ Push a small commit on the PR branch to trigger a re-review.
 
 ### E2E-25: W7 score guardrail — unverified-only Criticals don't block
 
+> **#240 fixed a gap in this scenario's "check stays advisory" claim:** the check-run conclusion previously counted RAW criticals, so an unverified-only critical failed the check ("1 critical issue found") while the score sat clamped at 3 — and the comment printed "All clear!" above "Unverified concerns". Both runtimes now count only verified criticals for the check (shared `countBlockingCriticals` helper), and the all-clear line defers to the unverified-concerns section.
+
 **Behavior**: when the orchestrator emits Critical(s) but the W2 verification pass can't confirm any of them against the file contents (LLM error, unparseable response, no clear verdict, etc.), the bot:
 - keeps the findings (fail-safe, never silently drops a real Critical),
 - tags each survivor with `verification: 'unverified'`,

--- a/packages/core/src/comment-formatter.test.ts
+++ b/packages/core/src/comment-formatter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatReviewComment, buildWorkDoneSection, type Finding } from './comment-formatter.js';
+import { formatReviewComment, buildWorkDoneSection, countBlockingCriticals, type Finding } from './comment-formatter.js';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -440,5 +440,61 @@ describe('buildWorkDoneSection', () => {
       3,
     );
     expect(result.hasDependencyFiles).toBe(false);
+  });
+});
+
+// ─── #240 — all-clear vs unverified concerns coherence ───────────────────────
+
+describe('formatReviewComment — unverified-only criticals (#240)', () => {
+  const unverifiedCritical = () => makeFinding({ verification: 'unverified', title: 'Possible race in cache' });
+
+  it('never shows "All clear!" alongside an "Unverified concerns" section', () => {
+    const result = formatReviewComment(baseOptions({ findings: [unverifiedCritical()] }));
+    expect(result).toContain('Unverified concerns (1)');
+    expect(result).not.toContain('All clear!');
+    expect(result).toContain('No blocking issues — see unverified concerns below.');
+  });
+
+  it('uses the advisory line even when allClearMessage is disabled', () => {
+    const result = formatReviewComment(baseOptions({
+      findings: [unverifiedCritical()],
+      ux: { allClearMessage: false },
+    }));
+    expect(result).not.toContain('looking good');
+    expect(result).toContain('No blocking issues — see unverified concerns below.');
+  });
+
+  it('keeps "All clear!" for a genuinely clean review', () => {
+    const result = formatReviewComment(baseOptions());
+    expect(result).toContain('All clear!');
+    expect(result).not.toContain('No blocking issues');
+  });
+
+  it('keeps "All clear!" when only info findings exist (no unverified criticals)', () => {
+    const result = formatReviewComment(baseOptions({
+      findings: [makeFinding({ severity: 'info', title: 'Nit' })],
+    }));
+    expect(result).toContain('All clear!');
+  });
+
+  it('a verified critical still renders the attention table, never all-clear', () => {
+    const result = formatReviewComment(baseOptions({
+      findings: [makeFinding({ verification: 'verified' })],
+    }));
+    expect(result).toContain('Requires your attention');
+    expect(result).not.toContain('All clear!');
+  });
+});
+
+describe('countBlockingCriticals (#240)', () => {
+  it('excludes unverified criticals and counts the rest', () => {
+    expect(countBlockingCriticals([])).toBe(0);
+    expect(countBlockingCriticals([makeFinding({ verification: 'unverified' })])).toBe(0);
+    expect(countBlockingCriticals([
+      makeFinding({ verification: 'unverified' }),
+      makeFinding({ verification: 'verified' }),
+      makeFinding({}), // no verification field — pre-W2 record, counts as blocking
+      makeFinding({ severity: 'warning' }),
+    ])).toBe(2);
   });
 });

--- a/packages/core/src/comment-formatter.ts
+++ b/packages/core/src/comment-formatter.ts
@@ -38,6 +38,23 @@ export interface WorkDoneSection {
   hasDependencyFiles: boolean;
 }
 
+/**
+ * #240 — criticals that may legitimately block a PR: severity 'critical' AND
+ * not tagged `verification: 'unverified'` by the W2 pass. The W7 score clamp
+ * and FP-L rendering already treat unverified criticals as advisory; this is
+ * the shared count both runtimes use for the check-run conclusion so the
+ * check can never fail on a critical the score refuses to block on. A
+ * finding with no `verification` field is a pre-W2 record and counts as
+ * blocking (unchanged behavior).
+ */
+export function countBlockingCriticals(
+  findings: ReadonlyArray<Pick<Finding, 'severity' | 'verification'>>,
+): number {
+  return findings.filter(
+    (f) => f.severity === 'critical' && f.verification !== 'unverified',
+  ).length;
+}
+
 interface FormatOptions {
   /** Markdown summary text from the summary agent */
   summary: string;
@@ -342,6 +359,27 @@ export function formatReviewComment(options: FormatOptions): string {
     lines.push('');
   }
 
+  // #240 — computed up front so the all-clear branches below can defer to
+  // the "Unverified concerns" section instead of contradicting it.
+  const unverifiedCriticalCount = findings.filter(
+    (f) => f.severity === 'critical' && f.verification === 'unverified',
+  ).length;
+
+  // #240 — the all-clear celebration is only honest when nothing below will
+  // render an unverified-concerns section. With unverified criticals present
+  // the score is W7-clamped to advisory, so say that instead.
+  const pushAllClearOrAdvisory = () => {
+    if (unverifiedCriticalCount > 0) {
+      lines.push('No blocking issues \u2014 see unverified concerns below.');
+      lines.push('');
+    } else if (ux?.allClearMessage !== false) {
+      lines.push('\uD83C\uDF89 **All clear!** No issues found \u2014 this PR looks good to go.');
+      lines.push('');
+    } else {
+      lines.push('No issues found \u2014 looking good! \u2705');
+    }
+  };
+
   // 7. Action items — critical + warning findings as checkboxes (single appearance)
   // FP-L — unverified criticals are excluded from the action-items table. They
   // render below under "Unverified concerns" instead, so the top-of-comment
@@ -355,12 +393,7 @@ export function formatReviewComment(options: FormatOptions): string {
   const infoFindings = grouped.get('info') ?? [];
 
   if (findings.length === 0) {
-    if (ux?.allClearMessage !== false) {
-      lines.push('\uD83C\uDF89 **All clear!** No issues found \u2014 this PR looks good to go.');
-      lines.push('');
-    } else {
-      lines.push('No issues found \u2014 looking good! \u2705');
-    }
+    pushAllClearOrAdvisory();
   } else if (!showIssuesTable) {
     lines.push(`${findings.length} issue${findings.length !== 1 ? 's' : ''} found.`);
   } else if (actionFindings.length > 0) {
@@ -375,13 +408,9 @@ export function formatReviewComment(options: FormatOptions): string {
     }
     lines.push('');
   } else {
-    // Only info findings — show "all clear" for action items
-    if (ux?.allClearMessage !== false) {
-      lines.push('\uD83C\uDF89 **All clear!** No issues found \u2014 this PR looks good to go.');
-      lines.push('');
-    } else {
-      lines.push('No issues found \u2014 looking good! \u2705');
-    }
+    // No action items (info-only, or #240: only unverified criticals) —
+    // all-clear, unless unverified concerns render below.
+    pushAllClearOrAdvisory();
   }
 
   // 8. Detailed findings — critical uncollapsed, warning/info collapsed

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -131,7 +131,7 @@ export {
 export type { ReviewThreadComment } from './github/client.js';
 
 // ─── Comment formatter ──────────────────────────────────────────────────────
-export { formatReviewComment, buildWorkDoneSection } from './comment-formatter.js';
+export { formatReviewComment, buildWorkDoneSection, countBlockingCriticals } from './comment-formatter.js';
 export type { Finding, WorkDoneSection } from './comment-formatter.js';
 
 // ─── Review delta ────────────────────────────────────────────────────────────

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -25,6 +25,7 @@ import {
   createCheckRun,
   runReviewPipeline,
   formatReviewComment,
+  countBlockingCriticals,
   mergeConfig,
   shouldSkipPR,
   extractIncludePatterns,
@@ -1107,10 +1108,17 @@ export async function handler(
     }
 
     // #235 — a blocking org agent fails the check too.
-    const hasCritical = criticalCount > 0;
+    // #240 — only VERIFIED criticals fail the check. Unverified ones are
+    // advisory everywhere else (W7 clamps the score, FP-L renders them under
+    // "Unverified concerns"); the check must agree instead of going red on a
+    // critical the review event refuses to block on.
+    const blockingCriticalCount = countBlockingCriticals(result.findings);
+    const unverifiedCriticalCount = criticalCount - blockingCriticalCount;
+    const hasCritical = blockingCriticalCount > 0;
     const checkConclusion = (hasCritical || orgBlocked) ? 'failure' as const : 'success' as const;
     const findingSummaryParts: string[] = [];
-    if (criticalCount) findingSummaryParts.push(`${criticalCount} critical`);
+    if (blockingCriticalCount) findingSummaryParts.push(`${blockingCriticalCount} critical`);
+    if (unverifiedCriticalCount) findingSummaryParts.push(`${unverifiedCriticalCount} unverified`);
     if (warningCount) findingSummaryParts.push(`${warningCount} warning`);
     if (infoCount) findingSummaryParts.push(`${infoCount} info`);
     if (orgBlocked) findingSummaryParts.push(`blocked by org agent: ${orgBlockedBy.join(', ')}`);
@@ -1121,9 +1129,9 @@ export async function handler(
       title: orgBlocked
         ? `Blocked by org agent: ${orgBlockedBy.join(', ')}`
         : hasCritical
-          ? `${criticalCount} critical issue${criticalCount > 1 ? 's' : ''} found`
+          ? `${blockingCriticalCount} critical issue${blockingCriticalCount > 1 ? 's' : ''} found`
           : result.findings.length > 0
-            ? `${result.findings.length} finding${result.findings.length > 1 ? 's' : ''} (no critical)`
+            ? `${result.findings.length} finding${result.findings.length > 1 ? 's' : ''} (no blocking critical)`
             : 'No issues found',
       summary: findingSummaryParts.length > 0
         ? `Found: ${findingSummaryParts.join(', ')}`

--- a/packages/server/src/review-processor.test.ts
+++ b/packages/server/src/review-processor.test.ts
@@ -333,7 +333,8 @@ describe('processReviewJob — check runs', () => {
       expect(completionCall[4]).toMatchObject({
         status: 'completed',
         conclusion: 'success',
-        title: '2 findings (no critical)',
+        // #240 — "blocking" qualifier: unverified criticals no longer count.
+        title: '2 findings (no blocking critical)',
         summary: 'Found: 1 warning, 1 info',
       });
     });
@@ -1104,5 +1105,80 @@ describe('processReviewJob — postSummaryOnClean (#350)', () => {
     await processReviewJob(makeJob(), deps);
 
     expect(postReviewComment).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #240 — unverified-only criticals keep the check advisory
+// ---------------------------------------------------------------------------
+
+describe('processReviewJob — check conclusion vs verification (#240)', () => {
+  const critical = (verification?: 'verified' | 'unverified') => ({
+    file: 'src/index.ts', line: 1, severity: 'critical', category: 'security',
+    title: 'Race', description: 'D', suggestion: 'S',
+    ...(verification ? { verification } : {}),
+  });
+
+  function completionCheckRun() {
+    // The completion check run is the last createCheckRun call with status 'completed'.
+    const calls = (createCheckRun as any).mock.calls.filter((c: any[]) => c[4]?.status === 'completed');
+    return calls[calls.length - 1]?.[4];
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getPRContext as any).mockResolvedValue(basePRContext);
+    (getPRDiff as any).mockResolvedValue('diff content');
+    (shouldSkipPR as any).mockReturnValue(null);
+    (shouldSkipByRules as any).mockReturnValue(null);
+    (fetchRepoConfig as any).mockResolvedValue(null);
+    (findExistingBotComment as any).mockResolvedValue(null);
+    (postReviewComment as any).mockResolvedValue(100);
+  });
+
+  it('unverified-only critical → check stays advisory (success), title never claims a critical', async () => {
+    (runReviewPipeline as any).mockResolvedValue({
+      ...basePipelineResult, findings: [critical('unverified')], mergeScore: 3,
+    });
+    await processReviewJob(makeJob(), makeDeps());
+
+    const check = completionCheckRun();
+    expect(check.conclusion).toBe('success');
+    expect(check.title).not.toContain('critical issue');
+    expect(check.title).toContain('no blocking critical');
+    expect(check.summary).toContain('1 unverified');
+  });
+
+  it('verified critical → check still fails with the critical title (no regression)', async () => {
+    (runReviewPipeline as any).mockResolvedValue({
+      ...basePipelineResult, findings: [critical('verified')], mergeScore: 2,
+    });
+    await processReviewJob(makeJob(), makeDeps());
+
+    const check = completionCheckRun();
+    expect(check.conclusion).toBe('failure');
+    expect(check.title).toBe('1 critical issue found');
+  });
+
+  it('a critical with no verification field (pre-W2 record) still fails the check', async () => {
+    (runReviewPipeline as any).mockResolvedValue({
+      ...basePipelineResult, findings: [critical()], mergeScore: 2,
+    });
+    await processReviewJob(makeJob(), makeDeps());
+
+    expect(completionCheckRun().conclusion).toBe('failure');
+  });
+
+  it('mixed verified + unverified → fails on the verified one, discloses the unverified one', async () => {
+    (runReviewPipeline as any).mockResolvedValue({
+      ...basePipelineResult, findings: [critical('verified'), critical('unverified')], mergeScore: 2,
+    });
+    await processReviewJob(makeJob(), makeDeps());
+
+    const check = completionCheckRun();
+    expect(check.conclusion).toBe('failure');
+    expect(check.title).toBe('1 critical issue found');
+    expect(check.summary).toContain('1 critical');
+    expect(check.summary).toContain('1 unverified');
   });
 });

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -2,7 +2,7 @@ import type { ReviewJobPayload, IInstallationStore, IReviewStore, IGitHubAuthPro
 import {
   getPRDiff, getPRContext, addPRReaction, removePRReaction, postReviewComment, updateReviewComment,
   findExistingBotComment, getCommentReactions, createCheckRun,
-  formatReviewComment, runReviewPipeline, shouldSkipPR, shouldSkipByRules, isAutoReviewOff, extractIncludePatterns,
+  formatReviewComment, countBlockingCriticals, runReviewPipeline, shouldSkipPR, shouldSkipByRules, isAutoReviewOff, extractIncludePatterns,
   loadCategoryDisputeRates,
   filterDiff,
   DEFAULT_CONFIG, mergeConfig,
@@ -946,10 +946,17 @@ export async function processReviewJob(
 
     // Create structured check run (matches Lambda pattern). #235 — a blocking
     // org agent fails the check too, even if (hypothetically) nothing else did.
-    const hasCritical = criticalCount > 0;
+    // #240 — only VERIFIED criticals fail the check. Unverified ones are
+    // advisory everywhere else (W7 clamps the score, FP-L renders them under
+    // "Unverified concerns"); the check must agree instead of going red on a
+    // critical the review event refuses to block on.
+    const blockingCriticalCount = countBlockingCriticals(result.findings);
+    const unverifiedCriticalCount = criticalCount - blockingCriticalCount;
+    const hasCritical = blockingCriticalCount > 0;
     const checkConclusion = (hasCritical || orgBlocked) ? 'failure' as const : 'success' as const;
     const findingSummaryParts: string[] = [];
-    if (criticalCount) findingSummaryParts.push(`${criticalCount} critical`);
+    if (blockingCriticalCount) findingSummaryParts.push(`${blockingCriticalCount} critical`);
+    if (unverifiedCriticalCount) findingSummaryParts.push(`${unverifiedCriticalCount} unverified`);
     if (warningCount) findingSummaryParts.push(`${warningCount} warning`);
     if (infoCount) findingSummaryParts.push(`${infoCount} info`);
     if (orgBlocked) findingSummaryParts.push(`blocked by org agent: ${orgBlockedBy.join(', ')}`);
@@ -960,9 +967,9 @@ export async function processReviewJob(
       title: orgBlocked
         ? `Blocked by org agent: ${orgBlockedBy.join(', ')}`
         : hasCritical
-          ? `${criticalCount} critical issue${criticalCount > 1 ? 's' : ''} found`
+          ? `${blockingCriticalCount} critical issue${blockingCriticalCount > 1 ? 's' : ''} found`
           : result.findings.length > 0
-            ? `${result.findings.length} finding${result.findings.length > 1 ? 's' : ''} (no critical)`
+            ? `${result.findings.length} finding${result.findings.length > 1 ? 's' : ''} (no blocking critical)`
             : 'No issues found',
       summary: findingSummaryParts.length > 0
         ? `Found: ${findingSummaryParts.join(', ')}`


### PR DESCRIPTION
Closes #240. Re-verified before fixing: both bugs still reproduced on `main` exactly as filed (raw critical count at `review-agent.ts:961` / `review-processor.ts:831`; unguarded all-clear branch at `comment-formatter.ts:377`).

## Bug 1 — check run failed on unverified-only criticals

New shared `countBlockingCriticals()` in core (`comment-formatter.ts`, exported from the package index) counts criticals with `verification !== 'unverified'`. Both runtimes now derive `hasCritical`, the check title, and the summary from it — in lock-step, per the issue's helper suggestion:

- Unverified-only PR → conclusion `success`, title `"N finding(s) (no blocking critical)"`, summary discloses `"N unverified"`.
- Verified critical (or a pre-W2 finding with no `verification` field) → `failure` + `"N critical issue(s) found"`, unchanged.
- #235 org-blocking gate untouched as an independent failure trigger.

## Bug 2 — "All clear!" above "Unverified concerns"

Both all-clear branches in the formatter now route through one helper that emits **"No blocking issues — see unverified concerns below."** whenever an unverified-concerns section will render — including the `ux.allClearMessage: false` variant, whose "looking good!" line was equally wrong for this case.

## Acceptance criteria (from #240)

- ✅ Unverified-only critical → check not `failure`, title never claims "N critical issue(s) found" — tested
- ✅ "All clear! No issues found" can never co-render with "Unverified concerns" — tested (both `ux` variants + genuinely-clean and info-only stay celebratory)
- ✅ Verified critical still fails the check; org blocking agents still gate — tested (mixed case included)
- ✅ Lambda and server behave identically — both consume the same helper with byte-identical conclusion blocks; the server harness pins the matrix (the Lambda handler has no direct unit harness, as elsewhere in the repo)

10 new tests (5 formatter coherence, 1 helper, 4 check-conclusion matrix); one pre-existing title assertion updated to the new `(no blocking critical)` wording. RUNBOOK E2E-25 notes the closed gap. Full workspace build / typecheck / test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)