### PR TITLE
fix(core): work-done tallies come from the filtered diff, not raw PR totals (#358)

### DIFF
--- a/packages/core/src/diff-filter.test.ts
+++ b/packages/core/src/diff-filter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { filterDiff, extractChangedLines, isLineNearChange } from './diff-filter.js';
+import { filterDiff, extractChangedLines, isLineNearChange, computeDiffStats } from './diff-filter.js';
 
 const makeDiff = (...files: string[]) =>
   files
@@ -238,5 +238,55 @@ describe('isLineNearChange', () => {
   it('returns false for empty changed set', () => {
     const empty = new Map([['src/index.ts', new Set<number>()]]);
     expect(isLineNearChange(empty, 'src/index.ts', 10, 3)).toBe(false);
+  });
+});
+
+// ─── #358 — computeDiffStats ─────────────────────────────────────────────────
+
+describe('computeDiffStats (#358)', () => {
+  const twoFileDiff = [
+    'diff --git a/src/handler.ts b/src/handler.ts',
+    'index 111..222 100644',
+    '--- a/src/handler.ts',
+    '+++ b/src/handler.ts',
+    '@@ -1,3 +1,4 @@',
+    ' const a = 1;',
+    '+const sql = `SELECT * FROM users WHERE id = ${id}`;',
+    '+run(sql);',
+    '-const old = true;',
+    'diff --git a/src/api.generated.ts b/src/api.generated.ts',
+    'index 333..444 100644',
+    '--- a/src/api.generated.ts',
+    '+++ b/src/api.generated.ts',
+    '@@ -1,2 +1,3 @@',
+    '+// generated',
+    '+export const x = 1;',
+  ].join('\n');
+
+  it('counts files and +/- lines, excluding the +++/--- file headers', () => {
+    const stats = computeDiffStats(twoFileDiff);
+    expect(stats.files).toEqual(['src/handler.ts', 'src/api.generated.ts']);
+    expect(stats.additions).toBe(4);
+    expect(stats.deletions).toBe(1);
+  });
+
+  it('reflects the filter: stats of a filtered diff omit the excluded file entirely', () => {
+    // The E2E-77 regression: raw PR totals counted excluded files as scanned.
+    const { filteredDiff } = filterDiff(twoFileDiff, ['**/*.generated.ts']);
+    const stats = computeDiffStats(filteredDiff);
+    expect(stats.files).toEqual(['src/handler.ts']);
+    expect(stats.additions).toBe(2);
+    expect(stats.deletions).toBe(1);
+  });
+
+  it('a fully-excluded diff yields zero everything (77b: no more "2 files scanned")', () => {
+    const { filteredDiff } = filterDiff(twoFileDiff, ['**/*.ts']);
+    expect(computeDiffStats(filteredDiff)).toEqual({ files: [], additions: 0, deletions: 0 });
+  });
+
+  it('handles empty input and binary-file sections', () => {
+    expect(computeDiffStats('')).toEqual({ files: [], additions: 0, deletions: 0 });
+    const binary = 'diff --git a/logo.png b/logo.png\nindex 111..222 100644\nBinary files a/logo.png and b/logo.png differ\n';
+    expect(computeDiffStats(binary)).toEqual({ files: ['logo.png'], additions: 0, deletions: 0 });
   });
 });

--- a/packages/core/src/diff-filter.ts
+++ b/packages/core/src/diff-filter.ts
@@ -149,3 +149,39 @@ export function isLineNearChange(
   }
   return false;
 }
