### PR TITLE
feat(infra): SQS admission control between webhook and review agent (#355, PR 2)

### DIFF
--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -219,7 +219,12 @@ Resources:
       Environment:
         Variables:
           # The ReviewAgent function ARN — needed to invoke it asynchronously
+          # (legacy fallback path when the queue URL is unset).
           REVIEW_AGENT_FUNCTION_NAME: !Ref ReviewAgent
+          # #355 — review jobs go through SQS for admission control; the
+          # webhook falls back to direct async invoke if this is unset
+          # (deploy-order safety on stacks that predate the queue).
+          REVIEW_QUEUE_URL: !Ref ReviewQueue
 
     # Build with esbuild for TypeScript support and tree-shaking
     Metadata:
@@ -263,8 +268,22 @@ Resources:
 
       Role: !GetAtt LambdaExecutionRole.Arn
 
-      # No API Gateway event — this function is invoked programmatically
-      # by WebhookHandler using the Lambda Invoke API
+      # #355 — reviews arrive via SQS with a hard concurrency cap. Lambda
+      # concurrency is elastic but the Bedrock on-demand quota is not: a
+      # 57-PR burst used to fan out into ~57 concurrent reviews, exhaust the
+      # model quota, and terminally fail 32 of them. The queue turns bursts
+      # into a paced backlog; MaximumConcurrency bounds the sustained request
+      # rate Bedrock sees. BatchSize 1 keeps one review per invocation so a
+      # throttle-rethrow returns exactly that review to the queue (redrive
+      # x3 → DLQ — bounded, visible, never silent).
+      Events:
+        ReviewJobs:
+          Type: SQS
+          Properties:
+            Queue: !GetAtt ReviewQueue.Arn
+            BatchSize: 1
+            ScalingConfig:
+              MaximumConcurrency: 8
 
     Metadata:
       BuildMethod: esbuild
@@ -274,6 +293,41 @@ Resources:
         Sourcemap: true
         EntryPoints:
           - handlers/review-agent.ts
+
+  # ===========================================================================
+  # SQS: Review job queue (#355)
+  # ===========================================================================
+  # Admission control between WebhookHandler and ReviewAgent. Visibility
+  # timeout must exceed the ReviewAgent Timeout (Lambda/SQS requirement, and
+  # it doubles as the retry delay when a throttled review is rethrown).
+
+  ReviewQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub 'mergewatch-review-queue-${Stage}'
+      VisibilityTimeout: 360
+      # A review job older than a day is stale — the PR has moved on.
+      MessageRetentionPeriod: 86400
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt ReviewDLQ.Arn
+        maxReceiveCount: 3
+      Tags:
+        - Key: Project
+          Value: MergeWatch
+        - Key: Stage
+          Value: !Ref Stage
+
+  ReviewDLQ:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub 'mergewatch-review-dlq-${Stage}'
+      # 14 days — long enough for an operator to notice and redrive.
+      MessageRetentionPeriod: 1209600
+      Tags:
+        - Key: Project
+          Value: MergeWatch
+        - Key: Stage
+          Value: !Ref Stage
 
   # ===========================================================================
   # Lambda Function: BillingHandler
@@ -1066,6 +1120,16 @@ Resources:
                 Action:
                   - lambda:InvokeFunction
                 Resource: !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:mergewatch-review-agent-${Stage}'
+              # #355 — the webhook sends review jobs to the queue; the
+              # ReviewAgent's SQS event source polls it (custom-role
+              # functions don't get these attached automatically by SAM).
+              - Effect: Allow
+                Action:
+                  - sqs:SendMessage
+                  - sqs:ReceiveMessage
+                  - sqs:DeleteMessage
+                  - sqs:GetQueueAttributes
+                Resource: !GetAtt ReviewQueue.Arn
 
   # ===========================================================================
   # AWS Amplify Hosting — Next.js Dashboard

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -16,6 +16,7 @@
     "@mergewatch/llm-bedrock": "workspace:*",
     "@aws-sdk/client-dynamodb": "^3.721.0",
     "@aws-sdk/client-lambda": "^3.721.0",
+    "@aws-sdk/client-sqs": "^3.721.0",
     "@aws-sdk/client-ssm": "^3.721.0",
     "@aws-sdk/lib-dynamodb": "^3.721.0",
     "@octokit/auth-app": "^7.1.0",

--- a/packages/lambda/src/handlers/review-agent-event.test.ts
+++ b/packages/lambda/src/handlers/review-agent-event.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { payloadFromEvent } from './review-agent-event.js';
+
+const job = { installationId: 1, owner: 'octo', repo: 'repo', prNumber: 7, mode: 'review' as const };
+
+describe('payloadFromEvent (#355)', () => {
+  it('passes a direct-invoke payload through untouched', () => {
+    expect(payloadFromEvent(job as any)).toEqual(job);
+  });
+
+  it('unwraps a single SQS record body', () => {
+    expect(payloadFromEvent({ Records: [{ body: JSON.stringify(job) }] })).toEqual(job);
+  });
+
+  it('fails loudly on batch-size drift instead of silently dropping PRs', () => {
+    expect(() => payloadFromEvent({ Records: [] })).toThrow('Expected exactly 1 SQS record');
+    expect(() => payloadFromEvent({
+      Records: [{ body: JSON.stringify(job) }, { body: JSON.stringify(job) }],
+    })).toThrow('got 2');
+  });
+
+  it('throws on an unparseable record body (goes to redrive, then DLQ)', () => {
+    expect(() => payloadFromEvent({ Records: [{ body: 'not-json' }] })).toThrow();
+  });
+});

--- a/packages/lambda/src/handlers/review-agent-event.ts
+++ b/packages/lambda/src/handlers/review-agent-event.ts
@@ -1,0 +1,35 @@
+/**
+ * #355 — review-agent event normalization.
+ *
+ * The review agent historically received a bare `ReviewJobPayload` via
+ * direct async Lambda invoke. With the SQS admission-control queue the same
+ * payload arrives wrapped in an SQS event (`Records[].body`, BatchSize 1).
+ * Both shapes must work: the queue is the steady state, direct invoke
+ * remains the webhook's deploy-order fallback and the operator's manual
+ * re-drive tool.
+ */
+import type { ReviewJobPayload } from '@mergewatch/core';
+
+interface SqsRecordLike {
+  body: string;
+}
+
+export type ReviewAgentEvent = ReviewJobPayload | { Records: SqsRecordLike[] };
+
+/**
+ * Unwrap the job payload from either invocation shape. The event source is
+ * configured with BatchSize 1, so an SQS event carries exactly one record;
+ * anything else (0 or >1) is a configuration drift worth failing loudly on
+ * rather than silently reviewing only the first PR.
+ */
+export function payloadFromEvent(event: ReviewAgentEvent): ReviewJobPayload {
+  if (event != null && typeof event === 'object' && 'Records' in event && Array.isArray(event.Records)) {
+    if (event.Records.length !== 1) {
+      throw new Error(
+        `Expected exactly 1 SQS record (BatchSize 1), got ${event.Records.length}`,
+      );
+    }
+    return JSON.parse(event.Records[0].body) as ReviewJobPayload;
+  }
+  return event as ReviewJobPayload;
+}

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -91,6 +91,7 @@ import {
 import { BedrockLLMProvider, SUPPORTED_MODELS } from '@mergewatch/llm-bedrock';
 import { isSaas, billingCheck, recordReview, postBlockedCheckRun, ensureBillingIssue, updateBillingFields, getStripe, isLapsedOssGrant } from '@mergewatch/billing';
 import { SSMGitHubAuthProvider } from '../github-auth-ssm.js';
+import { payloadFromEvent, type ReviewAgentEvent } from './review-agent-event.js';
 
 // -- Singletons (re-used across warm invocations) ----------------------------
 
@@ -362,8 +363,11 @@ async function handleInlineReplyMode(
 // -- Lambda handler ----------------------------------------------------------
 
 export async function handler(
-  event: ReviewJobPayload,
+  rawEvent: ReviewAgentEvent,
 ): Promise<{ statusCode: number; body: string }> {
+  // #355 — jobs arrive via the SQS queue (Records-wrapped) or legacy direct
+  // invoke; normalize before anything touches the payload.
+  const event = payloadFromEvent(rawEvent);
   const { installationId, owner, repo, prNumber, mode, existingCommentId, userComment, userCommentAuthor } = event;
   const repoFullName = `${owner}/${repo}`;
 

--- a/packages/lambda/src/handlers/webhook.test.ts
+++ b/packages/lambda/src/handlers/webhook.test.ts
@@ -22,6 +22,17 @@ vi.mock('@mergewatch/core', async (importOriginal) => {
   };
 });
 
+const mockSqsSend = vi.fn().mockResolvedValue({});
+vi.mock('@aws-sdk/client-sqs', () => ({
+  SQSClient: class {
+    send(cmd: unknown) { return mockSqsSend(cmd); }
+  },
+  SendMessageCommand: class {
+    input: unknown;
+    constructor(input: unknown) { this.input = input; }
+  },
+}));
+
 vi.mock('@aws-sdk/client-lambda', () => ({
   LambdaClient: class {
     send(cmd: unknown) { return mockEnqueue(cmd); }
@@ -602,5 +613,41 @@ describe('handler — OSS repo identity on the job payload (#261)', () => {
     await handler(makeApiGatewayEvent(body));
 
     expect(enqueuedPayload().repoId).toBe(987654);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #355 — review jobs go through SQS when the queue is configured
+// ---------------------------------------------------------------------------
+
+describe('enqueueReviewJob transport (#355)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetInstallationOctokit.mockResolvedValue({});
+    mockFetchRepoConfig.mockResolvedValue(null);
+    mockClassifyPrSource.mockResolvedValue({ source: 'human' });
+    delete process.env.REVIEW_QUEUE_URL;
+  });
+
+  it('sends the job to SQS when REVIEW_QUEUE_URL is set — never a direct invoke', async () => {
+    process.env.REVIEW_QUEUE_URL = 'https://sqs.us-west-2.amazonaws.com/1/mergewatch-review-queue-test';
+    const body = JSON.stringify(makePullRequestEvent());
+    await handler(makeApiGatewayEvent(body));
+
+    expect(mockSqsSend).toHaveBeenCalledTimes(1);
+    expect(mockEnqueue).not.toHaveBeenCalled();
+    const input = (mockSqsSend.mock.calls[0][0] as { input: { QueueUrl: string; MessageBody: string } }).input;
+    expect(input.QueueUrl).toContain('mergewatch-review-queue-test');
+    const payload = JSON.parse(input.MessageBody);
+    expect(payload.mode).toBe('review');
+    expect(payload.prNumber).toBeDefined();
+  });
+
+  it('falls back to direct async invoke when the queue URL is unset (deploy-order safety)', async () => {
+    const body = JSON.stringify(makePullRequestEvent());
+    await handler(makeApiGatewayEvent(body));
+
+    expect(mockEnqueue).toHaveBeenCalledTimes(1);
+    expect(mockSqsSend).not.toHaveBeenCalled();
   });
 });

--- a/packages/lambda/src/handlers/webhook.ts
+++ b/packages/lambda/src/handlers/webhook.ts
@@ -12,6 +12,7 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 import type { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import { LambdaClient, InvokeCommand, InvocationType } from "@aws-sdk/client-lambda";
+import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb";
 import {
@@ -46,6 +47,7 @@ import { SSMGitHubAuthProvider, getWebhookSecret } from '../github-auth-ssm.js';
 // ---------------------------------------------------------------------------
 
 const lambda = new LambdaClient({});
+const sqs = new SQSClient({});
 const dynamodb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const authProvider = new SSMGitHubAuthProvider();
 
@@ -120,6 +122,21 @@ function ossRepoFields(repository: { id: number; private: boolean }) {
 }
 
 async function enqueueReviewJob(payload: ReviewJobPayload): Promise<void> {
+  // #355 — review jobs go through SQS so the ReviewAgent's event-source
+  // MaximumConcurrency bounds the burst that reaches Bedrock. Direct async
+  // invoke remains as the fallback for a stack deployed without the queue
+  // (deploy-order safety, same pattern as the #335 GSI fallback).
+  const queueUrl = process.env.REVIEW_QUEUE_URL;
+  if (queueUrl) {
+    await sqs.send(
+      new SendMessageCommand({
+        QueueUrl: queueUrl,
+        MessageBody: JSON.stringify(payload),
+      })
+    );
+    return;
+  }
+
   const functionName =
     process.env.REVIEW_AGENT_FUNCTION_NAME ?? "mergewatch-review-agent";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
       '@aws-sdk/client-lambda':
         specifier: ^3.721.0
         version: 3.1047.0
+      '@aws-sdk/client-sqs':
+        specifier: ^3.721.0
+        version: 3.1111.0
       '@aws-sdk/client-ssm':
         specifier: ^3.721.0
         version: 3.1047.0
@@ -412,6 +415,10 @@ packages:
     resolution: {integrity: sha512-Iyq2gC0ttPocNmigQuXc7tLm/yQtd7brYfThW1qmOL8VDdIyohaa96Cye0bIqSKoVAp0MreWHb9343cXfK1hEQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-sqs@3.1111.0':
+    resolution: {integrity: sha512-xeyZhY/yL5d5mcLqtHEsdKkTdNuSGslcmIOgx402dMFji2lzRigzX8caNTdmtpTHwa47DGBoTHB3v9UgbmSnvg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-ssm@3.1047.0':
     resolution: {integrity: sha512-D9mad6p76UkI9BJjBVBHk/rTJNzf3DngYU1wBjvo8Iy4yz+ZlJNe1HyWJJtt/e5d7H3T8cM2YppkGUEzmMU2Mg==}
     engines: {node: '>=20.0.0'}
@@ -421,36 +428,72 @@ packages:
     engines: {node: '>=20.0.0'}
     deprecated: Deprecated due to an error deserialization bug in JSON 1.0 protocol services, see https://github.com/aws/aws-sdk-js-v3/pull/8031. Newer version available.
 
+  '@aws-sdk/core@3.977.8':
+    resolution: {integrity: sha512-7+Kcrkvrk9lM/m7jRhHpT4jCdvzGHsuaSRbF8TdzzkY1mRzp/Ogwf9c7H29k4gGhey0BBWhCWr16+t0J61gwmg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-env@3.972.36':
     resolution: {integrity: sha512-gE+CGuPZD1eqUWGSrM8CXDjlwuPujIuwI+IlorD1wE2RcANKKT4jscB9GY1nTJbjmXzD18sycsYbgCG5m3n4/g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.69':
+    resolution: {integrity: sha512-AreCFzcB4kH2HF9031Ot0jSJr3KXvRg6e8uDeub20JEVdZU3Bv0sTq1plc7VsT3KiqutlzH7l0j50UcCWHUioA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.38':
     resolution: {integrity: sha512-cHZo3bV6zN9joDQ2AYVctfzHTKStxWKwnGu0z7GwCUC+DAtB3qL/+26l+a63RbmFbVvb1JK+0vJKodN3hRMwyw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-http@3.972.71':
+    resolution: {integrity: sha512-A8ObcqVmDMnk4F9NozZ7JwmUu9Q4xyBJkmyq1C5U+wNM9ht9J7+EuuyabsLWXZnOoTqFaJuYBYTKf5CTipkEjA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-ini@3.972.40':
     resolution: {integrity: sha512-0NFGS9I3PD2yMveQqqpwpRdyZVStzgk0Yr2rZHh80kV/QNqQCK5lSrksvU3nBcRNSUF5Uk8rL3Xk0EVR+UVAnA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.14':
+    resolution: {integrity: sha512-7c+Wti2LsERNWMfm7ySz3/6RPopFW3Nmn7s63Xpcq6R/tRuY5hpvkHA2xVgi5ukJbvok9l0IDtVEvqTtg+X7dw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.40':
     resolution: {integrity: sha512-IEIl+UQnrEjZP53TSl91e8LBephi4i1Mt9WZrMgN8pOg6xPOLZdkN1GhsEzjkMD1TQy4Fp2dwWA/9ToTQFOlLA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-login@3.972.76':
+    resolution: {integrity: sha512-LVixwOnEJfrrfKHeZjBA8pIMTZjNDq8ak8VpcoWUuCJDrSnBNU8POJksULMgvN089P0MXtQYH2Zs627/MK1K0g==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-node@3.972.41':
     resolution: {integrity: sha512-h6BlclpsPGkx7Pv7ukr8oKVqN3jvxnH5n9ZIUQa8focr1ZkKd2MYiPJ2Nv9GI97dohJVJBfZAsTp/qoZL5R1pw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.80':
+    resolution: {integrity: sha512-bE2qh8ww4iClO1jHsBXdOE8FUgzDbdxbyorNjSCoPSkQd51k3jODItuPZfuwcLHZqDXsH+bI4AMHhqtuyR7mSg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.36':
     resolution: {integrity: sha512-eDQ6X7clTAOxXegOx4rGT1hyfusGEYdJGCGo0Ym2+CKeMQBjk+SJSxSVev11NJew5xJHJ/c3hryl2awKaxuSEA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-process@3.972.69':
+    resolution: {integrity: sha512-9kpTNdZTrcqXTfhxM7fgl9Z68ek3Fu5oe3Yf+A/pJGibEqpgZxz2tSY7SinmyCIU2PJ+ygY4FPoBBnLpocMtrQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-sso@3.972.40':
     resolution: {integrity: sha512-jaABbsoOkGlKg5kaHetYmUV6mWM57H89ia0Yksom1XxC847mfjmEVb4p7VijS1sjPbXjUii4cftJuwsl4MXkRg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.973.13':
+    resolution: {integrity: sha512-Oc81qauMPzUoTnAS2YKpNwY6sY/LUyQTEeaf6yP197WMxkEBQfcKLR1MFpD7+pNTubXnfkH6gwpji+Gc7iyD2Q==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.40':
     resolution: {integrity: sha512-bfIrM8IIzbRtXRQWx/vNEUBLTImLZyX5uKk8uSdeSAZ4Mj3Yi4UnRJLK4FkQLWErbM3McpVLQ1DaM6XO66Ed5g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.75':
+    resolution: {integrity: sha512-YPN6uoGDgjjjeVFZrcOeCJqmB6zpXoeeNgIjqe+DexJaWqdjVfCCe+VAZwli9Z2h8KhFW8oxkO39emQ1tyz/Mw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/dynamodb-codec@3.973.10':
@@ -491,6 +534,10 @@ packages:
     resolution: {integrity: sha512-5eltYxKB4MfdQv7/VhWxRbAVQKow5dz9votRFigTYrWJHMQXwLMltlbk7KFWSZh5NDBySfmjT7Jv/DWfYCmDng==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-sdk-sqs@3.972.41':
+    resolution: {integrity: sha512-07AbG/6LlaoC3YJ97vPgWVYFGWg3W3Bdr1ow3xjwti5u9/PjVD8+wB+qu2jDZnIvE6F7Y4ONWYCDQTPxiepdnA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-user-agent@3.972.40':
     resolution: {integrity: sha512-QLpD+HNQtL1Mc49/GRa6RmZvi/TEYBWPevC9F3L+j96IoG3xOSRctdQfbkX0lETb3TX9QQXU1oGYDmAB+YJprA==}
     engines: {node: '>=20.0.0'}
@@ -498,6 +545,10 @@ packages:
   '@aws-sdk/middleware-websocket@3.972.18':
     resolution: {integrity: sha512-MlaAUTAoUYDjHpRJULrxwA13guIknZG540ae3xsJIQT7m63lkmCPtuaVnWV8W5SpPSElvmI94+Q4LrMjNuJEUA==}
     engines: {node: '>= 14.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.43':
+    resolution: {integrity: sha512-bit+VpqWNyi3wHxFoTsTliNXimCSL2r2OeDTm7ZrG+YsTZ2D7ofDJ6r/t9PVBn80i6/v0X2h9Tgw6QP2MAKfPw==}
+    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/nested-clients@3.997.8':
     resolution: {integrity: sha512-/Vw2M27w+0APfMDzDpvv8auA4WiJ4D22+lC61pMS2M8Wk+4IydeRqh5utbrh+A5gQRxgUYd/xz3tdv8nQlmiHg==}
@@ -511,12 +562,24 @@ packages:
     resolution: {integrity: sha512-2N62veqdMZBCwQUHsbhtnaovOFjOa5Dn3dAD1nRqFTUXR4QmirT3HZnfus/L1DS08Vm5CkoKmL0iMVt6YbqEag==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/signature-v4-multi-region@3.996.45':
+    resolution: {integrity: sha512-bBuyztukzXq6plzFGHAWiQt0QXo+HL8b8lX5cFTzkez/74PtS1c0qPFCIVuHkyoT+miH2qOjAcm1/yoro2ESPA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/token-providers@3.1047.0':
     resolution: {integrity: sha512-GwJUeMijpeO2SOGGLRg4q2Nj9foBUBd7hTALYVId+m8fQmA4P2hITp5dmrZFd4AjEkSVmt2eFqmk3TttF7HZeQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/token-providers@3.1111.0':
+    resolution: {integrity: sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/types@3.973.8':
     resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.4':
+    resolution: {integrity: sha512-dSFDNG00MEz0/xl5gxL62giLd1iYyJsTxZ1I1DOj6lC+bbgLB4TRsYClJg3b62dhXT1uATzsTNXPnC+33EJV3A==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-dynamodb@3.996.2':
@@ -549,8 +612,16 @@ packages:
     resolution: {integrity: sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/xml-builder@3.972.39':
+    resolution: {integrity: sha512-FTti8DS5MMWXNUWiRwXAJeYS+0GHHiMy0+7XOhcwk63ILHmfS2UFy2z/HNpZCSOJJ3P3dnWY6hfYNW3DF0nXUA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws/lambda-invoke-store@0.2.4':
     resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
     engines: {node: '>=18.0.0'}
 
   '@babel/helper-string-parser@7.27.1':
@@ -1347,17 +1418,33 @@ packages:
     resolution: {integrity: sha512-IKS7qX59fAGCYBmt5JChcDswQDupZqT2Yn2ZBA3UgTlsjRNNkQzZobbn95xoAAdtTyJmBiJB3Y02qR3rgy3Zog==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.33.2':
+    resolution: {integrity: sha512-CUGXpnPkVdjUCbix+83sWLW9VFgQOm44MDOx/ihITJMAnOZKvL8YYIc7DR9pP/tZ8CIRvMiON/TucvygqbHO3w==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.3.2':
     resolution: {integrity: sha512-iYr9ekBjmZ+FwkiHEopqGscBbl78X62cq3p5Dd0eC+gNd7fybNZFQQdDuOQjTVmFymleuA8YRWZnuXWZ8B3kKA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.5.2':
+    resolution: {integrity: sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/fetch-http-handler@5.4.2':
     resolution: {integrity: sha512-3wF40g8OOCA5BnwQUvwtzZqYBbWWftDjpAlWIUo6Yld3ZzJaMAKqg7MWQBPjE8oLaqvZQUE7tVGlZPsae6A4bQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/fetch-http-handler@5.7.2':
+    resolution: {integrity: sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/is-array-buffer@2.2.0':
     resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
     engines: {node: '>=14.0.0'}
+
+  '@smithy/node-http-handler@4.11.2':
+    resolution: {integrity: sha512-avwAh9HM3h2lcfjvP3zYIZGf+XVgLQ91wOJ2qoFbNpW1UZeZb33aGlhTZvtkANHfcGhJroRY64525OjfgOg30g==}
+    engines: {node: '>=18.0.0'}
 
   '@smithy/node-http-handler@4.7.2':
     resolution: {integrity: sha512-EdksTZ8UXYxGUgQ4mpIKrHoaj9WVGsp66TpZuixLAz1Jex8YDLnS4RH9ktGED5aOpN0OJlEtrsC9IGt76go1eA==}
@@ -1367,8 +1454,16 @@ packages:
     resolution: {integrity: sha512-1km1OjdLRFuITWpCPofjFqzZ+tbeWuB72ZhcYjbjkCxZ21tTPfIs4GUxRrelMyKMLxLghGD58RENnXorU/O8cw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/signature-v4@5.7.2':
+    resolution: {integrity: sha512-P7Ki6px6OOrxVtx8K7nLmyx4SlXUW/uTKDdMG44UHefmPGSRMBKe2v+TM59WdLcpUIrBrnuCsIqiM2MbsZjmhw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/types@4.14.1':
     resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.17.2':
+    resolution: {integrity: sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-buffer-from@2.2.0':
@@ -3498,6 +3593,18 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/client-sqs@3.1111.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/credential-provider-node': 3.972.80
+      '@aws-sdk/middleware-sdk-sqs': 3.972.41
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/client-ssm@3.1047.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -3530,12 +3637,31 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.977.8':
+    dependencies:
+      '@aws-sdk/types': 3.974.4
+      '@aws-sdk/xml-builder': 3.972.39
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.33.2
+      '@smithy/signature-v4': 5.7.2
+      '@smithy/types': 4.17.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-env@3.972.36':
     dependencies:
       '@aws-sdk/core': 3.974.10
       '@aws-sdk/types': 3.973.8
       '@smithy/core': 3.24.2
       '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.69':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.972.38':
@@ -3546,6 +3672,16 @@ snapshots:
       '@smithy/fetch-http-handler': 5.4.2
       '@smithy/node-http-handler': 4.7.2
       '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.71':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.2
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.972.40':
@@ -3566,6 +3702,22 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-ini@3.973.14':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/credential-provider-env': 3.972.69
+      '@aws-sdk/credential-provider-http': 3.972.71
+      '@aws-sdk/credential-provider-login': 3.972.76
+      '@aws-sdk/credential-provider-process': 3.972.69
+      '@aws-sdk/credential-provider-sso': 3.973.13
+      '@aws-sdk/credential-provider-web-identity': 3.972.75
+      '@aws-sdk/nested-clients': 3.997.43
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.40':
     dependencies:
       '@aws-sdk/core': 3.974.10
@@ -3576,6 +3728,15 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.76':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/nested-clients': 3.997.43
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
 
   '@aws-sdk/credential-provider-node@3.972.41':
     dependencies:
@@ -3593,12 +3754,34 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-node@3.972.80':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.69
+      '@aws-sdk/credential-provider-http': 3.972.71
+      '@aws-sdk/credential-provider-ini': 3.973.14
+      '@aws-sdk/credential-provider-process': 3.972.69
+      '@aws-sdk/credential-provider-sso': 3.973.13
+      '@aws-sdk/credential-provider-web-identity': 3.972.75
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.36':
     dependencies:
       '@aws-sdk/core': 3.974.10
       '@aws-sdk/types': 3.973.8
       '@smithy/core': 3.24.2
       '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.69':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.972.40':
@@ -3613,6 +3796,16 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-sso@3.973.13':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/nested-clients': 3.997.43
+      '@aws-sdk/token-providers': 3.1111.0
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.40':
     dependencies:
       '@aws-sdk/core': 3.974.10
@@ -3623,6 +3816,15 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.75':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/nested-clients': 3.997.43
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
 
   '@aws-sdk/dynamodb-codec@3.973.10':
     dependencies:
@@ -3688,6 +3890,13 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-sdk-sqs@3.972.41':
+    dependencies:
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-user-agent@3.972.40':
     dependencies:
       '@aws-sdk/core': 3.974.10
@@ -3705,6 +3914,17 @@ snapshots:
       '@smithy/fetch-http-handler': 5.4.2
       '@smithy/signature-v4': 5.4.2
       '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.43':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/signature-v4-multi-region': 3.996.45
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.2
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/nested-clients@3.997.8':
@@ -3745,6 +3965,13 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/signature-v4-multi-region@3.996.45':
+    dependencies:
+      '@aws-sdk/types': 3.974.4
+      '@smithy/signature-v4': 5.7.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/token-providers@3.1047.0':
     dependencies:
       '@aws-sdk/core': 3.974.10
@@ -3756,9 +3983,23 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/token-providers@3.1111.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/nested-clients': 3.997.43
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/types@3.973.8':
     dependencies:
       '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.4':
+    dependencies:
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/util-dynamodb@3.996.2(@aws-sdk/client-dynamodb@3.1047.0)':
@@ -3799,7 +4040,14 @@ snapshots:
       fast-xml-parser: 5.7.3
       tslib: 2.8.1
 
+  '@aws-sdk/xml-builder@3.972.39':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws/lambda-invoke-store@0.2.4': {}
+
+  '@aws/lambda-invoke-store@0.3.0': {}
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -4378,10 +4626,21 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@smithy/core@3.33.2':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.3.2':
     dependencies:
       '@smithy/core': 3.24.2
       '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.5.2':
+    dependencies:
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@smithy/fetch-http-handler@5.4.2':
@@ -4390,8 +4649,20 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@smithy/fetch-http-handler@5.7.2':
+    dependencies:
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@smithy/is-array-buffer@2.2.0':
     dependencies:
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.11.2':
+    dependencies:
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@smithy/node-http-handler@4.7.2':
@@ -4406,7 +4677,17 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@smithy/signature-v4@5.7.2':
+    dependencies:
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@smithy/types@4.14.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@4.17.2':
     dependencies:
       tslib: 2.8.1
 


### PR DESCRIPTION
Part of #355 — PR 2 of 3, follows #361 (merged). PR 3 (Postgres queue for self-hosted) closes the issue.

## What

Lambda concurrency is elastic; the Bedrock on-demand quota is not — the 57-PR burst fanned out into ~57 concurrent reviews and terminally lost 32 (#355). Reviews now flow through SQS with a hard concurrency cap:

- **`ReviewQueue` + `ReviewDLQ`** (redrive ×3, 14-day DLQ retention), visibility timeout 360s — above the 300s function timeout as SQS/Lambda requires, and it doubles as the retry delay when #361's throttle-rethrow returns a review to the queue.
- **Event source on the ReviewAgent** with `ScalingConfig.MaximumConcurrency: 8` and `BatchSize: 1` — one review per invocation, so a rethrow requeues exactly that review; bursts become a paced backlog Bedrock can absorb. Combined with #361: throttle → check stays "queued — rate limited" → redrive ×3 → DLQ. Bounded, visible, never silent.
- **Webhook** sends jobs to the queue when `REVIEW_QUEUE_URL` is set, falling back to the legacy direct async invoke when unset (deploy-order safety — same pattern as the #335 GSI fallback).
- **`payloadFromEvent()`** normalizes both invocation shapes (SQS `Records` / bare payload) and fails loudly on batch-size drift instead of silently reviewing only the first record.
- **IAM**: `SendMessage` for the webhook, `ReceiveMessage`/`DeleteMessage`/`GetQueueAttributes` for the event source — custom-role functions don't get these attached by SAM automatically.

## Tests

6 new (SQS transport with queue URL set / legacy fallback without; event normalization matrix incl. batch-drift and unparseable-body failure). 43/43 webhook suite, full workspace build/typecheck/test green (verified by exit codes), template parse covered by `template.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)