### PR TITLE
feat(llm): implement structured outputs in all four providers (#390)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,7 +62,14 @@ All agent logic depends only on these interfaces. No package in `core/` imports 
 ```typescript
 // packages/core/src/llm/types.ts
 export interface ILLMProvider {
-  invoke(modelId: string, prompt: string, maxTokens?: number): Promise<string>;
+  invoke(modelId: string, prompt: string, maxTokens?: number, sampling?: LLMSamplingConfig): Promise<string | LLMInvokeResult>;
+  // #390 — optional schema-constrained invocation: the provider forces the
+  // model to emit an object matching the JSON Schema (forced tool use on
+  // Anthropic/Bedrock, response_format json_schema on OpenAI-compatible
+  // endpoints, `format` on Ollama). Providers that can't support it throw
+  // StructuredOutputUnsupportedError pre-network; the pipeline falls back
+  // to the hardened text parser.
+  invokeStructured?(modelId: string, prompt: string, schema: object, maxTokens?: number, sampling?: LLMSamplingConfig): Promise<LLMStructuredResult>;
 }
 ```
 

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -215,6 +215,7 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-86](#e2e-86-336--p95-duration-nearest-rank--minimum-sample) | Analytics p95 duration uses nearest-rank (`⌈n × 0.95⌉`, clamped) instead of returning the maximum for n ≤ 20; below 20 completed reviews the UI shows "—" with an explanatory tooltip and no P95 bar (#336) | 2m | 30s | #336 |
 | [E2E-87](#e2e-87-337--date-only-range-bounds-include-their-whole-day) | `/api/analytics` date-only `start_date`/`end_date` expand to the UTC day's edge instants at the boundary (`end_date=2026-08-16` includes the whole 16th); full timestamps pass through untouched; identical on both backends; UTC bucketing documented in the route (#337) | 2m | 30s | #337 |
 | [E2E-88](#e2e-88-355--pr-burst-resilience) | A PR burst never silently loses reviews: throttles park the review (`pending` + in_progress "rate limited" check, never terminal FAILURE) and admission control paces the backlog — SQS `MaximumConcurrency` on SaaS, Postgres `SKIP LOCKED` worker at `REVIEW_CONCURRENCY` on self-hosted; exhaustion lands in a DLQ/`status='dead'`, visibly (#355) | 20m | n/a | #355 |
+| [E2E-90](#e2e-90-390--structured-outputs-zero-parse-failures) | On a provider with structured-output support, a full-suite run produces ZERO "Could not parse agent JSON response" log lines and no "Unparsed agent output" disclosures; the text parser is exercised only on fallback paths (#390) | 2m | 60s | #390 |
 | [E2E-89](#e2e-89-372--intent-claims-never-suppress-findings) | In-code comments claiming a defect is intentional ("test-only", "simulates", "regression guard") never suppress a finding — agents still report, and an intent-shaped verifier dismissal is refused (kept as advisory `unverified`); the same intent declared in the conventions doc suppresses as before (#372) | 3m | 60s | #372 |
 
 ---
@@ -3098,6 +3099,28 @@ Branch: `fixture/85-time-ordered-reviews`. Seed one repo with reviews for PR num
 - [ ] Conventions-declared intent → suppressed as before (channel contrast)
 - [ ] Technical verifier dismissals unaffected
 - [ ] Intent-refusal shows the distinct log line and renders under "Unverified concerns"
+
+---
+
+### E2E-90: #390 — Structured outputs: zero parse failures
+
+**Status:** 🚧 In review (#390).
+
+**Behavior:** every findings-bearing LLM call (6 built-in agents, custom agents, orchestrator, W2 verifier) prefers `invokeStructured` — the provider forces the model to emit an object matching an explicit JSON Schema (forced tool use on Anthropic/Bedrock; `response_format: json_schema` on LiteLLM; `format` on Ollama). Free-text JSON parsing — and with it the entire #382 class of silent finding loss — happens only on fallback paths: providers without structured support (Bedrock Titan, older Ollama, LiteLLM upstreams that reject `response_format`) throw `StructuredOutputUnsupportedError` pre-network and drop to the hardened text parser (#383/#391). The agentic file-fetch protocol is a `requestFiles` field of the same schema, eliminating the bare-object ambiguity of #382 mode A.
+
+**How to run.** Any full-suite run on prod (Bedrock Anthropic models) after the #390 deploy.
+
+**Expected outcomes.**
+- [ ] Zero `Could not parse agent JSON response` lines in the agent logs across the whole run (CloudWatch filter on `/aws/lambda/mergewatch-review-agent-prod`)
+- [ ] Zero "⚠️ Unparsed agent output" disclosures in review comments
+- [ ] No `[structured] structured invocation failed` warnings (a few are tolerable — each one must show the text fallback recovering, not a lost review)
+- [ ] Findings quality unchanged or better vs. the previous run's healthy fixtures (03/20/32/39/54d/77a/80a/81 catch their baits)
+- [ ] Agentic file fetching still works: at least one fixture shows `Agent fetched N file(s)` with a structured provider
+
+**Failure modes.**
+- ❌ Any review that LOSES findings relative to text mode (schema over-constraining — check `required` fields vs. what the model emits)
+- ❌ `[structured]` fallback warnings on EVERY call (provider integration broken; the run silently became a text-mode run — quality identical but #390's guarantee is not exercised)
+- ❌ Throttle storms doubling: a parked review re-invoking structured AND text per agent (the throttle-rethrow guard regressed)
 
 ---
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,6 @@
 // ─── Interfaces ─────────────────────────────────────────────────────────────
-export type { ILLMProvider, TokenUsage, LLMInvokeResult, LLMSamplingConfig } from './llm/types.js';
-export { normalizeLLMResult } from './llm/types.js';
+export type { ILLMProvider, TokenUsage, LLMInvokeResult, LLMSamplingConfig, LLMStructuredResult } from './llm/types.js';
+export { normalizeLLMResult, StructuredOutputUnsupportedError } from './llm/types.js';
 export { TokenAccumulator, TrackingLLMProvider } from './llm/token-accumulator.js';
 export { estimateCost, DEFAULT_PRICING, parseEnvModelPricing } from './llm/pricing.js';
 export { isThrottleError } from './llm/throttle.js';

--- a/packages/llm-anthropic/src/anthropic-provider.test.ts
+++ b/packages/llm-anthropic/src/anthropic-provider.test.ts
@@ -43,6 +43,34 @@ describe('AnthropicLLMProvider', () => {
     expect((result as { stopReason?: string }).stopReason).toBe('max_tokens');
   });
 
+  it('#390 — invokeStructured forces the emit_result tool and returns its input', async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: 'tool_use', id: 't1', name: 'emit_result', input: { valid: false, reason: 'r' } }],
+      usage: { input_tokens: 5, output_tokens: 9 },
+      stop_reason: 'tool_use',
+    });
+    const provider = new AnthropicLLMProvider('test-api-key');
+    const schema = { type: 'object', properties: { valid: { type: 'boolean' } } };
+    const result = await provider.invokeStructured('claude-sonnet-4-20250514', 'verify', schema);
+
+    expect(result.object).toEqual({ valid: false, reason: 'r' });
+    expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({
+      tools: [expect.objectContaining({ name: 'emit_result', input_schema: schema })],
+      tool_choice: { type: 'tool', name: 'emit_result' },
+    }));
+  });
+
+  it('#390 — invokeStructured throws when the response has no tool_use block', async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: 'text', text: 'prose' }],
+      usage: { input_tokens: 5, output_tokens: 9 },
+      stop_reason: 'end_turn',
+    });
+    const provider = new AnthropicLLMProvider('test-api-key');
+    await expect(provider.invokeStructured('claude-sonnet-4-20250514', 'verify', {}))
+      .rejects.toThrow(/no tool_use block/);
+  });
+
   it('returns text from first content block', async () => {
     mockCreate.mockResolvedValueOnce({
       content: [{ type: 'text', text: 'The answer is 42' }],

--- a/packages/llm-anthropic/src/anthropic-provider.ts
+++ b/packages/llm-anthropic/src/anthropic-provider.ts
@@ -1,5 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk';
-import type { ILLMProvider, LLMInvokeResult, LLMSamplingConfig } from '@mergewatch/core';
+import type { ILLMProvider, LLMInvokeResult, LLMSamplingConfig, LLMStructuredResult } from '@mergewatch/core';
 
 export class AnthropicLLMProvider implements ILLMProvider {
   private client: Anthropic;
@@ -28,6 +28,44 @@ export class AnthropicLLMProvider implements ILLMProvider {
     }
     return {
       text: block.text,
+      usage: {
+        inputTokens: response.usage.input_tokens,
+        outputTokens: response.usage.output_tokens,
+      },
+      stopReason: response.stop_reason ?? undefined,
+    };
+  }
+
+  // #390 — schema-constrained invocation via forced tool use: the model MUST
+  // call the single tool, and the API validates/constrains its input against
+  // the JSON Schema — no free-text JSON to parse.
+  async invokeStructured(
+    modelId: string,
+    prompt: string,
+    schema: object,
+    maxTokens = 4096,
+    sampling: LLMSamplingConfig = {},
+  ): Promise<LLMStructuredResult> {
+    const response = await this.client.messages.create({
+      model: modelId,
+      max_tokens: maxTokens,
+      temperature: sampling.temperature ?? 0,
+      ...(sampling.topP !== undefined ? { top_p: sampling.topP } : {}),
+      ...(sampling.topK !== undefined ? { top_k: sampling.topK } : {}),
+      tools: [{
+        name: 'emit_result',
+        description: 'Emit the structured result of your analysis.',
+        input_schema: schema as Anthropic.Messages.Tool['input_schema'],
+      }],
+      tool_choice: { type: 'tool', name: 'emit_result' },
+      messages: [{ role: 'user', content: prompt }],
+    });
+    const block = response.content.find((b) => b.type === 'tool_use');
+    if (!block || block.type !== 'tool_use') {
+      throw new Error(`Structured invocation returned no tool_use block (stop_reason: ${response.stop_reason})`);
+    }
+    return {
+      object: block.input,
       usage: {
         inputTokens: response.usage.input_tokens,
         outputTokens: response.usage.output_tokens,

--- a/packages/llm-bedrock/src/bedrock-provider.test.ts
+++ b/packages/llm-bedrock/src/bedrock-provider.test.ts
@@ -155,6 +155,42 @@ describe('BedrockLLMProvider', () => {
     expect(body.max_tokens).toBe(8192);
   });
 
+  it('#390 — invokeStructured forces the emit_result tool and returns its input', async () => {
+    mockSend.mockResolvedValueOnce(makeResponse({
+      content: [{ type: 'tool_use', name: 'emit_result', input: { findings: [] } }],
+      usage: { input_tokens: 50, output_tokens: 20 },
+      stop_reason: 'tool_use',
+    }));
+
+    const provider = new BedrockLLMProvider();
+    const schema = { type: 'object', properties: { findings: { type: 'array' } } };
+    const result = await provider.invokeStructured('us.anthropic.claude-opus-4-6-v1', 'prompt', schema);
+
+    expect(result.object).toEqual({ findings: [] });
+    expect(result.stopReason).toBe('tool_use');
+    const body = getLastCommandBody();
+    expect(body.tools[0].name).toBe('emit_result');
+    expect(body.tools[0].input_schema).toEqual(schema);
+    expect(body.tool_choice).toEqual({ type: 'tool', name: 'emit_result' });
+  });
+
+  it('#390 — invokeStructured throws when no tool_use block came back', async () => {
+    mockSend.mockResolvedValueOnce(makeResponse({
+      content: [{ type: 'text', text: 'prose instead' }],
+      stop_reason: 'end_turn',
+    }));
+    const provider = new BedrockLLMProvider();
+    await expect(provider.invokeStructured('us.anthropic.claude-opus-4-6-v1', 'prompt', {}))
+      .rejects.toThrow(/no tool_use block/);
+  });
+
+  it('#390 — Titan throws StructuredOutputUnsupportedError before any network call', async () => {
+    const provider = new BedrockLLMProvider();
+    await expect(provider.invokeStructured('amazon.titan-text-express-v1', 'prompt', {}))
+      .rejects.toMatchObject({ name: 'StructuredOutputUnsupportedError' });
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
   it('has correct SUPPORTED_MODELS mapping', () => {
     expect(SUPPORTED_MODELS['claude-opus-4.6']).toBe('us.anthropic.claude-opus-4-6-v1');
     expect(SUPPORTED_MODELS['claude-sonnet-4']).toBe('us.anthropic.claude-sonnet-4-20250514-v1:0');

--- a/packages/llm-bedrock/src/bedrock-provider.ts
+++ b/packages/llm-bedrock/src/bedrock-provider.ts
@@ -16,7 +16,8 @@ import {
   BedrockRuntimeClient,
   InvokeModelCommand,
 } from '@aws-sdk/client-bedrock-runtime';
-import type { ILLMProvider, LLMInvokeResult, LLMSamplingConfig, TokenUsage } from '@mergewatch/core';
+import type { ILLMProvider, LLMInvokeResult, LLMSamplingConfig, LLMStructuredResult, TokenUsage } from '@mergewatch/core';
+import { StructuredOutputUnsupportedError } from '@mergewatch/core';
 
 // ─── Supported model IDs ───────────────────────────────────────────────────
 export const SUPPORTED_MODELS = {
@@ -82,6 +83,40 @@ function buildAnthropicBody(
     anthropic_version: 'bedrock-2023-05-31',
     max_tokens: maxTokens,
     messages: [{ role: 'user', content: prompt }],
+  };
+  if (acceptsSamplingParams(modelId)) {
+    body.temperature = sampling.temperature ?? 0;
+    if (sampling.topP !== undefined) body.top_p = sampling.topP;
+    if (sampling.topK !== undefined) body.top_k = sampling.topK;
+  }
+  return {
+    body: JSON.stringify(body),
+    contentType: 'application/json',
+    accept: 'application/json',
+  };
+}
+
+/**
+ * #390 — Anthropic-family body with a single forced tool: the model must call
+ * `emit_result` and the API constrains its input against the JSON Schema.
+ */
+function buildAnthropicStructuredBody(
+  prompt: string,
+  schema: object,
+  maxTokens: number,
+  sampling: LLMSamplingConfig,
+  modelId: string,
+): ModelRequestBody {
+  const body: Record<string, unknown> = {
+    anthropic_version: 'bedrock-2023-05-31',
+    max_tokens: maxTokens,
+    messages: [{ role: 'user', content: prompt }],
+    tools: [{
+      name: 'emit_result',
+      description: 'Emit the structured result of your analysis.',
+      input_schema: schema,
+    }],
+    tool_choice: { type: 'tool', name: 'emit_result' },
   };
   if (acceptsSamplingParams(modelId)) {
     body.temperature = sampling.temperature ?? 0;
@@ -211,6 +246,44 @@ export class BedrockLLMProvider implements ILLMProvider {
     const rawResponse = new TextDecoder().decode(response.body);
     const parsed = parseResponse(modelId, rawResponse);
     return { text: parsed.text, usage: parsed.usage, stopReason: parsed.stopReason };
+  }
+
+  // #390 — schema-constrained invocation via forced tool use. Only the
+  // Anthropic model family supports tools on Bedrock; Titan throws
+  // StructuredOutputUnsupportedError BEFORE any network call so the caller's
+  // text fallback costs nothing.
+  async invokeStructured(
+    modelId: string,
+    prompt: string,
+    schema: object,
+    maxTokens = 4096,
+    sampling: LLMSamplingConfig = {},
+  ): Promise<LLMStructuredResult> {
+    if (isTitanModel(modelId)) {
+      throw new StructuredOutputUnsupportedError(`Titan models have no tool support (${modelId})`);
+    }
+    const { body, contentType, accept } = buildAnthropicStructuredBody(prompt, schema, maxTokens, sampling, modelId);
+    const command = new InvokeModelCommand({
+      modelId,
+      body: new TextEncoder().encode(body),
+      contentType,
+      accept,
+    });
+    const response = await this.sendWithSignatureRecovery(command);
+    const parsed = JSON.parse(new TextDecoder().decode(response.body));
+    const block = Array.isArray(parsed.content)
+      ? parsed.content.find((b: { type?: string }) => b.type === 'tool_use')
+      : undefined;
+    if (!block) {
+      throw new Error(`Structured invocation returned no tool_use block (stop_reason: ${parsed.stop_reason})`);
+    }
+    return {
+      object: block.input,
+      usage: parsed.usage
+        ? { inputTokens: parsed.usage.input_tokens ?? 0, outputTokens: parsed.usage.output_tokens ?? 0 }
+        : undefined,
+      stopReason: parsed.stop_reason ?? undefined,
+    };
   }
 
   // Recover from SDK v3's poisoned systemClockOffset in long-lived warm Lambdas.

--- a/packages/llm-litellm/src/litellm-provider.test.ts
+++ b/packages/llm-litellm/src/litellm-provider.test.ts
@@ -30,6 +30,30 @@ describe('LiteLLMProvider', () => {
     expect((result as { stopReason?: string }).stopReason).toBe('max_tokens');
   });
 
+  it('#390 — invokeStructured sends response_format json_schema and parses the content object', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        choices: [{ message: { content: '{"findings": []}' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 3, completion_tokens: 4 },
+      }),
+    );
+    const provider = new LiteLLMProvider('http://localhost:4000');
+    const schema = { type: 'object', properties: { findings: { type: 'array' } } };
+    const result = await provider.invokeStructured('gpt-4', 'prompt', schema);
+
+    expect(result.object).toEqual({ findings: [] });
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.response_format).toEqual({ type: 'json_schema', json_schema: { name: 'result', schema, strict: false } });
+  });
+
+  it('#390 — invokeStructured throws when the upstream ignored response_format (prose content)', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ choices: [{ message: { content: 'I found no issues.' }, finish_reason: 'stop' }] }),
+    );
+    const provider = new LiteLLMProvider('http://localhost:4000');
+    await expect(provider.invokeStructured('gpt-4', 'prompt', {})).rejects.toThrow();
+  });
+
   it('constructs correct URL from baseUrl + /chat/completions', async () => {
     mockFetch.mockResolvedValueOnce(
       jsonResponse({

--- a/packages/llm-litellm/src/litellm-provider.ts
+++ b/packages/llm-litellm/src/litellm-provider.ts
@@ -1,4 +1,4 @@
-import type { ILLMProvider, LLMInvokeResult, LLMSamplingConfig } from '@mergewatch/core';
+import type { ILLMProvider, LLMInvokeResult, LLMSamplingConfig, LLMStructuredResult } from '@mergewatch/core';
 
 export class LiteLLMProvider implements ILLMProvider {
   constructor(
@@ -53,5 +53,52 @@ export class LiteLLMProvider implements ILLMProvider {
     // OpenAI vocab says 'length' where Anthropic says 'max_tokens' — normalize.
     const finishReason = choice?.finish_reason;
     return { text, usage, stopReason: finishReason === 'length' ? 'max_tokens' : finishReason ?? undefined };
+  }
+
+  // #390 — schema-constrained invocation via the OpenAI `response_format:
+  // json_schema` contract. `strict: false` because upstream support for the
+  // strict validator varies wildly across LiteLLM's 100+ providers; the
+  // format constraint alone eliminates prose-wrapped/multi-object responses.
+  // An upstream that rejects response_format entirely returns a 4xx, which
+  // throws here — the caller falls back to the hardened text path.
+  async invokeStructured(
+    modelId: string,
+    prompt: string,
+    schema: object,
+    maxTokens = 4096,
+    sampling: LLMSamplingConfig = {},
+  ): Promise<LLMStructuredResult> {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (this.apiKey) headers['Authorization'] = `Bearer ${this.apiKey}`;
+    const url = `${this.baseUrl.replace(/\/$/, '')}/chat/completions`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        model: modelId,
+        max_tokens: maxTokens,
+        temperature: sampling.temperature ?? 0,
+        ...(sampling.topP !== undefined ? { top_p: sampling.topP } : {}),
+        ...(sampling.topK !== undefined ? { top_k: sampling.topK } : {}),
+        response_format: { type: 'json_schema', json_schema: { name: 'result', schema, strict: false } },
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    });
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`LiteLLM structured request failed (${response.status}): ${body}`);
+    }
+    const data = await response.json() as any;
+    const choice = data.choices?.[0];
+    const content = choice?.message?.content ?? '';
+    // The format contract guarantees the content IS the object — a parse
+    // failure here means the upstream ignored response_format; throwing
+    // routes the caller to the text fallback.
+    const object = JSON.parse(content);
+    const usage = data.usage
+      ? { inputTokens: data.usage.prompt_tokens ?? 0, outputTokens: data.usage.completion_tokens ?? 0 }
+      : undefined;
+    const finishReason = choice?.finish_reason;
+    return { object, usage, stopReason: finishReason === 'length' ? 'max_tokens' : finishReason ?? undefined };
   }
 }

--- a/packages/llm-ollama/src/ollama-provider.test.ts
+++ b/packages/llm-ollama/src/ollama-provider.test.ts
@@ -32,6 +32,32 @@ describe('OllamaLLMProvider', () => {
     expect((result as { stopReason?: string }).stopReason).toBe('max_tokens');
   });
 
+  it('#390 — invokeStructured sends the schema as `format` and parses the content object', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        message: { content: '{"findings": []}' },
+        done_reason: 'stop',
+        prompt_eval_count: 3,
+        eval_count: 4,
+      }),
+    );
+    const provider = new OllamaLLMProvider('http://myhost:11434');
+    const schema = { type: 'object', properties: { findings: { type: 'array' } } };
+    const result = await provider.invokeStructured('llama3', 'prompt', schema);
+
+    expect(result.object).toEqual({ findings: [] });
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.format).toEqual(schema);
+  });
+
+  it('#390 — invokeStructured throws on prose content (older Ollama ignoring `format`)', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ message: { content: 'no json here' }, done_reason: 'stop' }),
+    );
+    const provider = new OllamaLLMProvider('http://myhost:11434');
+    await expect(provider.invokeStructured('llama3', 'prompt', {})).rejects.toThrow();
+  });
+
   it('constructs correct URL: {baseUrl}/api/chat', async () => {
     mockFetch.mockResolvedValueOnce(
       jsonResponse({

--- a/packages/llm-ollama/src/ollama-provider.ts
+++ b/packages/llm-ollama/src/ollama-provider.ts
@@ -1,4 +1,4 @@
-import type { ILLMProvider, LLMInvokeResult, LLMSamplingConfig } from '@mergewatch/core';
+import type { ILLMProvider, LLMInvokeResult, LLMSamplingConfig, LLMStructuredResult } from '@mergewatch/core';
 
 export class OllamaLLMProvider implements ILLMProvider {
   constructor(private baseUrl: string = 'http://localhost:11434') {}
@@ -39,5 +39,47 @@ export class OllamaLLMProvider implements ILLMProvider {
       : undefined;
     // Ollama says 'length' where Anthropic says 'max_tokens' — normalize.
     return { text, usage, stopReason: data.done_reason === 'length' ? 'max_tokens' : data.done_reason ?? undefined };
+  }
+
+  // #390 — schema-constrained invocation via Ollama structured outputs: the
+  // request's `format` field carries the JSON Schema and constrained decoding
+  // guarantees conformant output (Ollama ≥ 0.5). Older servers ignore the
+  // field and may return prose — the JSON.parse below then throws and the
+  // caller falls back to the hardened text path.
+  async invokeStructured(
+    modelId: string,
+    prompt: string,
+    schema: object,
+    maxTokens = 4096,
+    sampling: LLMSamplingConfig = {},
+  ): Promise<LLMStructuredResult> {
+    const url = `${this.baseUrl.replace(/\/$/, '')}/api/chat`;
+    const options: Record<string, unknown> = {
+      num_predict: maxTokens,
+      temperature: sampling.temperature ?? 0,
+    };
+    if (sampling.topP !== undefined) options.top_p = sampling.topP;
+    if (sampling.topK !== undefined) options.top_k = sampling.topK;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: modelId,
+        stream: false,
+        options,
+        format: schema,
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    });
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`Ollama structured request failed (${response.status}): ${body}`);
+    }
+    const data = await response.json() as any;
+    const object = JSON.parse(data.message?.content ?? '');
+    const usage = (data.prompt_eval_count != null || data.eval_count != null)
+      ? { inputTokens: data.prompt_eval_count ?? 0, outputTokens: data.eval_count ?? 0 }
+      : undefined;
+    return { object, usage, stopReason: data.done_reason === 'length' ? 'max_tokens' : data.done_reason ?? undefined };
   }
 }


### PR DESCRIPTION
## What (Phase 2 of 2 — stacked on #392)

Implements `invokeStructured` in all four providers, activating the schema-constrained path #392 wired through the pipeline:

| Provider | Mechanism | Unsupported path |
|---|---|---|
| `llm-anthropic` | forced tool use (`emit_result` + `tool_choice`) | — |
| `llm-bedrock` | same, via InvokeModel for the Anthropic family | Titan throws `StructuredOutputUnsupportedError` **pre-network** |
| `llm-litellm` | `response_format: json_schema` (`strict: false` — upstream strict-validator support varies) | 4xx / prose content throws → text fallback |
| `llm-ollama` | `format: <schema>` constrained decoding (≥ 0.5) | older servers ignore it → prose throws → text fallback |

Also: core index exports the new types; RUNBOOK gains **E2E-90** (a structured-provider suite run must show zero `Could not parse agent JSON response` lines and zero "Unparsed agent output" disclosures, with explicit failure modes for schema over-constraining, silent all-fallback runs, and throttle double-invocation); `docs/architecture.md` documents the extended interface.

## Tests

Per provider: request-shape assertions (tools/tool_choice, response_format, format), response extraction to `result.object`, and the failure paths (no tool_use block, prose content, Titan pre-network unsupported with `mockSend` never called). Full workspace `build` / `typecheck` / `test` green.

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)