### PR TITLE
feat(billing): OSS pre-approval claimed automatically on install (#409, stage 2)

### DIFF
--- a/docs/feat/20260820-01-oss-org-grants-and-preapproval.plan.md
+++ b/docs/feat/20260820-01-oss-org-grants-and-preapproval.plan.md
@@ -100,14 +100,14 @@ The SK is `account.login.toLowerCase()` — GitHub logins are case-insensitive f
 
 ### Phase 1 — org scope in the gate
 
-- [ ] **Goal:** `ossGrantScope: 'org'` sponsors every public repo in the installation. Pure logic; nothing writes the field yet.
+- [x] **Goal:** `ossGrantScope: 'org'` sponsors every public repo in the installation. Pure logic; nothing writes the field yet. **Shipped in PR #410** (MergeWatch 5/5, no findings).
 - **Files:** `packages/core/src/types/db.ts` (two fields + revise the "no installation-wide mode" comment), `packages/billing/src/oss-grant.ts` (the branch), `packages/billing/src/index.ts` (re-export any new type), `packages/billing/src/oss-grant.test.ts`, `packages/billing/src/record-review.test.ts`.
 - **Tests:** org-scope eligible with an empty/absent repo list; org scope still rejects private (`repo_not_public`); org scope still respects expiry and cap; absent `ossGrantScope` behaves byte-for-byte as today (back-compat); `repos` scope with an empty list is still `no_grant`; `recordReview` accrues (and does not touch balance or `freeReviewsUsed`) under org scope.
 - **RUNBOOK:** E2E-91 — org-scoped grant sponsors a new public repo with no operator action, and stops sponsoring it when flipped private.
 
 ### Phase 2 — pre-approval store + claim on install
 
-- [ ] **Goal:** pre-approve an org that hasn't installed; the grant lands automatically on `installation.created`.
+- [x] **Goal:** pre-approve an org that hasn't installed; the grant lands automatically on `installation.created`. **Shipped in PR #411.**
 - **Files:** new `packages/billing/src/oss-preapproval.ts` (`putPreapproval`, `getPreapproval`, `listPreapprovals`, `claimOssPreapproval`), `packages/billing/src/index.ts`, `packages/lambda/src/handlers/webhook.ts` (call the claim from `handleInstallationEvent`, `created` action only), new `packages/billing/src/oss-preapproval.test.ts`, `packages/lambda/src/handlers/webhook.test.ts`.
 - **Tests:** claim writes an org-scoped grant; redelivery is a no-op (condition fails); an existing grant is never overwritten; an expired pre-approval writes nothing and stamps `expiredAt`; a claimed row is inert on reinstall; login casing is normalized; a claim failure doesn't break `storeInstallation`; non-`created` actions never claim.
 - **RUNBOOK:** E2E-92 — pre-approve an org, install the App, first PR is sponsored with no operator step in between.
@@ -120,6 +120,12 @@ The SK is `account.login.toLowerCase()` — GitHub logins are case-insensitive f
 - **Tests:** `ossStatus` returns non-null for an org-scoped grant with no repo list; still `null` with no grant at all; script arg-parsing rejects `--org` combined with a repo list.
 - **RUNBOOK:** E2E-93 — operator lifecycle: `--org`, `--preapprove`, `--list-preapprovals`, `--inspect`, `--revoke`; `--stage` guard still refuses to default.
 - **Docs:** update `docs/oss-program.md` **in place** rather than creating a `docs/pending/` doc. The #261 doc already graduated; a parallel pending doc that gets merged back in at the end is pure churn, and the "named repos only" section is now actively wrong and should not stay wrong for three PRs.
+
+## Deviations from the plan as written
+
+- **`OSS_PREAPPROVAL_TTL_DAYS` moved from stage 3 to stage 2.** `putPreapproval` needs it to compute `preapprovalExpiresAt`, so it had to ship with the store rather than with the script that calls it.
+- **`getBillingFields`'s `ProjectionExpression` was missing the stage-1 fields.** Found while writing stage 2. `packages/billing/src/dynamo-billing.ts` projects an explicit attribute list, and stage 1 added `ossGrantScope` / `ossGrantAccount` to `BillingFields` without adding them there — so the gate would have read `ossGrantScope` as `undefined`, defaulted to `'repos'`, and silently ignored every org-scoped grant. Latent (nothing wrote the field until stage 2), fixed in stage 2. The file's own comment warns about exactly this; MergeWatch's review of #410 did not catch it.
+- **Date arithmetic is UTC, not local.** `setMonth`/`setDate` shift by an extra hour across a DST boundary, which would make a grant's expiry depend on the timezone of whoever ran the operator script. `addMonths` uses `setUTCMonth`; the TTL is plain millisecond arithmetic. Pinned by tests that run the same computation under four timezones.
 
 ## Out of scope / deferred
 

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -215,6 +215,7 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-86](#e2e-86-336--p95-duration-nearest-rank--minimum-sample) | Analytics p95 duration uses nearest-rank (`⌈n × 0.95⌉`, clamped) instead of returning the maximum for n ≤ 20; below 20 completed reviews the UI shows "—" with an explanatory tooltip and no P95 bar (#336) | 2m | 30s | #336 |
 | [E2E-87](#e2e-87-337--date-only-range-bounds-include-their-whole-day) | `/api/analytics` date-only `start_date`/`end_date` expand to the UTC day's edge instants at the boundary (`end_date=2026-08-16` includes the whole 16th); full timestamps pass through untouched; identical on both backends; UTC bucketing documented in the route (#337) | 2m | 30s | #337 |
 | [E2E-88](#e2e-88-355--pr-burst-resilience) | A PR burst never silently loses reviews: throttles park the review (`pending` + in_progress "rate limited" check, never terminal FAILURE) and admission control paces the backlog — SQS `MaximumConcurrency` on SaaS, Postgres `SKIP LOCKED` worker at `REVIEW_CONCURRENCY` on self-hosted; exhaustion lands in a DLQ/`status='dead'`, visibly (#355) | 20m | n/a | #355 |
+| [E2E-92](#e2e-92-409--oss-pre-approval-claimed-automatically-on-install) | An org pre-approved before installing gets an org-scoped grant written automatically on `installation.created`; a webhook redelivery never resets an existing grant, a claimed row never re-fires on reinstall, and an expired pre-approval is ignored (#409) | 8m | n/a | #409 |
 | [E2E-91](#e2e-91-409--oss-org-scoped-grant-covers-every-public-repo) | An `ossGrantScope: 'org'` grant sponsors every PUBLIC repo in the installation including newly-created ones, while private repos, expiry, and the monthly cap still gate it; pre-#409 grants with no scope field still match only their named repo ids (#409) | 5m | n/a | #409 |
 | [E2E-90](#e2e-90-390--structured-outputs-zero-parse-failures) | On a provider with structured-output support, a full-suite run produces ZERO "Could not parse agent JSON response" log lines and no "Unparsed agent output" disclosures; the text parser is exercised only on fallback paths (#390) | 2m | 60s | #390 |
 | [E2E-89](#e2e-89-372--intent-claims-never-suppress-findings) | In-code comments claiming a defect is intentional ("test-only", "simulates", "regression guard") never suppress a finding — agents still report, and an intent-shaped verifier dismissal is refused (kept as advisory `unverified`); the same intent declared in the conventions doc suppresses as before (#372) | 3m | 60s | #372 |
@@ -3162,6 +3163,48 @@ Then exhaust the free tier (or set `freeReviewsUsed` to 5 and `balanceCents` to 
 - ❌ A pre-#409 grant starts covering unnamed repos (absent `ossGrantScope` misread as org) — this silently sponsors open-core commercial repos
 - ❌ The cap stops applying under org scope (`cap_exceeded` never fires) — a runaway org has no ceiling
 - ❌ Gate and accrual disagree: `billingCheck` says `oss` but `recordReview` charges anyway, or vice versa
+
+---
+
+### E2E-92: #409 — OSS pre-approval claimed automatically on install
+
+**Status:** 🚧 In review (#409, stage 2).
+
+**Behavior:** an operator can approve an org **before** it has installed the App. The approval is parked as a `#PENDING-OSS` row in the installations table, keyed by the lowercased org login. When `installation.created` arrives, the webhook claims it: an org-scoped grant is written to that installation's `#SETTINGS` row and the pending row is marked `claimedAt`. The org's very first PR is already sponsored — no operator step in between.
+
+The claim is guarded on `attribute_not_exists(ossGrantExpiresAt)`, so a webhook redelivery (or an operator who granted manually in the meantime) never resets an existing grant. A claimed row is inert: uninstall/reinstall does not re-grant.
+
+**Setup.** Stage 2 ships no operator command (`--preapprove` lands in stage 3), so write the pending row by hand on dev:
+
+```bash
+aws dynamodb put-item --profile mergewatch --region us-west-2 \
+  --table-name mergewatch-installations-dev \
+  --item '{"installationId":{"S":"#PENDING-OSS"},"repoFullName":{"S":"<org-login-lowercased>"},
+           "orgLogin":{"S":"<Org-Login>"},"capCents":{"N":"2000"},"months":{"N":"12"},
+           "note":{"S":"e2e-92"},"preapprovedAt":{"S":"2026-08-20T12:00:00.000Z"},
+           "preapprovalExpiresAt":{"S":"2026-11-18T12:00:00.000Z"}}'
+```
+
+Then install the App on a test org that has **never** installed it before (an existing installation won't emit `installation.created`).
+
+**Expected outcomes.**
+- [ ] Webhook log shows `[oss] pre-approval claimed for <org> install=<id> scope=org cap=2000c expires=…`
+- [ ] The installation's `#SETTINGS` row now has `ossGrantScope=org`, `ossGrantAccount={id,login}`, `ossGrantExpiresAt` ~12 months out, `ossMonthlyCapCents=2000`, and an `ossGrantNote` containing both the operator note and `claimed from pre-approval`
+- [ ] The pending row now carries `claimedAt` and `claimedInstallationId`
+- [ ] A PR on any **public** repo in that org is sponsored — `[billing] allow install=<id> reason=oss` — with `freeReviewsUsed` still 0
+- [ ] Grant term runs from the **claim**, not the approval (write a pre-approval dated weeks ago; expiry should still be ~12 months from install)
+- [ ] Redeliver the `installation.created` webhook from the GitHub App's Advanced tab → log shows `reason=grant_exists`, and `ossGrantExpiresAt` is **unchanged**
+- [ ] Uninstall and reinstall → log shows `reason=already_claimed`; no new grant is written
+- [ ] A pending row with `preapprovalExpiresAt` in the past → `reason=expired`, nothing written to `#SETTINGS`, row stamped `expiredAt`
+- [ ] Casing: a row written as `acme-corp` is still claimed when the org login is `Acme-Corp`
+- [ ] An org with **no** pending row installs normally, with no `[oss]` log line at all
+
+**Failure modes.**
+- ❌ A redelivery **resets** `ossGrantExpiresAt` — the condition guard regressed, and an operator's amendment or revocation is silently undone
+- ❌ The pending row is marked claimed but no grant landed (ordering inverted) — the approval is spent and the org gets nothing, with no error anywhere
+- ❌ A claim failure returns non-200 or aborts `storeInstallation` — the installation record is lost, which is far worse than a missed sponsorship
+- ❌ An expired pre-approval still fires — the 90-day TTL is the only forcing function to re-review a stale decision
+- ❌ The claim runs in self-hosted mode (`isSaas()` guard regressed) — Postgres has no billing columns and the write targets a table that doesn't exist
 
 ---
 

--- a/packages/billing/src/constants.ts
+++ b/packages/billing/src/constants.ts
@@ -24,3 +24,14 @@ export const OSS_DEFAULT_MONTHLY_CAP_CENTS = 2000;
 
 /** #261 — Default OSS grant term in months, after which it needs renewal. */
 export const OSS_DEFAULT_TERM_MONTHS = 12;
+
+/**
+ * #409 — Days an unclaimed OSS pre-approval stays live. After this it is ignored
+ * at install time, so an org that installs long after a forgotten decision does
+ * not get silently sponsored.
+ *
+ * Enforced logically at claim time rather than by a DynamoDB TTL: the
+ * installations table has no `TimeToLiveSpecification`, and a logical check also
+ * leaves the lapsed row in place to be audited.
+ */
+export const OSS_PREAPPROVAL_TTL_DAYS = 90;

--- a/packages/billing/src/dynamo-billing.ts
+++ b/packages/billing/src/dynamo-billing.ts
@@ -23,9 +23,13 @@ export async function getBillingFields(
       + 'prCount, prTimestamps, totalBilledCents, autoReloadEnabled, '
       + 'autoReloadThresholdCents, autoReloadAmountCents, autoReloadInFlight, '
       + 'blockedAt, blockIssueNumber, blockIssueRepo, '
-      // OSS Program (#261). Omitting a field here reads it back as undefined
-      // with no error, which would silently disable sponsorship — keep this
-      // list in sync with BillingFields.
+      // OSS Program (#261, org scope #409). Omitting a field here reads it back
+      // as undefined with no error, which would silently disable sponsorship —
+      // keep this list in sync with BillingFields. `ossGrantScope` in
+      // particular: absent reads as 'repos', so leaving it out of the
+      // projection would make every org-scoped grant behave as a grant naming
+      // no repos at all.
+      + 'ossGrantScope, ossGrantAccount, '
       + 'ossGrantRepos, ossGrantExpiresAt, ossGrantedAt, ossGrantNote, '
       + 'ossMonthlyCapCents, ossPeriod, ossSponsoredCentsThisPeriod, '
       + 'ossSponsoredCentsLifetime',

--- a/packages/billing/src/index.ts
+++ b/packages/billing/src/index.ts
@@ -11,6 +11,7 @@ export {
   MIN_BALANCE_CENTS,
   OSS_DEFAULT_MONTHLY_CAP_CENTS,
   OSS_DEFAULT_TERM_MONTHS,
+  OSS_PREAPPROVAL_TTL_DAYS,
 } from './constants';
 
 // ─── OSS Program grant (#261) ───────────────────────────────────────────────
@@ -20,6 +21,22 @@ export {
   sponsoredCentsThisPeriod,
 } from './oss-grant';
 export type { RepoContext, OssEligibility, OssIneligibleReason } from './oss-grant';
+
+// ─── OSS Program pre-approval (#409) ────────────────────────────────────────
+export {
+  PREAPPROVAL_PK,
+  normalizeLogin,
+  putPreapproval,
+  getPreapproval,
+  listPreapprovals,
+  claimOssPreapproval,
+} from './oss-preapproval';
+export type {
+  OssPreapproval,
+  PreapprovalInput,
+  ClaimResult,
+  ClaimSkipReason,
+} from './oss-preapproval';
 
 // ─── Cost calculation ───────────────────────────────────────────────────────
 export { calculateReviewCost } from './cost';

--- a/packages/billing/src/oss-preapproval.test.ts
+++ b/packages/billing/src/oss-preapproval.test.ts
@@ -1,0 +1,366 @@
+/**
+ * #409 — OSS Program pre-approval.
+ *
+ * The claim runs unattended on a webhook, so the failure modes that matter are
+ * the ones nobody would notice: a redelivery resetting a grant an operator had
+ * since amended, a spent approval silently re-firing on reinstall, or a stale
+ * approval sponsoring an org that installed two years after the decision.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  PREAPPROVAL_PK,
+  normalizeLogin,
+  putPreapproval,
+  getPreapproval,
+  listPreapprovals,
+  claimOssPreapproval,
+} from './oss-preapproval';
+import type { OssPreapproval } from './oss-preapproval';
+import { OSS_DEFAULT_MONTHLY_CAP_CENTS, OSS_DEFAULT_TERM_MONTHS, OSS_PREAPPROVAL_TTL_DAYS } from './constants';
+
+const table = 'test-installations';
+const NOW = new Date('2026-08-20T12:00:00.000Z');
+const account = { id: 9931, login: 'Acme-Corp' };
+const INSTALL_ID = '48210231';
+
+/** A live pre-approval for `acme-corp`, written 10 days ago. */
+function pendingRow(overrides: Partial<OssPreapproval> = {}): OssPreapproval {
+  return {
+    installationId: PREAPPROVAL_PK,
+    repoFullName: 'acme-corp',
+    orgLogin: 'Acme-Corp',
+    capCents: 2000,
+    months: 12,
+    note: 'form response #42',
+    preapprovedAt: '2026-08-10T12:00:00.000Z',
+    preapprovalExpiresAt: '2026-11-08T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+/**
+ * Minimal DynamoDBDocumentClient double. Commands are identified by their
+ * constructor name so the assertions read like the calls they check.
+ */
+function makeClient(getItem: OssPreapproval | null) {
+  const sent: { type: string; input: any }[] = [];
+  const conditionFailures = new Set<string>();
+
+  const client = {
+    send: vi.fn(async (cmd: any) => {
+      const type = cmd.constructor.name;
+      sent.push({ type, input: cmd.input });
+
+      if (type === 'GetCommand') return { Item: getItem ?? undefined };
+      if (type === 'QueryCommand') return { Items: getItem ? [getItem] : [] };
+      if (type === 'UpdateCommand' && conditionFailures.has(cmd.input.Key.repoFullName)) {
+        const err = new Error('The conditional request failed');
+        (err as any).name = 'ConditionalCheckFailedException';
+        throw err;
+      }
+      return {};
+    }),
+  } as any;
+
+  return {
+    client,
+    sent,
+    /** Make the next UpdateCommand on this sort key fail its condition. */
+    failConditionOn: (sk: string) => conditionFailures.add(sk),
+    of: (type: string) => sent.filter((s) => s.type === type),
+  };
+}
+
+describe('normalizeLogin', () => {
+  it('lowercases and trims, so operator casing never breaks a claim', () => {
+    // GitHub logins are case-insensitive; the operator types whatever the
+    // application form had.
+    expect(normalizeLogin('Acme-Corp')).toBe('acme-corp');
+    expect(normalizeLogin('  ACME-CORP  ')).toBe('acme-corp');
+    expect(normalizeLogin('acme-corp')).toBe('acme-corp');
+  });
+});
+
+describe('putPreapproval', () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it('writes under the sentinel PK with a normalized sort key', async () => {
+    const h = makeClient(null);
+    const row = await putPreapproval(h.client, table, { orgLogin: 'Acme-Corp' }, NOW);
+
+    expect(row.installationId).toBe(PREAPPROVAL_PK);
+    expect(row.repoFullName).toBe('acme-corp');
+    // Original casing is kept for display only.
+    expect(row.orgLogin).toBe('Acme-Corp');
+  });
+
+  it('defaults cap and term to the program defaults', async () => {
+    const h = makeClient(null);
+    const row = await putPreapproval(h.client, table, { orgLogin: 'acme-corp' }, NOW);
+
+    expect(row.capCents).toBe(OSS_DEFAULT_MONTHLY_CAP_CENTS);
+    expect(row.months).toBe(OSS_DEFAULT_TERM_MONTHS);
+  });
+
+  it('expires the pre-approval OSS_PREAPPROVAL_TTL_DAYS out', async () => {
+    const h = makeClient(null);
+    const row = await putPreapproval(h.client, table, { orgLogin: 'acme-corp' }, NOW);
+
+    const days = (Date.parse(row.preapprovalExpiresAt) - NOW.getTime()) / 86_400_000;
+    expect(days).toBeCloseTo(OSS_PREAPPROVAL_TTL_DAYS, 5);
+  });
+
+  it('honours explicit cap, term, and ttl overrides', async () => {
+    const h = makeClient(null);
+    const row = await putPreapproval(
+      h.client,
+      table,
+      { orgLogin: 'acme-corp', capCents: 5000, months: 6, ttlDays: 30, note: 'ref #7' },
+      NOW,
+    );
+
+    expect(row.capCents).toBe(5000);
+    expect(row.months).toBe(6);
+    expect(row.note).toBe('ref #7');
+    const days = (Date.parse(row.preapprovalExpiresAt) - NOW.getTime()) / 86_400_000;
+    expect(days).toBeCloseTo(30, 5);
+  });
+
+  it('omits note entirely rather than storing undefined', async () => {
+    const h = makeClient(null);
+    const row = await putPreapproval(h.client, table, { orgLogin: 'acme-corp' }, NOW);
+    expect('note' in row).toBe(false);
+  });
+});
+
+describe('getPreapproval / listPreapprovals', () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it('looks up by normalized login regardless of casing', async () => {
+    const h = makeClient(pendingRow());
+    await getPreapproval(h.client, table, 'ACME-CORP');
+
+    expect(h.of('GetCommand')[0].input.Key).toEqual({
+      installationId: PREAPPROVAL_PK,
+      repoFullName: 'acme-corp',
+    });
+  });
+
+  it('returns null when nothing is pending', async () => {
+    const h = makeClient(null);
+    expect(await getPreapproval(h.client, table, 'nobody')).toBeNull();
+  });
+
+  it('queries the sentinel partition', async () => {
+    const h = makeClient(pendingRow());
+    const rows = await listPreapprovals(h.client, table);
+
+    expect(h.of('QueryCommand')[0].input.ExpressionAttributeValues).toEqual({
+      ':pk': PREAPPROVAL_PK,
+    });
+    expect(rows).toHaveLength(1);
+  });
+});
+
+describe('claimOssPreapproval', () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it('writes an org-scoped grant onto the installation #SETTINGS row', async () => {
+    const h = makeClient(pendingRow());
+    const result = await claimOssPreapproval(h.client, table, INSTALL_ID, account, NOW);
+
+    expect(result).toMatchObject({ claimed: true, capCents: 2000 });
+
+    const settingsWrite = h.of('UpdateCommand')
+      .find((c) => c.input.Key.repoFullName === '#SETTINGS')!;
+    expect(settingsWrite.input.Key.installationId).toBe(INSTALL_ID);
+    expect(settingsWrite.input.ExpressionAttributeValues[':scope']).toBe('org');
+    expect(settingsWrite.input.ExpressionAttributeValues[':account']).toEqual({
+      id: 9931,
+      login: 'Acme-Corp',
+    });
+    expect(settingsWrite.input.ExpressionAttributeValues[':cap']).toBe(2000);
+  });
+
+  it('guards the grant write so a redelivery cannot reset it', async () => {
+    const h = makeClient(pendingRow());
+    await claimOssPreapproval(h.client, table, INSTALL_ID, account, NOW);
+
+    const settingsWrite = h.of('UpdateCommand')
+      .find((c) => c.input.Key.repoFullName === '#SETTINGS')!;
+    expect(settingsWrite.input.ConditionExpression).toBe(
+      'attribute_not_exists(ossGrantExpiresAt)',
+    );
+  });
+
+  it('runs the grant term from the claim, not from the approval', async () => {
+    // An org that took six weeks to install still gets its full 12 months.
+    const h = makeClient(pendingRow({ months: 12 }));
+    const result = await claimOssPreapproval(h.client, table, INSTALL_ID, account, NOW);
+
+    expect(result.claimed).toBe(true);
+    expect((result as any).expiresAt).toBe('2027-08-20T12:00:00.000Z');
+  });
+
+  it('marks the pending row claimed AFTER the grant lands', async () => {
+    const h = makeClient(pendingRow());
+    await claimOssPreapproval(h.client, table, INSTALL_ID, account, NOW);
+
+    const updates = h.of('UpdateCommand');
+    const settingsIdx = updates.findIndex((c) => c.input.Key.repoFullName === '#SETTINGS');
+    const claimIdx = updates.findIndex((c) => c.input.Key.installationId === PREAPPROVAL_PK);
+
+    // Order matters: if the mark fails, a redelivery retries and stops at
+    // grant_exists. Marking first would risk losing the grant entirely.
+    expect(settingsIdx).toBeLessThan(claimIdx);
+    expect(updates[claimIdx].input.ExpressionAttributeValues[':inst']).toBe(INSTALL_ID);
+  });
+
+  it('is a no-op when no pre-approval exists', async () => {
+    const h = makeClient(null);
+    const result = await claimOssPreapproval(h.client, table, INSTALL_ID, account, NOW);
+
+    expect(result).toEqual({ claimed: false, reason: 'no_preapproval' });
+    expect(h.of('UpdateCommand')).toHaveLength(0);
+  });
+
+  it('never re-fires a claimed pre-approval on reinstall', async () => {
+    // Uninstall/reinstall must not silently re-grant — a spent approval goes
+    // back through an operator.
+    const h = makeClient(pendingRow({ claimedAt: '2026-08-15T00:00:00.000Z' }));
+    const result = await claimOssPreapproval(h.client, table, INSTALL_ID, account, NOW);
+
+    expect(result).toEqual({ claimed: false, reason: 'already_claimed' });
+    expect(h.of('UpdateCommand')).toHaveLength(0);
+  });
+
+  it('refuses an expired pre-approval and stamps it', async () => {
+    const h = makeClient(pendingRow({ preapprovalExpiresAt: '2026-08-01T00:00:00.000Z' }));
+    const result = await claimOssPreapproval(h.client, table, INSTALL_ID, account, NOW);
+
+    expect(result).toEqual({ claimed: false, reason: 'expired' });
+
+    const updates = h.of('UpdateCommand');
+    // Only the expiry stamp — nothing was written to #SETTINGS.
+    expect(updates).toHaveLength(1);
+    expect(updates[0].input.Key.installationId).toBe(PREAPPROVAL_PK);
+    expect(updates[0].input.UpdateExpression).toBe('SET expiredAt = :at');
+  });
+
+  it('fails closed on an unparseable expiry', async () => {
+    const h = makeClient(pendingRow({ preapprovalExpiresAt: 'not-a-date' }));
+    const result = await claimOssPreapproval(h.client, table, INSTALL_ID, account, NOW);
+
+    expect(result).toEqual({ claimed: false, reason: 'expired' });
+  });
+
+  it('treats an existing grant as a successful no-op, not an error', async () => {
+    // The redelivery case: an operator amended or revoked the grant in between.
+    const h = makeClient(pendingRow());
+    h.failConditionOn('#SETTINGS');
+
+    const result = await claimOssPreapproval(h.client, table, INSTALL_ID, account, NOW);
+
+    expect(result).toEqual({ claimed: false, reason: 'grant_exists' });
+    // The pending row must NOT be marked claimed — the grant it describes was
+    // never the one that landed.
+    expect(h.of('UpdateCommand').some((c) => c.input.Key.installationId === PREAPPROVAL_PK))
+      .toBe(false);
+  });
+
+  it('rethrows a non-condition DynamoDB failure', async () => {
+    const h = makeClient(pendingRow());
+    h.client.send = vi.fn(async (cmd: any) => {
+      if (cmd.constructor.name === 'GetCommand') return { Item: pendingRow() };
+      throw Object.assign(new Error('ProvisionedThroughputExceeded'), {
+        name: 'ProvisionedThroughputExceededException',
+      });
+    });
+
+    await expect(
+      claimOssPreapproval(h.client, table, INSTALL_ID, account, NOW),
+    ).rejects.toThrow('ProvisionedThroughputExceeded');
+  });
+
+  it('matches a pre-approval written with different casing', async () => {
+    const h = makeClient(pendingRow());
+    await claimOssPreapproval(h.client, table, INSTALL_ID, { id: 1, login: 'ACME-CORP' }, NOW);
+
+    expect(h.of('GetCommand')[0].input.Key.repoFullName).toBe('acme-corp');
+  });
+
+  it('carries the operator note into the grant for provenance', async () => {
+    const h = makeClient(pendingRow({ note: 'form response #42' }));
+    await claimOssPreapproval(h.client, table, INSTALL_ID, account, NOW);
+
+    const settingsWrite = h.of('UpdateCommand')
+      .find((c) => c.input.Key.repoFullName === '#SETTINGS')!;
+    expect(settingsWrite.input.ExpressionAttributeValues[':note'])
+      .toContain('form response #42');
+    expect(settingsWrite.input.ExpressionAttributeValues[':note'])
+      .toContain('claimed from pre-approval');
+  });
+
+  it('still records provenance when the operator left no note', async () => {
+    const h = makeClient(pendingRow({ note: undefined }));
+    await claimOssPreapproval(h.client, table, INSTALL_ID, account, NOW);
+
+    const settingsWrite = h.of('UpdateCommand')
+      .find((c) => c.input.Key.repoFullName === '#SETTINGS')!;
+    expect(settingsWrite.input.ExpressionAttributeValues[':note'])
+      .toBe('Claimed from pre-approval 2026-08-10T12:00:00.000Z');
+  });
+
+  it('does not touch balance, free tier, or any non-OSS billing field', async () => {
+    // The claim writes an entitlement, not money.
+    const h = makeClient(pendingRow());
+    await claimOssPreapproval(h.client, table, INSTALL_ID, account, NOW);
+
+    const settingsWrite = h.of('UpdateCommand')
+      .find((c) => c.input.Key.repoFullName === '#SETTINGS')!;
+    const expr = settingsWrite.input.UpdateExpression as string;
+    expect(expr).not.toMatch(/balanceCents|freeReviewsUsed|stripeCustomerId/);
+  });
+});
+
+describe('date arithmetic is timezone-independent', () => {
+  // Local-time setDate/setMonth shift by an extra hour across a DST boundary,
+  // which would make a grant's expiry depend on whose laptop ran the script.
+  const TZ_CASES = ['UTC', 'America/Los_Angeles', 'Australia/Sydney', 'Asia/Kolkata'];
+
+  it('produces the same TTL in every timezone', async () => {
+    const results = new Set<string>();
+    for (const tz of TZ_CASES) {
+      const original = process.env.TZ;
+      process.env.TZ = tz;
+      const h = makeClient(null);
+      const row = await putPreapproval(h.client, table, { orgLogin: 'acme-corp' }, NOW);
+      results.add(row.preapprovalExpiresAt);
+      process.env.TZ = original;
+    }
+    expect(results.size).toBe(1);
+  });
+
+  it('lands the TTL exactly 90 × 24h out, DST boundary or not', async () => {
+    // Aug 20 -> Nov 18 crosses the US DST change on Nov 1.
+    const h = makeClient(null);
+    const row = await putPreapproval(h.client, table, { orgLogin: 'acme-corp' }, NOW);
+
+    expect(Date.parse(row.preapprovalExpiresAt) - NOW.getTime())
+      .toBe(OSS_PREAPPROVAL_TTL_DAYS * 86_400_000);
+  });
+
+  it('produces the same grant expiry in every timezone', async () => {
+    const results = new Set<string>();
+    for (const tz of TZ_CASES) {
+      const original = process.env.TZ;
+      process.env.TZ = tz;
+      const h = makeClient(pendingRow({ months: 12 }));
+      const result = await claimOssPreapproval(h.client, table, INSTALL_ID, account, NOW);
+      results.add((result as any).expiresAt);
+      process.env.TZ = original;
+    }
+    expect(results.size).toBe(1);
+    expect([...results][0]).toBe('2027-08-20T12:00:00.000Z');
+  });
+});

--- a/packages/billing/src/oss-preapproval.ts
+++ b/packages/billing/src/oss-preapproval.ts
@@ -1,0 +1,283 @@
+/**
+ * #409 — OSS Program pre-approval.
+ *
+ * Approving a project used to require the maintainer to install the App first:
+ * `scripts/grant-oss.ts` resolves a repo to its installation, and without an
+ * installation there is no `#SETTINGS` row to write a grant onto. A pre-approval
+ * parks the decision in a pending row keyed by org login; the webhook claims it
+ * on `installation.created` and the org's very first PR is already sponsored.
+ *
+ * The pending row lives in the installations table under a sentinel partition
+ * key, alongside the existing `#SETTINGS` / `#AGENTS` sentinel idiom. That costs
+ * no new infrastructure: the webhook Lambda already writes this table.
+ */
+
+import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { GetCommand, PutCommand, QueryCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import type { OssGrantAccount } from '@mergewatch/core';
+import {
+  OSS_DEFAULT_MONTHLY_CAP_CENTS,
+  OSS_DEFAULT_TERM_MONTHS,
+  OSS_PREAPPROVAL_TTL_DAYS,
+} from './constants';
+
+/** Partition key every pending pre-approval row shares. */
+export const PREAPPROVAL_PK = '#PENDING-OSS';
+
+const SETTINGS_SK = '#SETTINGS';
+
+/**
+ * A parked approval, waiting for the org to install the App.
+ *
+ * The sort key is the table's `repoFullName` attribute — an artifact of reusing
+ * the installations table, not a repository name. It holds the **lowercased**
+ * org login; `orgLogin` keeps the operator's original casing for display.
+ */
+export interface OssPreapproval {
+  /** Always `PREAPPROVAL_PK`. */
+  installationId: string;
+  /** Sort key: lowercased org login. Not a repository. */
+  repoFullName: string;
+  /** The login as the operator typed it. Display only — never matched on. */
+  orgLogin: string;
+  /** Monthly fair-use ceiling the claimed grant will carry. */
+  capCents: number;
+  /** Grant term in months, applied from the moment of the claim, not of approval. */
+  months: number;
+  /** Provenance: application reference, project name, approver. */
+  note?: string;
+  preapprovedAt: string;
+  /** After this instant the pre-approval is dead and will not be claimed. */
+  preapprovalExpiresAt: string;
+  /** Set once the org installed and the grant was written. A claimed row is inert. */
+  claimedAt?: string;
+  claimedInstallationId?: string;
+  /** Set when a claim attempt found the row already past `preapprovalExpiresAt`. */
+  expiredAt?: string;
+}
+
+export type ClaimSkipReason =
+  | 'no_preapproval'
+  | 'already_claimed'
+  | 'expired'
+  | 'grant_exists';
+
+export type ClaimResult =
+  | { claimed: true; expiresAt: string; capCents: number }
+  | { claimed: false; reason: ClaimSkipReason };
+
+/**
+ * GitHub logins are case-insensitive, and an operator types whatever casing the
+ * application form had. Normalizing on both write and read is what makes
+ * `--preapprove Acme-Corp` match an install by `acme-corp`.
+ */
+export function normalizeLogin(login: string): string {
+  return login.trim().toLowerCase();
+}
+
+/**
+ * `from` shifted by whole calendar months, in UTC.
+ *
+ * `setUTCMonth`, not `setMonth`: the local-time variants shift by an extra hour
+ * across a DST boundary, which would make a grant's expiry depend on the
+ * timezone of whoever ran the script. Lambda runs in UTC; an operator's laptop
+ * does not.
+ *
+ * Calendar months, so Jan 31 + 1 month lands in early March rather than Feb 31.
+ * At the 6–12 month terms this is used for, that edge is not worth special-casing.
+ */
+function addMonths(from: Date, months: number): Date {
+  const d = new Date(from.getTime());
+  d.setUTCMonth(d.getUTCMonth() + months);
+  return d;
+}
+
+/**
+ * `from` shifted by whole days.
+ *
+ * A TTL is a duration, not a calendar concept, so this is plain millisecond
+ * arithmetic — exactly `days × 24h` regardless of DST or timezone.
+ */
+function addDays(from: Date, days: number): Date {
+  return new Date(from.getTime() + days * 86_400_000);
+}
+
+export interface PreapprovalInput {
+  orgLogin: string;
+  capCents?: number;
+  months?: number;
+  note?: string;
+  /** Days before an unclaimed pre-approval goes stale. */
+  ttlDays?: number;
+}
+
+/**
+ * Write (or overwrite) a pending pre-approval.
+ *
+ * Deliberately an unconditional `Put`: re-running `--preapprove` for an org is
+ * how an operator renews or corrects one, and refusing would just push them to
+ * delete-then-write. Overwriting a **claimed** row would silently un-claim it,
+ * so the operator script is responsible for showing existing state and
+ * confirming before calling this — the same posture `grant-oss.ts` already
+ * takes with its blast-radius print.
+ */
+export async function putPreapproval(
+  client: DynamoDBDocumentClient,
+  table: string,
+  input: PreapprovalInput,
+  now: Date = new Date(),
+): Promise<OssPreapproval> {
+  const item: OssPreapproval = {
+    installationId: PREAPPROVAL_PK,
+    repoFullName: normalizeLogin(input.orgLogin),
+    orgLogin: input.orgLogin.trim(),
+    capCents: input.capCents ?? OSS_DEFAULT_MONTHLY_CAP_CENTS,
+    months: input.months ?? OSS_DEFAULT_TERM_MONTHS,
+    ...(input.note ? { note: input.note } : {}),
+    preapprovedAt: now.toISOString(),
+    preapprovalExpiresAt: addDays(now, input.ttlDays ?? OSS_PREAPPROVAL_TTL_DAYS).toISOString(),
+  };
+
+  await client.send(new PutCommand({ TableName: table, Item: item }));
+  return item;
+}
+
+/** Read one pending pre-approval by org login, or null. */
+export async function getPreapproval(
+  client: DynamoDBDocumentClient,
+  table: string,
+  orgLogin: string,
+): Promise<OssPreapproval | null> {
+  const res = await client.send(new GetCommand({
+    TableName: table,
+    Key: { installationId: PREAPPROVAL_PK, repoFullName: normalizeLogin(orgLogin) },
+  }));
+  return (res.Item as OssPreapproval | undefined) ?? null;
+}
+
+/**
+ * Every pre-approval ever written, claimed and unclaimed alike. Claimed rows are
+ * kept rather than deleted so this stays an honest record of who was approved
+ * and what became of it — the same reason #261 keeps `ossGrantedAt` and
+ * `ossGrantNote` on the grant itself.
+ */
+export async function listPreapprovals(
+  client: DynamoDBDocumentClient,
+  table: string,
+): Promise<OssPreapproval[]> {
+  const out: OssPreapproval[] = [];
+  let lastKey: Record<string, unknown> | undefined;
+  do {
+    const res = await client.send(new QueryCommand({
+      TableName: table,
+      KeyConditionExpression: 'installationId = :pk',
+      ExpressionAttributeValues: { ':pk': PREAPPROVAL_PK },
+      ExclusiveStartKey: lastKey,
+    }));
+    out.push(...((res.Items ?? []) as OssPreapproval[]));
+    lastKey = res.LastEvaluatedKey;
+  } while (lastKey);
+  return out.sort((a, b) => a.repoFullName.localeCompare(b.repoFullName));
+}
+
+/** Mark a row so a later `--list-preapprovals` shows why it never fired. */
+async function stampExpired(
+  client: DynamoDBDocumentClient,
+  table: string,
+  sk: string,
+  now: Date,
+): Promise<void> {
+  await client.send(new UpdateCommand({
+    TableName: table,
+    Key: { installationId: PREAPPROVAL_PK, repoFullName: sk },
+    UpdateExpression: 'SET expiredAt = :at',
+    ExpressionAttributeValues: { ':at': now.toISOString() },
+  }));
+}
+
+/**
+ * Apply a pending pre-approval to a freshly-created installation.
+ *
+ * Called from the `installation.created` webhook. Three properties matter more
+ * than the happy path:
+ *
+ * **Idempotent.** `installation.created` is redeliverable, and an operator may
+ * amend or revoke the grant afterwards. The `#SETTINGS` write is conditional on
+ * `attribute_not_exists(ossGrantExpiresAt)`, so a redelivery can never reset a
+ * grant that has since been changed. A failed condition is a successful no-op,
+ * not an error.
+ *
+ * **Ordered.** The pending row is marked claimed only *after* the grant lands.
+ * If the mark fails, a redelivery retries and stops at `grant_exists` — the
+ * grant is never written twice, and never lost because a bookkeeping write
+ * failed.
+ *
+ * **Never re-fires.** A row carrying `claimedAt` is inert, so uninstalling and
+ * reinstalling does not silently re-grant. A spent approval goes back through an
+ * operator.
+ *
+ * The grant term runs from the claim, not from the approval: an org that takes
+ * six weeks to install still gets its full 12 months.
+ */
+export async function claimOssPreapproval(
+  client: DynamoDBDocumentClient,
+  table: string,
+  installationId: string,
+  account: OssGrantAccount,
+  now: Date = new Date(),
+): Promise<ClaimResult> {
+  const sk = normalizeLogin(account.login);
+
+  const pending = await getPreapproval(client, table, account.login);
+  if (!pending) return { claimed: false, reason: 'no_preapproval' };
+  if (pending.claimedAt) return { claimed: false, reason: 'already_claimed' };
+
+  const expiresAt = Date.parse(pending.preapprovalExpiresAt);
+  // An unparseable date fails closed, same as the grant-expiry check.
+  if (!Number.isFinite(expiresAt) || expiresAt <= now.getTime()) {
+    await stampExpired(client, table, sk, now);
+    return { claimed: false, reason: 'expired' };
+  }
+
+  const grantExpiresAt = addMonths(now, pending.months).toISOString();
+  const account_: OssGrantAccount = { id: account.id, login: account.login };
+
+  try {
+    await client.send(new UpdateCommand({
+      TableName: table,
+      Key: { installationId, repoFullName: SETTINGS_SK },
+      UpdateExpression:
+        'SET ossGrantScope = :scope, ossGrantAccount = :account, '
+        + 'ossGrantExpiresAt = :expires, ossMonthlyCapCents = :cap, '
+        + 'ossGrantedAt = :granted, ossGrantNote = :note',
+      // Never overwrite a grant that already exists — this is what makes a
+      // webhook redelivery, or an operator who granted manually in the meantime,
+      // harmless.
+      ConditionExpression: 'attribute_not_exists(ossGrantExpiresAt)',
+      ExpressionAttributeValues: {
+        ':scope': 'org',
+        ':account': account_,
+        ':expires': grantExpiresAt,
+        ':cap': pending.capCents,
+        ':granted': now.toISOString(),
+        ':note': pending.note
+          ? `${pending.note} (claimed from pre-approval ${pending.preapprovedAt})`
+          : `Claimed from pre-approval ${pending.preapprovedAt}`,
+      },
+    }));
+  } catch (err) {
+    if ((err as { name?: string }).name === 'ConditionalCheckFailedException') {
+      return { claimed: false, reason: 'grant_exists' };
+    }
+    throw err;
+  }
+
+  await client.send(new UpdateCommand({
+    TableName: table,
+    Key: { installationId: PREAPPROVAL_PK, repoFullName: sk },
+    UpdateExpression: 'SET claimedAt = :at, claimedInstallationId = :inst',
+    ExpressionAttributeValues: { ':at': now.toISOString(), ':inst': installationId },
+  }));
+
+  return { claimed: true, expiresAt: grantExpiresAt, capCents: pending.capCents };
+}

--- a/packages/lambda/src/handlers/webhook.test.ts
+++ b/packages/lambda/src/handlers/webhook.test.ts
@@ -54,6 +54,13 @@ vi.mock('@aws-sdk/lib-dynamodb', () => ({
   PutCommand: class { input: unknown; constructor(input: unknown) { this.input = input; } },
 }));
 
+const mockClaimOssPreapproval = vi.fn();
+const mockIsSaas = vi.fn(() => true);
+vi.mock('@mergewatch/billing', () => ({
+  claimOssPreapproval: (...args: unknown[]) => mockClaimOssPreapproval(...args),
+  isSaas: () => mockIsSaas(),
+}));
+
 vi.mock('../github-auth-ssm.js', () => ({
   SSMGitHubAuthProvider: class {
     getInstallationOctokit(id: number) { return mockGetInstallationOctokit(id); }
@@ -780,5 +787,98 @@ describe('handler — repo config is read at the PR head ref (#399/#400)', () =>
     const payload = enqueuedPayload();
     expect(payload.mentionTriggered).toBe(true);
     expect(payload.headSha).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #409 — OSS pre-approval claimed on installation.created
+// ---------------------------------------------------------------------------
+
+describe('handler — OSS pre-approval claim on install (#409)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsSaas.mockReturnValue(true);
+    mockClaimOssPreapproval.mockResolvedValue({ claimed: false, reason: 'no_preapproval' });
+  });
+
+  function makeInstallationEvent(action = 'created') {
+    return {
+      action,
+      installation: {
+        id: 48210231,
+        account: { id: 9931, login: 'acme-corp' },
+        app_id: 1,
+        target_type: 'Organization',
+        created_at: '2026-08-20T12:00:00Z',
+        updated_at: '2026-08-20T12:00:00Z',
+      },
+      repositories: [{ id: 1, full_name: 'acme-corp/api', private: false }],
+      sender: { login: 'someone', id: 1, type: 'User' },
+    };
+  }
+
+  function installationApiEvent(action = 'created'): any {
+    const body = JSON.stringify(makeInstallationEvent(action));
+    return {
+      body,
+      headers: {
+        'x-hub-signature-256': signBody(body),
+        'x-github-event': 'installation',
+      },
+    };
+  }
+
+  it('attempts a claim on installation.created', async () => {
+    await handler(installationApiEvent('created'));
+
+    expect(mockClaimOssPreapproval).toHaveBeenCalledTimes(1);
+    const [, , installationId, account] = mockClaimOssPreapproval.mock.calls[0];
+    expect(installationId).toBe('48210231');
+    expect(account).toEqual({ id: 9931, login: 'acme-corp' });
+  });
+
+  it('passes the installation id as a string, matching the table key type', async () => {
+    await handler(installationApiEvent('created'));
+    expect(typeof mockClaimOssPreapproval.mock.calls[0][2]).toBe('string');
+  });
+
+  for (const action of ['deleted', 'suspend', 'unsuspend', 'new_permissions_accepted']) {
+    it(`never claims on installation.${action}`, async () => {
+      // These carry the same account. Claiming on any of them would burn a
+      // pre-approval against an installation that is going away or already
+      // granted.
+      await handler(installationApiEvent(action));
+      expect(mockClaimOssPreapproval).not.toHaveBeenCalled();
+    });
+  }
+
+  it('does not claim in self-hosted mode', async () => {
+    // The whole OSS gate sits behind isSaas(); Postgres has no billing columns.
+    mockIsSaas.mockReturnValue(false);
+    await handler(installationApiEvent('created'));
+    expect(mockClaimOssPreapproval).not.toHaveBeenCalled();
+  });
+
+  it('still returns 200 when the claim throws', async () => {
+    // An installation must be recorded even if the OSS claim fails — losing the
+    // install record is far worse than missing a sponsorship.
+    mockClaimOssPreapproval.mockRejectedValue(new Error('dynamo exploded'));
+
+    const result = await handler(installationApiEvent('created'));
+
+    expect(result.statusCode).toBe(200);
+  });
+
+  it('returns 200 on a successful claim', async () => {
+    mockClaimOssPreapproval.mockResolvedValue({
+      claimed: true,
+      expiresAt: '2027-08-20T12:00:00.000Z',
+      capCents: 2000,
+    });
+
+    const result = await handler(installationApiEvent('created'));
+
+    expect(result.statusCode).toBe(200);
+    expect(mockClaimOssPreapproval).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/lambda/src/handlers/webhook.ts
+++ b/packages/lambda/src/handlers/webhook.ts
@@ -26,6 +26,7 @@ import {
   isBotActor,
   sweepInlineReactionsOnClose,
 } from '@mergewatch/core';
+import { claimOssPreapproval, isSaas } from '@mergewatch/billing';
 import type {
   PullRequestEvent,
   IssueCommentEvent,
@@ -546,10 +547,55 @@ async function handleCheckRunEvent(event: CheckRunEvent): Promise<void> {
 // Installation event handler
 // ---------------------------------------------------------------------------
 
+/**
+ * #409 — apply a pending OSS pre-approval, if this account has one.
+ *
+ * Best-effort by design: an installation must still be recorded even if the
+ * OSS claim throws, so this never propagates. Same posture as
+ * `recordPrLifecycle`. A missing pre-approval is the overwhelmingly common
+ * case and is not logged as anything notable.
+ */
+async function claimOssPreapprovalIfAny(event: InstallationEvent): Promise<void> {
+  if (!isSaas()) return;
+
+  const { account, id } = event.installation;
+  const table = process.env.INSTALLATIONS_TABLE ?? "mergewatch-installations";
+
+  try {
+    const result = await claimOssPreapproval(
+      dynamodb,
+      table,
+      String(id),
+      { id: account.id, login: account.login },
+    );
+
+    if (result.claimed) {
+      console.log(
+        `[oss] pre-approval claimed for ${account.login} install=${id} `
+        + `scope=org cap=${result.capCents}c expires=${result.expiresAt}`
+      );
+    } else if (result.reason !== 'no_preapproval') {
+      console.log(
+        `[oss] pre-approval not applied for ${account.login} install=${id} reason=${result.reason}`
+      );
+    }
+  } catch (err) {
+    console.warn(`[oss] pre-approval claim failed for ${account.login} (install=${id}):`, err);
+  }
+}
+
 async function handleInstallationEvent(
   event: InstallationEvent
 ): Promise<void> {
   await storeInstallation(event);
+
+  // Only on `created`. A `deleted` / `suspend` / `new_permissions_accepted`
+  // event carries the same account, and claiming on any of those would burn a
+  // pre-approval against an installation that is going away or already granted.
+  if (event.action === "created") {
+    await claimOssPreapprovalIfAny(event);
+  }
+
   console.log(
     `Installation ${event.action}: ${event.installation.account.login} (id=${event.installation.id})`
   );


### PR DESCRIPTION
**Stage 2 of 3** for #409. Stacks conceptually on #410 (merged), branched off `main` — no PR dependency.

## What this ships

An operator can approve an org **before** it installs the App. The approval is parked as a `#PENDING-OSS` row in the installations table, keyed by lowercased org login, and claimed by the webhook on `installation.created`. The org's first PR is already sponsored.

Previously a grant couldn't exist without an installation to attach to, so approval meant *"install, then tell us, then we'll grant"* — three round trips before a single sponsored review.

```
operator: --preapprove acme-corp   (stage 3 ships the command)
    │
    ▼
PK #PENDING-OSS   SK acme-corp   { scope, capCents, months, note,
                                   preapprovedAt, preapprovalExpiresAt }
    │   …org installs…
    ▼
PK <installationId>  SK #SETTINGS  { ossGrantScope: 'org', ossGrantAccount,
                                     ossGrantExpiresAt, ossMonthlyCapCents, … }
  PK #PENDING-OSS    SK acme-corp   { …, claimedAt, claimedInstallationId }
```

## The three properties this is built around

The claim runs unattended on a webhook, so the failure modes that matter are the ones nobody would notice:

**Idempotent.** The `#SETTINGS` write is conditional on `attribute_not_exists(ossGrantExpiresAt)`. `installation.created` is redeliverable, and an operator may amend or revoke the grant afterwards — a redelivery must never reset it. A failed condition is a successful no-op, not an error.

**Ordered.** The pending row is marked claimed only *after* the grant lands. If the mark fails, a redelivery retries and stops at `grant_exists`. Marking first would risk spending the approval while the org gets nothing, silently.

**Never re-fires.** A row carrying `claimedAt` is inert, so uninstall/reinstall doesn't re-grant. A spent approval goes back through an operator.

Unclaimed pre-approvals go stale after `OSS_PREAPPROVAL_TTL_DAYS` (90), enforced logically at claim time — the installations table has no `TimeToLiveSpecification`, and keeping the lapsed row leaves it auditable.

## ⚠️ Fixes a latent bug from stage 1

`getBillingFields` projects an **explicit attribute list**, and #410 added `ossGrantScope` / `ossGrantAccount` to `BillingFields` without adding them to that `ProjectionExpression`. The gate would have read the scope back as `undefined`, defaulted to `'repos'`, and **silently ignored every org-scoped grant**.

Harmless so far only because nothing wrote the field until this PR. The file's own comment warns about exactly this failure ("Omitting a field here reads it back as undefined with no error, which would silently disable sponsorship"). MergeWatch's review of #410 did not catch it, and neither did I when I wrote it.

## Date arithmetic is UTC

`setMonth` / `setDate` operate in **local** time and shift by an extra hour across a DST boundary — which would make a grant's expiry depend on the timezone of whoever ran the operator script. Lambda runs in UTC; a laptop does not. `addMonths` uses `setUTCMonth`; the TTL is plain millisecond arithmetic, since a TTL is a duration rather than a calendar concept.

Caught by a test that asserted an exact 90-day offset and got 90 days + 1 hour. Now pinned by tests running the same computation under four timezones.

## Verification

- `pnpm run build` — 12/12
- `pnpm run typecheck` — 20/20
- `pnpm run test` — 21/21; **171 billing** (+26) and **100 lambda** (+9) tests pass

Coverage includes: sentinel-key normalization across casings; TTL and term defaults/overrides; grant term running from the claim rather than the approval; the condition guard; write ordering (grant before mark); redelivery → `grant_exists` with the pending row left unmarked; reinstall → `already_claimed`; expired and unparseable-date rows failing closed and stamping `expiredAt`; non-condition DynamoDB errors rethrown rather than swallowed; the claim never touching `balanceCents` / `freeReviewsUsed` / `stripeCustomerId`; `installation.deleted|suspend|unsuspend|new_permissions_accepted` never claiming; self-hosted mode never claiming; a claim failure still returning 200.

**E2E-92** added, with the manual `put-item` seed needed until stage 3 ships `--preapprove`.

## No infra change

The webhook Lambda already had table write access and a `@mergewatch/billing` dependency. No `template.yaml` edit, no IAM change.

## Deferred to stage 3

`grant-oss.ts --org` / `--preapprove` / `--list-preapprovals`, the `ossStatus` fix (still returns `null` when the repo list is empty, so org-scoped grants remain invisible on the dashboard), `BillingClient` rendering, and the `docs/oss-program.md` rewrite — it still says "there is no installation-wide mode".

🤖 Generated with [Claude Code](https://claude.com/claude-code)