### PR TITLE
fix(lambda): throttle-parked checks show attempt, parked-at time, and expectations (#370)

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -3080,7 +3080,7 @@ Branch: `fixture/85-time-ordered-reviews`. Seed one repo with reviews for PR num
 
 **Expected outcomes.**
 - [ ] 57/57 PRs reviewed — zero terminal "Too many requests" failures (vs 32/57 lost in the #355 run)
-- [ ] Throttled PRs show "Review queued — rate limited" in_progress checks while waiting, then complete
+- [ ] Throttled PRs show "Review queued — rate limited (attempt N)" in_progress checks with parked-at time + retry/DLQ expectations in the summary (#370), then complete — a parked check is distinguishable from a hang at a glance
 - [ ] SaaS: review Lambda concurrency stays ≤ the event-source cap; DLQ empty at end of run
 - [ ] Self-hosted: `review_jobs` drains to `done`; no `dead` rows; a mid-burst restart loses nothing
 - [ ] A genuinely failing review (non-throttle) still fails its check exactly as before

--- a/packages/lambda/src/handlers/review-agent-event.test.ts
+++ b/packages/lambda/src/handlers/review-agent-event.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { payloadFromEvent } from './review-agent-event.js';
+import { payloadFromEvent, attemptFromEvent, rateLimitedCheckSummary } from './review-agent-event.js';
 
 const job = { installationId: 1, owner: 'octo', repo: 'repo', prNumber: 7, mode: 'review' as const };
 
@@ -21,5 +21,31 @@ describe('payloadFromEvent (#355)', () => {
 
   it('throws on an unparseable record body (goes to redrive, then DLQ)', () => {
     expect(() => payloadFromEvent({ Records: [{ body: 'not-json' }] })).toThrow();
+  });
+});
+
+describe('attemptFromEvent (#370)', () => {
+  it('reads the SQS ApproximateReceiveCount', () => {
+    expect(attemptFromEvent({
+      Records: [{ body: JSON.stringify(job), attributes: { ApproximateReceiveCount: '2' } }],
+    })).toBe(2);
+  });
+
+  it('defaults to 1 for direct invokes and missing/garbage attributes', () => {
+    expect(attemptFromEvent(job as any)).toBe(1);
+    expect(attemptFromEvent({ Records: [{ body: '{}' }] })).toBe(1);
+    expect(attemptFromEvent({
+      Records: [{ body: '{}', attributes: { ApproximateReceiveCount: 'NaN' } }],
+    })).toBe(1);
+  });
+});
+
+describe('rateLimitedCheckSummary (#370)', () => {
+  it('carries attempt, parked-at time, retry expectations, and the DLQ end-state', () => {
+    const s = rateLimitedCheckSummary(2, '2026-08-18T01:35:13.000Z');
+    expect(s).toContain('Attempt 2 of 3');
+    expect(s).toContain('parked at 2026-08-18T01:35:13.000Z');
+    expect(s).toContain('retries automatically');
+    expect(s).toContain('dead-letter queue');
   });
 });

--- a/packages/lambda/src/handlers/review-agent-event.ts
+++ b/packages/lambda/src/handlers/review-agent-event.ts
@@ -12,6 +12,8 @@ import type { ReviewJobPayload } from '@mergewatch/core';
 
 interface SqsRecordLike {
   body: string;
+  /** SQS delivery bookkeeping — "1" on first receive, incremented on redelivery. */
+  attributes?: { ApproximateReceiveCount?: string };
 }
 
 export type ReviewAgentEvent = ReviewJobPayload | { Records: SqsRecordLike[] };
@@ -32,4 +34,30 @@ export function payloadFromEvent(event: ReviewAgentEvent): ReviewJobPayload {
     return JSON.parse(event.Records[0].body) as ReviewJobPayload;
   }
   return event as ReviewJobPayload;
+}
+
+/**
+ * #370 — delivery attempt for this invocation: SQS's ApproximateReceiveCount
+ * ("2" means this is the first redelivery), or 1 for direct invokes. Drives
+ * the attempt number on the throttle-parked check run so a parked review is
+ * distinguishable from a hung one.
+ */
+export function attemptFromEvent(event: ReviewAgentEvent): number {
+  if (event != null && typeof event === 'object' && 'Records' in event && Array.isArray(event.Records)) {
+    const n = Number(event.Records[0]?.attributes?.ApproximateReceiveCount);
+    if (Number.isFinite(n) && n >= 1) return n;
+  }
+  return 1;
+}
+
+/**
+ * #370 — the throttle-parked check-run summary. A parked review used to show
+ * a static "will retry shortly", which E2E graders (and humans) read as a
+ * hang once it aged past a few minutes. Attempt count + parked-at time +
+ * explicit expectations make the state self-explanatory.
+ */
+export function rateLimitedCheckSummary(attempt: number, parkedAtIso: string): string {
+  return `Attempt ${attempt} of 3 parked at ${parkedAtIso} — the model provider is rate limiting requests. `
+    + 'MergeWatch retries automatically via the review queue; under burst load a retry can take ~30 minutes. '
+    + 'If all attempts exhaust, the job lands in the review dead-letter queue for operator redrive.';
 }

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -92,7 +92,7 @@ import {
 import { BedrockLLMProvider, SUPPORTED_MODELS } from '@mergewatch/llm-bedrock';
 import { isSaas, billingCheck, recordReview, postBlockedCheckRun, ensureBillingIssue, updateBillingFields, getStripe, isLapsedOssGrant } from '@mergewatch/billing';
 import { SSMGitHubAuthProvider } from '../github-auth-ssm.js';
-import { payloadFromEvent, type ReviewAgentEvent } from './review-agent-event.js';
+import { payloadFromEvent, attemptFromEvent, rateLimitedCheckSummary, type ReviewAgentEvent } from './review-agent-event.js';
 
 // -- Singletons (re-used across warm invocations) ----------------------------
 
@@ -367,8 +367,10 @@ export async function handler(
   rawEvent: ReviewAgentEvent,
 ): Promise<{ statusCode: number; body: string }> {
   // #355 — jobs arrive via the SQS queue (Records-wrapped) or legacy direct
-  // invoke; normalize before anything touches the payload.
+  // invoke; normalize before anything touches the payload. #370 — the SQS
+  // receive count numbers the throttle-parked check's attempts.
   const event = payloadFromEvent(rawEvent);
+  const deliveryAttempt = attemptFromEvent(rawEvent);
   const { installationId, owner, repo, prNumber, mode, existingCommentId, userComment, userCommentAuthor } = event;
   const repoFullName = `${owner}/${repo}`;
 
@@ -1174,8 +1176,10 @@ export async function handler(
 
       await createCheckRun(octokit, owner, repo, headSha, {
         status: 'in_progress',
-        title: 'Review queued — rate limited',
-        summary: 'The model provider is rate limiting requests. MergeWatch will retry this review shortly.',
+        title: `Review queued — rate limited (attempt ${deliveryAttempt})`,
+        // #370 — attempt + parked-at + expectations: a parked review must be
+        // distinguishable from a hung one at a glance.
+        summary: rateLimitedCheckSummary(deliveryAttempt, new Date().toISOString()),
       }).catch((checkErr) => {
         console.error('Failed to post rate-limited check run:', checkErr);
       });


### PR DESCRIPTION
Closes #370.

## Diagnosis — there was no hang

Prod logs for `fixtures#345` (full trail on the issue tracker comment): the 01:35:08 attempt hit provider throttling at 01:35:13 and was **parked by design** (#355 phase 1 — status `pending`, in_progress check, rethrow → SQS redelivery); the queued retry ran at 02:08:36 and **completed successfully** at 02:08:48 under the 57-PR burst backlog. `/verify-suite` graded at ~01:56, mid-queue, and read the parked window as a hang. The suspected #359 truncation path is exonerated — `truncateConventions` ran cleanly on both attempts and the completed review disclosed the truncation as expected.

## The real fix — parked ≠ hung, at a glance

- **`attemptFromEvent()`**: SQS `ApproximateReceiveCount` (1 for direct invokes, garbage-safe).
- The parked check now reads **"Review queued — rate limited (attempt N)"** with a summary carrying the **parked-at timestamp**, the automatic-retry expectation (~30 min under burst load), and the DLQ end-state — via a pure `rateLimitedCheckSummary()` builder.
- RUNBOOK E2E-88's expected outcome updated to the attempt-numbered parked check.

## Tests

4 new (receive-count parsing incl. direct-invoke/garbage defaults; summary content) — 7/7 event suite, full workspace gates green by exit code.

## Datapoint for #360

Throttling fired even under the SQS `MaximumConcurrency: 8` cap (≈8 reviews × ~4 concurrent Bedrock calls still exceeds the on-demand quota) — the quota request is what removes these parking events; this PR makes them legible in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)