### PR TITLE
fix(core): default severity threshold must not suppress info findings (#357)

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -2733,7 +2733,7 @@ curl -s "$MCP_URL" \
 
 ### E2E-78: Output shaping — `minSeverity`, `maxFindings`, `postSummaryOnClean`
 
-**Status:** ⬜ NOT YET COVERED. (All three knobs were documented-but-unwired at various points: `minSeverity` until #310, `maxTokensPerAgent` and `postSummaryOnClean` until #350 — all three now exist; fixture still to be run.)
+**Status:** ⬜ NOT YET COVERED. (All three knobs were documented-but-unwired at various points: `minSeverity` until #310, `maxTokensPerAgent` and `postSummaryOnClean` until #350 — all three now exist; fixture still to be run. #357: the default severity threshold is **Low** — info findings render out of the box; `Med`/`High` are explicit opt-ins, and wiring `minSeverity` with a `Med` default had silently suppressed every info-tier finding.)
 
 **Behavior:** Three independent knobs on what reaches the PR: `minSeverity` (`info` | `warning` | `critical`) drops lower-severity findings; `maxFindings` caps how many are posted; `postSummaryOnClean` decides whether a clean PR gets a comment at all.
 

--- a/packages/core/src/types/db.ts
+++ b/packages/core/src/types/db.ts
@@ -147,7 +147,13 @@ export interface InstallationSettings {
 }
 
 export const DEFAULT_INSTALLATION_SETTINGS: InstallationSettings = {
-  severityThreshold: 'Med',
+  // #357 — 'Low' (→ minSeverity 'info'), NOT 'Med'. This default was inert
+  // until #310 wired minSeverity; the moment it went live, 'Med' meant every
+  // default-settings installation silently dropped all info-tier findings
+  // (E2E-02: no "Info (N)" section, "no issues" verdict on an info-only PR).
+  // Out-of-the-box behavior must report everything; Med/High are explicit
+  // opt-ins. Matches the Postgres settings column default ('Low').
+  severityThreshold: 'Low',
   commentTypes: { syntax: true, logic: true, style: true },
   maxComments: 10,
   summary: {

--- a/packages/dashboard/components/SettingsForm.tsx
+++ b/packages/dashboard/components/SettingsForm.tsx
@@ -18,7 +18,9 @@ interface InstallationSettings {
 }
 
 const DEFAULT_SETTINGS: InstallationSettings = {
-  severityThreshold: "Med",
+  // #357 — 'Low' reports every tier; saving untouched settings must not
+  // silently opt an installation into info-suppression.
+  severityThreshold: "Low",
   commentTypes: { syntax: true, logic: true, style: true },
   maxComments: 10,
   summary: {

--- a/packages/server/src/review-processor.test.ts
+++ b/packages/server/src/review-processor.test.ts
@@ -1241,3 +1241,52 @@ describe('processReviewJob — throttle handling (#355)', () => {
     expect(statusCalls.some((c: any[]) => c[2] === 'failed')).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// #357 — the default severity threshold must not suppress info findings
+// ---------------------------------------------------------------------------
+
+describe('processReviewJob — severityThreshold → minSeverity mapping (#357)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getPRContext as any).mockResolvedValue(basePRContext);
+    (getPRDiff as any).mockResolvedValue('diff content');
+    (shouldSkipPR as any).mockReturnValue(null);
+    (shouldSkipByRules as any).mockReturnValue(null);
+    (runReviewPipeline as any).mockResolvedValue(basePipelineResult);
+    (fetchRepoConfig as any).mockResolvedValue(null);
+    (findExistingBotComment as any).mockResolvedValue(null);
+    (postReviewComment as any).mockResolvedValue(100);
+  });
+
+  function pipelineMinSeverity() {
+    return (runReviewPipeline as any).mock.calls[0][0].minSeverity;
+  }
+
+  it("default settings map to 'info' — info-tier findings render out of the box", async () => {
+    // E2E-02's regression: the old 'Med' default became minSeverity 'warning'
+    // the moment #310 wired the key, silently dropping every info finding.
+    await processReviewJob(makeJob(), makeDeps());
+    expect(pipelineMinSeverity()).toBe('info');
+  });
+
+  it("an explicit 'Med' threshold maps to 'warning' (opt-in suppression works)", async () => {
+    const deps = makeDeps();
+    (deps.installationStore.getSettings as any).mockResolvedValue({
+      ...DEFAULT_INSTALLATION_SETTINGS,
+      severityThreshold: 'Med',
+    });
+    await processReviewJob(makeJob(), deps);
+    expect(pipelineMinSeverity()).toBe('warning');
+  });
+
+  it("an unknown threshold value falls back to 'info', never suppression", async () => {
+    const deps = makeDeps();
+    (deps.installationStore.getSettings as any).mockResolvedValue({
+      ...DEFAULT_INSTALLATION_SETTINGS,
+      severityThreshold: 'Extreme',
+    });
+    await processReviewJob(makeJob(), deps);
+    expect(pipelineMinSeverity()).toBe('info');
+  });
+});

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -414,7 +414,9 @@ export async function processReviewJob(
   // Severity: Low → info, Med → warning, High → critical
   const severityMap: Record<string, 'info' | 'warning' | 'critical'> = { Low: 'info', Med: 'warning', High: 'critical' };
   const settingsOverrides: Partial<MergeWatchConfig> = {
-    minSeverity: severityMap[instSettings.severityThreshold] ?? 'warning',
+    // #357 — unknown values fall back to 'info' (report everything): a
+    // malformed threshold must never silently suppress findings.
+    minSeverity: severityMap[instSettings.severityThreshold] ?? 'info',
     maxFindings: instSettings.maxComments,
     agents: {
       security: instSettings.commentTypes?.logic ?? true,


### PR DESCRIPTION
Closes #357.

## Root cause — not stochastic

The issue left open whether E2E-02's zero findings were stochastic ("the LLM emitted no info notes") or a real drop. It's the latter, and we introduced it: the suite ran hours after #310/#349 wired `minSeverity`, and `DEFAULT_INSTALLATION_SETTINGS.severityThreshold = 'Med'` maps to `minSeverity: 'warning'`. Inert for as long as the key was dead — the moment it went live, **every installation without saved dashboard settings silently dropped all info-tier findings pre-render**: no "Info (N)" section, "No issues found" verdicts on info-only PRs, and the #134 info-only reconciliation path never reached.

Two adjacent latents fixed in the same pass: the Postgres settings column already defaulted `'Low'` (contradicting the TS default — a row created by column default behaved differently from no-row defaults), and the server's `?? 'warning'` fallback suppressed on unknown values.

## Fix

- `DEFAULT_INSTALLATION_SETTINGS.severityThreshold`: `'Med'` → `'Low'` — out-of-the-box behavior reports every tier (the pre-#349 reality); `Med`/`High` are what they always claimed to be: explicit opt-ins. Now consistent with the Postgres column default.
- Server mapping fallback → `?? 'info'` (malformed threshold ≠ suppression). The Lambda path has no fallback and already degrades safely to the pipeline's `'info'` default.
- `SettingsForm` initial value → `'Low'`, so saving untouched settings doesn't persist an unintended suppression opt-in.

## Tests

3 regression tests pin the mapping end-to-end through the processor (default → `'info'`, explicit `Med` → `'warning'`, unknown → `'info'`) — 62/62 server suite; full workspace build/typecheck/test green (verified by exit codes). RUNBOOK E2E-78 documents the default.

## Follow-ups (out of scope here)

- Fixture-bait strengthening lives in `mergewatch/fixtures`.
- Installations that explicitly saved settings while `'Med'` was the preselected form value have a persisted opt-in they may not have intended — quantifying that in prod is blocked on an expired AWS session; noted on the tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)