+
+/** #358 — stats of a (possibly already-filtered) unified diff. */
+export interface DiffStats {
+  /** Files present in the diff, in order of appearance. */
+  files: string[];
+  additions: number;
+  deletions: number;
+}
+
+/**
+ * #358 — compute file/line stats from the diff itself.
+ *
+ * The work-done header ("N files scanned · M lines reviewed") previously came
+ * from raw PR-level totals, so files removed by `excludePatterns` were still
+ * counted as scanned — on a fully-excluded PR the header claimed real work.
+ * Deriving the stats from the FILTERED diff makes the tallies describe
+ * exactly what the agents saw.
+ *
+ * Counting matches GitHub's additions/deletions semantics: `+`/`-` content
+ * lines, excluding the `+++`/`---` file-header lines. Binary files appear in
+ * `files` (they have a `diff --git` section) with zero line counts.
+ */
+export function computeDiffStats(diff: string): DiffStats {
+  if (!diff) return { files: [], additions: 0, deletions: 0 };
+
+  const sections = splitDiffByFile(diff);
+  let additions = 0;
+  let deletions = 0;
+  for (const { section } of sections) {
+    for (const line of section.split('\n')) {
+      if (line.startsWith('+') && !line.startsWith('+++')) additions++;
+      else if (line.startsWith('-') && !line.startsWith('---')) deletions++;
+    }
+  }
+  return { files: sections.map((s) => s.file), additions, deletions };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -241,7 +241,8 @@ export type { AgentKind, ClassificationResult } from './agent-detection.js';
 export { isBotActor } from './bot-actor.js';
 
 // ─── Diff filtering ─────────────────────────────────────────────────────────
-export { filterDiff, extractChangedLines, isLineNearChange } from './diff-filter.js';
+export { filterDiff, extractChangedLines, isLineNearChange, computeDiffStats } from './diff-filter.js';
+export type { DiffStats } from './diff-filter.js';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 export type {

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -27,6 +27,7 @@ import {
   formatReviewComment,
   countBlockingCriticals,
   isThrottleError,
+  computeDiffStats,
   mergeConfig,
   shouldSkipPR,
   extractIncludePatterns,
@@ -830,11 +831,14 @@ export async function handler(
 
     const reviewDetailUrl = `${DASHBOARD_BASE_URL}/dashboard/reviews/${encodeURIComponent(`${repoFullName}:${prNumberCommitSha}`)}`;
 
-    // Build work-done section from PR context stats
+    // Build work-done section from the FILTERED diff (#358) — the tallies
+    // must describe what the agents actually reviewed. Raw PR totals counted
+    // excludePatterns-removed files as "scanned".
+    const diffStats = computeDiffStats(filteredDiff);
     const workDone = buildWorkDoneSection(
-      prContext.files,
-      prContext.totalAdditions,
-      prContext.totalDeletions,
+      diffStats.files,
+      diffStats.additions,
+      diffStats.deletions,
       result.enabledAgentCount,
     );
 

--- a/packages/server/src/review-processor.test.ts
+++ b/packages/server/src/review-processor.test.ts
@@ -1290,3 +1290,51 @@ describe('processReviewJob — severityThreshold → minSeverity mapping (#357)'
     expect(pipelineMinSeverity()).toBe('info');
   });
 });
+
+// ---------------------------------------------------------------------------
+// #358 — work-done tallies come from the FILTERED diff
+// ---------------------------------------------------------------------------
+
+describe('processReviewJob — work-done stats from filtered diff (#358)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getPRContext as any).mockResolvedValue({
+      ...basePRContext,
+      // Raw PR stats deliberately DISAGREE with the filtered diff below —
+      // the tallies must follow the diff, not these.
+      files: [{ filename: 'src/handler.ts' }, { filename: 'src/api.generated.ts' }],
+      totalAdditions: 30,
+      totalDeletions: 1,
+    });
+    (getPRDiff as any).mockResolvedValue('raw diff');
+    (shouldSkipPR as any).mockReturnValue(null);
+    (shouldSkipByRules as any).mockReturnValue(null);
+    (runReviewPipeline as any).mockResolvedValue(basePipelineResult);
+    (fetchRepoConfig as any).mockResolvedValue(null);
+    (findExistingBotComment as any).mockResolvedValue(null);
+    (postReviewComment as any).mockResolvedValue(100);
+  });
+
+  it('builds the work-done section from the post-filter diff, not raw PR totals', async () => {
+    const filteredDiff = [
+      'diff --git a/src/handler.ts b/src/handler.ts',
+      '--- a/src/handler.ts',
+      '+++ b/src/handler.ts',
+      '@@ -1,2 +1,3 @@',
+      '+const a = 1;',
+      '+const b = 2;',
+      '-const c = 3;',
+    ].join('\n');
+    const { filterDiff, buildWorkDoneSection } = await import('@mergewatch/core');
+    (filterDiff as any).mockReturnValue({ filteredDiff, excludedFiles: ['src/api.generated.ts'] });
+
+    await processReviewJob(makeJob(), makeDeps());
+
+    expect(buildWorkDoneSection).toHaveBeenCalledWith(
+      ['src/handler.ts'], // excluded file absent from "files scanned"
+      2,                  // additions from the filtered diff, not the raw 30
+      1,
+      expect.any(Number),
+    );
+  });
+});

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -2,7 +2,7 @@ import type { ReviewJobPayload, IInstallationStore, IReviewStore, IGitHubAuthPro
 import {
   getPRDiff, getPRContext, addPRReaction, removePRReaction, postReviewComment, updateReviewComment,
   findExistingBotComment, getCommentReactions, createCheckRun,
-  formatReviewComment, countBlockingCriticals, isThrottleError, runReviewPipeline, shouldSkipPR, shouldSkipByRules, isAutoReviewOff, extractIncludePatterns,
+  formatReviewComment, countBlockingCriticals, isThrottleError, computeDiffStats, runReviewPipeline, shouldSkipPR, shouldSkipByRules, isAutoReviewOff, extractIncludePatterns,
   loadCategoryDisputeRates,
   filterDiff,
   DEFAULT_CONFIG, mergeConfig,
@@ -692,11 +692,14 @@ export async function processReviewJob(
 
     const durationMs = Date.now() - startTime;
 
-    // Build work-done section from PR context stats
+    // Build work-done section from the FILTERED diff (#358) — the tallies
+    // must describe what the agents actually reviewed. Raw PR totals counted
+    // excludePatterns-removed files as "scanned".
+    const diffStats = computeDiffStats(filteredDiff);
     const workDone = buildWorkDoneSection(
-      prContext.files,
-      prContext.totalAdditions,
-      prContext.totalDeletions,
+      diffStats.files,
+      diffStats.additions,
+      diffStats.deletions,
       result.enabledAgentCount,
     );
 


### PR DESCRIPTION
Closes #358.

## Root cause

`PRContext` carries only raw PR-level stats (file names, summed additions/deletions), and both runtimes handed those straight to `buildWorkDoneSection` — `excludePatterns` filters the diff the agents see but never touched the tallies. 77b is the unambiguous case: "2 files scanned · 31 lines reviewed" on a fully-excluded PR whose effective diff was empty.

## Fix

- **`computeDiffStats(diff)`** in core `diff-filter.ts`: files/additions/deletions parsed from the unified diff itself, matching GitHub's counting semantics (`+`/`-` content lines, `+++`/`---` headers excluded; binary sections yield the file with zero lines; empty diff → zeros).
- **Both runtimes** now build the work-done section from `computeDiffStats(filteredDiff)` — the tallies describe exactly what the agents reviewed. Excluded files vanish from "files scanned", their lines from "lines reviewed", and the dependency-file hint only considers reviewed files.

## Tests

4 new `computeDiffStats` tests (two-file parse, filtered-diff reflection, fully-excluded → zeros, empty/binary) + a server wiring test where the raw PR stats deliberately disagree with the filtered diff and the work-done call must follow the diff — 63/63 server suite, 25/25 diff-filter suite, full workspace gates green by exit code.

## Out of scope, per the fixture README

The missed `handler.ts` control defect ("re-run; the control must fire") — that run predates the #357 default-severity fix and overlapped the GitHub-outage window; the next `scripts/run-suite.sh` pass verifies both halves of E2E-77 together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)