### PR TITLE
docs: close gaps found by a systematic docs-vs-code audit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,3 +56,7 @@ ANTHROPIC_API_KEY=
 # GITHUB_APP_SLUG=               # GitHub App slug (for install link in dashboard)
 # PORT=3000                      # Server port (default: 3000)
 # INSIGHTS_ROLLUP_INTERVAL_MINUTES=60   # Dashboard insight rollup cadence (default: 60 = hourly; raise to reduce DB load)
+# REVIEW_CONCURRENCY=3           # Reviews processed concurrently by the queue worker (default: 3).
+#                                # A PR burst is paced instead of hitting your LLM provider all at once.
+# DASHBOARD_BASE_URL=            # Public dashboard URL — used for deep links in PR comments
+#                                # (e.g. https://dashboard.example.com)

--- a/docs-site/configuration/review-behavior.mdx
+++ b/docs-site/configuration/review-behavior.mdx
@@ -60,10 +60,27 @@ Every review tracked by MergeWatch has one of the following statuses, visible in
 | **Reviewed** | The review completed successfully and findings have been posted to GitHub. |
 | **Skipped** | The PR matched a skip rule. The reason is logged and visible in the detail drawer. |
 | **Failed** | A Lambda error or Bedrock failure occurred. The review can be re-triggered. |
+| **Queued** | The LLM provider rate-limited the review, so it was parked and will retry automatically. The GitHub check stays in progress and its title shows the attempt number — no action needed unless it persists past the final attempt. |
 
 <Tip>
 Failed reviews can always be retried by commenting `@mergewatch review` on the pull request.
 </Tip>
+
+## What the GitHub check run shows
+
+MergeWatch posts a single **MergeWatch Review** check run on every reviewed commit. Its title leads with the merge score so the verdict is visible from the checks tab without opening the summary comment:
+
+| Check title | Conclusion | Meaning |
+|---|---|---|
+| `5/5 — No issues found` | success | Nothing to report on the changed lines. |
+| `3/5 — 2 findings (no blocking critical)` | success | Findings exist and are worth reading, but none of them block. |
+| `1/5 — 2 critical issues found` | failure | At least one **verified** critical finding. |
+| `2/5 — Blocked by org agent: no-todo` | failure | An organization custom agent set to *blocking* raised a critical. |
+| `Review queued — rate limited (attempt 2)` | in progress | Parked after a provider rate limit; retries automatically. |
+
+<Note>
+Only **verified** critical findings fail the check. A critical the verification pass could not confirm is reported as an advisory concern and the check still succeeds — the score is clamped instead, so a green check never means "the review found nothing worth reading". Read the score in the title.
+</Note>
 
 ## Comment editing behavior
 

--- a/docs-site/reference/changelog.mdx
+++ b/docs-site/reference/changelog.mdx
@@ -7,6 +7,29 @@ All notable changes to MergeWatch are documented here. The changelog in the sour
 
 ---
 
+## [0.5.0] — 2026-08-19
+
+First tagged release since `0.1.0`. Four months of work: competitive parity, org-level controls, and a sustained push on review reliability.
+
+### Highlights
+
+- **Org custom agents** — define review agents once in the dashboard and enforce them across every repository, with path/language targeting and an optional *blocking* mode that fails the check on a critical finding. See [Custom agents](/dashboard/custom-agents).
+- **MCP server** — expose MergeWatch review to MCP-compatible clients for pre-commit review.
+- **Structured LLM output** — agents now emit findings against an enforced JSON schema on every supported provider, eliminating a class of failure where a malformed response silently discarded findings.
+- **Burst resilience** — a durable job queue with bounded concurrency (SQS on SaaS, Postgres on self-hosted) paces a flood of pull requests instead of hitting the provider's rate limit all at once. Rate-limited reviews park and retry rather than failing. Tunable via [`REVIEW_CONCURRENCY`](/reference/env-vars).
+- **Merge score in the check title** — the GitHub check run leads with the verdict (`3/5 — 2 findings`), so a passing check no longer hides an advisory result. See [Review behavior](/configuration/review-behavior).
+- **False-positive reduction** — grounding findings against the diff, a claim-verification pass, cross-agent deduplication, clustering of related concerns, and a configurable confidence floor ([`minConfidence`](/configuration/mergewatch-yml)).
+- **Configuration that actually applies** — `minSeverity`, `maxTokensPerAgent`, and `postSummaryOnClean` are now read by the pipeline; several were previously documented but unwired.
+- **Analytics** — windowed rollups, p95 time-to-merge, and per-day counters, with the 500-review ceiling removed.
+- **Cost visibility** — per-PR and dashboard cost for self-hosted deployments, including custom model pricing for models MergeWatch does not price by default.
+
+### Notes
+
+- The default dashboard severity threshold is **Low** (report every tier). `Med` and `High` are explicit opt-ins.
+- Docker images are published per release: `ghcr.io/mergewatch/mergewatch:0.5.0` and `ghcr.io/mergewatch/mergewatch-dashboard:0.5.0`.
+
+---
+
 ## [0.1.0] — 2026-04-04
 
 Initial release of MergeWatch — AI-powered GitHub PR review with a multi-agent pipeline.

