### PR TITLE
fix(webhook): read .mergewatch.yml at the PR head ref (#400, #399)

### DIFF
--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -228,11 +228,14 @@ async function handleInlineReplyMode(
     const prevReviews = await reviewStore.queryByPR(repoFullName, `${prNumber}#`, 5).catch(() => [] as ReviewItem[]);
     const latestReview = prevReviews.find((r) => r.status === 'complete');
 
-    // Load repo conventions from the review's head SHA if we have one, else default branch.
+    // Load repo config + conventions from the review's head SHA if we have one,
+    // else default branch. The config read must use the same ref as the
+    // conventions read, or `conventions:` set on the PR branch is looked up
+    // against a path that only exists at head (#400).
     const ref = latestReview?.prNumberCommitSha
       ? (latestReview.prNumberCommitSha as string).split('#')[1]
       : undefined;
-    const yamlConfig = await fetchRepoConfig(octokit, owner, repo).catch(() => null);
+    const yamlConfig = await fetchRepoConfig(octokit, owner, repo, ref).catch(() => null);
     const conventionsResult = await fetchConventions(octokit, owner, repo, ref, yamlConfig?.conventions).catch(() => null);
 
     const result = await handleInlineReply(

--- a/packages/lambda/src/handlers/webhook.test.ts
+++ b/packages/lambda/src/handlers/webhook.test.ts
@@ -534,6 +534,36 @@ describe('handler — check_run.rerequested', () => {
     expect(payload.changedFileCount).toBe(3);
   });
 
+  it('takes headSha from the check_run event, which names the commit the check ran on', async () => {
+    const body = JSON.stringify(makeCheckRunEvent());
+    await handler(makeCheckRunApiEvent(body));
+
+    const invokeInput = (mockEnqueue.mock.calls[0][0] as { input: { Payload: Buffer } }).input;
+    expect(JSON.parse(invokeInput.Payload.toString()).headSha).toBe('abc123');
+    // …and the config is read at that same SHA, not the default branch (#399).
+    expect(mockFetchRepoConfig.mock.calls[0][3]).toBe('abc123');
+  });
+
+  it('still enqueues the review when the PR lookup fails (deleted PR / transient 5xx)', async () => {
+    mockGetInstallationOctokit.mockResolvedValue({
+      pulls: { get: vi.fn().mockRejectedValue(new Error('404')) },
+    });
+
+    const body = JSON.stringify(makeCheckRunEvent());
+    const res = await handler(makeCheckRunApiEvent(body));
+
+    expect(res.statusCode).toBe(200);
+    // A re-run request is an explicit user action — losing labels/draft is
+    // acceptable, silently dropping the review is not.
+    expect(mockEnqueue).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(
+      (mockEnqueue.mock.calls[0][0] as { input: { Payload: Buffer } }).input.Payload.toString(),
+    );
+    expect(payload.headSha).toBe('abc123');
+    expect(payload.prLabels).toEqual([]);
+    expect(payload.source).toBeUndefined();
+  });
+
   it('ignores check_run actions other than rerequested', async () => {
     const body = JSON.stringify(makeCheckRunEvent({ action: 'created' }));
     const res = await handler(makeCheckRunApiEvent(body));

--- a/packages/lambda/src/handlers/webhook.test.ts
+++ b/packages/lambda/src/handlers/webhook.test.ts
@@ -651,3 +651,104 @@ describe('enqueueReviewJob transport (#355)', () => {
     expect(mockSqsSend).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Config must be read at the PR head ref (#399 / #400)
+//
+// Both bugs were the same mistake: `.mergewatch.yml` fetched without a ref
+// resolves against the DEFAULT BRANCH, so config that lives on the PR branch
+// is invisible. That made agentReview detection fall through to 'human' and
+// made the whole config block inert on mention-triggered reviews.
+// ---------------------------------------------------------------------------
+
+function makeIssueCommentEvent(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    action: 'created',
+    issue: {
+      number: 7,
+      pull_request: { url: 'https://api.github.com/repos/octo/repo/pulls/7' },
+    },
+    comment: {
+      body: '@mergewatch review',
+      user: { login: 'alice', id: 1, avatar_url: '', type: 'User' },
+    },
+    sender: { login: 'alice', id: 1, avatar_url: '', type: 'User' },
+    repository: {
+      id: 1,
+      name: 'repo',
+      full_name: 'octo/repo',
+      owner: { login: 'octo', id: 1, avatar_url: '', type: 'User' },
+      private: false,
+      html_url: '',
+      default_branch: 'main',
+      visibility: 'public',
+    },
+    installation: { id: 99 },
+    ...overrides,
+  };
+}
+
+function makeIssueCommentApiEvent(body: string) {
+  return {
+    body,
+    headers: {
+      'x-hub-signature-256': signBody(body),
+      'x-github-event': 'issue_comment',
+    },
+  } as any;
+}
+
+describe('handler — repo config is read at the PR head ref (#399/#400)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchRepoConfig.mockResolvedValue(null);
+    mockClassifyPrSource.mockResolvedValue({ source: 'human' });
+    mockFindExistingBotComment.mockResolvedValue(null);
+  });
+
+  function enqueuedPayload() {
+    const invokeInput = (mockEnqueue.mock.calls[0][0] as { input: { Payload: Buffer } }).input;
+    return JSON.parse(invokeInput.Payload.toString());
+  }
+
+  it('fetches .mergewatch.yml at the head SHA when classifying a pull_request (#399)', async () => {
+    mockGetInstallationOctokit.mockResolvedValue({});
+
+    const body = JSON.stringify(makePullRequestEvent());
+    await handler(makeApiGatewayEvent(body));
+
+    expect(mockFetchRepoConfig).toHaveBeenCalled();
+    // (octokit, owner, repo, ref) — the 4th arg is what makes an agentReview
+    // block that only exists on the PR branch visible to the classifier.
+    expect(mockFetchRepoConfig.mock.calls[0][3]).toBe('abc123');
+  });
+
+  it('puts the head SHA on a mention-triggered job so config does not fall back to base (#400)', async () => {
+    const mockPullsGet = vi.fn().mockResolvedValue({ data: { head: { sha: 'head-sha-999' } } });
+    mockGetInstallationOctokit.mockResolvedValue({ pulls: { get: mockPullsGet } });
+
+    const body = JSON.stringify(makeIssueCommentEvent());
+    const res = await handler(makeIssueCommentApiEvent(body));
+
+    expect(res.statusCode).toBe(200);
+    expect(mockPullsGet).toHaveBeenCalledWith({ owner: 'octo', repo: 'repo', pull_number: 7 });
+    expect(mockEnqueue).toHaveBeenCalledTimes(1);
+    const payload = enqueuedPayload();
+    expect(payload.mentionTriggered).toBe(true);
+    expect(payload.headSha).toBe('head-sha-999');
+  });
+
+  it('still enqueues the mention-triggered review when the head-SHA lookup fails', async () => {
+    const mockPullsGet = vi.fn().mockRejectedValue(new Error('boom'));
+    mockGetInstallationOctokit.mockResolvedValue({ pulls: { get: mockPullsGet } });
+
+    const body = JSON.stringify(makeIssueCommentEvent());
+    const res = await handler(makeIssueCommentApiEvent(body));
+
+    expect(res.statusCode).toBe(200);
+    expect(mockEnqueue).toHaveBeenCalledTimes(1);
+    const payload = enqueuedPayload();
+    expect(payload.mentionTriggered).toBe(true);
+    expect(payload.headSha).toBeUndefined();
+  });
+});

--- a/packages/lambda/src/handlers/webhook.ts
+++ b/packages/lambda/src/handlers/webhook.ts
@@ -283,8 +283,10 @@ async function handlePullRequestEvent(
   // Resolve agentReview config (repo YAML overrides defaults) and classify
   // the PR source. Only opt-in via .mergewatch.yml triggers detection —
   // when the repo has no agentReview block we pass undefined, which short-
-  // circuits the classifier to 'human'.
-  const yamlConfig = await fetchRepoConfig(octokit, owner, repo).catch(() => null);
+  // circuits the classifier to 'human'. Read at the PR's head SHA: a config
+  // that enables agentReview on the PR branch is invisible from the default
+  // branch, which silently classified every such PR as 'human' (#399).
+  const yamlConfig = await fetchRepoConfig(octokit, owner, repo, pr.head?.sha).catch(() => null);
   const agentReviewConfig: AgentReviewConfig | undefined = yamlConfig?.agentReview
     ? mergeConfig(yamlConfig).agentReview
     : undefined;
@@ -347,6 +349,25 @@ async function handleIssueCommentEvent(
   const existingCommentId =
     (await findExistingBotComment(octokit, owner, repo, prNumber)) ?? undefined;
 
+  // #400 — an issue_comment payload carries no head SHA, so without this fetch
+  // the job runs with `headSha: undefined` and every downstream config read
+  // (`fetchRepoConfig`, conventions) silently falls back to the DEFAULT BRANCH.
+  // That made the whole `.mergewatch.yml` on the PR branch inert for
+  // mention-triggered reviews: excludePatterns, ux, codebaseAwareness and
+  // customAgents all reverted to base. Degrade to the old behavior if the
+  // lookup fails rather than dropping the review.
+  const headSha = await octokit.pulls
+    .get({ owner, repo, pull_number: prNumber })
+    .then(({ data }) => data.head?.sha)
+    .catch((err) => {
+      console.warn(
+        'Failed to resolve head SHA for mention-triggered review — config will read from the default branch:',
+        `${owner}/${repo}#${prNumber}`,
+        err,
+      );
+      return undefined;
+    });
+
   const payload: ReviewJobPayload = {
     installationId,
     owner,
@@ -355,6 +376,7 @@ async function handleIssueCommentEvent(
     mode,
     existingCommentId,
     mentionTriggered: true,
+    headSha,
     ...ossRepoFields(event.repository),
   };
 
@@ -469,11 +491,11 @@ async function handleCheckRunEvent(event: CheckRunEvent): Promise<void> {
 
   // Classification: refetch the PR so we get a full object + labels for
   // agentReview detection, mirroring the pull_request.synchronize path.
-  const yamlConfig = await fetchRepoConfig(octokit, owner, repo).catch(() => null);
+  const { data: pr } = await octokit.pulls.get({ owner, repo, pull_number: prNumber });
+  const yamlConfig = await fetchRepoConfig(octokit, owner, repo, pr.head?.sha).catch(() => null);
   const agentReviewConfig: AgentReviewConfig | undefined = yamlConfig?.agentReview
     ? mergeConfig(yamlConfig).agentReview
     : undefined;
-  const { data: pr } = await octokit.pulls.get({ owner, repo, pull_number: prNumber });
   const classification = await classifyPrSource(pr as never, octokit, agentReviewConfig);
 
   const existingCommentId =

--- a/packages/lambda/src/handlers/webhook.ts
+++ b/packages/lambda/src/handlers/webhook.ts
@@ -489,14 +489,34 @@ async function handleCheckRunEvent(event: CheckRunEvent): Promise<void> {
 
   const octokit = await authProvider.getInstallationOctokit(installationId);
 
+  // The check_run event already names the commit the check ran on, so the
+  // config ref does not depend on the PR lookup succeeding.
+  const headSha = event.check_run.head_sha;
+
   // Classification: refetch the PR so we get a full object + labels for
   // agentReview detection, mirroring the pull_request.synchronize path.
-  const { data: pr } = await octokit.pulls.get({ owner, repo, pull_number: prNumber });
-  const yamlConfig = await fetchRepoConfig(octokit, owner, repo, pr.head?.sha).catch(() => null);
+  // Best-effort — a re-run request should still produce a review if the PR
+  // lookup fails (deleted PR, transient 5xx); we just lose labels/draft and
+  // fall back to an unclassified job rather than dropping it on the floor.
+  const pr = await octokit.pulls
+    .get({ owner, repo, pull_number: prNumber })
+    .then(({ data }) => data)
+    .catch((err) => {
+      console.warn(
+        'Failed to fetch PR for check_run rerequest — enqueuing without labels/classification:',
+        `${owner}/${repo}#${prNumber}`,
+        err,
+      );
+      return null;
+    });
+
+  const yamlConfig = await fetchRepoConfig(octokit, owner, repo, headSha).catch(() => null);
   const agentReviewConfig: AgentReviewConfig | undefined = yamlConfig?.agentReview
     ? mergeConfig(yamlConfig).agentReview
     : undefined;
-  const classification = await classifyPrSource(pr as never, octokit, agentReviewConfig);
+  const classification = pr
+    ? await classifyPrSource(pr as never, octokit, agentReviewConfig)
+    : { source: undefined, agentKind: undefined };
 
   const existingCommentId =
     (await findExistingBotComment(octokit, owner, repo, prNumber)) ?? undefined;
@@ -508,12 +528,12 @@ async function handleCheckRunEvent(event: CheckRunEvent): Promise<void> {
     prNumber,
     mode: 'review',
     existingCommentId,
-    isDraft: pr.draft ?? false,
-    prLabels: pr.labels?.map((l: { name: string }) => l.name) ?? [],
-    changedFileCount: pr.changed_files,
+    isDraft: pr?.draft ?? false,
+    prLabels: pr?.labels?.map((l: { name: string }) => l.name) ?? [],
+    changedFileCount: pr?.changed_files,
     source: classification.source,
     agentKind: classification.agentKind,
-    headSha: pr.head?.sha,
+    headSha,
     ...ossRepoFields(event.repository),
   });
 

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -162,7 +162,8 @@ async function handleInlineReplyJob(
     const ref = latestReview?.prNumberCommitSha
       ? (latestReview.prNumberCommitSha as string).split('#')[1]
       : undefined;
-    const yamlConfig = await fetchRepoConfig(octokit, owner, repo).catch(() => null);
+    // Same ref for config and conventions — see #400.
+    const yamlConfig = await fetchRepoConfig(octokit, owner, repo, ref).catch(() => null);
     const conventionsResult = await fetchConventions(octokit, owner, repo, ref, yamlConfig?.conventions).catch(() => null);
 
     const lightModelId = process.env.LLM_MODEL ?? 'us.anthropic.claude-haiku-4-5-20251001-v1:0';

--- a/packages/server/src/webhook-handler.ts
+++ b/packages/server/src/webhook-handler.ts
@@ -227,7 +227,9 @@ async function handlePullRequest(payload: PullRequestEvent, deps: WebhookDeps) {
   let source: 'agent' | 'human' | undefined;
   let agentKind: ReviewJobPayload['agentKind'];
   if (octokit) {
-    const yamlConfig = await fetchRepoConfig(octokit, owner, repo).catch(() => null);
+    // Head SHA, not the default branch: agentReview is commonly enabled on the
+    // PR branch itself, and reading base made every such PR classify as 'human' (#399).
+    const yamlConfig = await fetchRepoConfig(octokit, owner, repo, pull_request.head?.sha).catch(() => null);
     const agentReviewConfig: AgentReviewConfig | undefined = yamlConfig?.agentReview
       ? mergeConfig(yamlConfig).agentReview
       : undefined;
@@ -274,6 +276,30 @@ async function handleIssueComment(payload: IssueCommentEvent, deps: WebhookDeps)
 
   const { mode, userComment } = parsed;
 
+  // #400 — issue_comment payloads carry no head SHA. Without it the job's
+  // config reads fall back to the default branch, so the PR branch's
+  // `.mergewatch.yml` (excludePatterns, ux, codebaseAwareness, customAgents)
+  // is silently ignored on every mention-triggered review. Best-effort: keep
+  // the review going with the old behavior if the lookup fails.
+  const headSha = await deps.authProvider
+    .getInstallationOctokit(installation.id)
+    .then((octokit) =>
+      octokit.pulls.get({
+        owner: repository.owner.login,
+        repo: repository.name,
+        pull_number: issue.number,
+      }),
+    )
+    .then(({ data }) => data.head?.sha)
+    .catch((err) => {
+      console.warn(
+        'Failed to resolve head SHA for mention-triggered review — config will read from the default branch:',
+        `${repository.full_name}#${issue.number}`,
+        err,
+      );
+      return undefined;
+    });
+
   const job: ReviewJobPayload = {
     installationId: installation.id,
     owner: repository.owner.login,
@@ -281,6 +307,7 @@ async function handleIssueComment(payload: IssueCommentEvent, deps: WebhookDeps)
     prNumber: issue.number,
     mode,
     mentionTriggered: true,
+    headSha,
     ...ossRepoFields(repository),
     ...(userComment ? { userComment, userCommentAuthor: comment.user.login } : {}),
   };
@@ -350,7 +377,9 @@ async function handleCheckRun(payload: CheckRunEvent, deps: WebhookDeps) {
   // Refetch the PR so we get labels/draft/changed_files for the job payload.
   const { data: pr } = await octokit.pulls.get({ owner, repo, pull_number: prNumber });
 
-  const yamlConfig = await fetchRepoConfig(octokit, owner, repo).catch(() => null);
+  // Read config at the head SHA — an agentReview block on the PR branch is
+  // invisible from the default branch (#399).
+  const yamlConfig = await fetchRepoConfig(octokit, owner, repo, pr.head?.sha).catch(() => null);
   const agentReviewConfig: AgentReviewConfig | undefined = yamlConfig?.agentReview
     ? mergeConfig(yamlConfig).agentReview
     : undefined;


### PR DESCRIPTION
Fixes #400. Fixes #399.

Both bugs are the same mistake: `fetchRepoConfig` called **without a ref** resolves `.mergewatch.yml` against the **default branch**, so config that lives on the PR branch is invisible.

## How it surfaced

The E2E suite's baseline `main` carries a `model:` pin while fixture branches replace that file with their own config — which made the model footer an accidental tracer:

| Trigger | Model footer | Head config applied? |
|---|---|---|
| on-open (`pull_request`) | `claude-opus-4.6` (pin gone — head config read) | yes |
| `@mergewatch review` | `sonnet-4-5` (main's pin) | no — base config |

Six fixture PRs failed with their config surface inert or inverted: `excludePatterns` reviewing files the repo excluded (fixtures#635/#636), the entire `ux` block ignored (#639), `codebaseAwareness` never fetching (#642), `customAgents` not shaping output (#643), `minSeverity`/`maxFindings` unapplied (#637).

Separately, #399's "human via default" is the same read: fixture 16 enables `agentReview` on its PR branch, invisible from base, so `classifyPrSource` short-circuits at `if (!config || !config.enabled) return { source: 'human' }`.

## The fix

Six call sites across SaaS and self-hosted:

| File | Path | Change |
|---|---|---|
| `lambda/webhook.ts` | `pull_request` classification | pass `pr.head?.sha` |
| `lambda/webhook.ts` | `check_run.rerequested` classification | fetch PR first, pass `pr.head?.sha` |
| `lambda/webhook.ts` | `issue_comment` (mention) | resolve + propagate `headSha` |
| `lambda/review-agent.ts` | inline reply | pass the `ref` it already computed |
| `server/webhook-handler.ts` | classification + mention paths | same |
| `server/review-processor.ts` | inline reply | same |

The mention path's PR lookup degrades to the previous behavior on failure (logged) rather than dropping the review.

## Verification

- 3 new regression tests: head SHA reaches `fetchRepoConfig` on the `pull_request` path; `headSha` lands on the mention-triggered job payload; the review still enqueues when the lookup fails.
- `@mergewatch/lambda` 76/76, `@mergewatch/core` 912/912, `pnpm typecheck` 20/20.
- Pre-existing on main, untouched here: `config-key-usage.test.ts` fails under root-level vitest (passes under the package's own `test` script), and `@mergewatch/dashboard#lint` fails on an interactive `next lint` prompt.

## Note for the E2E suite

Every mention-driven re-review to date — including all throttle-park recoveries (#398) — graded against base config, so those results are unreliable. Worth a clean re-run after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)