### PR TITLE
fix(core): FP-I L2 must not drop quote-then-propose suggestions (#359)

### DIFF
--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -2952,3 +2952,50 @@ describe('reconcileMergeScore', () => {
     });
   });
 });
+
+// ─── #359 — quote-then-propose suggestions must survive FP-I L2 ─────────────
+
+describe('suggestionMatchesExistingCode — quote-then-propose (#359)', () => {
+  const baitFile = [
+    '// conventions bait',
+    'var maxRetries = 3;',      // line 2 — violates the AGENTS.md `let` rule
+    'connect(maxRetries);',
+  ].join('\n');
+
+  it('keeps a suggestion that quotes the offending code before proposing the fix (E2E-80 shape)', () => {
+    // The quoted PROBLEM chunk (`var maxRetries = 3;`) is at the cited line —
+    // that is why it was quoted. Under the old any-chunk rule this executed
+    // the finding on its own evidence.
+    expect(suggestionMatchesExistingCode(
+      'Replace `var maxRetries = 3;` with `let maxRetries = 3;` per AGENTS.md.',
+      baitFile,
+      2,
+    )).toBe(false);
+  });
+
+  it('still drops a suggestion whose only chunk already exists at the location (original #169 catch)', () => {
+    expect(suggestionMatchesExistingCode(
+      'Add a retry cap: `var maxRetries = 3;`',
+      baitFile,
+      2,
+    )).toBe(true);
+  });
+
+  it('drops when EVERY qualifying chunk is already present (multi-chunk redundancy)', () => {
+    expect(suggestionMatchesExistingCode(
+      'Ensure `var maxRetries = 3;` and then `connect(maxRetries);` are in place.',
+      baitFile,
+      2,
+    )).toBe(true);
+  });
+
+  it('short chunks below the 10-char floor neither qualify nor rescue', () => {
+    // Only qualifying chunk is the existing line → redundant, despite the
+    // short `let x;` chunk that would not match.
+    expect(suggestionMatchesExistingCode(
+      'Use `let x;` style; keep `var maxRetries = 3;` for now.',
+      baitFile,
+      2,
+    )).toBe(true);
+  });
+});

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -1566,10 +1566,19 @@ export async function fetchFindingFileContents(
  * The verifier prompt asks the LLM the same question (FP-I Layer 1), but a
  * deterministic short-circuit catches the unambiguous cases without a model
  * call. Specifically: when the finding's `suggestion` field contains
- * code-shaped chunks (backticked inline OR fenced blocks) and one of those
- * chunks — after whitespace normalisation — already appears in the file
+ * code-shaped chunks (backticked inline OR fenced blocks) and EVERY such
+ * chunk — after whitespace normalisation — already appears in the file
  * within ±5 lines of the cited line, the suggestion is byte-redundant and
  * the finding must be dropped.
+ *
+ * ALL chunks, not ANY (#359): suggestions routinely QUOTE the offending
+ * code before proposing the fix — "Replace `var x = 3;` with `let x = 3;`".
+ * The quoted problem code trivially appears at the cited line (that is why
+ * it was quoted), so an any-chunk rule executed the finding on its own
+ * evidence — every convention citation in E2E-80 died this way. Under the
+ * all-chunks rule the proposal chunk fails to match and the finding
+ * survives to the LLM verdict (Layer 1), which still catches true
+ * redundancy this cheap check now skips.
  *
  * Returns `false` (cannot conclude redundant) when:
  *   • the suggestion has no code-shaped content (pure prose),
@@ -1605,14 +1614,18 @@ export function suggestionMatchesExistingCode(
   const windowText = allLines.slice(startLine, endLine).join('\n');
   const normalisedWindow = windowText.replace(/\s+/g, ' ').trim();
 
+  let qualifying = 0;
   for (const chunk of codeChunks) {
     const normalised = chunk.replace(/\s+/g, ' ').trim();
     // Too-generic chunks risk false-positive — a bare `;` would match
     // almost any file. Require ≥10 characters of non-whitespace content.
     if (normalised.length < 10) continue;
-    if (normalisedWindow.includes(normalised)) return true;
+    qualifying++;
+    // #359 — one non-matching chunk means the suggestion proposes something
+    // NOT already at the location; redundancy cannot be concluded.
+    if (!normalisedWindow.includes(normalised)) return false;
   }
-  return false;
+  return qualifying > 0;
 }
 
 export async function verifyFindings(


### PR DESCRIPTION
Closes #359.

## Root cause — deterministic, found in prod logs

E2E-80's conventions machinery worked end-to-end (discovery order, truncation disclosure, agents citing the rules) — and then the FP-I **Layer 2** short-circuit killed every citation. The 80a review log (request `8d8372ec…`):

> `[finding-verify] dropped critical "Convention violation: 'var' declaration used instead of 'let'" (src/conventions-bait.ts:16) — FP-I L2: suggestion already implemented at cited location`

`suggestionMatchesExistingCode` concluded redundancy when **any** backticked chunk (≥10 chars) from the suggestion appeared within ±5 lines of the cited line. Suggestions routinely **quote the offending code before proposing the fix** — *"Replace `var maxRetries = 3;` with `let maxRetries = 3;`"* — and the quoted *problem* chunk always matches at the cited line, because that's the point of quoting it. The finding is executed on its own evidence. Convention citations almost always take this shape → both fixtures lost 100% of their findings ("Suppressed: 2" = fp-c cross-agent merge + this drop).

## Fix

The redundancy conclusion now requires **all** qualifying chunks to already exist at the location — i.e., the *proposal itself* is present:

- Quote-then-propose survives (proposal chunk doesn't match) and proceeds to the FP-I **Layer 1** LLM verdict, which still catches genuine redundancy the cheap check now skips — fail-safe in the right direction.
- The original #169-era catch (suggestion = the exact existing line) is unchanged: single qualifying chunk, matches, drops.
- Sub-10-char chunks still neither qualify nor rescue.

## Tests

4 new regression tests (the E2E-80 shape kept; single-chunk redundancy still dropped; multi-chunk all-present dropped; short-chunk non-rescue) — all 12 pre-existing FP-I L2 tests pass unchanged under the new rule; 201/201 reviewer suite; full workspace gates green by exit code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)