### PR TITLE
fix(core): a provider throttle parks the review for retry instead of failing it (#355, PR 1)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export type { ILLMProvider, TokenUsage, LLMInvokeResult, LLMSamplingConfig } fro
 export { normalizeLLMResult } from './llm/types.js';
 export { TokenAccumulator, TrackingLLMProvider } from './llm/token-accumulator.js';
 export { estimateCost, DEFAULT_PRICING, parseEnvModelPricing } from './llm/pricing.js';
+export { isThrottleError } from './llm/throttle.js';
 export type {
   IInstallationStore,
   IReviewStore,

--- a/packages/core/src/llm/throttle.test.ts
+++ b/packages/core/src/llm/throttle.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { isThrottleError } from './throttle.js';
+
+describe('isThrottleError (#355)', () => {
+  it('recognizes AWS SDK throttle names (Bedrock)', () => {
+    expect(isThrottleError(Object.assign(new Error('Too many requests, please wait before trying again.'), { name: 'ThrottlingException' }))).toBe(true);
+    expect(isThrottleError(Object.assign(new Error('x'), { name: 'TooManyRequestsException' }))).toBe(true);
+    expect(isThrottleError({ code: 'ThrottlingException' })).toBe(true);
+  });
+
+  it('recognizes 429s in the shapes the providers throw', () => {
+    expect(isThrottleError({ $metadata: { httpStatusCode: 429 } })).toBe(true); // AWS SDK v3
+    expect(isThrottleError({ status: 429, message: 'rate_limit_error' })).toBe(true); // Anthropic direct
+    expect(isThrottleError({ statusCode: 429 })).toBe(true); // OpenAI-compatible proxies
+  });
+
+  it('recognizes throttle-shaped messages from wrapping layers', () => {
+    expect(isThrottleError(new Error('Too many requests, please wait before trying again.'))).toBe(true);
+    expect(isThrottleError(new Error('Rate limit exceeded for model'))).toBe(true);
+    expect(isThrottleError(new Error('Request was throttled'))).toBe(true);
+  });
+
+  it('does not classify ordinary failures as throttles', () => {
+    expect(isThrottleError(new Error('AccessDeniedException: not authorized'))).toBe(false);
+    expect(isThrottleError(Object.assign(new Error('boom'), { name: 'ValidationException' }))).toBe(false);
+    expect(isThrottleError({ status: 500, message: 'Internal error' })).toBe(false);
+    expect(isThrottleError('Too many requests')).toBe(false); // strings are not error objects
+    expect(isThrottleError(null)).toBe(false);
+    expect(isThrottleError(undefined)).toBe(false);
+  });
+});

--- a/packages/core/src/llm/throttle.ts
+++ b/packages/core/src/llm/throttle.ts
@@ -1,0 +1,30 @@
+/**
+ * #355 — provider-throttle classification.
+ *
+ * A rate-limited review is retriable work, not a failure: treating a
+ * throttle as terminal is how 32 of 57 burst reviews were silently lost
+ * (check FAILURE, no retry, no comment). Both runtimes use this one
+ * classifier so "what counts as a throttle" can never drift between them.
+ *
+ * Shapes covered:
+ *   - AWS SDK / Bedrock: `name` (or legacy `code`) 'ThrottlingException' /
+ *     'TooManyRequestsException', or `$metadata.httpStatusCode` 429.
+ *   - Anthropic direct / LiteLLM / OpenAI-compatible proxies: `status` 429.
+ *   - Anything wrapping the above into a message: "too many requests",
+ *     "rate limit", "throttl…". Bedrock's literal throttle message is
+ *     "Too many requests, please wait before trying again."
+ */
+export function isThrottleError(err: unknown): boolean {
+  if (err == null || typeof err !== 'object') return false;
+  const e = err as Record<string, unknown>;
+
+  const name = typeof e.name === 'string' ? e.name : typeof e.code === 'string' ? e.code : '';
+  if (name === 'ThrottlingException' || name === 'TooManyRequestsException') return true;
+
+  const metadata = e.$metadata as Record<string, unknown> | undefined;
+  if (metadata?.httpStatusCode === 429) return true;
+  if (e.status === 429 || e.statusCode === 429) return true;
+
+  const message = typeof e.message === 'string' ? e.message : '';
+  return /too many requests|rate limit|throttl/i.test(message);
+}

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -26,6 +26,7 @@ import {
   runReviewPipeline,
   formatReviewComment,
   countBlockingCriticals,
+  isThrottleError,
   mergeConfig,
   shouldSkipPR,
   extractIncludePatterns,
@@ -1151,6 +1152,29 @@ export async function handler(
       }),
     };
   } catch (error) {
+    // #355 — a provider throttle is retriable work, not a failure. Park the
+    // review back at 'pending' (claimable — see claimReview), keep the check
+    // run advisory-in-progress instead of terminally red, and RETHROW so the
+    // async invocation is retried by Lambda (returning without throwing is
+    // what suppressed every retry and silently lost 32/57 burst reviews).
+    if (isThrottleError(error)) {
+      console.warn(`Review throttled for ${repoFullName}#${prNumber} — parking for retry`);
+
+      await reviewStore.updateStatus(repoFullName, prNumberCommitSha, 'pending').catch((updateErr) => {
+        console.error('Failed to park throttled review as pending:', updateErr);
+      });
+
+      await createCheckRun(octokit, owner, repo, headSha, {
+        status: 'in_progress',
+        title: 'Review queued — rate limited',
+        summary: 'The model provider is rate limiting requests. MergeWatch will retry this review shortly.',
+      }).catch((checkErr) => {
+        console.error('Failed to post rate-limited check run:', checkErr);
+      });
+
+      throw error;
+    }
+
     console.error(`Review failed for ${repoFullName}#${prNumber}:`, error);
 
     await reviewStore.updateStatus(repoFullName, prNumberCommitSha, 'failed', {

--- a/packages/server/src/review-processor.test.ts
+++ b/packages/server/src/review-processor.test.ts
@@ -1182,3 +1182,62 @@ describe('processReviewJob — check conclusion vs verification (#240)', () => {
     expect(check.summary).toContain('1 unverified');
   });
 });
+
+// ---------------------------------------------------------------------------
+// #355 — a provider throttle is parked for retry, not terminally failed
+// ---------------------------------------------------------------------------
+
+describe('processReviewJob — throttle handling (#355)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getPRContext as any).mockResolvedValue(basePRContext);
+    (getPRDiff as any).mockResolvedValue('diff content');
+    (shouldSkipPR as any).mockReturnValue(null);
+    (shouldSkipByRules as any).mockReturnValue(null);
+    (fetchRepoConfig as any).mockResolvedValue(null);
+  });
+
+  it('parks a throttled review as pending with an in_progress "rate limited" check — never FAILURE', async () => {
+    (runReviewPipeline as any).mockRejectedValue(
+      Object.assign(new Error('Too many requests, please wait before trying again.'), { name: 'ThrottlingException' }),
+    );
+    const deps = makeDeps();
+    await expect(processReviewJob(makeJob(), deps)).rejects.toThrow('Too many requests');
+
+    // Status parked at pending — claimable by the retry — not failed.
+    const statusCalls = (deps.reviewStore.updateStatus as any).mock.calls;
+    expect(statusCalls.some((c: any[]) => c[2] === 'pending')).toBe(true);
+    expect(statusCalls.some((c: any[]) => c[2] === 'failed')).toBe(false);
+
+    // The completion check is in_progress/queued, never a failure conclusion.
+    const checkCalls = (createCheckRun as any).mock.calls.map((c: any[]) => c[4]);
+    expect(checkCalls.some((c: any) => c.conclusion === 'failure')).toBe(false);
+    expect(checkCalls.some((c: any) => c.status === 'in_progress' && /rate limited/i.test(c.title))).toBe(true);
+  });
+
+  it('a non-throttle pipeline error still fails the review and the check (no regression)', async () => {
+    (runReviewPipeline as any).mockRejectedValue(
+      Object.assign(new Error('model exploded'), { name: 'ValidationException' }),
+    );
+    const deps = makeDeps();
+    await expect(processReviewJob(makeJob(), deps)).rejects.toThrow('model exploded');
+
+    const statusCalls = (deps.reviewStore.updateStatus as any).mock.calls;
+    expect(statusCalls.some((c: any[]) => c[2] === 'failed')).toBe(true);
+
+    const checkCalls = (createCheckRun as any).mock.calls.map((c: any[]) => c[4]);
+    expect(checkCalls.some((c: any) => c.conclusion === 'failure' && c.title === 'Review failed')).toBe(true);
+  });
+
+  it('a 429 from a non-Bedrock provider (Anthropic/LiteLLM shape) is also parked', async () => {
+    (runReviewPipeline as any).mockRejectedValue(
+      Object.assign(new Error('rate_limit_error'), { status: 429 }),
+    );
+    const deps = makeDeps();
+    await expect(processReviewJob(makeJob(), deps)).rejects.toThrow();
+
+    const statusCalls = (deps.reviewStore.updateStatus as any).mock.calls;
+    expect(statusCalls.some((c: any[]) => c[2] === 'pending')).toBe(true);
+    expect(statusCalls.some((c: any[]) => c[2] === 'failed')).toBe(false);
+  });
+});

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -2,7 +2,7 @@ import type { ReviewJobPayload, IInstallationStore, IReviewStore, IGitHubAuthPro
 import {
   getPRDiff, getPRContext, addPRReaction, removePRReaction, postReviewComment, updateReviewComment,
   findExistingBotComment, getCommentReactions, createCheckRun,
-  formatReviewComment, countBlockingCriticals, runReviewPipeline, shouldSkipPR, shouldSkipByRules, isAutoReviewOff, extractIncludePatterns,
+  formatReviewComment, countBlockingCriticals, isThrottleError, runReviewPipeline, shouldSkipPR, shouldSkipByRules, isAutoReviewOff, extractIncludePatterns,
   loadCategoryDisputeRates,
   filterDiff,
   DEFAULT_CONFIG, mergeConfig,
@@ -981,6 +981,22 @@ export async function processReviewJob(
 
     console.log(`Review complete: ${repoFullName}#${prNumber} — score ${result.mergeScore}/5, ${result.findings.length} findings, ${durationMs}ms`);
   } catch (err) {
+    // #355 — a provider throttle (429 / ThrottlingException) is retriable
+    // work, not a failure. Park the review back at 'pending' (claimable —
+    // see claimReview) and keep the check advisory-in-progress instead of
+    // terminally red; the queue worker (#355 phase 2b) redelivers it.
+    if (isThrottleError(err)) {
+      console.warn(`Review throttled for ${repoFullName}#${prNumber} — parking for retry`);
+      await deps.reviewStore.updateStatus(repoFullName, prNumberCommitSha, 'pending')
+        .catch((updateErr) => console.warn('Failed to park throttled review as pending:', updateErr));
+      await createCheckRun(octokit, owner, repo, headSha, {
+        status: 'in_progress',
+        title: 'Review queued — rate limited',
+        summary: 'The model provider is rate limiting requests. MergeWatch will retry this review shortly.',
+      }).catch((checkErr) => console.warn('Failed to post rate-limited check run:', checkErr));
+      throw err;
+    }
+
     await deps.reviewStore.updateStatus(repoFullName, prNumberCommitSha, 'failed', {
       completedAt: new Date().toISOString(),
     });

--- a/packages/storage-dynamo/src/review-store.test.ts
+++ b/packages/storage-dynamo/src/review-store.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { PutCommand } from '@aws-sdk/lib-dynamodb';
+import { DynamoReviewStore } from './review-store.js';
+
+const TABLE = 'test-reviews';
+
+const review = {
+  repoFullName: 'octo/repo',
+  prNumberCommitSha: '7#abc1234',
+  status: 'pending' as const,
+  createdAt: '2026-08-16T00:00:00.000Z',
+};
+
+describe('DynamoReviewStore.claimReview (#355)', () => {
+  it("treats 'pending' as claimable so a throttled-and-parked review can be re-claimed", async () => {
+    const client = { send: vi.fn().mockResolvedValue({}) } as any;
+    const store = new DynamoReviewStore(client, TABLE);
+
+    expect(await store.claimReview(review as any)).toBe(true);
+    const cmd = client.send.mock.calls[0][0];
+    expect(cmd).toBeInstanceOf(PutCommand);
+    expect(cmd.input.ConditionExpression).toBe(
+      'attribute_not_exists(repoFullName) OR #s IN (:failed, :skipped, :complete, :pending)',
+    );
+    expect(cmd.input.ExpressionAttributeValues[':pending']).toBe('pending');
+    // The claim itself writes in_progress — that state stays unclaimable (dedup).
+    expect(cmd.input.Item.status).toBe('in_progress');
+  });
+
+  it('returns false (not throw) when the row is already in_progress', async () => {
+    const client = {
+      send: vi.fn().mockRejectedValue({ name: 'ConditionalCheckFailedException' }),
+    } as any;
+    const store = new DynamoReviewStore(client, TABLE);
+    expect(await store.claimReview(review as any)).toBe(false);
+  });
+
+  it('rethrows non-conditional errors', async () => {
+    const client = {
+      send: vi.fn().mockRejectedValue(Object.assign(new Error('boom'), { name: 'InternalServerError' })),
+    } as any;
+    const store = new DynamoReviewStore(client, TABLE);
+    await expect(store.claimReview(review as any)).rejects.toThrow('boom');
+  });
+});

--- a/packages/storage-dynamo/src/review-store.ts
+++ b/packages/storage-dynamo/src/review-store.ts
@@ -30,13 +30,17 @@ export class DynamoReviewStore implements IReviewStore {
         new PutCommand({
           TableName: this.tableName,
           Item: { ...review, status: 'in_progress' },
+          // #355 — 'pending' is claimable: a throttled review is parked back
+          // at 'pending' before the retry redelivers, and the retry must be
+          // able to re-claim it. 'in_progress' stays unclaimable (dedup).
           ConditionExpression:
-            'attribute_not_exists(repoFullName) OR #s IN (:failed, :skipped, :complete)',
+            'attribute_not_exists(repoFullName) OR #s IN (:failed, :skipped, :complete, :pending)',
           ExpressionAttributeNames: { '#s': 'status' },
           ExpressionAttributeValues: {
             ':failed': 'failed',
             ':skipped': 'skipped',
             ':complete': 'complete',
+            ':pending': 'pending',
           },
         }),
       );

--- a/packages/storage-postgres/src/review-store.test.ts
+++ b/packages/storage-postgres/src/review-store.test.ts
@@ -95,7 +95,7 @@ describe('PostgresReviewStore source + agentKind round-trip', () => {
 describe('PostgresReviewStore.claimReview (#355)', () => {
   it("includes 'pending' in the retriable claim set so a parked throttled review can be re-claimed", async () => {
     // claimReview goes through raw sql`` — capture the statement text.
-    const execute = vi.fn(async () => [] as unknown[]);
+    const execute = vi.fn(async (_stmt: unknown) => [] as unknown[]);
     const store = new PostgresReviewStore({ execute } as any);
     await store.claimReview({
       repoFullName: 'octo/repo',

--- a/packages/storage-postgres/src/review-store.test.ts
+++ b/packages/storage-postgres/src/review-store.test.ts
@@ -91,3 +91,23 @@ describe('PostgresReviewStore source + agentKind round-trip', () => {
     expect(got.agentKind).toBeUndefined();
   });
 });
+
+describe('PostgresReviewStore.claimReview (#355)', () => {
+  it("includes 'pending' in the retriable claim set so a parked throttled review can be re-claimed", async () => {
+    // claimReview goes through raw sql`` — capture the statement text.
+    const execute = vi.fn(async () => [] as unknown[]);
+    const store = new PostgresReviewStore({ execute } as any);
+    await store.claimReview({
+      repoFullName: 'octo/repo',
+      prNumberCommitSha: '7#abc1234',
+      status: 'pending',
+      createdAt: '2026-08-16T00:00:00.000Z',
+    } as ReviewItem);
+
+    const sqlArg = execute.mock.calls[0][0] as any;
+    const text = (sqlArg.queryChunks ?? [])
+      .map((c: any) => (typeof c === 'string' ? c : Array.isArray(c?.value) ? c.value.join('') : ''))
+      .join('');
+    expect(text).toContain("IN ('failed', 'skipped', 'complete', 'pending')");
+  });
+});

--- a/packages/storage-postgres/src/review-store.ts
+++ b/packages/storage-postgres/src/review-store.ts
@@ -81,7 +81,9 @@ export class PostgresReviewStore implements IReviewStore {
       )
       ON CONFLICT (repo_full_name, pr_number_commit_sha)
       DO UPDATE SET status = 'in_progress', created_at = ${review.createdAt}
-      WHERE reviews.status IN ('failed', 'skipped', 'complete')
+      -- #355: 'pending' is claimable — a throttled review is parked back at
+      -- 'pending' before the retry, and the retry must be able to re-claim it.
+      WHERE reviews.status IN ('failed', 'skipped', 'complete', 'pending')
       RETURNING repo_full_name
     `);
     return (result as any[]).length > 0;


### PR DESCRIPTION
Part of #355 — PR 1 of 3 (throttle semantics). PR 2 adds SQS admission control for SaaS; PR 3 adds the Postgres `SKIP LOCKED` queue for self-hosted.

## What

The burst run lost 32/57 reviews because a `ThrottlingException` was treated as terminal: review marked `failed`, FAILURE check posted, error swallowed (`return` without `throw`) — which also suppressed Lambda's built-in async retry. This PR makes a throttle what it actually is: retriable work.

- **`isThrottleError()`** in core — one classifier for both runtimes: AWS SDK names (`ThrottlingException`/`TooManyRequestsException`), 429 in the AWS-SDK / Anthropic-direct / OpenAI-proxy shapes, and throttle-shaped messages (Bedrock's literal "Too many requests, please wait before trying again.").
- **Both runtimes' catch paths**: on throttle → review status parked back to `pending`, check run posts `in_progress` "Review queued — rate limited" (never a FAILURE conclusion), and the error is **rethrown**. On Lambda that makes the async retry fire (2 attempts, ~1/2-min delays) — the first real retries this path has ever had. On self-hosted the rethrow surfaces to the dispatch `.catch` today and the phase-2b queue worker takes over redelivery.
- **`claimReview` retriable sets** in BOTH stores gain `'pending'` — without this, a parked review could never be re-claimed by the retry (`in_progress` remains unclaimable, preserving dedup).

Non-throttle errors keep byte-identical existing behavior.

## Tests

10 new: the classifier matrix (names / 429 shapes / messages / negatives), Dynamo + Postgres claim-from-pending, and the server catch-path matrix (Bedrock throttle parked, non-throttle still fails, non-Bedrock 429 parked) — 59/59 server suite. Full workspace build / typecheck / test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)