### PR TITLE
feat(core): configurable FP-A confidence floor (minConfidence, default 75)

### DIFF
--- a/.mergewatch.yml
+++ b/.mergewatch.yml
@@ -55,6 +55,10 @@ excludePatterns:
 # Minimum severity to report: info | warning | critical
 minSeverity: info
 
+# Minimum self-reported confidence (1-100) a finding needs to be reported.
+# Lower to see more speculative findings; raise for near-certain defects only.
+minConfidence: 75
+
 # Maximum findings posted per review.
 maxFindings: 25
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -457,6 +457,7 @@ export interface MergeWatchConfig {
   customStyleRules: string[];
   excludePatterns: string[];
   minSeverity: 'info' | 'warning' | 'critical';
+  minConfidence: number;             // Default: 75 (FP-A confidence floor, 1-100)
   maxFindings: number;               // Default: 25
   postSummaryOnClean: boolean;       // Post comment even if no findings
 }

--- a/packages/core/src/agents/prompts.test.ts
+++ b/packages/core/src/agents/prompts.test.ts
@@ -12,6 +12,7 @@ import {
   TONE_DIRECTIVES,
   TONE_PLACEHOLDER,
   CUSTOM_AGENT_RESPONSE_FORMAT,
+  applyConfidenceFloor,
 } from './prompts.js';
 
 // ─── Prompt constants are non-empty strings ─────────────────────────────────
@@ -221,5 +222,39 @@ describe('ORCHESTRATOR_PROMPT — anti-pedantry pass', () => {
 
   it('explicitly argues for fewer-but-substantive findings over a longer list with nits', () => {
     expect(ORCHESTRATOR_PROMPT).toMatch(/0-3 substantive findings beats a 6-finding review with 4 nits/i);
+  });
+});
+
+// ─── applyConfidenceFloor (configurable FP-A floor) ─────────────────────────
+
+describe('applyConfidenceFloor', () => {
+  it('returns the prompt unchanged at the default floor (75)', () => {
+    expect(applyConfidenceFloor(ORCHESTRATOR_PROMPT, 75)).toBe(ORCHESTRATOR_PROMPT);
+    expect(applyConfidenceFloor(SECURITY_REVIEWER_PROMPT, 75)).toBe(SECURITY_REVIEWER_PROMPT);
+  });
+
+  it('rewrites the agent self-filter rule to the configured floor', () => {
+    const rewritten = applyConfidenceFloor(SECURITY_REVIEWER_PROMPT, 50);
+    expect(rewritten).toContain('If you are less than 50% confident');
+    expect(rewritten).not.toContain('If you are less than 75% confident');
+  });
+
+  it('rewrites the orchestrator drop rule to the configured floor', () => {
+    const rewritten = applyConfidenceFloor(ORCHESTRATOR_PROMPT, 90);
+    expect(rewritten).toContain('Drop any finding with confidence below 90.');
+    expect(rewritten).not.toContain('Drop any finding with confidence below 75.');
+  });
+
+  it('leaves prompts without the targeted sentences untouched', () => {
+    const noRules = 'Summarise what changed on the latest commit.';
+    expect(applyConfidenceFloor(noRules, 50)).toBe(noRules);
+  });
+
+  // Aliveness tripwire: applyConfidenceFloor targets these EXACT sentences.
+  // If a prompt rewording changes them, the floor override silently stops
+  // working — this test makes that failure loud instead.
+  it('aliveness — the exact source sentences still exist in the prompts', () => {
+    expect(SECURITY_REVIEWER_PROMPT).toContain('If you are less than 75% confident');
+    expect(ORCHESTRATOR_PROMPT).toContain('Drop any finding with confidence below 75.');
   });
 });

--- a/packages/core/src/agents/prompts.ts
+++ b/packages/core/src/agents/prompts.ts
@@ -624,6 +624,23 @@ Respond with plain markdown text (NOT JSON). This will be posted directly as a G
  */
 export const PREVIOUS_FINDINGS_PLACEHOLDER = '{{PREVIOUS_FINDINGS}}';
 
