### PR TITLE
fix(core): escape repo/installation-controlled comment header and footer (#369)

### DIFF
--- a/packages/core/src/comment-formatter.test.ts
+++ b/packages/core/src/comment-formatter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatReviewComment, buildWorkDoneSection, countBlockingCriticals, type Finding } from './comment-formatter.js';
+import { formatReviewComment, buildWorkDoneSection, countBlockingCriticals, escapeUserContent, type Finding } from './comment-formatter.js';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -496,5 +496,48 @@ describe('countBlockingCriticals (#240)', () => {
       makeFinding({}), // no verification field — pre-W2 record, counts as blocking
       makeFinding({ severity: 'warning' }),
     ])).toBe(2);
+  });
+});
+
+// ─── #369 — commentHeader/footer injection is escaped ────────────────────────
+
+describe('escapeUserContent + injection sites (#369)', () => {
+  const payload = '# Acme Review Bot <img src=x onerror=alert(1)> [click](https://example.com/pwn) **bold**';
+
+  it('neutralizes HTML and markdown in the escape helper', () => {
+    const out = escapeUserContent(payload);
+    expect(out).not.toContain('<img');
+    expect(out).toContain('&lt;img');
+    expect(out).toContain('\\[click\\]');
+    expect(out).toContain('\\*\\*bold\\*\\*');
+    expect(out.startsWith('\\#')).toBe(true);
+  });
+
+  it('renders ux.commentHeader as literal text — the E2E-79 payload is inert', () => {
+    const result = formatReviewComment(baseOptions({ ux: { commentHeader: payload } }));
+    expect(result).not.toContain('<img src=x');
+    expect(result).not.toContain('[click](https://example.com/pwn)');
+    expect(result).not.toMatch(/^# Acme Review Bot/m);
+    expect(result).toContain('&lt;img');
+  });
+
+  it('renders the dashboard commentFooter through the same contract', () => {
+    const result = formatReviewComment(baseOptions({ commentFooter: payload }));
+    expect(result).not.toContain('<img src=x');
+    expect(result).not.toContain('[click](https://example.com/pwn)');
+  });
+
+  it('plain-text headers and footers remain visually intact', () => {
+    const result = formatReviewComment(baseOptions({
+      ux: { commentHeader: 'Acme Internal Review' },
+      commentFooter: 'Powered by ACME Corp',
+    }));
+    expect(result).toContain('Acme Internal Review');
+    expect(result).toContain('Powered by ACME Corp');
+  });
+
+  it('the default wordmark header (no custom header) is untouched', () => {
+    const result = formatReviewComment(baseOptions());
+    expect(result).toContain('mergewatch-wordmark.svg');
   });
 });

--- a/packages/core/src/comment-formatter.ts
+++ b/packages/core/src/comment-formatter.ts
@@ -39,6 +39,29 @@ export interface WorkDoneSection {
 }
 
 /**
+ * #369 — render repo/installation-controlled text as LITERAL text.
+ *
+ * `ux.commentHeader` (from `.mergewatch.yml` — anyone with repo write
+ * access) and the dashboard's comment header/footer setting are injected
+ * into every review comment the bot posts. Unescaped, they are an
+ * org-wide markdown/HTML injection surface (live headings, links, <img>
+ * tags — the E2E-79 payload). HTML metacharacters become entities and
+ * markdown-active punctuation is backslash-escaped, so GitHub renders
+ * exactly the characters the author typed, styling none of them.
+ */
+export function escapeUserContent(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    // Backslash-escape markdown punctuation. Valid CommonMark: an escaped
+    // punctuation char renders as the bare char. Covers headings (#),
+    // emphasis (*_~), code (`), links/images ([]()!), tables (|), block
+    // quotes handled via > above, and list/rule starters (+-.).
+    .replace(/[\\`*_{}[\]()#+\-.!|~=]/g, '\\$&');
+}
+
+/**
  * #240 — criticals that may legitimately block a PR: severity 'critical' AND
  * not tagged `verification: 'unverified'` by the W2 pass. The W7 score clamp
  * and FP-L rendering already treat unverified criticals as advisory; this is
@@ -280,7 +303,8 @@ export function formatReviewComment(options: FormatOptions): string {
 
   // 1. Header — custom or default logo wordmark
   if (ux?.commentHeader) {
-    lines.push(ux.commentHeader);
+    // #369 — repo-controlled: renders as literal text, never live markup.
+    lines.push(escapeUserContent(ux.commentHeader));
   } else {
     lines.push('<img src="https://raw.githubusercontent.com/mergewatch/mergewatch.ai/main/assets/mergewatch-wordmark.svg" alt="mergewatch" height="48" />');
   }
@@ -561,7 +585,8 @@ export function formatReviewComment(options: FormatOptions): string {
     footerParts.push(`[View full details](${reviewDetailUrl})`);
   }
   if (commentFooter) {
-    footerParts.push(commentFooter);
+    // #369 — installation-controlled: same escaping contract as the header.
+    footerParts.push(escapeUserContent(commentFooter));
   }
   if (footerParts.length > 0) {
     lines.push(`<sub>${footerParts.join(' \u00B7 ')}</sub>`);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -134,7 +134,7 @@ export {
 export type { ReviewThreadComment } from './github/client.js';
 
 // ─── Comment formatter ──────────────────────────────────────────────────────
-export { formatReviewComment, buildWorkDoneSection, countBlockingCriticals } from './comment-formatter.js';
+export { formatReviewComment, buildWorkDoneSection, countBlockingCriticals, escapeUserContent } from './comment-formatter.js';
 export type { Finding, WorkDoneSection } from './comment-formatter.js';
 
 // ─── Review delta ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #369.

## What

E2E-79's highest-severity clause tripped: `ux.commentHeader` (repo-write-controlled, from `.mergewatch.yml`) was pushed into every review comment **verbatim** (`comment-formatter.ts:283`) — the fixture payload rendered a live H1, a live link, and a raw `<img>` tag in the bot's comment. The dashboard's comment header/footer setting flowed raw through the footer site (`:563`) with the identical exposure.

- **`escapeUserContent()`** renders the text as the literal characters the author typed: `&`/`<`/`>` become entities (kills HTML), and markdown-active punctuation is backslash-escaped (valid CommonMark — an escaped punctuation char renders as the bare char, so plain-text headers look identical).
- Applied at **both** injection sites — one vulnerability class, one helper. The default wordmark header (no customization) is untouched.

## Tests

5 new: the helper against the exact fixture payload, both injection sites rendered inert end-to-end (no `<img`, no live link, no H1), plain-text header/footer visual passthrough, and the default-wordmark path — 53/53 formatter suite, full workspace gates green by exit code. The pre-existing "Powered by ACME Corp" footer test passes unchanged, confirming benign customizations are unaffected.

## Note

The missing planted defects on the same fixture PR are tracked in #368 — the merged FP-I quote-then-propose fix (#359/#367) is the likely cause there; the next suite run verifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)