### PR TITLE
fix(core): custom-agent findings bypass model filtering; refuted criticals demote (#385)

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -975,8 +975,8 @@ PR diff should only touch the `.map(...)` / `return` lines (so the `const rows =
 
 **Expected outcomes**
 
-- [ ] No surviving CRITICAL claiming `searchCandidates` is unawaited / a missing-await race
-- [ ] If an agent produced one, logs show `[critical-verify] dropped false-positive critical … ` with a reason citing the `await` on the assignment line
+- [ ] No BLOCKING critical claiming `searchCandidates` is unawaited / a missing-await race — **#385: a refuted critical demotes instead of deleting**, so the claim may legitimately appear under "Unverified concerns" (advisory, W7-clamped score), never in the attention table
+- [ ] If an agent produced one, logs show `[finding-verify] refuted critical … demoted to unverified (not dropped)` with a reason citing the `await` on the assignment line (warnings still log `dropped false-positive`)
 - [ ] A genuinely-unawaited variant (delete the `await`) is still reported (verification doesn't blanket-suppress)
 - [ ] LLM/infra failure path keeps the finding (do not regress the fail-safe — exercise by pointing at an unreachable model in a self-hosted run)
 
@@ -1241,6 +1241,8 @@ Run the fixtures separately to exercise both branches of the body-handling logic
 ### E2E-29: W10 finding consolidation — fragments on the same region merge
 
 **Behavior**: when the multi-agent pipeline emits multiple findings about the same underlying concern in the same code region — same file, line-span ≤ 50, ≥ 1 shared "significant" token across title + description — `clusterFindings` collapses them into **one** finding carrying the strongest severity, the earliest cited line, and a *"Related concerns clustered into this finding"* list of the absorbed siblings. The reader sees one row in "Requires your attention" where they would have seen N.
+
+> **#385 note:** on the 2026-08-19 run this fixture exposed a verifier false-refutation — the light-model W2 pass refuted the TRUE SQLi (it saw `$n` placeholder tokens and missed that `db.query(sql)` takes no values array), producing a false 5/5. A refuted **critical** now demotes to "Unverified concerns" (score W7-clamped) instead of deleting; a 5/5 all-clear whose summary prose describes a critical is a **failure mode**, never a pass.
 
 Canonical reproduction: voice-bot PR #37 raised three findings about a single "validate the parsed S3 chunk file" concern — `seed.ts:82` (type assertion without runtime validation), `seed.ts:130` (untrusted JSON parsing without validation), `seed.ts:150` (SQL injection risk in dynamic construction). All three share *validation / structure / chunk* tokens; transitively they cluster (`:82↔:130` is 48 lines, `:130↔:150` is 20 lines, both within span 50).
 
@@ -2058,9 +2060,9 @@ Branch: `fixture/54-abstraction-aware`. Three test PRs in sequence:
 
 **Expected outcomes**
 
-- [x] PR-A — verifier drops the "SQL injection on Drizzle eq()" finding with `[finding-verify] dropped false-positive critical "SQL injection..." (...): abstraction-safe — Drizzle eq() parameterizes the value`
-- [x] PR-B — verifier drops the "URL injection on encodeURIComponent" finding similarly
-- [x] PR-C — verifier drops the "XSS via text content" finding similarly
+- [x] PR-A — verifier refutes the "SQL injection on Drizzle eq()" finding; **#385: as a critical it DEMOTES** — log `[finding-verify] refuted critical "SQL injection..." … demoted to unverified (not dropped): abstraction-safe — Drizzle eq() parameterizes the value`; it renders (if at all) only under "Unverified concerns", never as a blocking finding
+- [x] PR-B — verifier refutes the "URL injection on encodeURIComponent" finding similarly (demoted if critical, dropped if warning)
+- [x] PR-C — verifier refutes the "XSS via text content" finding similarly (demoted if critical, dropped if warning)
 - [x] PR-D (regression) — verifier KEEPS the "SQL injection on raw concat" finding (the FP-K abstraction prefix is absent on the cited path → the model must return `valid: true`, the prompt instructs no override)
 - [x] **Back-compat**: a finding on info-only severity is NOT verified (info-level findings skip W2 entirely; no FP-K-augmented prompt is built for them)
 - [x] **Prompt-shape**: the FP-K block renders on FIRST reviews (`previousFindings` empty) — independent of the FP-H/J prior-context placeholder
@@ -2434,7 +2436,7 @@ The env price becomes a `customPricing` entry keyed to the `LLM_MODEL` value, ap
 
 **How to run.** As an org admin, on an installation with ≥1 repo.
 
-> **⚠️ Prerequisite (#382):** this scenario has a **dashboard-side setup step the automated suite does not seed** — the org agent must exist before the fixture PR opens. Verify the `#AGENTS` sentinel row exists (`aws dynamodb get-item --table-name mergewatch-installations-prod --key '{"installationId":{"S":"<id>"},"repoFullName":{"S":"#AGENTS"}}'`) or the run degrades silently: generic agents flag the planted TODOs and the anti-pedantry pass correctly drops them (the 2026-08-19 run's fixtures#455 "Suppressed: 2" was exactly this, not a filter bug).
+> **⚠️ Prerequisite (#382):** this scenario has a **dashboard-side setup step the automated suite does not seed** — the org agent must exist before the fixture PR opens. Verify the `#AGENTS` sentinel row exists (`aws dynamodb get-item --table-name mergewatch-installations-prod --key '{"installationId":{"S":"<id>"},"repoFullName":{"S":"#AGENTS"}}'`) or the run degrades silently: generic agents flag the planted TODOs and the anti-pedantry pass correctly drops them (the 2026-08-19 run's fixtures#455 "Suppressed: 2" was exactly this, not a filter bug). **With the row seeded**, #385 guarantees the agent's findings survive: custom/org-agent findings bypass the orchestrator's anti-pedantry pass and the W2 verifier's drop authority entirely (deterministic dedup + W3 triage are the only filters) — a seeded run where the TODO findings still vanish is a product regression.
 
 1. **Create (admin):** Settings → Custom Agents → Add agent. Name `no-todo`, prompt "Flag any new TODO comment", severity `critical`, enforcement **blocking**, scope **All repositories**. Save. Reload as a non-admin member → fields are read-only.
 2. **Advisory run:** set the agent to **advisory**, open a PR that adds a `// TODO`. The review surfaces a finding from `no-todo`; the check still passes / score is normal.

--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -1618,6 +1618,62 @@ describe('runReviewPipeline', () => {
     expect(result.findings[0].title).toBe('Legacy untagged');
   });
 
+  it('#385 — a custom-agent finding survives even when the orchestrator drops it', async () => {
+    const todoAgent = { name: 'no-todo', prompt: 'Flag any new TODO comment', severityDefault: 'critical' as const, enabled: true };
+    const customResponse = validFindingsJson([
+      { file: 'foo.ts', line: 3, severity: 'critical', title: 'New TODO comment added', confidence: 95 },
+    ]);
+    // Orchestrator returns ZERO findings — simulating its anti-pedantry pass
+    // eating the org agent's TODO finding (fixtures#515).
+    const orchestrator = JSON.stringify({ findings: [], mergeScore: 5, mergeScoreReason: 'Clean.' });
+    const llm = createMockLLM([
+      JSON.stringify({ findings: [] }), JSON.stringify({ findings: [] }), JSON.stringify({ findings: [] }),
+      JSON.stringify({ findings: [] }), JSON.stringify({ findings: [] }), JSON.stringify({ findings: [] }),
+      JSON.stringify({ summary: 'Adds code.' }), '%% overview\nflowchart TD\n  A-->B',
+      customResponse, orchestrator,
+    ]);
+    const result = await runReviewPipeline(
+      { diff: sampleDiff, context: sampleContext, modelId: 'heavy', lightModelId: 'light', maxFindings: 25, enabledAgents: allAgentsEnabled, customAgents: [todoAgent] },
+      { llm },
+    );
+
+    const todo = result.findings.find((f) => f.title === 'New TODO comment added');
+    expect(todo).toBeDefined();
+    expect(todo!.category).toBe('no-todo');
+    // No verification tag (never subjected to W2) → counts as blocking-capable.
+    expect(todo!.verification).toBeUndefined();
+  });
+
+  it('#385 — a custom-agent finding at a location already surfaced by a kept builtin finding is skipped', async () => {
+    const todoAgent = { name: 'no-todo', prompt: 'Flag any new TODO comment', severityDefault: 'warning' as const, enabled: true };
+    const securityFinding = validFindingsJson([{ file: 'foo.ts', line: 3, severity: 'warning', title: 'Builtin issue', confidence: 90 }]);
+    const customResponse = validFindingsJson([
+      { file: 'foo.ts', line: 3, severity: 'warning', title: 'Custom at same line', confidence: 95 },
+    ]);
+    const orchestrator = JSON.stringify({
+      findings: [
+        { file: 'foo.ts', line: 3, severity: 'warning', confidence: 90, category: 'security', title: 'Builtin issue', description: '', suggestion: '' },
+      ],
+      mergeScore: 3, mergeScoreReason: 'Has warnings.',
+    });
+    const llm = createMockLLM([
+      securityFinding, JSON.stringify({ findings: [] }), JSON.stringify({ findings: [] }),
+      JSON.stringify({ findings: [] }), JSON.stringify({ findings: [] }), JSON.stringify({ findings: [] }),
+      JSON.stringify({ summary: 'Adds code.' }), '%% overview\nflowchart TD\n  A-->B',
+      customResponse, orchestrator,
+    ]);
+    const result = await runReviewPipeline(
+      { diff: sampleDiff, context: sampleContext, modelId: 'heavy', lightModelId: 'light', maxFindings: 25, enabledAgents: allAgentsEnabled, customAgents: [todoAgent] },
+      { llm },
+    );
+
+    const atLine = result.findings.filter((f) => f.file === 'foo.ts' && f.line === 3);
+    expect(atLine).toHaveLength(1);
+    expect(atLine[0].title).toBe('Builtin issue');
+    // The skipped custom duplicate rolls into suppressedCount.
+    expect(result.suppressedCount).toBeGreaterThanOrEqual(1);
+  });
+
   it('#382 — counts agent-response parse failures in parseFailureCount', async () => {
     const bugFinding = validFindingsJson([{ file: 'foo.ts', line: 3, severity: 'warning', title: 'Real bug', confidence: 90 }]);
     const summary = JSON.stringify({ summary: 'Refactor.' });
@@ -2180,11 +2236,24 @@ describe('verifyFindings', () => {
   };
   const fileContents = { 'src/rag.ts': 'return await searchViaPostgres(q);\n' };
 
-  it('drops a critical the model judges invalid', async () => {
+  it('#385 — a refuted critical is DEMOTED to unverified, never dropped', async () => {
+    // The verifier runs on the light model and can refute a true critical
+    // with a confident misread (fixtures#495: false 5/5 on real SQLi). A
+    // wrongly demoted advisory is visible noise; a falsely refuted critical
+    // is an invisible approval.
     const llm = createMockLLM([
       '{"valid": false, "confidence": 0.95, "reason": "line 1 already awaits searchViaPostgres"}',
     ]);
     const result = await verifyFindings([critical], fileContents, 'light', llm);
+    expect(result).toEqual([{ ...critical, verification: 'unverified' }]);
+  });
+
+  it('#385 — a refuted WARNING is still dropped (drop authority below critical is unchanged)', async () => {
+    const warning = { ...critical, severity: 'warning' as const };
+    const llm = createMockLLM([
+      '{"valid": false, "confidence": 0.95, "reason": "line 1 already awaits searchViaPostgres"}',
+    ]);
+    const result = await verifyFindings([warning], fileContents, 'light', llm);
     expect(result).toEqual([]);
   });
 
@@ -2496,15 +2565,16 @@ describe('verifyFindings', () => {
       expect(fpKIdx).toBeLessThan(priorIdx);
     });
 
-    it('still drops the finding when the model returns valid:false citing the FP-K reason', async () => {
+    it('honours a valid:false FP-K verdict — the critical demotes to unverified (#385)', async () => {
       // End-to-end smoke: prompt instructs, model decides. We control the model
       // decision via the mock; this asserts the verifier honours an
       // abstraction-safe verdict identically to any other valid:false verdict.
+      // #385: on a CRITICAL the honoured verdict now demotes instead of drops.
       const llm = createMockLLM([
         '{"valid": false, "confidence": 0.92, "reason": "abstraction-safe — Drizzle eq() parameterizes the value"}',
       ]);
       const result = await verifyFindings([finding], fileContents, 'light', llm);
-      expect(result).toEqual([]);
+      expect(result).toEqual([{ ...finding, verification: 'unverified' }]);
     });
 
     it('still KEEPS the finding when the model returns valid:true (regression: FP-K must not over-suppress)', async () => {
@@ -3223,12 +3293,15 @@ describe('verifyFindings — intent-claim guard (#372)', () => {
     expect(result[0].verification).toBe('unverified');
   });
 
-  it('still drops a technically-dismissed finding (no regression on real FP removal)', async () => {
+  it('honours a technical (non-intent) dismissal — the critical demotes to unverified (#385)', async () => {
+    // Pre-#385 this dropped outright; the guard distinction still holds:
+    // a technical dismissal is honoured (demotion), an intent-shaped one
+    // is refused. Warnings keep full drop authority (see verifyFindings tests).
     const llm = createMockLLM([
       '{"valid": false, "reason": "The query goes through a parameterized prepared statement two lines up."}',
     ]);
     const result = await verifyFindings([critical], fileContents, 'light', llm);
-    expect(result).toEqual([]);
+    expect(result).toEqual([{ ...critical, verification: 'unverified' }]);
   });
 });
 

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -1872,6 +1872,25 @@ ${content}`;
             );
             return { keep: true, verification: 'unverified' };
           }
+          // #385 — a refuted CRITICAL demotes to advisory, never deletes.
+          // The verifier runs on the light model and can refute a true
+          // critical with a confident misread (fixtures#495: saw `$n`
+          // placeholder tokens, missed that db.query takes no values
+          // array → false 5/5 on real SQLi). Risk asymmetry: a wrongly
+          // demoted advisory is visible noise; a falsely refuted critical
+          // is an invisible approval. Warnings/info keep full drop
+          // authority; deterministic kills (FP-I L2 above, FP-K,
+          // grounding) are unchanged.
+          if (f.severity === 'critical') {
+            console.warn(
+              '[finding-verify] refuted critical "%s" (%s:%d) demoted to unverified (not dropped): %s',
+              f.title,
+              f.file,
+              f.line,
+              (parsed.reason ?? '').slice(0, 200),
+            );
+            return { keep: true, verification: 'unverified' };
+          }
           console.warn(
             '[finding-verify] dropped false-positive %s "%s" (%s:%d): %s',
             f.severity,
@@ -2365,12 +2384,25 @@ export async function runReviewPipeline(
   // suppression.
   const totalRawFindings = taggedFindings.reduce((sum, t) => sum + (t.findings?.length ?? 0), 0);
 
+  // #385 — custom/org-agent findings are user-legislated policy, so they are
+  // routed AROUND every model-taste layer: the orchestrator (whose
+  // anti-pedantry rule classified a blocking org agent's "new TODO" findings
+  // as pedantry — fixtures#515 — which also meant the #235 blocking gate
+  // could never fire), the W2 verifier's drop authority, FP-A, and the
+  // grounding/line-proximity geometry. They re-enter deterministically just
+  // before W3 triage below — the one legitimate filter, because triage is
+  // user action, not model opinion.
+  const customCategorySet = new Set(enabledCustomAgents.map((a) => a.name));
+  const builtinTagged = taggedFindings.filter((t) => !customCategorySet.has(t.category));
+
   // FP-C — pre-orchestrator same-`(file, line)` cross-agent dedup. Merges
   // exact-line doubles BEFORE the orchestrator's LLM call sees them so the
   // prompt is shorter AND we don't rely on the model to spot identical-
   // location duplicates. Wider line-region clustering is W10's job and runs
-  // POST-orchestrator on the final finding set.
-  const fpCResult = dedupeCrossAgentByLine(taggedFindings);
+  // POST-orchestrator on the final finding set. Custom-agent findings are
+  // excluded (#385): an fp-c merge into a builtin finding would re-expose
+  // them to the orchestrator's drop authority.
+  const fpCResult = dedupeCrossAgentByLine(builtinTagged);
   if (fpCResult.dedupedCount > 0) {
     console.warn(
       '[fp-c] merged %d cross-agent finding%s at the same (file, line)',
@@ -2526,12 +2558,39 @@ export async function runReviewPipeline(
     groundingFileContents,
   );
 
+  // #385 — re-enter the custom/org-agent findings (partitioned out before
+  // fp-c above). Deterministic dedup only: one entry per (agent, file, line),
+  // and a location already surfaced by a kept builtin finding is skipped
+  // (fp-c precedent — the skip rolls into `suppressedCount`). Everything the
+  // model layers could have done to them is bypassed by design.
+  const seenCustomKeys = new Set<string>();
+  const customFindings = customTagged
+    .flatMap((t) => (t.findings ?? []).map((f) => ({ ...f, category: t.category } as OrchestratedFinding)))
+    .filter((f) => {
+      const key = `${f.category}|${f.file}|${f.line}`;
+      if (seenCustomKeys.has(key)) return false;
+      seenCustomKeys.add(key);
+      return !onChangedLines.some((k) => k.file === f.file && k.line === f.line);
+    });
+  if (customFindings.length > 0) {
+    console.log(
+      '[org-agents] %d custom-agent finding%s bypass model filtering (#385)',
+      customFindings.length,
+      customFindings.length === 1 ? '' : 's',
+    );
+  }
+  const preTriageFindings = [
+    ...onChangedLines,
+    ...withCodeFingerprints(customFindings, groundingFileContents),
+  ];
+
   // W3 convergence guard: drop findings the author already rebutted/deferred
   // in a prior `## mergewatch triage` reply (keyed via the W9 stable
   // identity, so the suppression only sticks while the cited code is
-  // unchanged — edit the code and it correctly resurfaces).
+  // unchanged — edit the code and it correctly resurfaces). Applies to
+  // custom-agent findings too — triage is user action, not model taste.
   const { kept: filteredFindings, suppressed: triageSuppressed } = partitionDisputed(
-    onChangedLines,
+    preTriageFindings,
     disputedKeys,
   );
   for (const f of triageSuppressed) {


### PR DESCRIPTION
## What

Closes the two suppression paths #382 didn't cover, per the RCA on #385:

**1. Custom/org-agent findings are now model-taste-exempt (`fixtures#515`).** They were entering the orchestrator tagged `category: <agent name>` with no exemption, and its anti-pedantry rule ate the blocking org agent's TODO findings — which also made the #235 blocking gate unreachable (it reads post-filter findings). Custom findings are now partitioned out before FP-C and re-enter deterministically just before W3 triage, bypassing the orchestrator, the W2 verifier's drop authority, FP-A, grounding/line-proximity, and W10/W11. Triage still applies — it's user action, not model opinion. Dedup: one entry per (agent, file, line); a location already surfaced by a kept builtin finding is skipped and rolls into `suppressedCount`.

**2. A refuted critical demotes, never deletes (`fixtures#495`).** The verifier runs on the light model and refuted a *true* SQLi with a confident misread (saw `$n` placeholder tokens; missed that `db.query(sql)` takes no values argument) — `keep: false` turned that into a false 5/5. A `valid: false` verdict on a `severity: critical` finding now converts it to `verification: 'unverified'` (advisory under "Unverified concerns", W7-clamped score). Warnings/info keep full drop authority; deterministic kills (FP-I L2, FP-K, grounding) are unchanged, so 54a–c stay clean.

## Tests

- Pipeline: a custom-agent finding survives an orchestrator that returns zero findings (category preserved, no verification tag → blocking-capable); a custom finding at a location already surfaced by a kept builtin finding is skipped and counted as suppressed.
- `verifyFindings`: refuted critical → demoted to `unverified`; refuted warning → still dropped; FP-K and intent-guard tests updated to the demotion contract (verdict-honoring semantics unchanged).
- Full workspace `build` / `typecheck` / `test` green (core: 901 passed).

## Docs

RUNBOOK: E2E-22 and E2E-54 rewritten to the demotion contract; E2E-29 gains the false-refutation failure mode ("5/5 all-clear whose summary describes a critical is a failure, never a pass"); E2E-68 states the seeded-run guarantee (findings vanishing with the row seeded = product regression).

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)