### PR TITLE
feat(core): lead the completion check title with the merge score

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -336,7 +336,7 @@ No `.mergewatch.yml` needed.
 - [ ] "Requires your attention" table lists the SQL Injection row with 🔴
 - [ ] Formal PR review state = **Changes requested** (single review event — NOT multiple COMMENTED reviews)
 - [ ] Review body is a single line that points at the summary comment (e.g. `🔴 Critical issues found — see the full review in the summary comment above.`)
-- [ ] Check run conclusion = `failure` with a title like "N critical issues found"
+- [ ] Check run conclusion = `failure` with a title like "1/5 — N critical issues found" (#380: title leads with the merge score)
 
 **Failure modes to watch for**
 - ❌ Formal review state is `COMMENTED` instead of `CHANGES_REQUESTED` (regression of #139 — was the bug observed in mergewatch-fixtures PR #3)
@@ -1098,7 +1098,7 @@ Provide `groundingFetch` (the default on SaaS / when configured) so verification
 - [ ] If a Critical surfaces, the rendered comment shows score `3/5 — Review recommended` (not `2/5 — Needs fixes` or red)
 - [ ] Score-reason line includes phrasing like *"could not be confirmed against the source"* / *"verification inconclusive"* / *"advisory"*
 - [ ] Formal PR review event = **COMMENT** (not REQUEST_CHANGES)
-- [ ] `MergeWatch Review` check status = SUCCESS (advisory), not FAILURE
+- [ ] `MergeWatch Review` check status = SUCCESS (advisory), not FAILURE — with the check **title** leading with the score, e.g. `3/5 — 1 finding (no blocking critical)` (#380: the green check must still surface the verdict in the checks tab)
 - [ ] Each surviving Critical row carries the `verification: 'unverified'` tag in the stored review (DynamoDB / Postgres). Verify via the dashboard's "View full details" link or directly in the store.
 - [ ] Push a follow-up commit that makes the same code clearly broken (e.g. remove the inline guard); the next review's verification should now confirm the Critical → no clamp → score returns to ≤ 2 + REQUEST_CHANGES. Confirms the guardrail is gated on "W2 inconclusive," not "presence of any Critical."
 
@@ -2435,7 +2435,7 @@ The env price becomes a `customPricing` entry keyed to the `LLM_MODEL` value, ap
 **How to run.** As an org admin, on an installation with ≥1 repo.
 1. **Create (admin):** Settings → Custom Agents → Add agent. Name `no-todo`, prompt "Flag any new TODO comment", severity `critical`, enforcement **blocking**, scope **All repositories**. Save. Reload as a non-admin member → fields are read-only.
 2. **Advisory run:** set the agent to **advisory**, open a PR that adds a `// TODO`. The review surfaces a finding from `no-todo`; the check still passes / score is normal.
-3. **Blocking run:** set it to **blocking**, push another `// TODO`. The summary review is **REQUEST_CHANGES**, the MergeWatch check run is **failure** titled `Blocked by org agent: no-todo`.
+3. **Blocking run:** set it to **blocking**, push another `// TODO`. The summary review is **REQUEST_CHANGES**, the MergeWatch check run is **failure** titled `N/5 — Blocked by org agent: no-todo` (#380 score prefix).
 4. **Scope:** switch the agent to **Selected repositories** and pick only repo B. Open a PR in repo A → the agent does NOT run; in repo B → it does.
 5. **Targeting:** add path glob `src/**`. A PR touching only `docs/**` does NOT trigger it; one touching `src/**` does.
 6. **Union + precedence:** define a repo `.mergewatch.yml` `customAgents` entry with the SAME name as an org agent → only the org definition runs (org wins).

--- a/packages/core/src/comment-formatter.test.ts
+++ b/packages/core/src/comment-formatter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatReviewComment, buildWorkDoneSection, countBlockingCriticals, escapeUserContent, type Finding } from './comment-formatter.js';
+import { formatReviewComment, buildWorkDoneSection, countBlockingCriticals, buildCheckTitle, escapeUserContent, type Finding } from './comment-formatter.js';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -539,5 +539,41 @@ describe('escapeUserContent + injection sites (#369)', () => {
   it('the default wordmark header (no custom header) is untouched', () => {
     const result = formatReviewComment(baseOptions());
     expect(result).toContain('mergewatch-wordmark.svg');
+  });
+});
+
+// ─── buildCheckTitle (#380) ─────────────────────────────────────────────────
+
+describe('buildCheckTitle', () => {
+  it('leads every title with the merge score', () => {
+    expect(buildCheckTitle({ mergeScore: 5, findingCount: 0, blockingCriticalCount: 0 }))
+      .toBe('5/5 \u2014 No issues found');
+    expect(buildCheckTitle({ mergeScore: 3, findingCount: 1, blockingCriticalCount: 0 }))
+      .toBe('3/5 \u2014 1 finding (no blocking critical)');
+    expect(buildCheckTitle({ mergeScore: 4, findingCount: 2, blockingCriticalCount: 0 }))
+      .toBe('4/5 \u2014 2 findings (no blocking critical)');
+    expect(buildCheckTitle({ mergeScore: 1, findingCount: 2, blockingCriticalCount: 2 }))
+      .toBe('1/5 \u2014 2 critical issues found');
+  });
+
+  it('prefixes the org-blocked title too', () => {
+    expect(buildCheckTitle({
+      mergeScore: 2, findingCount: 1, blockingCriticalCount: 0,
+      orgBlocked: true, orgBlockedBy: ['sec-gate'],
+    })).toBe('2/5 \u2014 Blocked by org agent: sec-gate');
+  });
+
+  it('clamps out-of-range scores like the comment verdict does', () => {
+    expect(buildCheckTitle({ mergeScore: 7, findingCount: 0, blockingCriticalCount: 0 }))
+      .toBe('5/5 \u2014 No issues found');
+    expect(buildCheckTitle({ mergeScore: 0, findingCount: 0, blockingCriticalCount: 0 }))
+      .toBe('1/5 \u2014 No issues found');
+  });
+
+  it('falls back to the unprefixed pre-#380 title when no score exists', () => {
+    expect(buildCheckTitle({ findingCount: 0, blockingCriticalCount: 0 }))
+      .toBe('No issues found');
+    expect(buildCheckTitle({ findingCount: 1, blockingCriticalCount: 1 }))
+      .toBe('1 critical issue found');
   });
 });

--- a/packages/core/src/comment-formatter.ts
+++ b/packages/core/src/comment-formatter.ts
@@ -78,6 +78,37 @@ export function countBlockingCriticals(
   ).length;
 }
 
+/**
+ * #380 — completion check-run title, shared by both runtimes. The conclusion
+ * only fails on blocking criticals (#240), which means a 3/5 "review
+ * recommended" verdict renders a green check indistinguishable from a clean
+ * 5/5 in the checks tab — PR #363 merged with an unaddressed warning exactly
+ * that way. The title therefore always leads with the merge score (the
+ * pipeline's W7-reconciled score, same value the comment verdict renders),
+ * so the checks tab carries the signal without changing gating behavior.
+ * No score (legacy/edge case) → the pre-#380 title, unprefixed.
+ */
+export function buildCheckTitle(input: {
+  mergeScore?: number;
+  findingCount: number;
+  blockingCriticalCount: number;
+  orgBlocked?: boolean;
+  orgBlockedBy?: string[];
+}): string {
+  const { mergeScore, findingCount, blockingCriticalCount, orgBlocked, orgBlockedBy } = input;
+  const prefix = mergeScore != null
+    ? `${Math.max(1, Math.min(5, mergeScore))}/5 — `
+    : '';
+  if (orgBlocked) return `${prefix}Blocked by org agent: ${(orgBlockedBy ?? []).join(', ')}`;
+  if (blockingCriticalCount > 0) {
+    return `${prefix}${blockingCriticalCount} critical issue${blockingCriticalCount > 1 ? 's' : ''} found`;
+  }
+  if (findingCount > 0) {
+    return `${prefix}${findingCount} finding${findingCount > 1 ? 's' : ''} (no blocking critical)`;
+  }
+  return `${prefix}No issues found`;
+}
+
 interface FormatOptions {
   /** Markdown summary text from the summary agent */
   summary: string;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -135,7 +135,7 @@ export {
 export type { ReviewThreadComment } from './github/client.js';
 
 // ─── Comment formatter ──────────────────────────────────────────────────────
-export { formatReviewComment, buildWorkDoneSection, countBlockingCriticals, escapeUserContent } from './comment-formatter.js';
+export { formatReviewComment, buildWorkDoneSection, countBlockingCriticals, buildCheckTitle, escapeUserContent } from './comment-formatter.js';
 export type { Finding, WorkDoneSection } from './comment-formatter.js';
 
 // ─── Review delta ────────────────────────────────────────────────────────────

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -26,6 +26,7 @@ import {
   runReviewPipeline,
   formatReviewComment,
   countBlockingCriticals,
+  buildCheckTitle,
   isThrottleError,
   computeDiffStats,
   mergeConfig,
@@ -1139,13 +1140,15 @@ export async function handler(
     await createCheckRun(octokit, owner, repo, headSha, {
       status: 'completed',
       conclusion: checkConclusion,
-      title: orgBlocked
-        ? `Blocked by org agent: ${orgBlockedBy.join(', ')}`
-        : hasCritical
-          ? `${blockingCriticalCount} critical issue${blockingCriticalCount > 1 ? 's' : ''} found`
-          : result.findings.length > 0
-            ? `${result.findings.length} finding${result.findings.length > 1 ? 's' : ''} (no blocking critical)`
-            : 'No issues found',
+      // #380 — the title leads with the merge score so a 3/5-with-warnings
+      // verdict is visible in the checks tab despite the green conclusion.
+      title: buildCheckTitle({
+        mergeScore: result.mergeScore,
+        findingCount: result.findings.length,
+        blockingCriticalCount,
+        orgBlocked,
+        orgBlockedBy,
+      }),
       summary: findingSummaryParts.length > 0
         ? `Found: ${findingSummaryParts.join(', ')}`
         : 'No issues detected in this PR.',

--- a/packages/server/src/review-processor.test.ts
+++ b/packages/server/src/review-processor.test.ts
@@ -310,7 +310,8 @@ describe('processReviewJob — check runs', () => {
       expect(completionCall[4]).toMatchObject({
         status: 'completed',
         conclusion: 'failure',
-        title: '2 critical issues found',
+        // #380 — titles lead with the merge score.
+        title: '1/5 — 2 critical issues found',
         summary: 'Found: 2 critical',
       });
     });
@@ -334,7 +335,7 @@ describe('processReviewJob — check runs', () => {
         status: 'completed',
         conclusion: 'success',
         // #240 — "blocking" qualifier: unverified criticals no longer count.
-        title: '2 findings (no blocking critical)',
+        title: '4/5 — 2 findings (no blocking critical)',
         summary: 'Found: 1 warning, 1 info',
       });
     });
@@ -348,7 +349,7 @@ describe('processReviewJob — check runs', () => {
       expect(completionCall[4]).toMatchObject({
         status: 'completed',
         conclusion: 'success',
-        title: 'No issues found',
+        title: '5/5 — No issues found',
         summary: 'No issues detected in this PR.',
       });
     });
@@ -385,7 +386,7 @@ describe('processReviewJob — check runs', () => {
 
       const calls = (createCheckRun as any).mock.calls;
       const completionCall = calls[calls.length - 1];
-      expect(completionCall[4].title).toBe('1 critical issue found');
+      expect(completionCall[4].title).toBe('2/5 — 1 critical issue found');
     });
   });
 
@@ -1157,7 +1158,7 @@ describe('processReviewJob — check conclusion vs verification (#240)', () => {
 
     const check = completionCheckRun();
     expect(check.conclusion).toBe('failure');
-    expect(check.title).toBe('1 critical issue found');
+    expect(check.title).toBe('2/5 — 1 critical issue found');
   });
 
   it('a critical with no verification field (pre-W2 record) still fails the check', async () => {
@@ -1177,7 +1178,7 @@ describe('processReviewJob — check conclusion vs verification (#240)', () => {
 
     const check = completionCheckRun();
     expect(check.conclusion).toBe('failure');
-    expect(check.title).toBe('1 critical issue found');
+    expect(check.title).toBe('2/5 — 1 critical issue found');
     expect(check.summary).toContain('1 critical');
     expect(check.summary).toContain('1 unverified');
   });

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -2,7 +2,7 @@ import type { ReviewJobPayload, IInstallationStore, IReviewStore, IGitHubAuthPro
 import {
   getPRDiff, getPRContext, addPRReaction, removePRReaction, postReviewComment, updateReviewComment,
   findExistingBotComment, getCommentReactions, createCheckRun,
-  formatReviewComment, countBlockingCriticals, isThrottleError, computeDiffStats, runReviewPipeline, shouldSkipPR, shouldSkipByRules, isAutoReviewOff, extractIncludePatterns,
+  formatReviewComment, countBlockingCriticals, buildCheckTitle, isThrottleError, computeDiffStats, runReviewPipeline, shouldSkipPR, shouldSkipByRules, isAutoReviewOff, extractIncludePatterns,
   loadCategoryDisputeRates,
   filterDiff,
   DEFAULT_CONFIG, mergeConfig,
@@ -971,13 +971,15 @@ export async function processReviewJob(
     await createCheckRun(octokit, owner, repo, headSha, {
       status: 'completed',
       conclusion: checkConclusion,
-      title: orgBlocked
-        ? `Blocked by org agent: ${orgBlockedBy.join(', ')}`
-        : hasCritical
-          ? `${blockingCriticalCount} critical issue${blockingCriticalCount > 1 ? 's' : ''} found`
-          : result.findings.length > 0
-            ? `${result.findings.length} finding${result.findings.length > 1 ? 's' : ''} (no blocking critical)`
-            : 'No issues found',
+      // #380 — the title leads with the merge score so a 3/5-with-warnings
+      // verdict is visible in the checks tab despite the green conclusion.
+      title: buildCheckTitle({
+        mergeScore: result.mergeScore,
+        findingCount: result.findings.length,
+        blockingCriticalCount,
+        orgBlocked,
+        orgBlockedBy,
+      }),
       summary: findingSummaryParts.length > 0
         ? `Found: ${findingSummaryParts.join(', ')}`
         : 'No issues detected in this PR.',


### PR DESCRIPTION
## What

Implements the **alternative** option decided on #380: the check conclusion stays `success` (no gating change), but the completion check-run title now always leads with the merge score:

| Situation | Before | After |
|---|---|---|
| Clean | `No issues found` | `5/5 — No issues found` |
| Warnings only | `1 finding (no blocking critical)` | `3/5 — 1 finding (no blocking critical)` |
| Blocking criticals | `2 critical issues found` | `1/5 — 2 critical issues found` |
| Org-blocked | `Blocked by org agent: no-todo` | `1/5 — Blocked by org agent: no-todo` |

## Why

By #240's design a 3/5 "should be addressed before merge" verdict renders a green check indistinguishable from a clean 5/5 in the checks tab — PR #363 merged with an unaddressed warning exactly that way. The score in the title surfaces the verdict wherever checks are shown without changing what gates.

## How

New shared `buildCheckTitle()` in core's comment-formatter (next to `countBlockingCriticals`), replacing the duplicated title ternary in both runtimes. It uses the pipeline's W7-reconciled `result.mergeScore` — the same value the comment verdict renders — with the same 1–5 clamp, and falls back to the unprefixed pre-#380 title if no score exists.

## Tests / docs

Unit tests for all four title shapes, clamping, and the no-score fallback; server processor title expectations updated; RUNBOOK E2E-25 / E2E-33 / org-agent expectations updated. Full workspace `build` / `typecheck` / `test` green.

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)