+/**
+ * Rewrites the two hardcoded confidence-75 rules (SHARED_PREAMBLE's
+ * "less than 75% confident" self-filter and the orchestrator's "Drop any
+ * finding with confidence below 75") to a repo-configured floor. Without
+ * this, lowering `minConfidence` below 75 would be inert: the model would
+ * self-censor at 75 before the deterministic FP-A filter ever ran. The
+ * replacements target those exact sentences — prompts that don't contain
+ * them pass through untouched. reviewer.test.ts asserts both source
+ * sentences still exist so a prompt rewording breaks loudly, not silently.
+ */
+export function applyConfidenceFloor(prompt: string, floor: number): string {
+  if (floor === 75) return prompt;
+  return prompt
+    .replace('If you are less than 75% confident', `If you are less than ${floor}% confident`)
+    .replace('Drop any finding with confidence below 75.', `Drop any finding with confidence below ${floor}.`);
+}
+
 export const ORCHESTRATOR_PROMPT = `${SHARED_PREAMBLE}
 
 You receive findings from multiple review agents (security, bugs, style, error-handling, test-coverage, comment-accuracy).

--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -1550,6 +1550,65 @@ describe('runReviewPipeline', () => {
     expect(result.findings[0].title).toBe('Legacy untagged');
   });
 
+  it('minConfidence — a lowered floor keeps findings the default drops and rewrites the prompt rules', async () => {
+    const securityFinding = validFindingsJson([{ file: 'foo.ts', line: 3, severity: 'warning', title: 'trigger', confidence: 90 }]);
+    const summary = JSON.stringify({ summary: 'Refactor.' });
+    const diagram = '%% overview\nflowchart TD\n  A-->B';
+    const orchestrator = JSON.stringify({
+      findings: [
+        { file: 'foo.ts', line: 3, severity: 'warning', confidence: 50, category: 'style', title: 'Boundary at 50',  description: '', suggestion: '' },
+        { file: 'foo.ts', line: 3, severity: 'warning', confidence: 40, category: 'style', title: 'Below the floor', description: '', suggestion: '' },
+      ],
+      mergeScore: 3, mergeScoreReason: 'Has warnings.',
+    });
+    const llm = createMockLLM([
+      securityFinding, JSON.stringify({ findings: [] }), JSON.stringify({ findings: [] }),
+      JSON.stringify({ findings: [] }), JSON.stringify({ findings: [] }), JSON.stringify({ findings: [] }),
+      summary, diagram, orchestrator,
+    ]);
+    const result = await runReviewPipeline(
+      { diff: sampleDiff, context: sampleContext, modelId: 'heavy', lightModelId: 'light', maxFindings: 25, minConfidence: 50, enabledAgents: allAgentsEnabled },
+      { llm },
+    );
+
+    const titles = result.findings.map((f) => f.title);
+    expect(titles).toContain('Boundary at 50');
+    expect(titles).not.toContain('Below the floor');
+
+    // The prompt-side rules must track the floor, or the model self-censors
+    // at 75 before the deterministic filter ever sees a 50-confidence finding.
+    const agentCall = llm.calls.find((c) => c.prompt.includes('% confident'));
+    expect(agentCall?.prompt).toContain('If you are less than 50% confident');
+    const orchestratorCall = llm.calls.find((c) => c.prompt.includes('Drop any finding with confidence below'));
+    expect(orchestratorCall?.prompt).toContain('Drop any finding with confidence below 50.');
+  });
+
+  it('minConfidence — a raised floor drops boundary findings the default keeps', async () => {
+    const securityFinding = validFindingsJson([{ file: 'foo.ts', line: 3, severity: 'warning', title: 'trigger', confidence: 95 }]);
+    const summary = JSON.stringify({ summary: 'Refactor.' });
+    const diagram = '%% overview\nflowchart TD\n  A-->B';
+    const orchestrator = JSON.stringify({
+      findings: [
+        { file: 'foo.ts', line: 3, severity: 'warning', confidence: 95, category: 'security', title: 'Near-certain',       description: '', suggestion: '' },
+        { file: 'foo.ts', line: 3, severity: 'warning', confidence: 80, category: 'bug',      title: 'Default would keep', description: '', suggestion: '' },
+      ],
+      mergeScore: 3, mergeScoreReason: 'Has warnings.',
+    });
+    const llm = createMockLLM([
+      securityFinding, JSON.stringify({ findings: [] }), JSON.stringify({ findings: [] }),
+      JSON.stringify({ findings: [] }), JSON.stringify({ findings: [] }), JSON.stringify({ findings: [] }),
+      summary, diagram, orchestrator,
+    ]);
+    const result = await runReviewPipeline(
+      { diff: sampleDiff, context: sampleContext, modelId: 'heavy', lightModelId: 'light', maxFindings: 25, minConfidence: 90, enabledAgents: allAgentsEnabled },
+      { llm },
+    );
+
+    const titles = result.findings.map((f) => f.title);
+    expect(titles).toContain('Near-certain');
+    expect(titles).not.toContain('Default would keep');
+  });
+
 });
 
 // ─── agentAuthored flag (AGENT_MODE_SUFFIX injection) ───────────────

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -38,6 +38,7 @@ import {
   AGENT_MODE_PLACEHOLDER,
   AGENT_MODE_SUFFIX,
   INTENT_CLAIMS_DIRECTIVE,
+  applyConfidenceFloor,
 } from './prompts.js';
 import type { CustomAgentDef, UXConfig } from '../config/defaults.js';
 import type { ReviewDelta } from '../review-delta.js';
@@ -1058,6 +1059,13 @@ export interface ReviewPipelineOptions {
    * Defaults to 'info' (report everything) when absent.
    */
   minSeverity?: 'info' | 'warning' | 'critical';
+  /**
+   * Minimum self-reported confidence (1-100) a finding needs to survive the
+   * FP-A floor filter. Fed from `.mergewatch.yml` `minConfidence:`; defaults
+   * to CONFIDENCE_FLOOR (75) when absent, so unset configs see no change.
+   * Findings with no `confidence` field are always kept.
+   */
+  minConfidence?: number;
   /**
    * #350 — output-token cap applied to every LLM invocation this pipeline
    * makes (agents, summary, diagram, orchestrator, verification). A call
@@ -2135,6 +2143,7 @@ export async function runReviewPipeline(
     customStyleRules = [],
     maxFindings,
     minSeverity = 'info',
+    minConfidence = CONFIDENCE_FLOOR,
     maxTokensPerAgent,
     enabledAgents,
     fileFetchOptions,
@@ -2157,9 +2166,18 @@ export async function runReviewPipeline(
   // invocation in this pipeline (same decorator pattern as the tracking
   // wrapper above). Call sites that pass an explicit maxTokens keep it;
   // when unset, providers fall back to their built-in 4096 as before.
-  const llm: ILLMProvider = maxTokensPerAgent
+  const cappedLlm: ILLMProvider = maxTokensPerAgent
     ? { invoke: (m, p, t, s) => trackedLlm.invoke(m, p, t ?? maxTokensPerAgent, s) }
     : trackedLlm;
+  // Configurable FP-A floor: rewrite the prompts' hardcoded confidence-75
+  // rules to the configured value so the model's self-filter and the
+  // deterministic post-orchestrator filter enforce the SAME threshold
+  // (otherwise lowering the floor below 75 would be inert). No-op at the
+  // default. Applied at this choke point so every agent prompt gets it
+  // without threading the value through each builder.
+  const llm: ILLMProvider = minConfidence !== CONFIDENCE_FLOOR
+    ? { invoke: (m, p, t, s) => cappedLlm.invoke(m, applyConfidenceFloor(p, minConfidence), t, s) }
+    : cappedLlm;
 
   // Extract the changed-file set once, up front. Used for:
   //   - FP-D diagram path validation (passed into runDiagramAgent below).
@@ -2274,11 +2292,12 @@ export async function runReviewPipeline(
   // confidence < 75, but nothing in code enforces it. This deterministic post-
   // orchestrator filter catches the entire class of "model didn't honor its
   // own confidence rule" false positives. Findings with NO `confidence` field
-  // default to 100 (no surprise suppression of legacy findings).
+  // default to 100 (no surprise suppression of legacy findings). The floor is
+  // configurable via yml `minConfidence:` (default CONFIDENCE_FLOOR).
   {
     const before = orchestratorResult.findings.length;
     orchestratorResult.findings = orchestratorResult.findings.filter(
-      (f) => (f.confidence ?? 100) >= CONFIDENCE_FLOOR,
+      (f) => (f.confidence ?? 100) >= minConfidence,
     );
     const dropped = before - orchestratorResult.findings.length;
     if (dropped > 0) {
@@ -2286,7 +2305,7 @@ export async function runReviewPipeline(
         '[confidence-floor] dropped %d finding%s with confidence < %d',
         dropped,
         dropped === 1 ? '' : 's',
-        CONFIDENCE_FLOOR,
+        minConfidence,
       );
     }
   }

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -160,6 +160,13 @@ export interface MergeWatchConfig {
   includePatterns: string[];
   /** Minimum severity to report: 'info' | 'warning' | 'critical' */
   minSeverity: 'info' | 'warning' | 'critical';
+  /**
+   * Minimum self-reported confidence (1-100) a finding needs to be
+   * reported — the FP-A floor. Lower it to see more speculative findings
+   * (e.g. 50 while calibrating), raise it to only surface near-certain
+   * defects. Findings with no confidence field are always kept.
+   */
+  minConfidence: number;
   /** Maximum number of findings to include in the comment */
   maxFindings: number;
   /** Whether to post a summary even when there are no findings */
@@ -209,6 +216,7 @@ export const DEFAULT_CONFIG: MergeWatchConfig = {
   ],
   includePatterns: [],
   minSeverity: 'info',
+  minConfidence: 75,
   maxFindings: 25,
   postSummaryOnClean: true,
   codebaseAwareness: true,

--- a/packages/core/src/github/client.test.ts
+++ b/packages/core/src/github/client.test.ts
@@ -273,6 +273,20 @@ describe('parseRepoConfigYaml', () => {
     expect(result?.model).toBeUndefined();
   });
 
+  it('parses a valid minConfidence (FP-A floor override)', () => {
+    expect(parseRepoConfigYaml('minConfidence: 50')?.minConfidence).toBe(50);
+    expect(parseRepoConfigYaml('minConfidence: 100')?.minConfidence).toBe(100);
+    expect(parseRepoConfigYaml('minConfidence: 1')?.minConfidence).toBe(1);
+  });
+
+  it('ignores out-of-range or non-numeric minConfidence (keeps the default downstream)', () => {
+    expect(parseRepoConfigYaml('minConfidence: 0')?.minConfidence).toBeUndefined();
+    expect(parseRepoConfigYaml('minConfidence: 150')?.minConfidence).toBeUndefined();
+    expect(parseRepoConfigYaml('minConfidence: -5')?.minConfidence).toBeUndefined();
+    expect(parseRepoConfigYaml('minConfidence: "80"')?.minConfidence).toBeUndefined();
+    expect(parseRepoConfigYaml('minConfidence: high')?.minConfidence).toBeUndefined();
+  });
+
   it('parses a valid pricing override (#231)', () => {
     const yaml = `
 pricing:

