### PR TITLE
fix(lambda): don't re-drive dead-lettered reviews for closed PRs (#398)

### DIFF
--- a/packages/lambda/src/handlers/dlq-redrive.test.ts
+++ b/packages/lambda/src/handlers/dlq-redrive.test.ts
@@ -96,7 +96,7 @@ describe('dlq-redrive handler (#398)', () => {
 
     const result = await handler();
 
-    expect(result).toEqual({ redriven: 1, abandoned: 0 });
+    expect(result).toEqual({ redriven: 1, abandoned: 0, stale: 0 });
     const sends = sentCommands('send');
     expect(sends).toHaveLength(1);
     expect(sends[0].input.QueueUrl).toBe('https://sqs.test/queue');
@@ -134,7 +134,7 @@ describe('dlq-redrive handler (#398)', () => {
 
     const result = await handler();
 
-    expect(result).toEqual({ redriven: 0, abandoned: 1 });
+    expect(result).toEqual({ redriven: 0, abandoned: 1, stale: 0 });
     // Not re-sent — but the PR is not left with an in_progress check either.
     expect(sentCommands('send')).toHaveLength(0);
     expect(sentCommands('delete')).toHaveLength(1);
@@ -155,7 +155,7 @@ describe('dlq-redrive handler (#398)', () => {
 
     const result = await handler();
 
-    expect(result).toEqual({ redriven: 0, abandoned: 0 });
+    expect(result).toEqual({ redriven: 0, abandoned: 0, stale: 0 });
     // Never delete a message we failed to re-send — it must survive for the
     // next sweep.
     expect(sentCommands('delete')).toHaveLength(0);
@@ -166,9 +166,66 @@ describe('dlq-redrive handler (#398)', () => {
 
     const result = await handler();
 
-    expect(result).toEqual({ redriven: 0, abandoned: 0 });
+    expect(result).toEqual({ redriven: 0, abandoned: 0, stale: 0 });
     expect(sentCommands('send')).toHaveLength(0);
     expect(sentCommands('delete')).toHaveLength(1);
+  });
+
+  it('drops a dead-lettered job whose PR has since closed, without re-driving it', async () => {
+    // Observed in the first production sweep: jobs for PRs closed ~15 minutes
+    // earlier were re-driven and the agent started reviewing them, spending
+    // model calls nobody would read — and competing for the quota the live
+    // reviews were starved of.
+    mockGetInstallationOctokit.mockResolvedValue({
+      pulls: { get: vi.fn().mockResolvedValue({ data: { state: 'closed' } }) },
+    });
+    receiveOnce([{ Body: job(), ReceiptHandle: 'rh-1' }]);
+
+    const result = await handler();
+
+    expect(result).toEqual({ redriven: 0, abandoned: 0, stale: 1 });
+    expect(sentCommands('send')).toHaveLength(0);
+    expect(sentCommands('delete')).toHaveLength(1);
+    // The PR is gone — there is no check run worth completing.
+    expect(mockCreateCheckRun).not.toHaveBeenCalled();
+  });
+
+  it('drops a dead-lettered job whose PR 404s (deleted)', async () => {
+    mockGetInstallationOctokit.mockResolvedValue({
+      pulls: { get: vi.fn().mockRejectedValue(Object.assign(new Error('Not Found'), { status: 404 })) },
+    });
+    receiveOnce([{ Body: job(), ReceiptHandle: 'rh-1' }]);
+
+    const result = await handler();
+
+    expect(result).toEqual({ redriven: 0, abandoned: 0, stale: 1 });
+    expect(sentCommands('send')).toHaveLength(0);
+  });
+
+  it('still re-drives when the PR state cannot be determined (transient API error)', async () => {
+    // Indeterminate must not drop a real review — a blip on the liveness
+    // check is a worse failure than one wasted redrive.
+    mockGetInstallationOctokit.mockResolvedValue({
+      pulls: { get: vi.fn().mockRejectedValue(Object.assign(new Error('boom'), { status: 500 })) },
+    });
+    receiveOnce([{ Body: job(), ReceiptHandle: 'rh-1' }]);
+
+    const result = await handler();
+
+    expect(result).toEqual({ redriven: 1, abandoned: 0, stale: 0 });
+    expect(sentCommands('send')).toHaveLength(1);
+  });
+
+  it('re-drives a job whose PR is still open', async () => {
+    mockGetInstallationOctokit.mockResolvedValue({
+      pulls: { get: vi.fn().mockResolvedValue({ data: { state: 'open' } }) },
+    });
+    receiveOnce([{ Body: job(), ReceiptHandle: 'rh-1' }]);
+
+    const result = await handler();
+
+    expect(result).toEqual({ redriven: 1, abandoned: 0, stale: 0 });
+    expect(sentCommands('send')).toHaveLength(1);
   });
 
   it('is a no-op on an empty DLQ', async () => {
@@ -176,7 +233,7 @@ describe('dlq-redrive handler (#398)', () => {
 
     const result = await handler();
 
-    expect(result).toEqual({ redriven: 0, abandoned: 0 });
+    expect(result).toEqual({ redriven: 0, abandoned: 0, stale: 0 });
     expect(sentCommands('send')).toHaveLength(0);
     expect(sentCommands('delete')).toHaveLength(0);
   });

--- a/packages/lambda/src/handlers/dlq-redrive.ts
+++ b/packages/lambda/src/handlers/dlq-redrive.ts
@@ -84,14 +84,44 @@ async function completeAbandonedCheck(payload: ReviewJobPayload): Promise<void> 
   }
 }
 
-export async function handler(): Promise<{ redriven: number; abandoned: number }> {
+/**
+ * Is this job still worth re-driving? A dead-lettered review outlives the PR
+ * that asked for it: the first production sweep re-drove jobs for
+ * mergewatch/fixtures#635-643, all closed ~15 minutes earlier, and the review
+ * agent dutifully started reviewing them — spending model calls on PRs nobody
+ * would ever read, and (worse, during an outage) competing for the very quota
+ * the live reviews were starved of.
+ *
+ * `null` means "couldn't tell" — treated as alive, because dropping a real
+ * review on a transient API blip is the worse error.
+ */
+async function isPrStillOpen(payload: ReviewJobPayload): Promise<boolean | null> {
+  const { installationId, owner, repo, prNumber } = payload;
+  if (!installationId || !owner || !repo || !prNumber) return null;
+
+  try {
+    const octokit = await authProvider.getInstallationOctokit(installationId);
+    const { data } = await octokit.pulls.get({ owner, repo, pull_number: prNumber });
+    return data.state === 'open';
+  } catch (err) {
+    const status = (err as { status?: number } | null)?.status;
+    // A deleted PR is definitively not worth reviewing; anything else is
+    // indeterminate.
+    if (status === 404) return false;
+    console.warn(`Could not determine PR state for ${owner}/${repo}#${prNumber}:`, err);
+    return null;
+  }
+}
+
+export async function handler(): Promise<{ redriven: number; abandoned: number; stale: number }> {
   if (!REVIEW_QUEUE_URL || !REVIEW_DLQ_URL) {
     console.warn('REVIEW_QUEUE_URL / REVIEW_DLQ_URL unset — dlq-redrive is a no-op');
-    return { redriven: 0, abandoned: 0 };
+    return { redriven: 0, abandoned: 0, stale: 0 };
   }
 
   let redriven = 0;
   let abandoned = 0;
+  let stale = 0;
   let processed = 0;
 
   while (processed < MAX_MESSAGES_PER_RUN) {
@@ -132,6 +162,18 @@ export async function handler(): Promise<{ redriven: number; abandoned: number }
       }
 
       const label = `${payload.owner}/${payload.repo}#${payload.prNumber}`;
+
+      // Drop jobs whose PR has closed or merged while the job sat in the DLQ.
+      // No check run to complete — the PR is gone; reviving it would only
+      // burn model quota the live reviews need.
+      if ((await isPrStillOpen(payload)) === false) {
+        console.log(`Dropping dead-lettered review for ${label} — PR is no longer open`);
+        await sqs
+          .send(new DeleteMessageCommand({ QueueUrl: REVIEW_DLQ_URL, ReceiptHandle: message.ReceiptHandle }))
+          .catch((err) => console.error(`Failed to delete stale DLQ message for ${label}:`, err));
+        stale += 1;
+        continue;
+      }
 
       if (generation >= MAX_GENERATIONS) {
         console.warn(`Abandoning review after ${generation} redrive generations: ${label}`);
@@ -178,8 +220,10 @@ export async function handler(): Promise<{ redriven: number; abandoned: number }
     }
   }
 
-  if (redriven > 0 || abandoned > 0) {
-    console.log(`DLQ sweep complete: ${redriven} redriven, ${abandoned} abandoned`);
+  if (redriven > 0 || abandoned > 0 || stale > 0) {
+    console.log(
+      `DLQ sweep complete: ${redriven} redriven, ${abandoned} abandoned, ${stale} dropped (PR closed)`,
+    );
   }
-  return { redriven, abandoned };
+  return { redriven, abandoned, stale };
 }


### PR DESCRIPTION
Follow-up to #403 (#398), caught by the sweeper's **first production run**.

## What happened

The sweeper deployed at ~02:15 and immediately drained the DLQ backlog left by the 2026-08-19 outage. Those jobs belonged to fixtures PRs #635–643 — which had been **closed at 02:17** during an E2E teardown. The sweeper re-drove them anyway:

```
02:32:42  Redrove mergewatch/fixtures#636 (generation 1, delay 120s)
02:52:42  Redrove mergewatch/fixtures#636 (generation 2, delay 240s)
```

and the review agent dutifully picked them up:

```
Starting review for mergewatch/fixtures#636
[model] mergewatch/fixtures#636 using us.anthropic.claude-opus-4-6-v1
Review throttled for mergewatch/fixtures#636 — parking for retry
```

Model calls spent on PRs nobody will ever read — and, worse, spent *during* the kind of quota pressure the sweeper exists to recover from, competing with live reviews for the scarce budget. The generation cap bounded the cycling, but nothing asked whether the work was still wanted.

## The fix

Before re-driving, check the PR is still open:

- **closed / merged / 404** → drop the message. No check run is written: the PR is gone, there is nothing to report to (unlike the generation-cap path, where the PR is live and deserves an honest failing check).
- **indeterminate** (5xx, network) → re-drive anyway. Losing a real review to a transient blip on the liveness check is the worse error, so "couldn't tell" is treated as alive.

The sweep result now reports `{ redriven, abandoned, stale }` so the drop is visible in logs and metrics.

## Verification

4 new tests (closed PR, 404 PR, indeterminate-still-redrives, open-PR-still-redrives) alongside the existing suite: `@mergewatch/lambda` 91/91, `pnpm typecheck` 20/20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
