### PR TITLE
fix(core): don't render "All clear!" under a filtered-criticals verdict (#385)

### DIFF
--- a/packages/core/src/comment-formatter.test.ts
+++ b/packages/core/src/comment-formatter.test.ts
@@ -443,6 +443,45 @@ describe('buildWorkDoneSection', () => {
   });
 });
 
+// ─── #385 — all-clear vs a filtered-away-criticals verdict ───────────────────
+
+describe('formatReviewComment — criticals dropped by filtering (#385)', () => {
+  // The verdict line already says "NOT a clean-PR result"; the body used to
+  // answer it four lines later with "All clear! … looks good to go". On
+  // fixtures#668 that sentence sat under an unauthenticated admin endpoint
+  // that returned every user — a reader who skims to the body merges on the
+  // strength of the wrong half.
+  it('does not celebrate "All clear!" when the verdict was clamped to advisory', () => {
+    const result = formatReviewComment(baseOptions({
+      findings: [],
+      mergeScore: 3,
+      mergeScoreReason:
+        '1 critical finding was flagged by the orchestrator and then dropped by post-orchestrator '
+        + 'filtering, leaving nothing to render. This is an advisory verdict, NOT a clean-PR result.',
+    }));
+    expect(result).not.toContain('All clear!');
+    expect(result).not.toContain('looks good to go');
+    expect(result).toContain('Nothing rendered — see the verdict above before merging.');
+    // The verdict itself must still be present and unaltered.
+    expect(result).toContain('NOT a clean-PR result');
+  });
+
+  it('still celebrates a genuinely clean 5/5 review', () => {
+    const result = formatReviewComment(baseOptions({ findings: [], mergeScore: 5 }));
+    expect(result).toContain('All clear!');
+    expect(result).not.toContain('Nothing rendered');
+  });
+
+  it('leaves an info-only review alone even at an advisory score', () => {
+    // Info findings DO render, so "nothing rendered" would be false here.
+    const result = formatReviewComment(baseOptions({
+      findings: [makeFinding({ severity: 'info', title: 'Nit' })],
+      mergeScore: 3,
+    }));
+    expect(result).not.toContain('Nothing rendered');
+  });
+});
+
 // ─── #240 — all-clear vs unverified concerns coherence ───────────────────────
 
 describe('formatReviewComment — unverified-only criticals (#240)', () => {

--- a/packages/core/src/comment-formatter.ts
+++ b/packages/core/src/comment-formatter.ts
@@ -434,6 +434,16 @@ export function formatReviewComment(options: FormatOptions): string {
     if (unverifiedCriticalCount > 0) {
       lines.push('No blocking issues \u2014 see unverified concerns below.');
       lines.push('');
+    // `?? 5` keeps callers that omit mergeScore on the pre-#385 behavior.
+    } else if (findings.length === 0 && (mergeScore ?? 5) <= 3) {
+      // #385 \u2014 an empty finding list is not always a clean bill of health. When
+      // every finding the orchestrator raised was filtered away, the verdict is
+      // clamped to advisory and its subtitle says so; celebrating "All clear!"
+      // four lines under that subtitle contradicts it, and a reader who skims
+      // to the body merges on the strength of the wrong half. Defer to the
+      // verdict line rather than talking over it.
+      lines.push('Nothing rendered \u2014 see the verdict above before merging.');
+      lines.push('');
     } else if (ux?.allClearMessage !== false) {
       lines.push('\uD83C\uDF89 **All clear!** No issues found \u2014 this PR looks good to go.');
       lines.push('');


### PR DESCRIPTION
Follow-up to #404. The #385 clamp sets the **score and reason** correctly, but the comment **body** still celebrated. Live on fixtures#668 the same comment read:

> 🟡 **3/5 — Review recommended** — 1 critical finding was flagged by the orchestrator and then dropped by post-orchestrator filtering, leaving nothing to render. This is an advisory verdict, NOT a clean-PR result — re-run the review or inspect the diff manually before merging.

…and four lines below:

> 🎉 **All clear!** No issues found — this PR looks good to go.

That fixture's diff is an **unauthenticated admin endpoint returning every user**. A reader who skims past the verdict blockquote to the body merges on the strength of the wrong half — which is precisely the misleading-green signal #385 set out to kill, just relocated from the verdict line to the body.

Reproduced on three PRs in a single run: fixtures#661, #666, #668 — every PR that took the new clamp path.

## Fix

The all-clear branch was gated only on the rendered finding list being empty. It now also defers when the verdict was clamped to advisory, mirroring the **#240** precedent in the same function, where all-clear defers to the unverified-concerns section rather than talking over it:

```
} else if (findings.length === 0 && (mergeScore ?? 5) <= 3) {
  lines.push('Nothing rendered — see the verdict above before merging.');
```

Deliberately narrow:
- **Info-only reviews are unaffected** — their findings do render, so "nothing rendered" would be false; there's a test.
- **A genuinely clean 5/5 still celebrates.**
- **Callers that omit `mergeScore`** keep the previous behavior (`?? 5`).

## Verification

3 new tests (suppressed under a clamped verdict, clean 5/5 still celebrates, info-only untouched): `@mergewatch/core` 917/917, `pnpm typecheck` 20/20.

## Release note

This was the one CORRECTNESS defect standing between the current build and a ship — everything else found in the 2026-08-20 E2E run classified as capacity (provider quota) or fixture-side. Independent grading of fixtures 18a–32 reached the same root cause and proposed the same gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
