### PR TITLE
feat(server): durable Postgres review-job queue with a bounded worker (#355, PR 3)

### DIFF
--- a/docs/pending/burst-review-resilience.md
+++ b/docs/pending/burst-review-resilience.md
@@ -1,0 +1,53 @@
+# Burst review resilience
+
+**Status:** 🚧 In review
+**Issue:** [#355](https://github.com/mergewatch/mergewatch.ai/issues/355)
+
+A burst of PRs (the E2E suite opens ~57 in 15 minutes) used to silently lose reviews: Lambda fan-out scaled into a fixed Bedrock quota, throttles were treated as terminal failures, and nothing ever retried — 32/57 reviews died with a red check and no comment. Self-hosted had the same shape with a different limiter (unbounded fire-and-forget promises against the provider's rate limit, all lost on restart).
+
+## Architecture
+
+```
+before                                   after
+──────                                   ─────
+SaaS: webhook ─(async invoke)→ agent      webhook ─→ SQS ─(MaximumConcurrency: 8)→ agent
+      unbounded fan-out ❌                       paced backlog, redrive ×3 → DLQ ✅
+Self: webhook ─(fire-and-forget)→ pipeline webhook ─→ review_jobs (Postgres) ─→ worker
+      unbounded, lost on restart ❌              SKIP LOCKED claims, REVIEW_CONCURRENCY ✅
+both: throttle → FAILURE check, no retry   throttle → status 'pending', check stays
+      ❌                                        in_progress "rate limited", retried ✅
+```
+
+## Shared semantics (both runtimes)
+
+- `isThrottleError()` in core classifies provider throttling (`ThrottlingException`, HTTP 429 in AWS/Anthropic/proxy shapes, throttle-shaped messages).
+- On throttle: the review is parked back at `pending` (now claimable — `claimReview`'s retriable set includes it), the check run posts `in_progress` "Review queued — rate limited" instead of a terminal FAILURE, and the error is rethrown so the transport-level retry fires.
+- Non-throttle errors keep the exact previous failure semantics.
+
+## SaaS (SQS)
+
+- `ReviewQueue` between webhook and review agent: event source with `ScalingConfig.MaximumConcurrency: 8`, `BatchSize: 1`, visibility timeout 360s (> the 300s function timeout; doubles as the throttle-retry delay).
+- Redrive ×3 → `ReviewDLQ` (14-day retention) — exhaustion is visible, never silent.
+- The webhook falls back to legacy direct async invoke when `REVIEW_QUEUE_URL` is unset (deploy-order safety); `payloadFromEvent()` accepts both invocation shapes.
+
+## Self-hosted (Postgres — zero new infrastructure)
+
+- `review_jobs` table consumed via `SELECT … FOR UPDATE SKIP LOCKED`: durable across `docker-compose pull`, multi-replica-safe, at-least-once (made safe by `claimReview` idempotency).
+- In-process worker (`review-worker.ts`, same shape as the insights cron): claims up to **`REVIEW_CONCURRENCY`** (env, default 3) jobs per poll (**`2s`** interval), lock horizon 900s for crash recovery.
+- Throttle → exponential backoff (60s × 2^attempt), up to 5 attempts, then `status = 'dead'` — the DLQ analogue, inspectable with `SELECT * FROM review_jobs WHERE status = 'dead'`.
+- A processor-recorded terminal failure completes the job (delivery done); only throttles redeliver.
+- Webhooks enqueue (one INSERT); when no queue is wired (tests, custom embeddings) dispatch falls back to the previous in-process call.
+
+## Configuration
+
+| Env (self-hosted) | Default | Meaning |
+|---|---|---|
+| `REVIEW_CONCURRENCY` | `3` | Reviews processed concurrently by the worker |
+
+SaaS knobs (`MaximumConcurrency`, redrive, visibility) live in `infra/template.yaml`.
+
+## Known limitations / future work
+
+- All job modes share one queue — an inline reply queued behind a large review backlog waits its turn. Priority lanes are a possible refinement.
+- A job that dies after max throttle attempts leaves its check run `in_progress` ("stuck", visible) rather than converting to a failure — same shape as an SQS DLQ arrival. Operator action: inspect the DLQ / `status='dead'` rows and re-drive.
+- Bedrock quota sizing is tracked separately (#360), to be done after the concurrency cap defines the sustained rate.

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -214,6 +214,7 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-85](#e2e-85-335--time-ordered-dynamodb-review-listing) | SaaS `listReviews` queries the `ByRepoCreatedAt` GSI: reverse-chronological across any PR numbers, date bounds in the key condition (no pre-filter `Limit` loss), `limit` bounds the merged result with lossless v2 resume cursors; sticky legacy fallback when the GSI is absent (#335) | 3m | 60s | #335 |
 | [E2E-86](#e2e-86-336--p95-duration-nearest-rank--minimum-sample) | Analytics p95 duration uses nearest-rank (`⌈n × 0.95⌉`, clamped) instead of returning the maximum for n ≤ 20; below 20 completed reviews the UI shows "—" with an explanatory tooltip and no P95 bar (#336) | 2m | 30s | #336 |
 | [E2E-87](#e2e-87-337--date-only-range-bounds-include-their-whole-day) | `/api/analytics` date-only `start_date`/`end_date` expand to the UTC day's edge instants at the boundary (`end_date=2026-08-16` includes the whole 16th); full timestamps pass through untouched; identical on both backends; UTC bucketing documented in the route (#337) | 2m | 30s | #337 |
+| [E2E-88](#e2e-88-355--pr-burst-resilience) | A PR burst never silently loses reviews: throttles park the review (`pending` + in_progress "rate limited" check, never terminal FAILURE) and admission control paces the backlog — SQS `MaximumConcurrency` on SaaS, Postgres `SKIP LOCKED` worker at `REVIEW_CONCURRENCY` on self-hosted; exhaustion lands in a DLQ/`status='dead'`, visibly (#355) | 20m | n/a | #355 |
 
 ---
 
@@ -3062,6 +3063,26 @@ Branch: `fixture/85-time-ordered-reviews`. Seed one repo with reviews for PR num
 - [ ] Full-timestamp bounds honored exactly, never re-widened
 - [ ] Postgres and DynamoDB return identical results for the same parameters
 - [ ] Invalid date forms are ignored (no 500, no partial filter)
+
+---
+
+### E2E-88: #355 — PR-burst resilience
+
+**Status:** 🚧 In review (#355) — fixture = the full-suite burst itself.
+
+**Behavior:** a provider throttle is retriable work, never a terminal failure. Both runtimes classify throttles (`isThrottleError`), park the review at `pending` (claimable), keep the check run `in_progress` ("Review queued — rate limited"), and rethrow so the transport retries: Lambda async retry → SQS redrive (×3 → DLQ) on SaaS; the Postgres worker's exponential backoff (60s × 2^attempt, 5 attempts → `status='dead'`) on self-hosted. Admission control bounds what the provider sees in the first place: SQS event source `MaximumConcurrency: 8` (SaaS) / `REVIEW_CONCURRENCY` worker slots (self-hosted, default 3).
+
+**How to run.**
+1. `scripts/run-suite.sh` on mergewatch/fixtures with default pacing (~57 PRs / 15 min) — the original #355 repro.
+2. Watch the review checks: bursty PRs may sit `in_progress`/queued longer, but **no** check may land at FAILURE with "Too many requests".
+3. Self-hosted variant: same burst against a docker-compose instance with a low provider rate limit; restart the container mid-burst — queued reviews must survive and drain.
+
+**Expected outcomes.**
+- [ ] 57/57 PRs reviewed — zero terminal "Too many requests" failures (vs 32/57 lost in the #355 run)
+- [ ] Throttled PRs show "Review queued — rate limited" in_progress checks while waiting, then complete
+- [ ] SaaS: review Lambda concurrency stays ≤ the event-source cap; DLQ empty at end of run
+- [ ] Self-hosted: `review_jobs` drains to `done`; no `dead` rows; a mid-burst restart loses nothing
+- [ ] A genuinely failing review (non-throttle) still fails its check exactly as before
 
 ---
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,8 @@ export type {
   IPRLifecycleStore,
   ISatisfactionStore,
   IReviewCostStore,
+  IReviewJobQueue,
+  ClaimedReviewJob,
   PRLifecycleOpenInput,
   PRLifecycleCloseInput,
   FindingDispositionAttribution,

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -17,6 +17,7 @@ import type {
   ReviewCostRecord,
   OrgCustomAgent,
 } from '../types/db.js';
+import type { ReviewJobPayload } from '../types/github.js';
 
 export interface IInstallationStore {
   get(installationId: string, repoFullName: string): Promise<InstallationItem | null>;
@@ -351,4 +352,47 @@ export interface IReviewCostStore {
     installationId: string,
     opts?: { limit?: number; cursor?: string },
   ): Promise<{ items: ReviewCostRecord[]; nextCursor?: string }>;
+}
+
+// ─── #355 — Review job queue (self-hosted admission control) ────────────────
+
+/** A claimed job: the payload plus the bookkeeping the worker needs. */
+export interface ClaimedReviewJob {
+  /** Queue-assigned identity, opaque to the worker. */
+  id: string;
+  payload: ReviewJobPayload;
+  /** Delivery attempts so far (1 on first claim). Drives retry backoff. */
+  attempts: number;
+}
+
+/**
+ * #355 — durable admission-control queue between the webhook and the review
+ * processor. The self-hosted implementation is a Postgres table consumed via
+ * `SELECT … FOR UPDATE SKIP LOCKED` (no new infrastructure — Postgres is
+ * already part of the deployment contract); SaaS uses SQS with an
+ * event-source concurrency cap instead of this interface's consumer side.
+ *
+ * Delivery is at-least-once: `claimReview` on the review store makes
+ * processing idempotent, so a job redelivered after a crash is safe.
+ */
+export interface IReviewJobQueue {
+  /** Durably enqueue a job. One INSERT — safe to await in the webhook path. */
+  enqueue(payload: ReviewJobPayload): Promise<void>;
+
+  /**
+   * Claim up to `max` due jobs (queued and past their `next_attempt_at`, or
+   * processing rows whose lock expired — crash recovery). Claimed rows are
+   * invisible to other claimers until `lockSeconds` elapses.
+   */
+  claim(max: number, lockSeconds: number): Promise<ClaimedReviewJob[]>;
+
+  /** Delivery finished (success OR a terminal, non-retriable outcome). */
+  complete(id: string): Promise<void>;
+
+  /** Redeliver after `delaySeconds` (throttle backoff). Increments nothing —
+   *  `attempts` advances on claim. */
+  retry(id: string, delaySeconds: number): Promise<void>;
+
+  /** Give up: park the job as dead for operator inspection (DLQ analogue). */
+  kill(id: string): Promise<void>;
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -7,6 +7,7 @@ import { sql as drizzleSql } from 'drizzle-orm';
 import {
   PostgresInstallationStore,
   PostgresReviewStore,
+  PostgresReviewJobQueue,
   PostgresFindingDispositionStore,
   PostgresFPInsightStore,
   PostgresPRLifecycleStore,
@@ -18,6 +19,8 @@ import { EnvGitHubAuthProvider } from './github-auth-env.js';
 import { createLLMProvider } from './llm-factory.js';
 import { createWebhookHandler } from './webhook-handler.js';
 import { startInsightsCron } from './insights-cron.js';
+import { startReviewWorker } from './review-worker.js';
+import { processReviewJob } from './review-processor.js';
 
 function requireEnv(name: string): string {
   const value = process.env[name];
@@ -121,8 +124,12 @@ async function main() {
     legacyHeaders: false,
   });
 
-  // Webhook endpoint
-  app.post('/webhook', webhookLimiter, createWebhookHandler({
+  // #355 — durable review-job queue + bounded worker. Webhooks enqueue;
+  // the worker drains at REVIEW_CONCURRENCY so a PR burst becomes a paced
+  // backlog instead of an unbounded fan-out against the LLM rate limit.
+  const reviewQueue = new PostgresReviewJobQueue(db);
+
+  const webhookDeps = {
     webhookSecret,
     installationStore,
     reviewStore,
@@ -134,7 +141,13 @@ async function main() {
     authProvider,
     llm,
     dashboardBaseUrl,
-  }));
+    reviewQueue,
+  };
+
+  startReviewWorker(reviewQueue, (payload) => processReviewJob(payload, webhookDeps));
+
+  // Webhook endpoint
+  app.post('/webhook', webhookLimiter, createWebhookHandler(webhookDeps));
 
   app.listen(port, () => {
     console.log(`MergeWatch server listening on port ${port}`);

--- a/packages/server/src/review-worker.test.ts
+++ b/packages/server/src/review-worker.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from 'vitest';
+import { startReviewWorker } from './review-worker.js';
+import type { ClaimedReviewJob, IReviewJobQueue, ReviewJobPayload } from '@mergewatch/core';
+
+const payload = { installationId: 1, owner: 'octo', repo: 'repo', prNumber: 7, mode: 'review' } as ReviewJobPayload;
+
+function makeQueue(jobs: ClaimedReviewJob[][]): IReviewJobQueue & Record<string, any> {
+  let call = 0;
+  return {
+    enqueue: vi.fn(),
+    claim: vi.fn(async () => jobs[call++] ?? []),
+    complete: vi.fn(async () => {}),
+    retry: vi.fn(async () => {}),
+    kill: vi.fn(async () => {}),
+  };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe('startReviewWorker (#355)', () => {
+  it('processes a claimed job and completes it', async () => {
+    const queue = makeQueue([[{ id: '1', payload, attempts: 1 }]]);
+    const processJob = vi.fn(async () => {});
+    const worker = startReviewWorker(queue, processJob, { pollIntervalMs: 60_000 });
+
+    await worker.tick();
+    await flush();
+
+    expect(processJob).toHaveBeenCalledWith(payload);
+    expect(queue.complete).toHaveBeenCalledWith('1');
+    worker.stop();
+  });
+
+  it('retries a throttled job with exponential backoff', async () => {
+    const queue = makeQueue([[{ id: '1', payload, attempts: 2 }]]);
+    const processJob = vi.fn(async () => {
+      throw Object.assign(new Error('Too many requests, please wait before trying again.'), { name: 'ThrottlingException' });
+    });
+    const worker = startReviewWorker(queue, processJob, { pollIntervalMs: 60_000, backoffBaseSeconds: 60 });
+
+    await worker.tick();
+    await flush();
+
+    // attempt 2 → base × 2^(2-1) = 120s
+    expect(queue.retry).toHaveBeenCalledWith('1', 120);
+    expect(queue.complete).not.toHaveBeenCalled();
+    expect(queue.kill).not.toHaveBeenCalled();
+    worker.stop();
+  });
+
+  it('kills a job after maxAttempts throttles (DLQ analogue)', async () => {
+    const queue = makeQueue([[{ id: '9', payload, attempts: 5 }]]);
+    const processJob = vi.fn(async () => {
+      throw Object.assign(new Error('x'), { status: 429 });
+    });
+    const worker = startReviewWorker(queue, processJob, { pollIntervalMs: 60_000, maxAttempts: 5 });
+
+    await worker.tick();
+    await flush();
+
+    expect(queue.kill).toHaveBeenCalledWith('9');
+    expect(queue.retry).not.toHaveBeenCalled();
+    worker.stop();
+  });
+
+  it('completes (not retries) a job whose processor recorded a terminal failure', async () => {
+    const queue = makeQueue([[{ id: '2', payload, attempts: 1 }]]);
+    const processJob = vi.fn(async () => {
+      throw Object.assign(new Error('model exploded'), { name: 'ValidationException' });
+    });
+    const worker = startReviewWorker(queue, processJob, { pollIntervalMs: 60_000 });
+
+    await worker.tick();
+    await flush();
+
+    expect(queue.complete).toHaveBeenCalledWith('2');
+    expect(queue.retry).not.toHaveBeenCalled();
+    expect(queue.kill).not.toHaveBeenCalled();
+    worker.stop();
+  });
+
+  it('claims only the free concurrency slots', async () => {
+    // Two slow jobs occupy both slots; the next tick must claim 0.
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+    const queue = makeQueue([
+      [{ id: '1', payload, attempts: 1 }, { id: '2', payload, attempts: 1 }],
+      [],
+    ]);
+    const processJob = vi.fn(() => gate);
+    const worker = startReviewWorker(queue, processJob, { pollIntervalMs: 60_000, concurrency: 2 });
+
+    await worker.tick(); // claims 2, both in flight
+    await worker.tick(); // no free slots — must not claim
+    expect(queue.claim).toHaveBeenCalledTimes(1);
+
+    release();
+    await flush();
+    await worker.tick(); // slots free again
+    expect(queue.claim).toHaveBeenCalledTimes(2);
+    worker.stop();
+  });
+});

--- a/packages/server/src/review-worker.ts
+++ b/packages/server/src/review-worker.ts
@@ -1,0 +1,117 @@
+/**
+ * #355 — self-hosted review worker: drains the Postgres review-job queue
+ * with a bounded concurrency, which is the admission control the direct
+ * fire-and-forget dispatch never had (a 57-PR burst used to become 57
+ * concurrent pipelines against one provider rate limit).
+ *
+ * Same lightweight `setInterval` shape as insights-cron.ts — one in-process
+ * loop, no extra dependency. Multiple server replicas are safe: claims go
+ * through `SELECT … FOR UPDATE SKIP LOCKED`.
+ *
+ * Outcome handling:
+ *   - success            → complete (job done)
+ *   - throttle (429)     → retry with exponential backoff, up to MAX_ATTEMPTS,
+ *                          then dead (DLQ analogue — visible via the table,
+ *                          the check run stays in_progress as "stuck", never
+ *                          a silent loss)
+ *   - any other error    → complete: the processor already recorded the
+ *                          terminal outcome (status=failed + failure check);
+ *                          the queue's delivery job is done.
+ */
+
+import { isThrottleError } from '@mergewatch/core';
+import type { IReviewJobQueue, ClaimedReviewJob, ReviewJobPayload } from '@mergewatch/core';
+
+export interface ReviewWorkerOptions {
+  /** Max reviews processed concurrently. Env: REVIEW_CONCURRENCY (default 3). */
+  concurrency?: number;
+  /** Poll interval in ms (default 2000). */
+  pollIntervalMs?: number;
+  /** Lock horizon per claim in seconds — must exceed the slowest review (default 900). */
+  lockSeconds?: number;
+  /** Throttle redeliveries before a job is declared dead (default 5). */
+  maxAttempts?: number;
+  /** Base backoff in seconds; attempt N waits base × 2^(N-1) (default 60). */
+  backoffBaseSeconds?: number;
+}
+
+export interface ReviewWorkerHandle {
+  stop(): void;
+  /** Test seam — run one poll cycle immediately. */
+  tick(): Promise<void>;
+}
+
+export function startReviewWorker(
+  queue: IReviewJobQueue,
+  processJob: (payload: ReviewJobPayload) => Promise<void>,
+  options: ReviewWorkerOptions = {},
+): ReviewWorkerHandle {
+  const concurrency = options.concurrency
+    ?? (Number(process.env.REVIEW_CONCURRENCY) > 0 ? Number(process.env.REVIEW_CONCURRENCY) : 3);
+  const pollIntervalMs = options.pollIntervalMs ?? 2000;
+  const lockSeconds = options.lockSeconds ?? 900;
+  const maxAttempts = options.maxAttempts ?? 5;
+  const backoffBaseSeconds = options.backoffBaseSeconds ?? 60;
+
+  let active = 0;
+  let stopped = false;
+
+  async function handle(job: ClaimedReviewJob): Promise<void> {
+    active++;
+    try {
+      await processJob(job.payload);
+      await queue.complete(job.id);
+    } catch (err) {
+      if (isThrottleError(err)) {
+        if (job.attempts >= maxAttempts) {
+          console.error(
+            '[review-worker] job %s dead after %d throttled attempts — inspect review_jobs (status=dead)',
+            job.id, job.attempts,
+          );
+          await queue.kill(job.id).catch(() => {});
+        } else {
+          const delay = backoffBaseSeconds * 2 ** (job.attempts - 1);
+          console.warn('[review-worker] job %s throttled (attempt %d) — retrying in %ds', job.id, job.attempts, delay);
+          await queue.retry(job.id, delay).catch(() => {});
+        }
+      } else {
+        // The processor already recorded the terminal failure (status +
+        // failure check run) — delivery is complete from the queue's view.
+        await queue.complete(job.id).catch(() => {});
+      }
+    } finally {
+      active--;
+    }
+  }
+
+  async function tick(): Promise<void> {
+    if (stopped) return;
+    const slots = concurrency - active;
+    if (slots <= 0) return;
+    let jobs: ClaimedReviewJob[];
+    try {
+      jobs = await queue.claim(slots, lockSeconds);
+    } catch (err) {
+      console.warn('[review-worker] claim failed:', err);
+      return;
+    }
+    // Fire handlers without awaiting completion — the active counter is the
+    // concurrency gate; the next tick only claims what fits.
+    for (const job of jobs) void handle(job);
+  }
+
+  const interval = setInterval(() => void tick(), pollIntervalMs);
+  interval.unref?.();
+  console.log(
+    '[review-worker] started — concurrency %d, poll %dms, lock %ds, maxAttempts %d',
+    concurrency, pollIntervalMs, lockSeconds, maxAttempts,
+  );
+
+  return {
+    stop() {
+      stopped = true;
+      clearInterval(interval);
+    },
+    tick,
+  };
+}

--- a/packages/server/src/webhook-handler.test.ts
+++ b/packages/server/src/webhook-handler.test.ts
@@ -779,3 +779,45 @@ describe('createWebhookHandler — pull_request_review_comment bot filter', () =
     expect(mockProcessReviewJob.mock.calls[0][0].mode).toBe('inline_reply');
   });
 });
+
+// ---------------------------------------------------------------------------
+// #355 — review jobs go through the durable queue when wired
+// ---------------------------------------------------------------------------
+
+describe('dispatch via review queue (#355)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindExistingBotComment.mockResolvedValue(null);
+    mockFetchRepoConfig.mockResolvedValue(null);
+    mockClassifyPrSource.mockResolvedValue({ source: 'human' });
+  });
+
+  it('enqueues instead of processing in-process when deps.reviewQueue is set', async () => {
+    mockClassifyPrSource.mockResolvedValue({ source: 'human' });
+    const deps = makeDeps();
+    const enqueue = vi.fn().mockResolvedValue(undefined);
+    (deps as any).reviewQueue = { enqueue, claim: vi.fn(), complete: vi.fn(), retry: vi.fn(), kill: vi.fn() };
+
+    const handler = createWebhookHandler(deps);
+    const { req, res } = makeReqRes(JSON.stringify(makePullRequestEvent()));
+    await handler(req, res);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(enqueue).toHaveBeenCalledTimes(1);
+    expect(mockProcessReviewJob).not.toHaveBeenCalled();
+    const job = enqueue.mock.calls[0][0];
+    expect(job.mode).toBe('review');
+    expect(job.prNumber).toBeDefined();
+  });
+
+  it('falls back to in-process dispatch when no queue is wired (legacy/test path)', async () => {
+    mockClassifyPrSource.mockResolvedValue({ source: 'human' });
+    const deps = makeDeps();
+    const handler = createWebhookHandler(deps);
+    const { req, res } = makeReqRes(JSON.stringify(makePullRequestEvent()));
+    await handler(req, res);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(mockProcessReviewJob).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/server/src/webhook-handler.ts
+++ b/packages/server/src/webhook-handler.ts
@@ -1,14 +1,40 @@
 import { createHmac, timingSafeEqual } from 'crypto';
 import type { Request, Response } from 'express';
 import type { IInstallationStore, IReviewStore, IFindingDispositionStore, IFPInsightStore, IPRLifecycleStore, ISatisfactionStore, IReviewCostStore, IGitHubAuthProvider, ILLMProvider, AgentReviewConfig } from '@mergewatch/core';
-import type { ReviewJobPayload, ReviewMode, PullRequestEvent, IssueCommentEvent, PullRequestReviewCommentEvent, InstallationEvent, CheckRunEvent } from '@mergewatch/core';
+import type { ReviewJobPayload, ReviewMode, PullRequestEvent, IssueCommentEvent, PullRequestReviewCommentEvent, InstallationEvent, CheckRunEvent, IReviewJobQueue } from '@mergewatch/core';
 import { REVIEW_TRIGGERING_ACTIONS, COMMENT_LOOKUP_ACTIONS, MERGEWATCH_CHECK_RUN_NAME, findExistingBotComment, classifyPrSource, fetchRepoConfig, mergeConfig, isBotActor, sweepInlineReactionsOnClose } from '@mergewatch/core';
 import { processReviewJob } from './review-processor.js';
+
+/**
+ * #355 — route a review job through the durable queue when wired, else run
+ * it in-process (legacy/test path). Fire-and-forget either way: the webhook
+ * response must not wait on a review.
+ */
+function dispatchReviewJob(job: ReviewJobPayload, deps: WebhookDeps, label: string): void {
+  if (deps.reviewQueue) {
+    deps.reviewQueue.enqueue(job).catch((err) => {
+      console.error('Failed to enqueue %s:', label, err);
+    });
+    return;
+  }
+  processReviewJob(job, deps).catch((err) => {
+    console.error('%s failed:', label, err);
+  });
+}
+
 
 export interface WebhookDeps {
   webhookSecret: string;
   installationStore: IInstallationStore;
   reviewStore: IReviewStore;
+  /**
+   * #355 — durable admission-control queue. When set, review jobs are
+   * enqueued and drained by the bounded worker (startReviewWorker) instead
+   * of spawning an unbounded fire-and-forget pipeline per webhook. When
+   * unset (older wiring, unit tests), dispatch falls back to the direct
+   * in-process call.
+   */
+  reviewQueue?: IReviewJobQueue;
   /** FB-A — optional disposition store. Best-effort: when unset, writes are
    *  no-ops and the review pipeline runs unchanged. */
   dispositionStore?: IFindingDispositionStore;
@@ -229,10 +255,8 @@ async function handlePullRequest(payload: PullRequestEvent, deps: WebhookDeps) {
     ...ossRepoFields(repository),
   };
 
-  // Process in background
-  processReviewJob(job, deps).catch((err) => {
-    console.error('Review job failed for %s#%d:', repository.full_name, pull_request.number, err);
-  });
+  // Process in background (#355 — via the durable queue when wired)
+  dispatchReviewJob(job, deps, `review job ${repository.full_name}#${pull_request.number}`);
 }
 
 async function handleIssueComment(payload: IssueCommentEvent, deps: WebhookDeps) {
@@ -261,9 +285,7 @@ async function handleIssueComment(payload: IssueCommentEvent, deps: WebhookDeps)
     ...(userComment ? { userComment, userCommentAuthor: comment.user.login } : {}),
   };
 
-  processReviewJob(job, deps).catch((err) => {
-    console.error('Review job failed for %s#%d:', repository.full_name, issue.number, err);
-  });
+  dispatchReviewJob(job, deps, `review job ${repository.full_name}#${issue.number}`);
 }
 
 async function handleReviewComment(payload: PullRequestReviewCommentEvent, deps: WebhookDeps) {
@@ -282,9 +304,7 @@ async function handleReviewComment(payload: PullRequestReviewCommentEvent, deps:
     ...ossRepoFields(repository),
   };
 
-  processReviewJob(job, deps).catch((err) => {
-    console.error('Inline reply job failed for %s#%d:', repository.full_name, pull_request.number, err);
-  });
+  dispatchReviewJob(job, deps, `inline reply job ${repository.full_name}#${pull_request.number}`);
 }
 
 /**
@@ -355,9 +375,7 @@ async function handleCheckRun(payload: CheckRunEvent, deps: WebhookDeps) {
     ...ossRepoFields(payload.repository),
   };
 
-  processReviewJob(job, deps).catch((err) => {
-    console.error('Review job (check_run rerequested) failed for %s#%d:', payload.repository.full_name, prNumber, err);
-  });
+  dispatchReviewJob(job, deps, `review job (check_run rerequested) ${payload.repository.full_name}#${prNumber}`);
 }
 
 async function handleInstallation(payload: InstallationEvent, deps: WebhookDeps) {

--- a/packages/storage-postgres/drizzle/0016_sparkling_the_hood.sql
+++ b/packages/storage-postgres/drizzle/0016_sparkling_the_hood.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS "review_jobs" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"payload" jsonb NOT NULL,
+	"status" text DEFAULT 'queued' NOT NULL,
+	"attempts" integer DEFAULT 0 NOT NULL,
+	"next_attempt_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"locked_until" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "review_jobs_claim_idx" ON "review_jobs" USING btree ("status","next_attempt_at");

--- a/packages/storage-postgres/drizzle/meta/0016_snapshot.json
+++ b/packages/storage-postgres/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,1249 @@
+{
+  "id": "a7ac5547-9dee-4602-9119-e16f0b9837be",
+  "prevId": "bbeb7fe9-2289-4abe-bcc7-6bc30aada776",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_installation_idx": {
+          "name": "api_keys_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.finding_dispositions": {
+      "name": "finding_dispositions",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finding_match_key": {
+          "name": "finding_match_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "surface_count": {
+          "name": "surface_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dispute_count": {
+          "name": "dispute_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verified_count": {
+          "name": "verified_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unverified_count": {
+          "name": "unverified_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "silent_drop_count": {
+          "name": "silent_drop_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "agreement_count": {
+          "name": "agreement_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resolve_count": {
+          "name": "resolve_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_agent": {
+          "name": "top_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sig_tokens": {
+          "name": "sig_tokens",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reject_reasons": {
+          "name": "reject_reasons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_counts": {
+          "name": "period_counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "finding_dispositions_installation_idx": {
+          "name": "finding_dispositions_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "finding_dispositions_installation_id_repo_full_name_finding_match_key_pk": {
+          "name": "finding_dispositions_installation_id_repo_full_name_finding_match_key_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name",
+            "finding_match_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.helpful_votes": {
+      "name": "helpful_votes",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "up": {
+          "name": "up",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "down": {
+          "name": "down",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_vote_at": {
+          "name": "last_vote_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "helpful_votes_installation_idx": {
+          "name": "helpful_votes_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "helpful_votes_installation_id_repo_full_name_pr_number_pk": {
+          "name": "helpful_votes_installation_id_repo_full_name_pr_number_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name",
+            "pr_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installation_fp_insights": {
+      "name": "installation_fp_insights",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window": {
+          "name": "window",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_end": {
+          "name": "window_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_findings_surfaced": {
+          "name": "total_findings_surfaced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_disputes": {
+          "name": "total_disputes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dispute_rate": {
+          "name": "dispute_rate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_silent_drops": {
+          "name": "total_silent_drops",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_agreements": {
+          "name": "total_agreements",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "per_category": {
+          "name": "per_category",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "per_severity": {
+          "name": "per_severity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "per_repo": {
+          "name": "per_repo",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "top_clusters": {
+          "name": "top_clusters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "cycle_time": {
+          "name": "cycle_time",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "engagement": {
+          "name": "engagement",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "installation_fp_insights_installation_id_window_pk": {
+          "name": "installation_fp_insights_installation_id_window_pk",
+          "columns": [
+            "installation_id",
+            "window"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installation_settings": {
+      "name": "installation_settings",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "severity_threshold": {
+          "name": "severity_threshold",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Low'"
+        },
+        "comment_types": {
+          "name": "comment_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"syntax\":true,\"logic\":true,\"style\":true}'::jsonb"
+        },
+        "max_comments": {
+          "name": "max_comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 25
+        },
+        "summary": {
+          "name": "summary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"prSummary\":true,\"confidenceScore\":true,\"issuesTable\":true,\"diagram\":true}'::jsonb"
+        },
+        "custom_instructions": {
+          "name": "custom_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "comment_header": {
+          "name": "comment_header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "custom_agents": {
+          "name": "custom_agents",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installations": {
+      "name": "installations",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monitored": {
+          "name": "monitored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "installations_installation_id_repo_full_name_pk": {
+          "name": "installations_installation_id_repo_full_name_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_sessions": {
+      "name": "mcp_sessions",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_billed_at": {
+          "name": "first_billed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_billed_cents": {
+          "name": "max_billed_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iteration": {
+          "name": "iteration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nps_responses": {
+      "name": "nps_responses",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_user_id": {
+          "name": "github_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nps_responses_installation_idx": {
+          "name": "nps_responses_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "nps_responses_installation_id_github_user_id_pk": {
+          "name": "nps_responses_installation_id_github_user_id_pk",
+          "columns": [
+            "installation_id",
+            "github_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pr_lifecycle": {
+      "name": "pr_lifecycle",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_created_at": {
+          "name": "pr_created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_review_at": {
+          "name": "first_review_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "reviewed": {
+          "name": "reviewed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "skipped": {
+          "name": "skipped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "total_pushes": {
+          "name": "total_pushes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pushes_after_first_review": {
+          "name": "pushes_after_first_review",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pr_lifecycle_installation_idx": {
+          "name": "pr_lifecycle_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "pr_lifecycle_installation_id_repo_full_name_pr_number_pk": {
+          "name": "pr_lifecycle_installation_id_repo_full_name_pr_number_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name",
+            "pr_number"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_costs": {
+      "name": "review_costs",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "review_costs_installation_idx": {
+          "name": "review_costs_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "review_costs_installation_id_repo_full_name_pr_number_commit_sha_pk": {
+          "name": "review_costs_installation_id_repo_full_name_pr_number_commit_sha_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name",
+            "pr_number",
+            "commit_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_jobs": {
+      "name": "review_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_jobs_claim_idx": {
+          "name": "review_jobs_claim_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_number_commit_sha": {
+          "name": "pr_number_commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_title": {
+          "name": "pr_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_author": {
+          "name": "pr_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pr_author_avatar": {
+          "name": "pr_author_avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "head_branch": {
+          "name": "head_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_severity": {
+          "name": "top_severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_text": {
+          "name": "summary_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagram_text": {
+          "name": "diagram_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_score": {
+          "name": "merge_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merge_score_reason": {
+          "name": "merge_score_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "findings": {
+          "name": "findings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reactions": {
+          "name": "reactions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings_used": {
+          "name": "settings_used",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_cost_usd": {
+          "name": "estimated_cost_usd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inline_resolved_keys": {
+          "name": "inline_resolved_keys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "inline_reactions_snapshot": {
+          "name": "inline_reactions_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "reviews_installation_idx": {
+          "name": "reviews_installation_idx",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reviews_pr_idx": {
+          "name": "reviews_pr_idx",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "reviews_repo_full_name_pr_number_commit_sha_pk": {
+          "name": "reviews_repo_full_name_pr_number_commit_sha_pk",
+          "columns": [
+            "repo_full_name",
+            "pr_number_commit_sha"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/storage-postgres/drizzle/meta/_journal.json
+++ b/packages/storage-postgres/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1786901819294,
       "tag": "0015_useful_tony_stark",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1786940740187,
+      "tag": "0016_sparkling_the_hood",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/storage-postgres/src/index.ts
+++ b/packages/storage-postgres/src/index.ts
@@ -5,6 +5,7 @@ export { PostgresFPInsightStore } from './fp-insight-store.js';
 export { PostgresPRLifecycleStore } from './pr-lifecycle-store.js';
 export { PostgresSatisfactionStore } from './satisfaction-store.js';
 export { PostgresReviewCostStore } from './review-cost-store.js';
+export { PostgresReviewJobQueue } from './review-job-queue.js';
 export {
   installations, installationSettings, reviews, apiKeys, mcpSessions,
   findingDispositions, installationFpInsights, prLifecycle,

--- a/packages/storage-postgres/src/review-job-queue.test.ts
+++ b/packages/storage-postgres/src/review-job-queue.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { PostgresReviewJobQueue } from './review-job-queue.js';
+import type { ReviewJobPayload } from '@mergewatch/core';
+
+const payload = { installationId: 1, owner: 'octo', repo: 'repo', prNumber: 7, mode: 'review' } as ReviewJobPayload;
+
+/** Flatten a drizzle sql`` template into its literal text (params elided). */
+function sqlText(stmt: any): string {
+  return (stmt.queryChunks ?? [])
+    .map((c: any) => (typeof c === 'string' ? c : Array.isArray(c?.value) ? c.value.join('') : ''))
+    .join('');
+}
+
+function makeDb(result: unknown[] = []) {
+  return { execute: vi.fn(async (_stmt: unknown) => result) } as any;
+}
+
+describe('PostgresReviewJobQueue (#355)', () => {
+  it('enqueue inserts the payload as jsonb', async () => {
+    const db = makeDb();
+    await new PostgresReviewJobQueue(db).enqueue(payload);
+    const text = sqlText(db.execute.mock.calls[0][0]);
+    expect(text).toContain('INSERT INTO review_jobs');
+    expect(text).toContain('::jsonb');
+  });
+
+  it('claim uses SKIP LOCKED, picks due + expired-lock rows, bumps attempts', async () => {
+    const db = makeDb([{ id: 5, payload, attempts: 1 }]);
+    const jobs = await new PostgresReviewJobQueue(db).claim(3, 900);
+    const text = sqlText(db.execute.mock.calls[0][0]);
+    expect(text).toContain('FOR UPDATE SKIP LOCKED');
+    expect(text).toContain("status = 'queued' AND next_attempt_at <= now()");
+    expect(text).toContain("status = 'processing' AND locked_until < now()");
+    expect(text).toContain('attempts = attempts + 1');
+    expect(jobs).toEqual([{ id: '5', payload, attempts: 1 }]);
+  });
+
+  it('claim parses a string payload (driver-dependent jsonb decoding)', async () => {
+    const db = makeDb([{ id: 6, payload: JSON.stringify(payload), attempts: 2 }]);
+    const [job] = await new PostgresReviewJobQueue(db).claim(1, 900);
+    expect(job.payload).toEqual(payload);
+    expect(job.attempts).toBe(2);
+  });
+
+  it('retry re-queues with the backoff delay', async () => {
+    const db = makeDb();
+    await new PostgresReviewJobQueue(db).retry('5', 120);
+    const text = sqlText(db.execute.mock.calls[0][0]);
+    expect(text).toContain("status = 'queued'");
+    expect(text).toContain('next_attempt_at = now() + make_interval');
+  });
+
+  it('complete and kill park the row terminally', async () => {
+    const db = makeDb();
+    const q = new PostgresReviewJobQueue(db);
+    await q.complete('5');
+    await q.kill('6');
+    expect(sqlText(db.execute.mock.calls[0][0])).toContain("status = 'done'");
+    expect(sqlText(db.execute.mock.calls[1][0])).toContain("status = 'dead'");
+  });
+});

--- a/packages/storage-postgres/src/review-job-queue.ts
+++ b/packages/storage-postgres/src/review-job-queue.ts
@@ -1,0 +1,81 @@
+/**
+ * #355 — Postgres implementation of `IReviewJobQueue`.
+ *
+ * The self-hosted admission-control queue: webhooks INSERT, the in-process
+ * worker claims with `SELECT … FOR UPDATE SKIP LOCKED` so concurrent
+ * replicas never double-deliver, and a `processing` row whose lock expired
+ * is reclaimable (crash recovery — at-least-once, made safe by the review
+ * store's idempotent `claimReview`). Postgres is already part of the
+ * self-hosted deployment contract, so this adds zero infrastructure.
+ *
+ * Lifecycle: queued → processing → done (delivered, terminal outcome
+ * recorded by the processor) | dead (retries exhausted — the DLQ analogue,
+ * kept for operator inspection).
+ */
+
+import { sql } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import type { IReviewJobQueue, ClaimedReviewJob, ReviewJobPayload } from '@mergewatch/core';
+
+export class PostgresReviewJobQueue implements IReviewJobQueue {
+  constructor(private db: PostgresJsDatabase) {}
+
+  async enqueue(payload: ReviewJobPayload): Promise<void> {
+    await this.db.execute(sql`
+      INSERT INTO review_jobs (payload) VALUES (${JSON.stringify(payload)}::jsonb)
+    `);
+  }
+
+  async claim(max: number, lockSeconds: number): Promise<ClaimedReviewJob[]> {
+    // One atomic statement: pick due rows (fresh, backoff-elapsed, or
+    // expired-lock crash leftovers) with SKIP LOCKED, mark them processing,
+    // bump attempts, and return them. The inner SELECT's row locks make the
+    // claim race-free across replicas without an advisory-lock dance.
+    const rows = await this.db.execute(sql`
+      UPDATE review_jobs SET
+        status = 'processing',
+        attempts = attempts + 1,
+        locked_until = now() + make_interval(secs => ${lockSeconds}),
+        updated_at = now()
+      WHERE id IN (
+        SELECT id FROM review_jobs
+        WHERE (status = 'queued' AND next_attempt_at <= now())
+           OR (status = 'processing' AND locked_until < now())
+        ORDER BY id
+        LIMIT ${max}
+        FOR UPDATE SKIP LOCKED
+      )
+      RETURNING id, payload, attempts
+    `);
+    return (rows as unknown as Array<{ id: number; payload: unknown; attempts: number }>).map((r) => ({
+      id: String(r.id),
+      payload: (typeof r.payload === 'string' ? JSON.parse(r.payload) : r.payload) as ReviewJobPayload,
+      attempts: Number(r.attempts),
+    }));
+  }
+
+  async complete(id: string): Promise<void> {
+    await this.db.execute(sql`
+      UPDATE review_jobs SET status = 'done', locked_until = NULL, updated_at = now()
+      WHERE id = ${Number(id)}
+    `);
+  }
+
+  async retry(id: string, delaySeconds: number): Promise<void> {
+    await this.db.execute(sql`
+      UPDATE review_jobs SET
+        status = 'queued',
+        next_attempt_at = now() + make_interval(secs => ${delaySeconds}),
+        locked_until = NULL,
+        updated_at = now()
+      WHERE id = ${Number(id)}
+    `);
+  }
+
+  async kill(id: string): Promise<void> {
+    await this.db.execute(sql`
+      UPDATE review_jobs SET status = 'dead', locked_until = NULL, updated_at = now()
+      WHERE id = ${Number(id)}
+    `);
+  }
+}

--- a/packages/storage-postgres/src/schema.ts
+++ b/packages/storage-postgres/src/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, integer, jsonb, boolean, timestamp, primaryKey, index } from 'drizzle-orm/pg-core';
+import { pgTable, text, integer, jsonb, boolean, timestamp, primaryKey, index, bigserial } from 'drizzle-orm/pg-core';
 
 export const installations = pgTable('installations', {
   installationId: text('installation_id').notNull(),
@@ -231,4 +231,25 @@ export const reviewCosts = pgTable('review_costs', {
 }, (t) => ({
   pk: primaryKey({ columns: [t.installationId, t.repoFullName, t.prNumber, t.commitSha] }),
   installationIdx: index('review_costs_installation_idx').on(t.installationId),
+}));
+
+// #355 — durable review-job queue (self-hosted admission control). Consumed
+// via SELECT ... FOR UPDATE SKIP LOCKED by the in-process worker; survives
+// container restarts, supports multiple server replicas. See
+// PostgresReviewJobQueue for the lifecycle (queued → processing → done/dead).
+export const reviewJobs = pgTable('review_jobs', {
+  id: bigserial('id', { mode: 'number' }).primaryKey(),
+  payload: jsonb('payload').notNull(),
+  // queued | processing | done | dead
+  status: text('status').notNull().default('queued'),
+  attempts: integer('attempts').notNull().default(0),
+  // Earliest time the job may be (re)claimed — throttle backoff target.
+  nextAttemptAt: timestamp('next_attempt_at', { withTimezone: true }).notNull().defaultNow(),
+  // Visibility-timeout analogue: a 'processing' row whose lock expired is
+  // reclaimable (crash recovery).
+  lockedUntil: timestamp('locked_until', { withTimezone: true }),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+}, (t) => ({
+  claimIdx: index('review_jobs_claim_idx').on(t.status, t.nextAttemptAt),
 }));


### PR DESCRIPTION
PR 3 of 3 — follows #361 (throttle semantics) and #362 (SaaS SQS), both merged. Closes #355.

## What

Self-hosted had the same burst failure as SaaS with a different limiter: every webhook spawned an unbounded fire-and-forget pipeline against the provider's rate limit, and every queued/in-flight review died on a container restart (which self-hosted does on every upgrade). Review jobs now flow through a durable Postgres queue — **zero new infrastructure**, since Postgres is already part of the self-hosted deployment contract.

- **`IReviewJobQueue`** in core (`enqueue`/`claim`/`complete`/`retry`/`kill`) + **`PostgresReviewJobQueue`**: claims are one atomic `UPDATE … WHERE id IN (SELECT … FOR UPDATE SKIP LOCKED)` — multi-replica-safe, and expired-lock `processing` rows are reclaimed (crash recovery; at-least-once is safe via `claimReview` idempotency).
- **`review_jobs` table** with an idempotent migration (`CREATE TABLE IF NOT EXISTS`, `migrations:check` green), `(status, next_attempt_at)` claim index.
- **In-process worker** (`review-worker.ts`, same `setInterval` shape as `insights-cron.ts`): `REVIEW_CONCURRENCY` slots (env, default 3), 2s poll, 900s lock horizon. Throttles (the #361 classifier) retry with exponential backoff (60s × 2^attempt) up to 5 attempts, then `status='dead'` — the DLQ analogue, operator-inspectable. Processor-recorded terminal failures complete the job (delivery done).
- **All four webhook dispatch sites** route through one `dispatchReviewJob()`: enqueue when the queue is wired, the previous in-process call otherwise (unit tests, custom embeddings).

## Docs / acceptance

`docs/pending/burst-review-resilience.md` covers both deployment modes (incl. known limitations: single queue for all modes, dead jobs leave an in_progress check). RUNBOOK **E2E-88** is the acceptance scenario — the original 57-PR burst, expecting 57/57 reviewed with zero terminal "Too many requests" failures, plus a mid-burst container restart losing nothing.

## Tests

14 new: queue SQL construction (SKIP LOCKED, due/expired-lock selection, attempts bump, string-payload decoding), worker outcome matrix (success/throttle-backoff/max-attempts-dead/terminal-failure/concurrency slots), webhook queue-vs-fallback dispatch. Full workspace build/typecheck/test green (verified by exit codes); `migrations:check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)