### PR TITLE
fix(core): detect and self-heal truncated LLM responses

### DIFF
--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -169,10 +169,51 @@ describe('runSecurityAgent', () => {
     expect(findings[0].title).toBe('Stub');
   });
 
-  it('#382 — a truncated findings object still falls back to empty (no crash)', async () => {
+  it('#382 — a response truncated inside its FIRST element still falls back to empty (never "repaired" into a silent empty result)', async () => {
     const llm = createMockLLM(['{\n  "findings": [\n    { "file": "src/x.ts", "line": 4, "severity": "critical", "title": "Convention violation:']);
     const findings = await runSecurityAgent(sampleDiff, sampleContext, 'model-1', llm);
     expect(findings).toEqual([]);
+  });
+
+  it('json-repair — a response truncated after a complete element recovers the leading findings', async () => {
+    const complete = '{ "file": "a.ts", "line": 2, "severity": "critical", "confidence": 95, "title": "Real issue", "description": "d", "suggestion": "s" }';
+    const llm = createMockLLM([`{\n  "findings": [\n    ${complete},\n    { "file": "b.ts", "line": 9, "sev`]);
+    const findings = await runSecurityAgent(sampleDiff, sampleContext, 'model-1', llm);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].title).toBe('Real issue');
+  });
+
+  it('truncation retry — a stopReason max_tokens response is retried once with a raised cap', async () => {
+    const truncated = '{ "findings": [ { "file": "foo.ts", "line": 3, "severity": "critical", "title": "Cut';
+    const full = validFindingsJson([{ file: 'foo.ts', line: 3, severity: 'critical', title: 'Recovered on retry', confidence: 95 }]);
+    const calls: Array<{ prompt: string; maxTokens?: number }> = [];
+    let call = 0;
+    const inner: ILLMProvider = {
+      async invoke(_m, prompt, maxTokens) {
+        calls.push({ prompt, maxTokens });
+        call++;
+        // Call 1: security agent, truncated at the cap. Call 2: its retry
+        // (identical prompt), full response. Call 3: the orchestrator.
+        if (call === 1) return { text: truncated, stopReason: 'max_tokens' };
+        if (prompt === calls[0].prompt) return { text: full, stopReason: 'end_turn' };
+        return JSON.stringify({
+          findings: [{ file: 'foo.ts', line: 3, severity: 'critical', confidence: 95, category: 'security', title: 'Recovered on retry', description: '', suggestion: '' }],
+          mergeScore: 2, mergeScoreReason: 'Critical present.',
+        });
+      },
+    };
+    const result = await runReviewPipeline(
+      { diff: sampleDiff, context: sampleContext, modelId: 'heavy', lightModelId: 'light', maxFindings: 25, enabledAgents: { security: true, bugs: false, style: false, summary: false, diagram: false, errorHandling: false, testCoverage: false, commentAccuracy: false } },
+      { llm: inner },
+    );
+
+    // Retry happened: same prompt sent twice, second time with a raised cap.
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+    expect(calls[1].prompt).toBe(calls[0].prompt);
+    expect(calls[1].maxTokens).toBe(8192);
+    const titles = result.findings.map((f) => f.title);
+    expect(titles).toContain('Recovered on retry');
+    expect(result.parseFailureCount).toBe(0);
   });
 
   it('injects conventions into the prompt when provided', async () => {

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -260,12 +260,58 @@ function extractJsonObjects(text: string): string[] {
 }
 
 /**
+ * Last-resort repair candidates for a JSON object truncated mid-generation
+ * (stopReason max_tokens whose retry also truncated, or a hard stop). Walks
+ * the text string/escape-aware, recording every position where a NESTED
+ * structure closes cleanly; each candidate is the text cut at such a close
+ * plus the closers the open-bracket stack still needs. Cutting only at
+ * completed-element boundaries is load-bearing: a response truncated inside
+ * its FIRST element yields no candidates at all — it must surface as a parse
+ * failure (disclosure / fail-loud), never be "repaired" into a silently
+ * empty result.
+ */
+function repairTruncatedJson(text: string): string[] {
+  const start = text.indexOf('{');
+  if (start === -1) return [];
+  const stack: string[] = [];
+  let inString = false;
+  let escaped = false;
+  const closeSnapshots: Array<{ pos: number; closers: string }> = [];
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === '\\') escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') { inString = true; continue; }
+    if (ch === '{') stack.push('}');
+    else if (ch === '[') stack.push(']');
+    else if (ch === '}' || ch === ']') {
+      if (stack.length === 0) break;
+      stack.pop();
+      if (stack.length === 0) return []; // top-level object completed — not truncated
+      closeSnapshots.push({ pos: i, closers: stack.slice().reverse().join('') });
+    }
+  }
+  const candidates: string[] = [];
+  for (let k = closeSnapshots.length - 1; k >= 0 && candidates.length < 5; k--) {
+    const { pos, closers } = closeSnapshots[k];
+    candidates.push(text.slice(start, pos + 1) + closers);
+  }
+  return candidates;
+}
+
+/**
  * Parse JSON from a model response, or null if nothing usable parses.
  * The model may wrap JSON in markdown code fences, prefix it with prose, or
  * (#382) emit multiple objects — e.g. answering the file-fetch protocol with
  * `{"requestFiles": []}` before the findings object. When `requiredKey` is
  * given, only an object containing that key is accepted, so a protocol or
- * preamble object can never shadow the real payload.
+ * preamble object can never shadow the real payload. A truncated response is
+ * repaired as a last resort (see repairTruncatedJson) — recovering the
+ * complete leading elements rather than losing the whole payload.
  */
 function tryParseJson<T>(raw: string, requiredKey?: string): T | null {
   let cleaned = raw.trim();
@@ -284,6 +330,19 @@ function tryParseJson<T>(raw: string, requiredKey?: string): T | null {
       const parsed = JSON.parse(candidate) as T;
       if (hasKey(parsed)) return parsed;
     } catch { /* try the next candidate */ }
+  }
+  for (const repaired of repairTruncatedJson(cleaned)) {
+    try {
+      const parsed = JSON.parse(repaired) as T;
+      if (hasKey(parsed)) {
+        console.warn(
+          '[json-repair] recovered a truncated JSON response (%d of %d chars kept) — the trailing partial element was dropped',
+          repaired.length,
+          cleaned.length,
+        );
+        return parsed;
+      }
+    } catch { /* try an earlier cut */ }
   }
   return null;
 }
