### PR TITLE
fix(core): formal review body carries a one-line pointer, not a bare marker (#356)

### DIFF
--- a/packages/core/src/github/client.test.ts
+++ b/packages/core/src/github/client.test.ts
@@ -681,19 +681,25 @@ describe('submitPRReview body handling (W6)', () => {
     expect(calls[0].event).toBe('APPROVE');
   });
 
-  it('REQUEST_CHANGES with empty body → HTML-comment stub (GitHub requires body for this event)', async () => {
+  it('REQUEST_CHANGES with empty body → marker + one-line critical pointer (#356)', async () => {
+    // The original HTML-comment-only stub rendered as an EMPTY review body
+    // in the GitHub UI (HTML comments are stripped) — E2E-03's failure mode.
     const { octokit, calls } = captureCall();
     await submitPRReview(octokit, 'o', 'r', 1, '', 'REQUEST_CHANGES');
     expect(calls).toHaveLength(1);
-    expect(calls[0].body).toBe('<!-- mergewatch-review -->');
+    expect(calls[0].body).toBe(
+      '<!-- mergewatch-review -->\n🔴 Critical issues found — see the full review in the summary comment above.',
+    );
     expect(calls[0].event).toBe('REQUEST_CHANGES');
   });
 
-  it('COMMENT with empty body → HTML-comment stub (GitHub requires body for this event)', async () => {
+  it('COMMENT with empty body → marker + one-line feedback pointer (#356)', async () => {
     const { octokit, calls } = captureCall();
     await submitPRReview(octokit, 'o', 'r', 1, '', 'COMMENT');
     expect(calls).toHaveLength(1);
-    expect(calls[0].body).toBe('<!-- mergewatch-review -->');
+    expect(calls[0].body).toBe(
+      '<!-- mergewatch-review -->\n📝 Review feedback — see the full review in the summary comment above.',
+    );
     expect(calls[0].event).toBe('COMMENT');
   });
 
@@ -709,7 +715,7 @@ describe('submitPRReview body handling (W6)', () => {
     await submitPRReview(octokit, 'o', 'r', 1, '   \n\t  ', 'APPROVE');
     await submitPRReview(octokit, 'o', 'r', 1, '   ', 'REQUEST_CHANGES');
     expect('body' in calls[0]).toBe(false);
-    expect(calls[1].body).toBe('<!-- mergewatch-review -->');
+    expect(calls[1].body).toContain('Critical issues found');
   });
 
   it('passes inline comments through unchanged, batched in one API call', async () => {

--- a/packages/core/src/github/client.ts
+++ b/packages/core/src/github/client.ts
@@ -383,17 +383,19 @@ export async function submitPRReview(
 ): Promise<void> {
   // W6 — single authoritative review comment. The paired upserted issue
   // comment (carrying `BOT_COMMENT_MARKER`) is the canonical place for the
-  // verdict, findings, diagram, etc. The formal PR Review object only
-  // exists to carry (a) the APPROVE / REQUEST_CHANGES / COMMENT event and
-  // (b) the inline comments. Its body should add NO duplicate content.
+  // verdict, findings, diagram, etc. The formal PR Review object carries
+  // (a) the APPROVE / REQUEST_CHANGES / COMMENT event, (b) the inline
+  // comments, and (c) — since #356 — a ONE-LINE POINTER to the summary
+  // comment. The pointer replaced W6's original HTML-comment-only stub:
+  // GitHub strips HTML comments when rendering, so the stub produced a
+  // review that looked bodyless/broken in the UI (E2E-03's failure-mode
+  // clause). The full review content still lives only in the summary
+  // comment — the pointer duplicates nothing.
   //
   // GitHub's API constraints differ by event:
-  //   - APPROVE        → body is optional. Omit the field entirely.
-  //   - REQUEST_CHANGES / COMMENT → body is REQUIRED. We pass an HTML-
-  //     comment-only stub (`<!-- mergewatch-review -->`); GitHub's markdown
-  //     renderer strips HTML comments, so the Review object renders with
-  //     no visible body text and the timeline shows only the event label
-  //     ("requested changes" / "left a comment") plus the inline comments.
+  //   - APPROVE        → body is optional. Omit the field entirely (the
+  //     timeline's "approved these changes" says everything needed).
+  //   - REQUEST_CHANGES / COMMENT → body is REQUIRED → marker + pointer.
   //
   // A caller may still pass real body text — we pass it through unchanged
   // for forward-compatibility (e.g., a future tier that genuinely wants a
@@ -404,8 +406,10 @@ export async function submitPRReview(
     effectiveBody = body;
   } else if (event === 'APPROVE') {
     effectiveBody = undefined;
+  } else if (event === 'REQUEST_CHANGES') {
+    effectiveBody = '<!-- mergewatch-review -->\n🔴 Critical issues found — see the full review in the summary comment above.';
   } else {
-    effectiveBody = '<!-- mergewatch-review -->';
+    effectiveBody = '<!-- mergewatch-review -->\n📝 Review feedback — see the full review in the summary comment above.';
   }
 
   await octokit.pulls.createReview({


### PR DESCRIPTION
Closes #356.

## What

E2E-03 tripped its "review body is empty" failure clause: the formal `CHANGES_REQUESTED` review's body was literally `<!-- mergewatch-review -->`, which GitHub's renderer strips — an empty-looking review in the UI. That was W6's deliberate no-duplicate-content stub; the fixture contract has since superseded it with "a one-line pointer is the target."

`submitPRReview` now defaults the (API-required) body per event:

- **`REQUEST_CHANGES`** → marker + `🔴 Critical issues found — see the full review in the summary comment above.` (the issue's expected text)
- **`COMMENT`** → marker + `📝 Review feedback — see the full review in the summary comment above.` (same bug class — its body was also the bare marker)
- **`APPROVE`** → unchanged, body omitted (the timeline's "approved these changes" suffices)
- An explicit caller-supplied body still passes through verbatim (forward-compat preserved)

The summary comment remains the single authoritative surface (W6 intact) — the pointer duplicates nothing, it just makes the Review object legible. `dismissStaleReviews` filters by bot user type, not body content, so no marker-scanning path is affected.

## Tests

The existing W6 `submitPRReview` suite updated to the pointer contract (both event defaults, whitespace-only bodies, pass-through, APPROVE omission, inline-comment batching) — 71/71 client suite, full workspace gates green (verified by exit codes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)