--- a/packages/core/src/github/client.ts
+++ b/packages/core/src/github/client.ts
@@ -916,6 +916,14 @@ export function parseRepoConfigYaml(content: string): Partial<MergeWatchConfig> 
     if (typeof parsed.minSeverity === 'string' && ['info', 'warning', 'critical'].includes(parsed.minSeverity)) {
       config.minSeverity = parsed.minSeverity as 'info' | 'warning' | 'critical';
     }
+    // FP-A floor override — only a sane 1-100 number is accepted; anything
+    // else keeps the default (75) rather than silently disabling the filter.
+    if (
+      typeof parsed.minConfidence === 'number' && Number.isFinite(parsed.minConfidence)
+      && parsed.minConfidence >= 1 && parsed.minConfidence <= 100
+    ) {
+      config.minConfidence = parsed.minConfidence;
+    }
     if (typeof parsed.maxFindings === 'number') config.maxFindings = parsed.maxFindings;
     if (typeof parsed.postSummaryOnClean === 'boolean') config.postSummaryOnClean = parsed.postSummaryOnClean;
     if (typeof parsed.conventions === 'string' && parsed.conventions.trim()) {

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -812,6 +812,8 @@ export async function handler(
       maxFindings: runtimeConfig.maxFindings,
       // #310 — merged from yml `minSeverity:` + dashboard severityThreshold.
       minSeverity: runtimeConfig.minSeverity,
+      // FP-A floor from yml `minConfidence:` (default 75).
+      minConfidence: runtimeConfig.minConfidence,
       // #350 — per-invocation output-token cap from yml `maxTokensPerAgent:`.
       maxTokensPerAgent: runtimeConfig.maxTokensPerAgent,
       enabledAgents: mode === 'summary'

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -667,6 +667,8 @@ export async function processReviewJob(
         maxFindings: config.maxFindings,
         // #310 — merged from yml `minSeverity:` + dashboard severityThreshold.
         minSeverity: config.minSeverity,
+        // FP-A floor from yml `minConfidence:` (default 75).
+        minConfidence: config.minConfidence,
         // #350 — per-invocation output-token cap from yml `maxTokensPerAgent:`.
         maxTokensPerAgent: config.maxTokensPerAgent,
         enabledAgents: {


### PR DESCRIPTION
## What

Adds a `minConfidence:` key (1–100, default 75) to `.mergewatch.yml` that sets the FP-A confidence floor. Unset configs see zero behavior change.

## Why

The 5/5-uniformity audit showed the hardcoded 75 floor is one of the biggest levers on finding suppression, with no operator control. Repos calibrating the reviewer (or wanting only near-certain defects) can now tune it.

## How

The floor lives in **three** places that must agree, and now do:

1. The deterministic FP-A post-orchestrator filter (previously the `CONFIDENCE_FLOOR` constant).
2. `SHARED_PREAMBLE`'s "less than 75% confident → do NOT include" agent self-filter.
3. The orchestrator's rule 5 ("Drop any finding with confidence below 75").

Without (2)+(3), lowering the floor would be **inert** — the model self-censors at 75 before the code filter runs. `applyConfidenceFloor()` rewrites those two exact sentences at the pipeline's LLM-wrapper choke point (same decorator shape as #350's `maxTokensPerAgent`), so no agent-builder signatures change and the default path is a no-op. An aliveness test pins the exact source sentences so a prompt rewording breaks loudly instead of silently disabling the override.

Parsing accepts only finite numbers in `[1, 100]`; anything else keeps the default rather than silently disabling the filter. Wired through both runtimes (`review-agent.ts`, `review-processor.ts`); the #310 config-key tripwire covers the read. Findings with no `confidence` field are still always kept.

## Tests

- Pipeline: lowered floor (50) keeps a 50-confidence finding the default drops **and** the agent + orchestrator prompts sent to the LLM carry the rewritten rules; raised floor (90) drops an 80-confidence finding the default keeps.
- `applyConfidenceFloor`: no-op at 75, rewrites both rules, leaves rule-free prompts untouched, aliveness tripwire.
- Yml parsing: valid values accepted; 0 / 150 / negative / string / non-numeric ignored.

Full workspace `build` / `typecheck` / `test` green (core: 883 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)