### PR TITLE
fix(core): never render a clean verdict when flagged criticals were filtered away (#385)

### DIFF
--- a/packages/core/src/agents/reviewer.test.ts
+++ b/packages/core/src/agents/reviewer.test.ts
@@ -2933,8 +2933,9 @@ describe('reconcileMergeScore', () => {
       // The bug: review STATE was REQUEST_CHANGES (from the orchestrator's ≤2
       // score) while the CHECK was success (zero post-filter criticals). After
       // reconcile, the score must map to a NON-blocking review event for BOTH
-      // the warnings-remain (→ 3 / COMMENT) and nothing-remains (→ 5 / APPROVE)
-      // paths — so the review state can never contradict the success check.
+      // the warnings-remain and nothing-remains paths — both land on 3 /
+      // COMMENT since #385 stopped the nothing-remains case rendering a clean
+      // 5 — so the review state can never contradict the success check.
       for (const filteredFindings of [[warning()], [] as ReturnType<typeof warning>[]]) {
         const r = reconcileMergeScore({
           filteredFindings,
@@ -2964,6 +2965,49 @@ describe('reconcileMergeScore', () => {
       expect(r.mergeScore).toBe(3);
       expect(r.mergeScoreReason).toMatch(/3 critical findings were dropped/);
       expect(r.mergeScoreReason).toMatch(/1 warning\b/);
+    });
+
+    // #385 — the same drop, but with NOTHING left to render. This used to
+    // fall through to the clean-PR path: fixtures#610 shipped "🟢 5/5 — All
+    // clear!" on an unauthenticated admin endpoint whose missing auth the
+    // summary prose named in the same comment. An empty finding list is only
+    // evidence of a clean PR when nothing was filtered.
+    it('#385 — does not render a clean 5/5 when every flagged critical was filtered away', () => {
+      const r = reconcileMergeScore({
+        filteredFindings: [],
+        previousFindings: undefined,
+        orchestratorScore: 1,
+        orchestratorReason: 'Unauthenticated admin endpoint exposes all users; do not merge.',
+        orchestratorCriticalsCount: 2,
+      });
+
+      expect(r.mergeScore).toBe(3);
+      expect(r.mergeScore).not.toBe(5);
+      expect(r.mergeScoreReason).toMatch(/2 critical findings were flagged/i);
+      expect(r.mergeScoreReason).toMatch(/dropped by post-orchestrator filtering/i);
+      // The verdict must not read as a clean pass…
+      expect(r.mergeScoreReason).toMatch(/NOT a clean-PR result/);
+      // …and the stale blocking prose must not leak through either.
+      expect(r.mergeScoreReason).not.toContain('do not merge');
+      // Advisory, not blocking — the check conclusion follows post-filter
+      // criticals (zero → success), so blocking here would contradict it.
+      expect(mergeScoreToReviewEvent(r.mergeScore)).not.toBe('REQUEST_CHANGES');
+    });
+
+    it('#385 — a genuinely clean PR (orchestrator flagged nothing) still scores 5/5', () => {
+      // The guard keys on the orchestrator having flagged criticals, so the
+      // FP-K quartet — where the verifier correctly drops a false-positive
+      // critical the orchestrator never scored on — keeps its clean verdict.
+      const r = reconcileMergeScore({
+        filteredFindings: [],
+        previousFindings: undefined,
+        orchestratorScore: 5,
+        orchestratorReason: 'No issues found on changed lines.',
+        orchestratorCriticalsCount: 0,
+      });
+
+      expect(r.mergeScore).toBe(5);
+      expect(r.mergeScoreReason).toBe('No issues found on changed lines.');
     });
 
     it('does NOT fire when even one Critical survives post-filter (the surviving one still blocks)', () => {
@@ -3014,9 +3058,12 @@ describe('reconcileMergeScore', () => {
       expect(r.mergeScore).toBe(2);
     });
 
-    it('falls through to the no-action-items branch (mergeScore=5) when the only critical was dropped AND only info remains', () => {
-      // No warnings either — actionFindings.length === 0 → noActionItems
-      // branch wins before the FP-L clamp is consulted, returning 5/5.
+    it('#385 — does NOT fall through to 5/5 when the only critical was dropped and just info remains', () => {
+      // Was: actionFindings.length === 0 let the noActionItems branch win
+      // before the FP-L clamp was consulted, so a dropped "critical security
+      // vuln" shipped as 5/5 "only informational notes". That ordering was
+      // the #385 defect — an info-only remainder is not evidence the critical
+      // never existed, so the drop is disclosed instead.
       const r = reconcileMergeScore({
         filteredFindings: [{ ...warning(), severity: 'info' }],
         previousFindings: undefined,
@@ -3024,8 +3071,9 @@ describe('reconcileMergeScore', () => {
         orchestratorReason: 'critical security vuln',
         orchestratorCriticalsCount: 1,
       });
-      expect(r.mergeScore).toBe(5);
-      expect(r.mergeScoreReason).toMatch(/only informational/i);
+      expect(r.mergeScore).toBe(3);
+      expect(r.mergeScoreReason).toMatch(/dropped by post-orchestrator filtering/i);
+      expect(r.mergeScoreReason).not.toMatch(/only informational/i);
     });
 
     it('W7 unverified-criticals clamp still takes precedence when criticals are present (FP-L only fires when post-filter criticals are 0)', () => {
@@ -3169,13 +3217,16 @@ describe('reconcileMergeScore', () => {
       // noActionItems branch returns 5/5 with its own reason — the FP-L
       // append only runs on the orchestrator-passthrough branch, so the
       // earlier-branch reasons are never touched.
+      // `orchestratorCriticalsCount: 0` keeps this on the clean-PR branch:
+      // with flagged-then-dropped criticals it would (correctly, per #385)
+      // land on the disclosure branch instead, which isn't what this asserts.
       const r = reconcileMergeScore({
         filteredFindings: [],
         previousFindings: undefined,
         orchestratorScore: 2,
         orchestratorReason: 'Multiple things flagged.',
         orchestratorWarningsCount: 3,
-        orchestratorCriticalsCount: 1,
+        orchestratorCriticalsCount: 0,
       });
       expect(r.mergeScore).toBe(5);
       expect(r.mergeScoreReason).not.toMatch(/dropped or clustered/);

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -2314,6 +2314,24 @@ export function reconcileMergeScore(input: {
     ? `${highDisputeActionCount} of ${actionFindings.length} action finding${actionFindings.length === 1 ? '' : 's'} ${highDisputeActionCount === 1 ? 'is' : 'are'} from a category disputed ≥ ${Math.round(DISPUTE_RATE_HIGH_THRESHOLD * 100)}% of the time in this org's recent reviews — the verdict tier reflects that historical accuracy.`
     : undefined;
 
+  // #385 — "nothing to render" is only a clean PR when nothing was taken
+  // away. When the orchestrator scored blocking on criticals and every one of
+  // them vanished downstream, the clean-PR return below would ship
+  // "🟢 5/5 — All clear!" over the top of them: fixtures#610 approved an
+  // unauthenticated admin endpoint 5/5 while the summary prose in the very
+  // same comment named the missing auth. Disclose the loss instead. Gated on
+  // the orchestrator having flagged criticals, so a genuinely clean review —
+  // including one where the verifier correctly refuted a false positive the
+  // orchestrator never scored on (FP-K) — still returns 5.
+  if (noActionItems && (orchestratorCriticalsCount ?? 0) > 0 && orchestratorScore <= 2) {
+    const dropped = orchestratorCriticalsCount!;
+    return {
+      mergeScore: 3,
+      mergeScoreReason: `${dropped} critical finding${dropped === 1 ? ' was' : 's were'} flagged by the orchestrator and then dropped by post-orchestrator filtering, leaving nothing to render. This is an advisory verdict, NOT a clean-PR result — re-run the review or inspect the diff manually before merging.`,
+      ...(disputeDisclosure ? { disputeDisclosure } : {}),
+    };
+  }
+
   if (noActionItems) {
     return {
       mergeScore: 5,
@@ -2361,6 +2379,8 @@ export function reconcileMergeScore(input: {
   // conclusion.
   const droppedAllCriticals =
     (orchestratorCriticalsCount ?? 0) > 0 && currentCriticals.length === 0;
+  // (The zero-findings variant of this drop is handled earlier, before the
+  // clean-PR return — see #385 above.)
   if (droppedAllCriticals && orchestratorScore <= 2 && actionFindings.length > 0) {
     const w = actionFindings.length;
     const dropped = orchestratorCriticalsCount!;


### PR DESCRIPTION
Addresses the headline failure mode in #385.

## The bug

"Nothing to render" is only evidence of a clean PR when nothing was taken away.

The FP-L #183 clamp already covered the case where the orchestrator scored blocking on criticals that later got dropped **but warnings survived** — it downgrades to 3/5 and regenerates the reason. It deliberately sits *below* the `noActionItems` early return, so when the filters took **everything**, the review fell straight through to `🟢 5/5 — All clear!`.

That is exactly the shape #385 was filed for. On [fixtures#610](https://github.com/mergewatch/fixtures/pull/610) MergeWatch approved an **unauthenticated admin endpoint that returns every user** at 5/5, while the summary prose in the very same comment said the endpoint has "no error handling, authentication checks, or validation" — with `Suppressed: 8` in the footer. It reproduced on [fixtures#617](https://github.com/mergewatch/fixtures/pull/617) and [#621](https://github.com/mergewatch/fixtures/pull/621) the next run, and is model-independent (Opus and Sonnet both).

A green check here is worse than no review at all — it actively invites the merge.

## The fix

When the orchestrator scored blocking on criticals and **none** of them survive the downstream filters, the verdict becomes **3/5 advisory naming the loss**, instead of a clean pass:

> N critical findings were flagged by the orchestrator and then dropped by post-orchestrator filtering, leaving nothing to render. This is an advisory verdict, NOT a clean-PR result — re-run the review or inspect the diff manually before merging.

Advisory rather than blocking, so the review event still matches the check conclusion (which follows post-filter criticals) — the #183 invariant this logic lives inside is preserved.

## What deliberately still scores 5/5

The guard keys on **the orchestrator having flagged criticals**. A genuinely clean review is untouched, and critically so are the FP-K abstraction cases (fixtures 54a/54c) where the verifier correctly refutes a false positive the orchestrator never scored on — that quartet is currently 4-for-4 and stays that way. There's an explicit test for this.

## Note on the two changed tests

Two existing tests asserted the old ordering:

- `falls through to the no-action-items branch (mergeScore=5) when the only critical was dropped AND only info remains` — its own comment describes the mechanism ("noActionItems branch wins before the FP-L clamp is consulted"), i.e. it documented the defect rather than a product requirement. An info-only remainder is not evidence the critical never existed.
- `does NOT apply when an earlier branch returned its own reason` — its intent (the staleness append never touches earlier-branch reasons) is unchanged; its fixture just needed `orchestratorCriticalsCount: 0` to actually stay on the clean-PR branch.

Both updated with the reasoning inline.

## Scope

This closes the *false-green* half of #385 — the part that makes it a release blocker. The remaining half, **why** the filters non-deterministically eat legitimate criticals (identical bait armed on fixtures#622 and was filtered on #617/#621 in the same hour), is a separate investigation; #385 should stay open for it. This change means that when it happens, the user is told instead of being handed a green check.

## Verification

`@mergewatch/core` 914/914, `pnpm typecheck` 20/20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