@@ -2294,9 +2353,25 @@ export async function runReviewPipeline(
   // (otherwise lowering the floor below 75 would be inert). No-op at the
   // default. Applied at this choke point so every agent prompt gets it
   // without threading the value through each builder.
-  const llm: ILLMProvider = minConfidence !== CONFIDENCE_FLOOR
+  const floorLlm: ILLMProvider = minConfidence !== CONFIDENCE_FLOOR
     ? { invoke: (m, p, t, s) => cappedLlm.invoke(m, applyConfidenceFloor(p, minConfidence), t, s) }
     : cappedLlm;
+  // Truncation auto-retry: `stopReason === 'max_tokens'` means the response
+  // was cut off at the output cap — the tail (usually the back half of a
+  // findings JSON) was never generated, and no parser can recover it. Retry
+  // once with a doubled cap; if the retry truncates too, downstream handles
+  // it (JSON repair → parse-failure disclosure → fail-loud orchestrator).
+  // This is the detection #382 could not do: providers previously discarded
+  // stop_reason entirely.
+  const llm: ILLMProvider = {
+    invoke: async (m, p, t, s) => {
+      const first = await floorLlm.invoke(m, p, t, s);
+      if (normalizeLLMResult(first).stopReason !== 'max_tokens') return first;
+      const retryCap = Math.min(2 * (t ?? maxTokensPerAgent ?? 4096), 16384);
+      console.warn('[llm] response truncated at the output cap — retrying once with maxTokens %d', retryCap);
+      return floorLlm.invoke(m, p, retryCap, s);
+    },
+  };
 
   // Extract the changed-file set once, up front. Used for:
   //   - FP-D diagram path validation (passed into runDiagramAgent below).

--- a/packages/core/src/llm/token-accumulator.test.ts
+++ b/packages/core/src/llm/token-accumulator.test.ts
@@ -86,14 +86,17 @@ describe('TokenAccumulator', () => {
 });
 
 describe('TrackingLLMProvider', () => {
-  it('wraps inner provider and returns text string', async () => {
+  it('wraps inner provider and returns the full result (stopReason survives the wrapper)', async () => {
     const inner: ILLMProvider = {
-      invoke: async () => ({ text: 'hello', usage: { inputTokens: 10, outputTokens: 5 } }),
+      invoke: async () => ({ text: 'hello', usage: { inputTokens: 10, outputTokens: 5 }, stopReason: 'max_tokens' }),
     };
     const acc = new TokenAccumulator();
     const tracking = new TrackingLLMProvider(inner, acc);
     const result = await tracking.invoke('model', 'prompt');
-    expect(result).toBe('hello');
+    expect(result.text).toBe('hello');
+    // The truncation retry in runReviewPipeline depends on this field
+    // surviving the wrapper — it used to be stripped here.
+    expect(result.stopReason).toBe('max_tokens');
   });
 
   it('accumulates usage from LLMInvokeResult', async () => {
@@ -114,7 +117,7 @@ describe('TrackingLLMProvider', () => {
     const acc = new TokenAccumulator();
     const tracking = new TrackingLLMProvider(inner, acc);
     const result = await tracking.invoke('model-x', 'prompt');
-    expect(result).toBe('plain string');
+    expect(result.text).toBe('plain string');
     expect(acc.totalInputTokens).toBe(0);
     expect(acc.totalOutputTokens).toBe(0);
   });

--- a/packages/core/src/llm/token-accumulator.ts
+++ b/packages/core/src/llm/token-accumulator.ts
@@ -73,7 +73,7 @@ export class TokenAccumulator {
 
 /**
  * Wraps an ILLMProvider to transparently track token usage.
- * Returns the text string from invoke() so callers are unaffected,
+ * Returns the full LLMInvokeResult from invoke() (callers normalize),
  * while accumulating usage in the provided TokenAccumulator.
  */
 export class TrackingLLMProvider implements ILLMProvider {
@@ -92,10 +92,14 @@ export class TrackingLLMProvider implements ILLMProvider {
     prompt: string,
     maxTokens?: number,
     sampling?: LLMSamplingConfig,
-  ): Promise<string> {
+  ): Promise<LLMInvokeResult> {
     const raw = await this.inner.invoke(modelId, prompt, maxTokens, sampling);
     const result = normalizeLLMResult(raw);
     this.accumulator.add(modelId, result.usage);
-    return result.text;
+    // Return the full result (not just text) so `stopReason` survives the
+    // wrapper — the pipeline's truncation retry depends on seeing it. All
+    // callers normalize via normalizeLLMResult, so strings-only consumers
+    // are unaffected.
+    return result;
   }
 }

--- a/packages/core/src/llm/types.ts
+++ b/packages/core/src/llm/types.ts
@@ -18,6 +18,15 @@ export interface TokenUsage {
 export interface LLMInvokeResult {
   text: string;
   usage?: TokenUsage;
+  /**
+   * Why generation stopped, normalized to Anthropic vocabulary where the
+   * provider uses different names ('length' → 'max_tokens'). 'max_tokens'
+   * means the response was TRUNCATED at the output cap — the tail was never
+   * generated, so downstream JSON parsing cannot succeed and the pipeline
+   * retries once with a doubled cap. Absent on providers/paths that don't
+   * surface it (legacy behavior: truncation is undetectable).
+   */
+  stopReason?: string;
 }
 
 /**

--- a/packages/llm-anthropic/src/anthropic-provider.test.ts
+++ b/packages/llm-anthropic/src/anthropic-provider.test.ts
@@ -32,6 +32,17 @@ describe('AnthropicLLMProvider', () => {
     });
   });
 
+  it('surfaces stop_reason as stopReason (truncation detection)', async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: 'text', text: 'cut off mid-JSON' }],
+      usage: { input_tokens: 10, output_tokens: 4096 },
+      stop_reason: 'max_tokens',
+    });
+    const provider = new AnthropicLLMProvider('test-api-key');
+    const result = await provider.invoke('claude-sonnet-4-20250514', 'hello');
+    expect((result as { stopReason?: string }).stopReason).toBe('max_tokens');
+  });
+
   it('returns text from first content block', async () => {
     mockCreate.mockResolvedValueOnce({
       content: [{ type: 'text', text: 'The answer is 42' }],

--- a/packages/llm-anthropic/src/anthropic-provider.ts
+++ b/packages/llm-anthropic/src/anthropic-provider.ts
@@ -32,6 +32,7 @@ export class AnthropicLLMProvider implements ILLMProvider {
         inputTokens: response.usage.input_tokens,
         outputTokens: response.usage.output_tokens,
       },
+      stopReason: response.stop_reason ?? undefined,
     };
   }
 }

--- a/packages/llm-bedrock/src/bedrock-provider.test.ts
+++ b/packages/llm-bedrock/src/bedrock-provider.test.ts
@@ -107,6 +107,28 @@ describe('BedrockLLMProvider', () => {
     expect(result.usage).toBeUndefined();
   });
 
+  it('surfaces Anthropic stop_reason as stopReason (truncation detection)', async () => {
+    mockSend.mockResolvedValueOnce(makeResponse({
+      content: [{ type: 'text', text: 'cut off mid-JSON' }],
+      usage: { input_tokens: 100, output_tokens: 4096 },
+      stop_reason: 'max_tokens',
+    }));
+
+    const provider = new BedrockLLMProvider();
+    const result = await provider.invoke('us.anthropic.claude-opus-4-6-v1', 'prompt');
+    expect(result.stopReason).toBe('max_tokens');
+  });
+
+  it("normalizes Titan completionReason 'LENGTH' to stopReason 'max_tokens'", async () => {
+    mockSend.mockResolvedValueOnce(makeResponse({
+      results: [{ outputText: 'cut off', completionReason: 'LENGTH' }],
+    }));
+
+    const provider = new BedrockLLMProvider();
+    const result = await provider.invoke('amazon.titan-text-express-v1', 'prompt');
+    expect(result.stopReason).toBe('max_tokens');
+  });
+
   it('uses default maxTokens of 4096', async () => {
     mockSend.mockResolvedValueOnce(makeResponse({
       content: [{ type: 'text', text: 'ok' }],

--- a/packages/llm-bedrock/src/bedrock-provider.ts
+++ b/packages/llm-bedrock/src/bedrock-provider.ts
@@ -142,6 +142,7 @@ function buildRequestBody(
 interface ParsedResponse {
   text: string;
   usage?: TokenUsage;
+  stopReason?: string;
 }
 
 function parseAnthropicResponse(raw: string): ParsedResponse {
@@ -150,12 +151,17 @@ function parseAnthropicResponse(raw: string): ParsedResponse {
   const usage: TokenUsage | undefined = parsed.usage
     ? { inputTokens: parsed.usage.input_tokens ?? 0, outputTokens: parsed.usage.output_tokens ?? 0 }
     : undefined;
-  return { text, usage };
+  return { text, usage, stopReason: parsed.stop_reason ?? undefined };
 }
 
 function parseTitanResponse(raw: string): ParsedResponse {
   const parsed = JSON.parse(raw);
-  return { text: parsed.results?.[0]?.outputText ?? '' };
+  const completionReason = parsed.results?.[0]?.completionReason;
+  return {
+    text: parsed.results?.[0]?.outputText ?? '',
+    // Titan says LENGTH where Anthropic says max_tokens — normalize.
+    stopReason: completionReason === 'LENGTH' ? 'max_tokens' : completionReason ?? undefined,
+  };
 }
 
 function parseResponse(modelId: string, raw: string): ParsedResponse {
@@ -204,7 +210,7 @@ export class BedrockLLMProvider implements ILLMProvider {
     const response = await this.sendWithSignatureRecovery(command);
     const rawResponse = new TextDecoder().decode(response.body);
     const parsed = parseResponse(modelId, rawResponse);
-    return { text: parsed.text, usage: parsed.usage };
+    return { text: parsed.text, usage: parsed.usage, stopReason: parsed.stopReason };
   }
 
   // Recover from SDK v3's poisoned systemClockOffset in long-lived warm Lambdas.

--- a/packages/llm-litellm/src/litellm-provider.test.ts
+++ b/packages/llm-litellm/src/litellm-provider.test.ts
@@ -18,6 +18,18 @@ describe('LiteLLMProvider', () => {
     vi.clearAllMocks();
   });
 
+  it("normalizes OpenAI finish_reason 'length' to stopReason 'max_tokens'", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        choices: [{ message: { content: 'cut off' }, finish_reason: 'length' }],
+        usage: { prompt_tokens: 1, completion_tokens: 4096 },
+      }),
+    );
+    const provider = new LiteLLMProvider('http://localhost:4000');
+    const result = await provider.invoke('gpt-4', 'prompt');
+    expect((result as { stopReason?: string }).stopReason).toBe('max_tokens');
+  });
+
   it('constructs correct URL from baseUrl + /chat/completions', async () => {
     mockFetch.mockResolvedValueOnce(
       jsonResponse({

--- a/packages/llm-litellm/src/litellm-provider.ts
+++ b/packages/llm-litellm/src/litellm-provider.ts
@@ -46,6 +46,8 @@ export class LiteLLMProvider implements ILLMProvider {
     const usage = data.usage
       ? { inputTokens: data.usage.prompt_tokens ?? 0, outputTokens: data.usage.completion_tokens ?? 0 }
       : undefined;
-    return { text, usage };
+    // OpenAI vocab says 'length' where Anthropic says 'max_tokens' — normalize.
+    const finishReason = data.choices[0].finish_reason;
+    return { text, usage, stopReason: finishReason === 'length' ? 'max_tokens' : finishReason ?? undefined };
   }
 }

--- a/packages/llm-litellm/src/litellm-provider.ts
+++ b/packages/llm-litellm/src/litellm-provider.ts
@@ -47,7 +47,8 @@ export class LiteLLMProvider implements ILLMProvider {
       ? { inputTokens: data.usage.prompt_tokens ?? 0, outputTokens: data.usage.completion_tokens ?? 0 }
       : undefined;
     // OpenAI vocab says 'length' where Anthropic says 'max_tokens' — normalize.
-    const finishReason = data.choices[0].finish_reason;
+    // Optional-chained: some LiteLLM upstreams omit finish_reason entirely.
+    const finishReason = data.choices?.[0]?.finish_reason;
     return { text, usage, stopReason: finishReason === 'length' ? 'max_tokens' : finishReason ?? undefined };
   }
 }

--- a/packages/llm-litellm/src/litellm-provider.ts
+++ b/packages/llm-litellm/src/litellm-provider.ts
@@ -42,13 +42,16 @@ export class LiteLLMProvider implements ILLMProvider {
     }
 
     const data = await response.json() as any;
-    const text = data.choices[0].message.content;
+    // Optional-chained throughout: a misbehaving LiteLLM upstream can return
+    // an empty choices array or omit fields; an empty text degrades into the
+    // pipeline's parse-failure disclosure instead of crashing the review.
+    const choice = data.choices?.[0];
+    const text = choice?.message?.content ?? '';
     const usage = data.usage
       ? { inputTokens: data.usage.prompt_tokens ?? 0, outputTokens: data.usage.completion_tokens ?? 0 }
       : undefined;
     // OpenAI vocab says 'length' where Anthropic says 'max_tokens' — normalize.
-    // Optional-chained: some LiteLLM upstreams omit finish_reason entirely.
-    const finishReason = data.choices?.[0]?.finish_reason;
+    const finishReason = choice?.finish_reason;
     return { text, usage, stopReason: finishReason === 'length' ? 'max_tokens' : finishReason ?? undefined };
   }
 }

--- a/packages/llm-ollama/src/ollama-provider.test.ts
+++ b/packages/llm-ollama/src/ollama-provider.test.ts
@@ -18,6 +18,20 @@ describe('OllamaLLMProvider', () => {
     vi.clearAllMocks();
   });
 
+  it("normalizes done_reason 'length' to stopReason 'max_tokens'", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        message: { content: 'cut off' },
+        done_reason: 'length',
+        prompt_eval_count: 10,
+        eval_count: 4096,
+      }),
+    );
+    const provider = new OllamaLLMProvider('http://myhost:11434');
+    const result = await provider.invoke('llama3', 'prompt');
+    expect((result as { stopReason?: string }).stopReason).toBe('max_tokens');
+  });
+
   it('constructs correct URL: {baseUrl}/api/chat', async () => {
     mockFetch.mockResolvedValueOnce(
       jsonResponse({

--- a/packages/llm-ollama/src/ollama-provider.ts
+++ b/packages/llm-ollama/src/ollama-provider.ts
@@ -37,6 +37,7 @@ export class OllamaLLMProvider implements ILLMProvider {
     const usage = (data.prompt_eval_count != null || data.eval_count != null)
       ? { inputTokens: data.prompt_eval_count ?? 0, outputTokens: data.eval_count ?? 0 }
       : undefined;
-    return { text, usage };
+    // Ollama says 'length' where Anthropic says 'max_tokens' — normalize.
+    return { text, usage, stopReason: data.done_reason === 'length' ? 'max_tokens' : data.done_reason ?? undefined };
   }
 }


### PR DESCRIPTION
Reopened continuation of #389 (auto-closed by the stacked-base deletion when #388 merged — same branch, rebased onto main; all three commits and both review rounds' fixes included, final verdict there was 5/5).

## What

Eliminates the main surviving cause of agent-response parse failures: truncation at the output cap, previously **undetectable** because all four providers discarded the API's stop reason.

1. **`stopReason` on `LLMInvokeResult`** — surfaced by all four providers, normalized to Anthropic vocabulary (`length`/`LENGTH` → `max_tokens`); `TrackingLLMProvider` now returns the full result instead of stripping it to text.
2. **Truncation auto-retry** at the pipeline's LLM choke point — `max_tokens` responses retry once with a doubled cap (bounded at 16384).
3. **`repairTruncatedJson`** last resort in `tryParseJson` — recovers complete leading elements; deliberately yields nothing when truncation hit the first element (that must stay a disclosed parse failure, never a silent empty result).

Plus the review-round hardening: the LiteLLM provider's whole `choices[0]` access path is optional-chained, so a malformed upstream response degrades into the disclosed parse-failure path instead of crashing the review.

## Tests

Pipeline retry (same prompt, cap 8192, finding survives, parseFailureCount 0); repair recovery + first-element guard; stop-reason mapping tests for all four providers; tracking-wrapper passthrough. Full workspace gates green.

Part of the #385 follow-up; categorical fix tracked in #390.

🤖 Generated with [Claude Code](https://claude.com/claude-code)