### PR TITLE
fix(server): log queue kill/retry/complete failures in the review worker

### DIFF
--- a/packages/server/src/review-worker.test.ts
+++ b/packages/server/src/review-worker.test.ts
@@ -79,6 +79,46 @@ describe('startReviewWorker (#355)', () => {
     worker.stop();
   });
 
+  it('logs (not swallows) a queue.retry failure and frees the slot', async () => {
+    const queue = makeQueue([[{ id: '1', payload, attempts: 2 }], [{ id: '2', payload, attempts: 1 }]]);
+    vi.mocked(queue.retry).mockRejectedValueOnce(new Error('connection reset'));
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // Only the first job throttles; the second must still get its slot.
+    const processJob = vi.fn(async () => {
+      if (vi.mocked(queue.claim).mock.calls.length === 1) {
+        throw Object.assign(new Error('x'), { status: 429 });
+      }
+    });
+    const worker = startReviewWorker(queue, processJob, { pollIntervalMs: 60_000, concurrency: 1 });
+
+    await worker.tick();
+    await flush();
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('queue.retry failed'), '1', expect.any(Error));
+
+    await worker.tick(); // slot must be free again despite the retry failure
+    await flush();
+    expect(queue.complete).toHaveBeenCalledWith('2');
+    errSpy.mockRestore();
+    worker.stop();
+  });
+
+  it('logs (not swallows) a queue.kill failure', async () => {
+    const queue = makeQueue([[{ id: '9', payload, attempts: 5 }]]);
+    vi.mocked(queue.kill).mockRejectedValueOnce(new Error('connection reset'));
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const processJob = vi.fn(async () => {
+      throw Object.assign(new Error('x'), { status: 429 });
+    });
+    const worker = startReviewWorker(queue, processJob, { pollIntervalMs: 60_000, maxAttempts: 5 });
+
+    await worker.tick();
+    await flush();
+
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('queue.kill failed'), '9', expect.any(Error));
+    errSpy.mockRestore();
+    worker.stop();
+  });
+
   it('claims only the free concurrency slots', async () => {
     // Two slow jobs occupy both slots; the next tick must claim 0.
     let release!: () => void;

--- a/packages/server/src/review-worker.ts
+++ b/packages/server/src/review-worker.ts
@@ -68,16 +68,22 @@ export function startReviewWorker(
             '[review-worker] job %s dead after %d throttled attempts — inspect review_jobs (status=dead)',
             job.id, job.attempts,
           );
-          await queue.kill(job.id).catch(() => {});
+          await queue.kill(job.id).catch((qErr) => {
+            console.error('[review-worker] queue.kill failed for job %s — row stays processing until lock expiry:', job.id, qErr);
+          });
         } else {
           const delay = backoffBaseSeconds * 2 ** (job.attempts - 1);
           console.warn('[review-worker] job %s throttled (attempt %d) — retrying in %ds', job.id, job.attempts, delay);
-          await queue.retry(job.id, delay).catch(() => {});
+          await queue.retry(job.id, delay).catch((qErr) => {
+            console.error('[review-worker] queue.retry failed for job %s — row stays processing until lock expiry:', job.id, qErr);
+          });
         }
       } else {
         // The processor already recorded the terminal failure (status +
         // failure check run) — delivery is complete from the queue's view.
-        await queue.complete(job.id).catch(() => {});
+        await queue.complete(job.id).catch((qErr) => {
+          console.error('[review-worker] queue.complete failed for job %s — expect a duplicate delivery at lock expiry:', job.id, qErr);
+        });
       }
     } finally {
       active--;


### PR DESCRIPTION
## What

Replaces the three silent `.catch(() => {})` calls on `queue.kill()` / `queue.retry()` / `queue.complete()` in `packages/server/src/review-worker.ts` with logged catches that state the job id, the error, and the concrete consequence (row stays `processing` until lock expiry / duplicate delivery at lock expiry).

## Why

MergeWatch's own review of #363 flagged this (`review-worker.ts:67` — "Swallowed errors on queue.kill() and queue.retry() hide infrastructure failures") with a 3/5 verdict, and the finding was missed at merge time. The behavior was already *safe* (lock-expiry reclaim recovers the job) but *silent* — an operator had no signal that queue writes were failing.

## Tests

Two new unit tests: a rejected `queue.retry` is logged and the concurrency slot is still freed (next job proceeds); a rejected `queue.kill` is logged. Full workspace `build` / `typecheck` / `test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)