### PR TITLE
fix(core): verification never degrades verdicts under throttle; inconclusive verdicts retry once (#386)

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -980,6 +980,8 @@ PR diff should only touch the `.map(...)` / `return` lines (so the `const rows =
 - [ ] If an agent produced one, logs show `[finding-verify] refuted critical … demoted to unverified (not dropped)` with a reason citing the `await` on the assignment line (warnings still log `dropped false-positive`)
 - [ ] A genuinely-unawaited variant (delete the `await`) is still reported (verification doesn't blanket-suppress)
 - [ ] LLM/infra failure path keeps the finding (do not regress the fail-safe — exercise by pointing at an unreachable model in a self-hosted run)
+- [ ] **#386:** a THROTTLED verification call parks the whole review (queued check, redelivery) — it must NEVER tag the finding `unverified`, which would let the W7 clamp silently downgrade a blocking critical to advisory under burst pressure (the E2E-18a regression: real SQLi → 3/5 COMMENTED)
+- [ ] **#386:** an inconclusive verdict is retried once (`[finding-verify] no usable verdict … retrying once` log line) before the `unverified` tag can feed the clamp
 
 **Failure modes**
 - ❌ "Missing await" critical rendered despite `const rows = await kbStore.searchCandidates(...)` in the file (#31/#39 regression)

--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -2314,14 +2314,46 @@ describe('verifyFindings', () => {
     expect(llm.calls).toHaveLength(0);
   });
 
-  it('keeps the finding when the LLM call throws — tags it `unverified`', async () => {
+  it('keeps the finding when the LLM call fails on a NON-throttle error — tags it `unverified`', async () => {
     const llm: ILLMProvider = {
       async invoke() {
-        throw new Error('bedrock throttled');
+        throw new Error('model exploded');
       },
     };
     const result = await verifyFindings([critical], fileContents, 'light', llm);
     expect(result).toEqual([{ ...critical, verification: 'unverified' }]);
+  });
+
+  it('#386 — a THROTTLED verification call rejects the pass (review parks) instead of degrading the verdict', async () => {
+    // Pre-#386 this path tagged the finding 'unverified', letting the W7
+    // clamp convert a real blocking critical into an advisory 3/5 under
+    // rate-limit pressure (E2E-18a).
+    const llm: ILLMProvider = {
+      async invoke() {
+        throw Object.assign(new Error('Too many requests, please wait before trying again.'), { name: 'ThrottlingException' });
+      },
+    };
+    await expect(verifyFindings([critical], fileContents, 'light', llm)).rejects.toThrow(/Too many requests/);
+  });
+
+  it('#386 — an inconclusive verdict is retried once and the retry verdict wins', async () => {
+    const llm = createMockLLM([
+      '{"confidence": 0.5, "reason": "hard to tell"}',
+      '{"valid": true, "confidence": 0.9, "reason": "confirmed on retry"}',
+    ]);
+    const result = await verifyFindings([critical], fileContents, 'light', llm);
+    expect(result).toEqual([{ ...critical, verification: 'verified' }]);
+    expect(llm.calls).toHaveLength(2);
+  });
+
+  it('#386 — inconclusive twice → still fail-safe unverified (exactly two attempts)', async () => {
+    const llm = createMockLLM([
+      '{"confidence": 0.5, "reason": "hard to tell"}',
+      '{"confidence": 0.4, "reason": "still unsure"}',
+    ]);
+    const result = await verifyFindings([critical], fileContents, 'light', llm);
+    expect(result).toEqual([{ ...critical, verification: 'unverified' }]);
+    expect(llm.calls).toHaveLength(2);
   });
 
   it('keeps the finding on unparseable LLM output — tags it `unverified`', async () => {

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -1975,23 +1975,37 @@ ${content}`;
         // fall through to the text path silently. Any OTHER structured error
         // flows to the outer catch below, which keeps the finding as
         // 'unverified' — identical to a failed text invocation.
-        let verdict: { valid?: boolean; reason?: string } | null = null;
-        if (llm.invokeStructured) {
-          try {
-            verdict = (await llm.invokeStructured(modelId, prompt, VERIFIER_VERDICT_SCHEMA, undefined, { temperature: 0 }))
-              .object as { valid?: boolean; reason?: string };
-          } catch (err) {
-            if (!(err instanceof StructuredOutputUnsupportedError)) throw err;
+        const attemptVerdict = async (): Promise<{ valid?: boolean; reason?: string }> => {
+          let verdict: { valid?: boolean; reason?: string } | null = null;
+          if (llm.invokeStructured) {
+            try {
+              verdict = (await llm.invokeStructured(modelId, prompt, VERIFIER_VERDICT_SCHEMA, undefined, { temperature: 0 }))
+                .object as { valid?: boolean; reason?: string };
+            } catch (err) {
+              if (!(err instanceof StructuredOutputUnsupportedError)) throw err;
+            }
           }
+          // Sentinel default `{}` (not `{ valid: true }`) so an unparseable
+          // or verdict-less response is distinguishable from an explicit
+          // pass — the fail-safe "keep" is then logged AND tagged 'unverified'.
+          return verdict ?? safeParseJson<{ valid?: boolean; reason?: string }>(
+            normalizeLLMResult(await llm.invoke(modelId, prompt, undefined, { temperature: 0 })).text,
+            {},
+            'valid',
+          );
+        };
+        // #386 — an inconclusive verdict gets ONE retry before it can feed
+        // the W7 clamp: E2E-18a showed a raw string-interpolated SQLi (as
+        // verifiable as criticals get) coming back verdict-less once and
+        // being silently downgraded from blocking 1/5 to advisory 3/5.
+        let parsed = await attemptVerdict();
+        if (parsed.valid === undefined) {
+          console.warn(
+            '[finding-verify] no usable verdict for %s "%s" (%s:%d) — retrying once (#386)',
+            f.severity, f.title, f.file, f.line,
+          );
+          parsed = await attemptVerdict();
         }
-        // Sentinel default `{}` (not `{ valid: true }`) so an unparseable
-        // or verdict-less response is distinguishable from an explicit
-        // pass — the fail-safe "keep" is then logged AND tagged 'unverified'.
-        const parsed = verdict ?? safeParseJson<{ valid?: boolean; reason?: string }>(
-          normalizeLLMResult(await llm.invoke(modelId, prompt, undefined, { temperature: 0 })).text,
-          {},
-          'valid',
-        );
         if (parsed.valid === false) {
           // #372 — an intent-shaped dismissal ("the comment says this is
           // test code") is not a legitimate drop: intent does not change
@@ -2040,9 +2054,9 @@ ${content}`;
         if (parsed.valid === true) {
           return { keep: true, verification: 'verified' };
         }
-        // Ambiguous: parsed but no usable verdict.
+        // Ambiguous twice: parsed but no usable verdict even after the retry.
         console.warn(
-          '[finding-verify] no usable verdict for %s "%s" (%s:%d) — keeping finding (unverified, advisory)',
+          '[finding-verify] no usable verdict for %s "%s" (%s:%d) after retry — keeping finding (unverified, advisory)',
           f.severity,
           f.title,
           f.file,
@@ -2050,6 +2064,13 @@ ${content}`;
         );
         return { keep: true, verification: 'unverified' };
       } catch (err) {
+        // #386 — throttles PARK the review (#355 semantics), they never
+        // degrade the verdict: tagging 'unverified' here under rate-limit
+        // pressure let the W7 clamp convert a real blocking critical into
+        // an advisory 3/5 COMMENTED (E2E-18a). Rethrowing aborts the pass;
+        // the handler parks the review and SQS/queue redelivery re-runs it
+        // when the burst clears.
+        if (isThrottleError(err)) throw err;
         console.warn(
           '[finding-verify] verification call failed for %s "%s" (%s:%d) — keeping finding (unverified, advisory):',
           f.severity,


### PR DESCRIPTION
## What

Fixes the E2E-18a regression from #386: W2 verification came back inconclusive on a textbook SQLi during a throttle burst, and the `unverified` tag let the W7 clamp silently downgrade a blocking 1/5 CHANGES_REQUESTED to an advisory 3/5 COMMENTED.

Two changes in `verifyFindings`:

1. **Throttles park, never degrade.** A throttled verification call now rethrows (#355 semantics): the review parks with a queued check and redelivery re-runs it when the burst clears. Notably, the existing fail-safe test used `new Error('bedrock throttled')` — a message matching `isThrottleError`'s `/throttl/i` — so it was unknowingly locking in the bug. It now uses a genuine infra error, and a new test locks the park behavior.
2. **Inconclusive verdicts retry once.** A no-usable-verdict response gets exactly one retry (logged) before the `unverified` tag can feed the clamp. Structured verdicts (#390) make this path rare; the retry covers the text fallback and model refusals.

Unchanged and regression-tested: non-throttle infra errors keep the fail-safe (keep + `unverified`), #385's refuted-critical demotion, #372's intent-guard, and the unparseable-output path.

## Tests

Throttled verification rejects the pass (review parks); inconclusive→verified on retry (verdict wins, exactly 2 calls); inconclusive×2 → unverified (exactly 2 calls, no runaway); non-throttle error → unverified. RUNBOOK E2E-25 gains both expectations with the E2E-18a reference. Full workspace `build` / `typecheck` / `test` green.

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)