--- a/docs-site/reference/env-vars.mdx
+++ b/docs-site/reference/env-vars.mdx
@@ -28,6 +28,7 @@ Self-hosted deployments use a `.env` file alongside `docker-compose.yml`. See th
 | `DASHBOARD_URL` | No | `http://localhost:3001` | Consumed by `docker-compose.yml` to set `NEXTAUTH_URL` on the dashboard container. Set when serving the dashboard on a public domain. |
 | `LLM_MODEL_INPUT_PRICE_PER_1M` | No | — | USD per 1M **input** tokens for whatever `LLM_MODEL` is set to. Lets a self-hosted deployment show real per-PR and dashboard cost instead of "unpriced" — including for an opaque Bedrock inference-profile ARN. Must be set together with the output price. |
 | `LLM_MODEL_OUTPUT_PRICE_PER_1M` | No | — | USD per 1M **output** tokens for `LLM_MODEL`. Both prices must be finite and non-negative, and both must be present — if either is missing or invalid, neither is applied. `0` / `0` is valid and records a real $0 for a local model. |
+| `REVIEW_CONCURRENCY` | No | `3` | How many reviews the background worker processes at once. The worker drains a durable Postgres job queue, so a burst of pull requests becomes a paced stream instead of N simultaneous LLM calls against your provider's rate limit. Raise it if your provider quota allows more throughput; lower it to be gentler. Non-numeric or non-positive values fall back to the default. |
 | `INSIGHTS_ROLLUP_INTERVAL_MINUTES` | No | `60` | How often the insights rollup runs, in minutes. Raise it to reduce database load. Unset, non-numeric, or non-positive values fall back to the hourly default. |
 
 ### Provider-specific: Anthropic


### PR DESCRIPTION
## How these were found

Rather than reading pages looking for omissions, I compared each documentation surface against the code that defines it:

| Check | Result |
|---|---|
| `DEFAULT_CONFIG` keys vs the `.mergewatch.yml` reference table | ✅ all 17 documented |
| Documented defaults vs actual defaults | ✅ clean (`model` correctly defers to the deployment parameter) |
| `InstallationSettings` vs the dashboard schema table | ✅ complete (sub-keys documented individually) |
| Every `process.env` read vs the env-var reference | ❌ 2 gaps |
| `ReviewStatus` values vs the documented status table | ❌ 1 gap |
| Check-run output vs docs | ❌ undocumented entirely |
| docs-site changelog vs shipped releases | ❌ stale |

## The five gaps

**1. `REVIEW_CONCURRENCY` was undocumented** (env-var reference *and* `.env.example`). This is the self-hosted queue worker's concurrency — the knob that decides whether a PR burst becomes a paced stream or a wall of simultaneous LLM calls. Operators had no way to discover it.

**2. `DASHBOARD_BASE_URL` missing from `.env.example`** (it was in the reference). Anyone configuring from the example file alone would never set it, and PR-comment deep links would silently point nowhere.

**3. The review-status table omitted the queued/rate-limited state.** `ReviewStatus` has five values; the table documented four. The missing one is the parked-after-rate-limit state — the status a user is most likely to see and ask about, and the only one that resolves itself.

**4. Nothing documented what the GitHub check run shows.** Two behaviors are genuinely surprising if undocumented: the title now leads with the merge score, and **only verified criticals fail the check** — so a green check can sit alongside findings worth reading. Added as a table of real title/conclusion pairs, with a note explaining the verified-critical rule.

**5. The docs-site changelog ended at `0.1.0`** despite v0.5.0 shipping today. Added a curated 0.5.0 entry matching the page's existing style.

## Not changed

`commentTypes` and `summary` first looked missing from the dashboard schema — they're documented as dotted sub-keys (`commentTypes.syntax`, `summary.prSummary`). False positive from my own tooling, left alone.

## Verification

Because this PR is *about* documentation drifting from code, every claim I added was checked against the implementation — check-run titles against `buildCheckTitle`, the rate-limited title string against the handler, and the failure rule against the conclusion logic — rather than written from memory. Full `build` / `typecheck` / `test` green.

Docs-only; no behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)