### PR TITLE
docs: document minConfidence and correct two stale threshold claims

### DIFF
--- a/docs-site/configuration/false-positives.mdx
+++ b/docs-site/configuration/false-positives.mdx
@@ -19,7 +19,7 @@ The single worst failure mode for a reviewer is confident nonsense — a critica
 
 Findings are **grounded against the diff**: a claim is checked against the code it cites before it is reported. Warnings get the same treatment as criticals, and Mermaid diagrams that reference files outside the PR are dropped rather than shown.
 
-There is also a **confidence floor**. An agent that is guessing does not get to file a critical.
+There is also a **confidence floor**. An agent that is guessing does not get to file a critical. The floor defaults to `75` and is tunable per repo with [`minConfidence`](/configuration/mergewatch-yml): lower it (e.g. `minConfidence: 50`) to surface the speculative tier MergeWatch normally withholds, or raise it to report only near-certain defects.
 
 </Accordion>
 

--- a/docs-site/configuration/mergewatch-yml.mdx
+++ b/docs-site/configuration/mergewatch-yml.mdx
@@ -101,6 +101,10 @@ agentReview:
 # Minimum severity to report: info | warning | critical
 minSeverity: info
 
+# Minimum self-reported confidence (1-100) a finding needs to be reported.
+# Lower to surface more speculative findings; raise for near-certain defects only.
+minConfidence: 75
+
 # Maximum findings posted per review.
 maxFindings: 25
 
@@ -125,6 +129,7 @@ ux:
 | `lightModel` | `string` | `us.anthropic.claude-haiku-4-5-20251001-v1:0` | Lighter model used for low-complexity tasks such as summary generation. |
 | `maxTokensPerAgent` | `number` | `4096` | Maximum output tokens per agent invocation. Increase for large PRs; decrease to reduce cost. |
 | `minSeverity` | `string` | `info` | Minimum severity level to report. One of `info`, `warning`, `critical`. Findings below this threshold are suppressed. |
+| `minConfidence` | `number` | `75` | Minimum self-reported confidence (`1`--`100`) a finding needs to be reported. **Lower it** (e.g. `50`) to surface the speculative tier MergeWatch normally withholds — useful when calibrating or when you suspect findings are being over-suppressed. **Raise it** to report only near-certain defects. Values outside `1`--`100` are ignored and the default applies. |
 | `maxFindings` | `number` | `25` | Maximum number of findings posted per review. Prevents noisy reviews on large PRs. |
 | `postSummaryOnClean` | `boolean` | `true` | When `true`, MergeWatch posts a summary comment even when no findings are detected. Set to `false` to stay silent on clean PRs. If an earlier review already posted a comment on the PR, it is still updated — a previously-flagged PR that comes back clean never keeps a stale review. |
 | `codebaseAwareness` | `boolean` | `true` | Enable agentic file fetching for cross-file context. When `true`, agents can request additional files from the repository. |

--- a/docs-site/configuration/review-behavior.mdx
+++ b/docs-site/configuration/review-behavior.mdx
@@ -114,12 +114,12 @@ Each finding produced by MergeWatch includes a **confidence score** from 1 to 10
 |---|---|
 | 90-100 | High confidence — obvious, clear-cut issue |
 | 75-89 | Medium-high confidence — likely a real issue |
-| 50-74 | Lower confidence — suppressed by the orchestrator |
-| 1-49 | Low confidence — suppressed by the orchestrator |
+| 50-74 | Lower confidence — suppressed at the default floor |
+| 1-49 | Low confidence — suppressed at the default floor |
 
-Findings with confidence below **75** are dropped. The orchestrator prompt asks for this, and a deterministic filter enforces it afterwards — a prompt instruction alone was not reliable enough to depend on, so the floor is applied in code regardless of what the orchestrator returns.
+Findings with confidence below the floor (**75** by default) are dropped. The orchestrator prompt asks for this, and a deterministic filter enforces it afterwards — a prompt instruction alone was not reliable enough to depend on, so the floor is applied in code regardless of what the orchestrator returns.
 
-The threshold is not user-configurable. It is set to minimize false positives while surfacing real issues; see [How MergeWatch avoids false positives](/configuration/false-positives) for the other guards that run alongside it.
+The threshold defaults to **75** and is configurable per repo with [`minConfidence`](/configuration/mergewatch-yml) (`1`--`100`). Lower it (e.g. `minConfidence: 50`) to surface the speculative tier shown above as suppressed; raise it to report only near-certain defects. The default is set to minimize false positives while surfacing real issues; see [How MergeWatch avoids false positives](/configuration/false-positives) for the other guards that run alongside it.
 
 <Tip>
 If you notice a legitimate issue being suppressed, consider adding a [custom agent](/configuration/mergewatch-yml#custom-agents) with a targeted prompt. Custom agents with focused prompts tend to produce higher-confidence findings for domain-specific concerns.

--- a/docs-site/dashboard/settings.mdx
+++ b/docs-site/dashboard/settings.mdx
@@ -25,7 +25,7 @@ The stored settings object (`InstallationSettings` in `@mergewatch/core`) has th
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `severityThreshold` | `"Low" \| "Med" \| "High"` | `"Med"` | Minimum severity level to post as a comment. Findings below this threshold are suppressed. |
+| `severityThreshold` | `"Low" \| "Med" \| "High"` | `"Low"` | Minimum severity level to post as a comment. Findings below this threshold are suppressed. The default reports every tier including info; `Med` and `High` are explicit opt-ins that suppress lower tiers. |
 | `commentTypes.syntax` | boolean | `true` | Include syntax-category findings. |
 | `commentTypes.logic` | boolean | `true` | Include logic / bug-category findings. |
 | `commentTypes.style` | boolean | `true` | Include style-category findings. |


### PR DESCRIPTION
## What

`minConfidence` (the FP-A confidence floor, made configurable in #379 and shipped in **v0.5.0**) never made it into the public docs — it lived only in the self-referential `.mergewatch.yml` and the internal `docs/architecture.md`. A user had no way to discover it.

While adding it, two documented claims turned out to contradict the shipped code:

| Page | Said | Actually |
|---|---|---|
| `configuration/review-behavior.mdx` | "The threshold is **not user-configurable**" | tunable via `minConfidence` since #379 |
| `configuration/false-positives.mdx` | confidence floor described as fixed | same |
| `dashboard/settings.mdx` | `severityThreshold` defaults to `"Med"` | defaults to **`"Low"`** since #357 |

That last one is the consequential one: #357 changed the default to `Low` *because* `Med` silently suppressed every info-tier finding the moment #310 wired `minSeverity` (`DEFAULT_INSTALLATION_SETTINGS` in `packages/core/src/types/db.ts` carries the rationale). The docs were describing the exact bug that change fixed.

## Changes

- **`configuration/mergewatch-yml.mdx`** — `minConfidence` row in the reference table (range, default, both tuning directions, out-of-range behavior) + a line in the example YAML next to `minSeverity`.
- **`configuration/review-behavior.mdx`** — the "not user-configurable" paragraph now names the key and explains lowering vs raising; the confidence table rows and the "below 75 are dropped" line are phrased as default-relative rather than absolute.
- **`configuration/false-positives.mdx`** — the confidence-floor sentence now says it's tunable and links to the reference.
- **`dashboard/settings.mdx`** — corrected default to `"Low"` with a note that `Med`/`High` are explicit opt-ins.

Docs-only; no code or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)