### PR TITLE
fix(core): mermaid fail-safe — parity guard, edge-label healing, structural validation (#394)

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -1526,6 +1526,7 @@ Branch: `fixture/36-linter-aware`. Two arms (linter present / absent) sharing a 
 - ❌ ANY behavioral difference between the two arms (the prompt is linter-invariant by construction — a difference means something new is conditioning on repo contents)
 - ❌ A finding rationalized by linter enforcement ("will fail ESLint" / "the linter will flag") — the #387 inversion signature
 - ❌ The diagram embeds a finding/nit node ("ISSUE:", "BUG:", "WARNING:" labels)
+- ❌ **#394:** a review comment ships a mermaid block that fails to render (entity-mangled syntax `R&lsqb;…&rsqb;`, glued `<br/>` statements, unbalanced quotes, or a `|…|` label spanning lines) — the structural validation gate must DROP the diagram section instead; a `[diagram] unbalanced quotes — skipping sanitation` log line marks the bail path
 
 ---
 

--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -108,6 +108,38 @@ describe('isValidMermaidDiagram', () => {
   it('returns true when preceded by mermaid comment', () => {
     expect(isValidMermaidDiagram('%% caption\nflowchart TD\n  A-->B')).toBe(true);
   });
+
+  // ─── #394 — structural corruption checks (missing beats broken) ───────────
+
+  it('#394 — rejects unbalanced quotes', () => {
+    expect(isValidMermaidDiagram('flowchart TD\n  A["ok] --> B')).toBe(false);
+  });
+
+  it('#394 — rejects HTML entities outside quoted regions (parity-inversion signature)', () => {
+    expect(isValidMermaidDiagram('flowchart TD\n  R&lsqb;"TokenAccumulator"&rsqb; --> A')).toBe(false);
+  });
+
+  it('#394 — rejects literal <br/> outside quoted regions (glued statements)', () => {
+    expect(isValidMermaidDiagram('flowchart TD\n  A --> B<br/>C --> D')).toBe(false);
+  });
+
+  it('#394 — entities and <br/> INSIDE quoted labels remain legitimate', () => {
+    expect(isValidMermaidDiagram('flowchart TD\n  A["invoke&lpar;&rpar;<br/>wrapper"] --> B')).toBe(true);
+  });
+
+  it('#394 — rejects an unclosed edge label (raw newline inside |…|)', () => {
+    expect(isValidMermaidDiagram('flowchart TD\n  A -->|fallback on\nUnsupportedError| B')).toBe(false);
+  });
+
+  it('#394 — the verbatim PR #392 corrupted fragment is invalid', () => {
+    const corrupted = [
+      'flowchart TD',
+      '    Q["TrackingLLMProvider&lt;br/&gt;wrapper"] -->|forwards| A',
+      '    Q -->|tracks usage"&rsqb; R&lsqb;"TokenAccumulator"&rsqb;<br/>    <br/>    S&lsqb;"Truncation retry',
+      'wrapper"] -->|wraps| A',
+    ].join('\n');
+    expect(isValidMermaidDiagram(corrupted)).toBe(false);
+  });
 });
 
 // ─── runSecurityAgent ───────────────────────────────────────────────────────
@@ -342,6 +374,27 @@ describe('runSummaryAgent', () => {
 // ─── runDiagramAgent ────────────────────────────────────────────────────────
 
 describe('runDiagramAgent', () => {
+  it('#394 — heals an edge label broken across lines (raw newline inside |…|)', async () => {
+    const mermaid = '%% Flow\nflowchart TD\n  A -->|fallback on\nUnsupportedError| B\n  B --> C';
+    const llm = createMockLLM([mermaid]);
+    const result = await runDiagramAgent(sampleDiff, sampleContext, 'model-1', llm);
+    expect(result.diagram).toContain('|fallback on UnsupportedError|');
+    expect(isValidMermaidDiagram(result.diagram)).toBe(true);
+  });
+
+  it('#394 — a corrupt diagram is DROPPED, never shipped (unbalanced quotes / entity-mangled syntax)', async () => {
+    const corrupted = [
+      '%% wiring',
+      'flowchart TD',
+      '    Q["Tracking wrapper"] -->|forwards| A',
+      '    Q -->|tracks usage"&rsqb; R&lsqb;"TokenAccumulator"&rsqb;<br/>    S&lsqb;"Truncation retry',
+      'wrapper"] -->|wraps| A',
+    ].join('\n');
+    const llm = createMockLLM([corrupted]);
+    const result = await runDiagramAgent(sampleDiff, sampleContext, 'model-1', llm);
+    expect(result.diagram).toBe('');
+  });
+
   it('returns DiagramResult for valid mermaid', async () => {
     const mermaid = '%% Auth flow\nsequenceDiagram\n  Client->>API: request\n  API->>Auth: validate';
     const llm = createMockLLM([mermaid]);

--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -131,6 +131,15 @@ describe('isValidMermaidDiagram', () => {
     expect(isValidMermaidDiagram('flowchart TD\n  A -->|fallback on\nUnsupportedError| B')).toBe(false);
   });
 
+  it('#394 — backslash-"escaped" quotes are NOT an escape in mermaid — odd totals drop the diagram', () => {
+    // Mermaid has no \" escaping (quotes in labels are #quot;/&quot;), so the
+    // quote counter deliberately treats every `"` as a delimiter, matching the
+    // renderer. Three quotes total → unbalanced → invalid → dropped.
+    expect(isValidMermaidDiagram('flowchart TD\n  A["a\\"b"] --> B')).toBe(false);
+    // The sanctioned escape form stays valid.
+    expect(isValidMermaidDiagram('flowchart TD\n  A["say &quot;hi&quot;"] --> B')).toBe(true);
+  });
+
   it('#394 — the verbatim PR #392 corrupted fragment is invalid', () => {
     const corrupted = [
       'flowchart TD',

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -690,7 +690,51 @@ function decodeMermaidOutsideQuotes(diagram: string): string {
   return parts.join('');
 }
 
+/**
+ * #394 — heal edge labels broken across lines. Mermaid edge labels (`|…|`)
+ * cannot span lines, but the model sometimes emits
+ * `-->|fallback on\nSomeLongName| G` — joining the offending line with the
+ * next (newline → space) restores a parseable single-line label. Detection
+ * is a per-line pipe-parity check counting only pipes OUTSIDE quoted
+ * regions; bounded to the line count so a pathological input can't loop.
+ */
+function joinBrokenEdgeLabels(diagram: string): string {
+  const unquotedPipeCount = (line: string): number =>
+    line.split(/("[^"]*")/).filter((_, i) => i % 2 === 0).join('').split('|').length - 1;
+  const lines = diagram.split('\n');
+  const out: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    let line = lines[i];
+    let guard = lines.length;
+    while (unquotedPipeCount(line) % 2 === 1 && i + 1 < lines.length && guard-- > 0) {
+      line = `${line} ${lines[++i].trim()}`;
+    }
+    out.push(line);
+  }
+  return out.join('\n');
+}
+
+/** Count double quotes — the sanitizer's quote-segmentation is only sound on balanced input (#394). */
+function hasBalancedQuotes(diagram: string): boolean {
+  return ((diagram.match(/"/g) ?? []).length) % 2 === 0;
+}
+
 function sanitizeMermaidOutput(diagram: string): string {
+  // #394 — heal newline-broken edge labels BEFORE any quote-based pass.
+  diagram = joinBrokenEdgeLabels(diagram);
+
+  // #394 — parity guard: every quote-segmented pass below assumes balanced
+  // quotes. On an odd count the even/odd segment alternation INVERTS from
+  // the stray quote onward — unquoted syntax gets label-escaped into
+  // `R&lsqb;"…"&rsqb;` and statements glue with `<br/>` (the PR #392
+  // corruption). Transforming would corrupt; bail with the raw text and let
+  // isValidMermaidDiagram decide (it rejects unbalanced quotes, so the
+  // diagram is dropped — missing beats broken).
+  if (!hasBalancedQuotes(diagram)) {
+    console.warn('[diagram] unbalanced quotes — skipping sanitation passes (#394); validation will drop the diagram');
+    return diagram;
+  }
+
   // Pass 0 — OUTSIDE quoted regions: decode HTML entities the model sometimes
   // emits in syntactic positions, and convert any literal `<br/>` outside a
   // label back into a statement-separating newline. See decode helper above.
@@ -787,7 +831,27 @@ export function isValidMermaidDiagram(diagram: string): boolean {
 
   // Extract the first word and check against known diagram types
   const firstWord = firstMeaningful.trim().split(/[\s-]/)[0];
-  return MERMAID_DIAGRAM_TYPES.has(firstWord.toLowerCase());
+  if (!MERMAID_DIAGRAM_TYPES.has(firstWord.toLowerCase())) return false;
+
+  // #394 — structural corruption checks. A diagram that trips any of these
+  // will not parse; the caller drops the section entirely (missing beats a
+  // broken code block shipped to every reader — PR #392's live corruption).
+  // 1. Unbalanced quotes: the sanitizer's quote segmentation was unsound,
+  //    or a label broke out of its quoted region.
+  if (!hasBalancedQuotes(diagram)) return false;
+  // 2. HTML entities or literal <br/> OUTSIDE quoted regions: entity-escaped
+  //    structural syntax (`R&lsqb;"…"&rsqb;`) / glued statements — the parity-
+  //    inversion signature. Inside quotes both are legitimate label content.
+  const unquoted = diagram.split(/("[^"]*")/).filter((_, i) => i % 2 === 0).join('');
+  if (/&(?:lsqb|rsqb|lbrace|rbrace|lpar|rpar|lt|gt|quot|amp);/.test(unquoted)) return false;
+  if (/<br\s*\/?>/i.test(unquoted)) return false;
+  // 3. Unclosed edge label: an odd number of unquoted pipes on a line means
+  //    a `|…|` label never closed (raw newline inside the label).
+  for (const line of lines) {
+    const lineUnquoted = line.split(/("[^"]*")/).filter((_, i) => i % 2 === 0).join('');
+    if ((lineUnquoted.split('|').length - 1) % 2 === 1) return false;
+  }
+  return true;
 }
 
 /**

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -714,7 +714,19 @@ function joinBrokenEdgeLabels(diagram: string): string {
   return out.join('\n');
 }
 
-/** Count double quotes — the sanitizer's quote-segmentation is only sound on balanced input (#394). */
+/**
+ * Count double quotes — the sanitizer's quote-segmentation is only sound on
+ * balanced input (#394).
+ *
+ * Deliberately no `\"` escape handling: Mermaid's grammar has NO
+ * backslash-quote escaping — a quote inside a label is written `#quot;` /
+ * `&quot;` (exactly what escapeMermaidLabelChars emits), and Mermaid's own
+ * parser treats a backslash-preceded quote as a plain delimiter. Treating
+ * `\"` as escaped here would make this counter DISAGREE with the renderer:
+ * a diagram we judged balanced would still fail to render. A model emitting
+ * `\"` produces invalid Mermaid regardless; it trips this parity check and
+ * the diagram is dropped — the #394 contract (missing beats broken).
+ */
 function hasBalancedQuotes(diagram: string): boolean {
   return ((diagram.match(/"/g) ?? []).length) % 2 === 0;
 }


### PR DESCRIPTION
## What

Closes #394 (the broken mermaid block on PR #392's review). Three layers:

1. **`joinBrokenEdgeLabels`** — a line whose *unquoted* pipe count is odd joins with the next, healing `-->|label\ncontinued|` into a parseable single-line label (bounded, quote-aware).
2. **Parity guard** in `sanitizeMermaidOutput` — an odd quote count makes every quote-segmented pass unsound (the exact #392 corruption mechanism: segments invert from the stray quote onward, entity-escaping structural syntax and gluing statements with `<br/>`). The sanitizer now bails with the raw text and lets validation decide.
3. **Structural checks** in `isValidMermaidDiagram` — unbalanced quotes, HTML entities (`&lsqb;` family) or literal `<br/>` **outside** quoted regions, or an unclosed `|…|` label fail validation, and `parseDiagramResponse` drops the diagram section entirely. **Missing beats broken** — no corrupt code block ever ships to a comment again.

Deliberately narrow: entities and `<br/>` *inside* quoted labels remain legitimate (that's the mermaid line-break syntax), and the healing pass runs before any guard so a newline-broken label is recovered rather than dropped when possible.

## Tests

The verbatim PR #392 corrupted fragment: invalid at the validator and dropped at the `runDiagramAgent` level (locked regression). Healed edge label renders and validates. Six new validator cases covering each rejection plus the inside-quotes legitimacy case. Full workspace `build` / `typecheck` / `test` green (core: 911).

## Deferred

The 5/5-verdict + stale-attention-row comment inconsistency observed on the same PR is a different subsystem (W6 comment upsert) — flagged in #394's "related observation"; say the word and it gets its own issue.

Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)