### PR TITLE
feat(billing): OSS operator commands, dashboard, and docs (#409, stage 3)

### DIFF
--- a/docs/feat/20260820-01-oss-org-grants-and-preapproval.plan.md
+++ b/docs/feat/20260820-01-oss-org-grants-and-preapproval.plan.md
@@ -115,7 +115,7 @@ The SK is `account.login.toLowerCase()` — GitHub logins are case-insensitive f
 
 ### Phase 3 — operator script, dashboard, docs
 
-- [ ] **Goal:** make both features operable and visible.
+- [x] **Goal:** make both features operable and visible. **Shipped in PR #412.**
 - **Files:** `scripts/grant-oss.ts` (`--org`, `--preapprove`, `--list-preapprovals`; `--inspect` renders scope + any pending row; `--revoke` handles org grants and pending rows), `packages/lambda/src/handlers/billing.ts` (`ossStatus` currently returns `null` when the repo list is empty — line 242 — which would make every org-scoped grant invisible; add `scope` and `account` to the payload), `packages/dashboard/app/dashboard/billing/BillingClient.tsx` (render "all public repositories" instead of a repo list under org scope), `docs/oss-program.md`, `e2e/RUNBOOK.md`, `packages/billing/src/constants.ts` (`OSS_PREAPPROVAL_TTL_DAYS = 90`).
 - **Tests:** `ossStatus` returns non-null for an org-scoped grant with no repo list; still `null` with no grant at all; script arg-parsing rejects `--org` combined with a repo list.
 - **RUNBOOK:** E2E-93 — operator lifecycle: `--org`, `--preapprove`, `--list-preapprovals`, `--inspect`, `--revoke`; `--stage` guard still refuses to default.
@@ -125,6 +125,9 @@ The SK is `account.login.toLowerCase()` — GitHub logins are case-insensitive f
 
 - **`OSS_PREAPPROVAL_TTL_DAYS` moved from stage 3 to stage 2.** `putPreapproval` needs it to compute `preapprovalExpiresAt`, so it had to ship with the store rather than with the script that calls it.
 - **`getBillingFields`'s `ProjectionExpression` was missing the stage-1 fields.** Found while writing stage 2. `packages/billing/src/dynamo-billing.ts` projects an explicit attribute list, and stage 1 added `ossGrantScope` / `ossGrantAccount` to `BillingFields` without adding them there — so the gate would have read `ossGrantScope` as `undefined`, defaulted to `'repos'`, and silently ignored every org-scoped grant. Latent (nothing wrote the field until stage 2), fixed in stage 2. The file's own comment warns about exactly this; MergeWatch's review of #410 did not catch it.
+- **`ossStatus` had to be exported** from `packages/lambda/src/handlers/billing.ts` to be testable. It is a pure function over billing fields; the alternative was leaving the regression this stage fixes uncovered.
+- **`scripts/grant-oss.ts` duplicates constants and the pre-approval row shape** from `@mergewatch/billing` instead of importing them. Forced: workspace packages do not resolve from the repo root (root `package.json` has no dependencies and pnpm only hoists third-party deps there), so the script can import the AWS SDK and Octokit but never `@mergewatch/*`. The file already duplicated `DEFAULT_CAP_CENTS` / `DEFAULT_TERM_MONTHS` for the same reason. Both sides are commented; E2E-93 lists drift as a failure mode.
+- **Dashboard lint could not be run** — `packages/dashboard` has no ESLint config and `pnpm run lint` drops into an interactive setup prompt. Pre-existing; the dashboard still builds as part of `pnpm run build`.
 - **Date arithmetic is UTC, not local.** `setMonth`/`setDate` shift by an extra hour across a DST boundary, which would make a grant's expiry depend on the timezone of whoever ran the operator script. `addMonths` uses `setUTCMonth`; the TTL is plain millisecond arithmetic. Pinned by tests that run the same computation under four timezones.
 
 ## Out of scope / deferred

--- a/docs/oss-program.md
+++ b/docs/oss-program.md
@@ -1,6 +1,6 @@
 # MergeWatch for Open Source — sponsored reviews
 
-**Status:** ✅ Shipped (#261)
+**Status:** ✅ Shipped (#261; org scope + pre-approval #409)
 
 Approved open-source repositories have their PR reviews sponsored: no balance, no payment method, and no consumption of the standard 5-review free tier. This is the runtime behind the promise on [mergewatch.ai/open-source](https://mergewatch.ai/open-source).
 
@@ -12,18 +12,20 @@ A grant is an **entitlement**, not money. It lives on the installation's `#SETTI
 
 | Field | Meaning |
 |---|---|
-| `ossGrantRepos` | `{ id, fullName }[]` — the repositories covered. Required and non-empty for an active grant. |
+| `ossGrantScope` | `'repos'` (default when absent) or `'org'`. Decides whether coverage is the named list or every public repo in the installation. |
+| `ossGrantAccount` | `{ id, login }` — the account the grant was written for. Display and audit only; the gate never matches on it. |
+| `ossGrantRepos` | `{ id, fullName }[]` — the repositories covered. Required and non-empty under `'repos'` scope; ignored entirely under `'org'`. |
 | `ossGrantExpiresAt` | ISO 8601. Presence + a future date = active. Revoking is setting this to the past. |
 | `ossGrantedAt` | When the grant was written. Informational. |
 | `ossGrantNote` | Application reference, project name, approver. Informational. |
-| `ossMonthlyCapCents` | Fair-use ceiling per calendar month, shared across the named repos. |
+| `ossMonthlyCapCents` | Fair-use ceiling per calendar month, shared across everything the grant covers. Installation-level under both scopes. |
 | `ossPeriod` | Accrual period (`YYYY-MM`) the period counter belongs to. |
 | `ossSponsoredCentsThisPeriod` | Sponsored cost accrued this period. |
 | `ossSponsoredCentsLifetime` | Sponsored cost accrued over the grant's life. Monotonic. |
 
 Three design choices are load-bearing:
 
-**Named repos only.** There is no installation-wide mode. An installation can mix a genuinely-OSS repo with public-but-commercial ones (open core), and a blanket grant would sponsor all of them. A cap bounds the money but not the principle.
+**Named repos by default, org-wide by choice.** `'repos'` scope stays the default because an installation can mix a genuinely-OSS repo with public-but-commercial ones (open core), and a blanket grant would sponsor all of them — a cap bounds the money but not the principle. `'org'` scope (#409) is the opposite trade, made deliberately per grant: for an account where everything public is open source, enumerating repos means every new one silently falls outside the grant until an operator notices. The operator picks; nothing infers it.
 
 **Matched on the numeric repo id.** GitHub renames and org transfers change `full_name` while `id` is immutable. A name-keyed list would silently stop matching after a rename — sponsorship lapses, the next PR gets gated, and a "credits required" issue lands on a public OSS repo. `fullName` is stored for readability only and may be stale.
 
@@ -34,11 +36,15 @@ Three design choices are load-bearing:
 All of the following must hold, evaluated fresh on every review:
 
 1. The grant has not expired.
-2. The repository's numeric id appears in `ossGrantRepos`.
+2. Coverage matches — under `'repos'` scope the repository's numeric id appears in `ossGrantRepos`; under `'org'` scope every repository in the installation qualifies at this step.
 3. The repository is **public right now**.
 4. The month's accrued sponsored cost is under `ossMonthlyCapCents`.
 
-Being named is necessary but not sufficient. Visibility is read from the webhook payload of the triggering event rather than snapshotted at approval time, so a repo flipped private after approval stops being sponsored on its very next review — that is the actual cost leak, and an approval-time check cannot catch it.
+Org scope widens step 2 and nothing else. Visibility, expiry, and the cap are identical in both scopes, and the cap stays installation-level — org scope widens coverage, not the ceiling.
+
+Org scope does not need to check the account, because a grant lives on exactly one installation's `#SETTINGS` row: anything reviewed under that installation belongs to that account by construction.
+
+Being covered is necessary but not sufficient. Visibility is read from the webhook payload of the triggering event rather than snapshotted at approval time, so a repo flipped private after approval stops being sponsored on its very next review — that is the actual cost leak, and an approval-time check cannot catch it.
 
 ## What happens when a grant doesn't apply
 
@@ -77,20 +83,81 @@ scripts/grant-oss.ts --revoke octocat/hello-world --stage prod
 
 # Audit an existing grant months later
 scripts/grant-oss.ts --inspect octocat/hello-world --stage prod
+
+# --- Org-scoped: every PUBLIC repo in the org, including ones created later ---
+scripts/grant-oss.ts --org acme-corp --stage prod --note "form response #42"
+scripts/grant-oss.ts --inspect --org acme-corp --stage prod
+scripts/grant-oss.ts --revoke  --org acme-corp --stage prod
+
+# --- Pre-approval: the org has NOT installed the App yet ---
+scripts/grant-oss.ts --preapprove acme-corp --stage prod --note "form response #43"
+scripts/grant-oss.ts --list-preapprovals --stage prod
 ```
 
-Options: `--cap <cents>` (default 2000 = $20/month), `--months <n>` (default 12), `--note "<text>"`, `--yes` to skip the confirmation.
+Options: `--cap <cents>` (default 2000 = $20/month), `--months <n>` (default 12), `--ttl-days <n>` (pre-approval lifetime, default 90), `--note "<text>"`, `--yes` to skip the confirmation.
 
-Three things the script does before writing:
+Picking a mode:
+
+| Situation | Command |
+|---|---|
+| Installed, some repos are OSS (open core) | a repo list |
+| Installed, everything public is OSS | `--org` |
+| Not installed yet | `--preapprove` |
+
+`--preapprove` refuses if the org has **already** installed, because a pre-approval is only ever claimed on `installation.created` — that event has already fired and will not fire again. It points at `--org` instead.
+
+Four things the script does before writing:
 
 1. **Refuses to run without `--stage`.** There is no default. It writes to a live table, and defaulting the environment is how a grant lands in the wrong one.
 2. **Verifies the repo is public** and reports last-push and open-issue counts, so the human approving has the activity signal in front of them.
-3. **Prints the blast radius** — the repos this grant will cover *and* the other repos in the same installation it will not. An accidental omission is then visible before the write, not after a maintainer reports that half their project isn't being reviewed.
+3. **Prints the blast radius** — the repos this grant will cover *and* the other repos in the same installation it will not. An accidental omission is then visible before the write, not after a maintainer reports that half their project isn't being reviewed. Under `--org` it instead lists every public repo currently known and warns explicitly about the open-core case, since there is no omission to spot — the point of that mode is that coverage is unbounded.
+4. **Refuses `--org` combined with a repo list.** They are two different coverage models; guessing which one was meant is exactly the kind of silent wrong answer a grant script must never give.
 
-Under the hood it needs two GitHub identities: an **App JWT** to call `GET /repos/{owner}/{repo}/installation` (the repo→installation lookup, which a user token cannot reach — this is why it isn't a `gh api` one-liner), then an **installation token** to read the repository itself. Credentials come from SSM (`/mergewatch/{stage}/github-app-id`, `/mergewatch/{stage}/github-private-key`) using the `mergewatch` AWS profile.
+Under the hood it needs two GitHub identities: an **App JWT** to call `GET /repos/{owner}/{repo}/installation` (the repo→installation lookup, which a user token cannot reach — this is why it isn't a `gh api` one-liner), then an **installation token** to read the repository itself. Org-targeted modes use the JWT-only `GET /orgs/{org}/installation`, falling back to `GET /users/{username}/installation` for a personal account. Credentials come from SSM (`/mergewatch/{stage}/github-app-id`, `/mergewatch/{stage}/github-private-key`) using the `mergewatch` AWS profile.
+
+`scripts/grant-oss.ts` duplicates a handful of constants and the pre-approval row shape from `@mergewatch/billing` rather than importing them. That is forced: workspace packages do not resolve from the repo root, so the script can only import hoisted third-party dependencies. The duplicated values are marked in both files.
+
+## Pre-approving an org that hasn't installed (#409)
+
+A grant attaches to an installation, so before #409 approval was blocked on the maintainer installing first — "install, then tell us, then we'll grant", three round trips before a single sponsored review.
+
+A **pre-approval** parks the decision instead. It lives in the same installations table under a `#PENDING-OSS` partition key, sorted by the **lowercased org login**:
+
+| Field | Meaning |
+|---|---|
+| `orgLogin` | The login as the operator typed it. Display only. |
+| `capCents` / `months` | What the claimed grant will carry. The term runs from the **claim**, not the approval, so a slow-to-install org still gets its full year. |
+| `note` | Provenance, carried into `ossGrantNote` on claim. |
+| `preapprovedAt` | When the decision was made. |
+| `preapprovalExpiresAt` | After this, the pre-approval is dead. Default 90 days. |
+| `claimedAt` / `claimedInstallationId` | Set when the org installed and the grant landed. A claimed row is inert. |
+| `expiredAt` | Set when a claim attempt found the row already stale. |
+
+When `installation.created` arrives, the webhook (`packages/lambda/src/handlers/webhook.ts`) looks for a pending row and writes an **org-scoped** grant onto the new installation's `#SETTINGS` row.
+
+Three properties matter more than the happy path, because this runs unattended:
+
+**Idempotent.** The `#SETTINGS` write is conditional on `attribute_not_exists(ossGrantExpiresAt)`. `installation.created` is redeliverable, and an operator may amend or revoke the grant afterwards — a redelivery must never reset it. A failed condition is a successful no-op.
+
+**Ordered.** The pending row is marked claimed only *after* the grant lands. If the mark fails, a redelivery retries and stops at `grant_exists`. Marking first would risk spending the approval while the org gets nothing, silently.
+
+**Never re-fires.** A row carrying `claimedAt` is inert, so uninstall/reinstall does not re-grant. A spent approval goes back through an operator.
+
+Claim failures never propagate: an installation must still be recorded even if the OSS claim throws.
+
+### Known limitation — matched on login, not id
+
+The sort key is the org login, lowercased. This is the one place the system matches on a mutable name rather than a numeric id, because before installation the numeric account id is not reliably obtainable (an App JWT cannot read `GET /orgs/{org}`).
+
+If an org renames between approval and install, the pre-approval silently does not fire. The blast radius is bounded — they land on the standard free tier rather than someone else being mis-sponsored — but it is a real failure mode, and `--list-preapprovals` is how you'd notice a row that never got claimed.
+
+### Expiry
+
+An unclaimed pre-approval goes stale after 90 days (`OSS_PREAPPROVAL_TTL_DAYS`), enforced logically at claim time rather than by a DynamoDB TTL — the installations table has no `TimeToLiveSpecification`, and keeping the lapsed row leaves it auditable. A stale row is stamped `expiredAt` and nothing is written to `#SETTINGS`.
 
 ## Scope
 
 - **SaaS only.** The gate is behind `isSaas()`; `installation_settings` in Postgres has no billing columns at all.
 - **Webhook path only.** MCP `review_diff` is not sponsored: its `repo` input is optional and often literally `'unknown'`, so visibility cannot be verified at review time.
-- Approval stays manual, as the public page promises. There is no automated eligibility detection.
+- Approval stays manual, as the public page promises. There is no automated eligibility detection — including for pre-approvals, which are still an operator decision, just one that no longer has to wait for an install.
+- **A claimed pre-approval is spent.** Uninstall/reinstall does not re-grant; re-approving means running the script again.

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -215,6 +215,7 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-86](#e2e-86-336--p95-duration-nearest-rank--minimum-sample) | Analytics p95 duration uses nearest-rank (`⌈n × 0.95⌉`, clamped) instead of returning the maximum for n ≤ 20; below 20 completed reviews the UI shows "—" with an explanatory tooltip and no P95 bar (#336) | 2m | 30s | #336 |
 | [E2E-87](#e2e-87-337--date-only-range-bounds-include-their-whole-day) | `/api/analytics` date-only `start_date`/`end_date` expand to the UTC day's edge instants at the boundary (`end_date=2026-08-16` includes the whole 16th); full timestamps pass through untouched; identical on both backends; UTC bucketing documented in the route (#337) | 2m | 30s | #337 |
 | [E2E-88](#e2e-88-355--pr-burst-resilience) | A PR burst never silently loses reviews: throttles park the review (`pending` + in_progress "rate limited" check, never terminal FAILURE) and admission control paces the backlog — SQS `MaximumConcurrency` on SaaS, Postgres `SKIP LOCKED` worker at `REVIEW_CONCURRENCY` on self-hosted; exhaustion lands in a DLQ/`status='dead'`, visibly (#355) | 20m | n/a | #355 |
+| [E2E-93](#e2e-93-409--oss-operator-lifecycle-org-grants-pre-approval-inspect) | `grant-oss.ts --org` writes an org-scoped grant, `--preapprove` parks one for an uninstalled org (and refuses if they already installed), `--list-preapprovals` / `--inspect` render both, and the dashboard shows org-wide coverage rather than an empty repo list (#409) | 10m | n/a | #409 |
 | [E2E-92](#e2e-92-409--oss-pre-approval-claimed-automatically-on-install) | An org pre-approved before installing gets an org-scoped grant written automatically on `installation.created`; a webhook redelivery never resets an existing grant, a claimed row never re-fires on reinstall, and an expired pre-approval is ignored (#409) | 8m | n/a | #409 |
 | [E2E-91](#e2e-91-409--oss-org-scoped-grant-covers-every-public-repo) | An `ossGrantScope: 'org'` grant sponsors every PUBLIC repo in the installation including newly-created ones, while private repos, expiry, and the monthly cap still gate it; pre-#409 grants with no scope field still match only their named repo ids (#409) | 5m | n/a | #409 |
 | [E2E-90](#e2e-90-390--structured-outputs-zero-parse-failures) | On a provider with structured-output support, a full-suite run produces ZERO "Could not parse agent JSON response" log lines and no "Unparsed agent output" disclosures; the text parser is exercised only on fallback paths (#390) | 2m | 60s | #390 |
@@ -3205,6 +3206,45 @@ Then install the App on a test org that has **never** installed it before (an ex
 - ❌ A claim failure returns non-200 or aborts `storeInstallation` — the installation record is lost, which is far worse than a missed sponsorship
 - ❌ An expired pre-approval still fires — the 90-day TTL is the only forcing function to re-review a stale decision
 - ❌ The claim runs in self-hosted mode (`isSaas()` guard regressed) — Postgres has no billing columns and the write targets a table that doesn't exist
+
+---
+
+### E2E-93: #409 — OSS operator lifecycle: org grants, pre-approval, inspect
+
+**Status:** 🚧 In review (#409, stage 3).
+
+**Behavior:** `scripts/grant-oss.ts` gains three coverage models and the guards between them. `--org <login>` writes an org-scoped grant by resolving the org to its installation via the JWT-only `GET /orgs/{org}/installation` (falling back to the user endpoint for a personal account). `--preapprove <login>` parks an approval for an org that has **not** installed. `--list-preapprovals` renders every pending row and its state. `--inspect` reports the grant's scope and any pending pre-approval for the same account. `--revoke` works against either a repo or `--org`.
+
+**Setup.** Requires AWS credentials for the `mergewatch` profile and a dev-stage test org.
+
+**Expected outcomes — arg guards (no AWS needed).**
+- [ ] No `--stage` → refuses, naming both `dev` and `prod`
+- [ ] `--org acme octo/hello --stage dev` → refuses; says pick one coverage model
+- [ ] `--stage dev` with no target → refuses, naming both target forms
+- [ ] `--org octo/hello --stage dev` → refuses ("Not an org login … drop --org")
+- [ ] `--cap 0`, `--months 0`, `--ttl-days 0` → each refused as a probable typo
+- [ ] `--revoke --org acme --stage dev` parses as revoke-targeting-an-org, NOT as a repo literally named `--org`
+
+**Expected outcomes — org grants.**
+- [ ] `--org <test-org> --stage dev` prints every public repo currently known, the open-core warning, cap and expiry, then writes `ossGrantScope=org` + `ossGrantAccount`
+- [ ] `--inspect --org <test-org> --stage dev` shows `Scope: org — every PUBLIC repo`, the account, cap, and accrual counters
+- [ ] Granting `--org` over an installation that had a repos-scoped grant reports the old list as "IGNORED under org scope" and leaves it in place
+- [ ] `--revoke --org <test-org> --stage dev` sets expiry to the past and says the grant was org-scoped
+- [ ] Dashboard `/dashboard/billing` shows "All / Public repositories" and "Every public repository, including ones you create later" — **not** an empty repo list or a missing panel
+
+**Expected outcomes — pre-approval.**
+- [ ] `--preapprove <uninstalled-org> --stage dev` writes a pending row and warns that matching is on the login, not a numeric id
+- [ ] `--preapprove <ALREADY-installed-org>` → refuses and points at `--org`, because `installation.created` has already fired and will never fire again
+- [ ] `--list-preapprovals --stage dev` shows the row as `pending — expires …`
+- [ ] After the org installs (see E2E-92), `--list-preapprovals` shows `claimed … by installation <id>` and `--inspect --org` shows the org-scoped grant
+- [ ] Re-running `--preapprove` for an already-claimed org shows the existing row and warns that overwriting resets it to pending without touching the grant already written
+
+**Failure modes.**
+- ❌ `--org` writes a grant but leaves `ossGrantScope` unset — the gate would read `'repos'`, find no list, and sponsor nothing while `--inspect` claims the grant is active
+- ❌ `--revoke` rewrites `ossGrantScope` — a later renewal would silently change what the grant covers
+- ❌ The dashboard shows an org-scoped grant as "no grant" (the `ossStatus` regression this stage fixes) or renders a stale repo list as if it were the coverage
+- ❌ `--preapprove` succeeds for an already-installed org — the row would sit unclaimed forever with nobody looking at it
+- ❌ Script constants drift from `packages/billing/src/constants.ts` (cap, term, TTL, `#PENDING-OSS`) — they are duplicated by necessity, so a change on one side must be mirrored
 
 ---
 

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -3235,6 +3235,7 @@ Then install the App on a test org that has **never** installed it before (an ex
 **Expected outcomes — pre-approval.**
 - [ ] `--preapprove <uninstalled-org> --stage dev` writes a pending row and warns that matching is on the login, not a numeric id
 - [ ] `--preapprove <ALREADY-installed-org>` → refuses and points at `--org`, because `installation.created` has already fired and will never fire again
+- [ ] A **transient** GitHub failure during that check (5xx / rate limit — simulate by revoking the App key mid-run) aborts with "Refusing to guess" rather than writing a pre-approval that could never be claimed
 - [ ] `--list-preapprovals --stage dev` shows the row as `pending — expires …`
 - [ ] After the org installs (see E2E-92), `--list-preapprovals` shows `claimed … by installation <id>` and `--inspect --org` shows the org-scoped grant
 - [ ] Re-running `--preapprove` for an already-claimed org shows the existing row and warns that overwriting resets it to pending without touching the grant already written
@@ -3244,6 +3245,7 @@ Then install the App on a test org that has **never** installed it before (an ex
 - ❌ `--revoke` rewrites `ossGrantScope` — a later renewal would silently change what the grant covers
 - ❌ The dashboard shows an org-scoped grant as "no grant" (the `ossStatus` regression this stage fixes) or renders a stale repo list as if it were the coverage
 - ❌ `--preapprove` succeeds for an already-installed org — the row would sit unclaimed forever with nobody looking at it
+- ❌ A non-404 installation-lookup failure is swallowed as "not installed" — same outcome, but triggered by a transient blip rather than operator error, so it is even less likely to be noticed
 - ❌ Script constants drift from `packages/billing/src/constants.ts` (cap, term, TTL, `#PENDING-OSS`) — they are duplicated by necessity, so a change on one side must be mirrored
 
 ---

--- a/packages/dashboard/app/dashboard/billing/BillingClient.tsx
+++ b/packages/dashboard/app/dashboard/billing/BillingClient.tsx
@@ -17,13 +17,17 @@ interface BillingStatus {
   prCount: number;
   prTimestamps: string[];
   /**
-   * OSS Program (#261). Null for every installation without a grant.
-   * `active` is computed server-side so this panel can't drift from the
+   * OSS Program (#261, org scope #409). Null for every installation without a
+   * grant. `active` is computed server-side so this panel can't drift from the
    * billing gate's own notion of an active grant.
    */
   oss: {
     active: boolean;
-    repos: string[];
+    /** 'org' sponsors every public repo in the installation; 'repos' only those named. */
+    scope: "repos" | "org";
+    account: { id: number; login: string } | null;
+    /** Null under org scope — coverage is not a fixed list there. */
+    repos: string[] | null;
     expiresAt: string;
     grantedAt: string | null;
     note: string | null;
@@ -248,8 +252,17 @@ export default function BillingClient({ installationId, accountLogin, setupCompl
 
             {status.oss.active ? (
               <p className="text-sm text-fg-secondary">
-                Reviews on the repositories below are sponsored by MergeWatch — no charge, and
-                they don&rsquo;t use your free reviews or balance.
+                {status.oss.scope === "org" ? (
+                  <>
+                    Every public repository in this organization is sponsored by MergeWatch — no
+                    charge, and sponsored reviews don&rsquo;t use your free reviews or balance.
+                  </>
+                ) : (
+                  <>
+                    Reviews on the repositories below are sponsored by MergeWatch — no charge, and
+                    they don&rsquo;t use your free reviews or balance.
+                  </>
+                )}
               </p>
             ) : (
               <p className="text-sm text-fg-secondary">
@@ -304,26 +317,49 @@ export default function BillingClient({ installationId, accountLogin, setupCompl
 
               <div>
                 <div className="text-2xl font-bold text-fg-primary tabular-nums">
-                  {status.oss.repos.length}
+                  {status.oss.scope === "org" ? "All" : status.oss.repos?.length ?? 0}
                 </div>
                 <p className="mt-1 text-xs text-fg-tertiary">
-                  {status.oss.repos.length === 1 ? "Covered repository" : "Covered repositories"}
+                  {status.oss.scope === "org"
+                    ? "Public repositories"
+                    : status.oss.repos?.length === 1
+                      ? "Covered repository"
+                      : "Covered repositories"}
                 </p>
               </div>
             </div>
 
             <div className="mt-5 pt-4 border-t border-border-default">
-              <p className="text-xs text-fg-tertiary mb-2">Covered repositories</p>
-              <ul className="space-y-1">
-                {status.oss.repos.map((r) => (
-                  <li key={r} className="text-sm text-fg-secondary">{r}</li>
-                ))}
-              </ul>
-              <p className="mt-3 text-[11px] text-fg-muted">
-                Only these repositories are sponsored, and only while they are public. Anything
-                else in this installation bills normally.
-                {status.oss.active && ` Grant runs until ${new Date(status.oss.expiresAt).toLocaleDateString()}.`}
-              </p>
+              {status.oss.scope === "org" ? (
+                <>
+                  <p className="text-xs text-fg-tertiary mb-2">
+                    Coverage
+                    {status.oss.account ? ` — ${status.oss.account.login}` : ""}
+                  </p>
+                  <p className="text-sm text-fg-secondary">
+                    Every public repository, including ones you create later.
+                  </p>
+                  <p className="mt-3 text-[11px] text-fg-muted">
+                    Private repositories are never sponsored and bill normally — and a repository
+                    switched to private stops being sponsored on its next review.
+                    {status.oss.active && ` Grant runs until ${new Date(status.oss.expiresAt).toLocaleDateString()}.`}
+                  </p>
+                </>
+              ) : (
+                <>
+                  <p className="text-xs text-fg-tertiary mb-2">Covered repositories</p>
+                  <ul className="space-y-1">
+                    {(status.oss.repos ?? []).map((r) => (
+                      <li key={r} className="text-sm text-fg-secondary">{r}</li>
+                    ))}
+                  </ul>
+                  <p className="mt-3 text-[11px] text-fg-muted">
+                    Only these repositories are sponsored, and only while they are public. Anything
+                    else in this installation bills normally.
+                    {status.oss.active && ` Grant runs until ${new Date(status.oss.expiresAt).toLocaleDateString()}.`}
+                  </p>
+                </>
+              )}
             </div>
           </div>
         )}

--- a/packages/lambda/src/handlers/billing-oss-status.test.ts
+++ b/packages/lambda/src/handlers/billing-oss-status.test.ts
@@ -1,0 +1,114 @@
+/**
+ * #409 — `ossStatus` must report org-scoped grants.
+ *
+ * Before this, the helper bailed to `null` whenever the repo list was empty,
+ * which is the normal state of an org-scoped grant — so the dashboard would
+ * have told a sponsored org it had no grant at all.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+// billing.ts constructs SSM/Dynamo clients and pulls in Stripe at module load.
+// None of that is exercised here — ossStatus is a pure function over fields.
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: class { send() { return Promise.resolve({}); } },
+}));
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: { from: () => ({ send: () => Promise.resolve({}) }) },
+}));
+vi.mock('@mergewatch/billing', () => ({
+  getStripe: vi.fn(),
+  ensureStripeCustomer: vi.fn(),
+  createSetupSession: vi.fn(),
+  createTopUp: vi.fn(),
+  getBillingFields: vi.fn(),
+  updateBillingFields: vi.fn(),
+  closeBillingIssue: vi.fn(),
+  FREE_REVIEW_LIMIT: 5,
+  MIN_BALANCE_CENTS: 5,
+  getStripeWebhookSecret: vi.fn(),
+  getBillingApiSecret: vi.fn(),
+}));
+vi.mock('../github-auth-ssm.js', () => ({
+  SSMGitHubAuthProvider: class { getInstallationOctokit() { return Promise.resolve({}); } },
+}));
+
+import { ossStatus } from './billing.js';
+
+const FUTURE = '2099-01-01T00:00:00.000Z';
+const PERIOD = new Date().toISOString().slice(0, 7);
+
+describe('ossStatus — org scope (#409)', () => {
+  it('reports an org-scoped grant that has no repo list', () => {
+    const status = ossStatus({
+      ossGrantScope: 'org',
+      ossGrantAccount: { id: 9931, login: 'acme-corp' },
+      ossGrantExpiresAt: FUTURE,
+      ossMonthlyCapCents: 2000,
+    } as any);
+
+    expect(status).not.toBeNull();
+    expect(status!.active).toBe(true);
+    expect(status!.scope).toBe('org');
+    expect(status!.account).toEqual({ id: 9931, login: 'acme-corp' });
+  });
+
+  it('reports repos as null under org scope rather than a stale list', () => {
+    // The gate ignores a leftover list from an earlier repos-scoped grant;
+    // rendering it would understate coverage to the maintainer.
+    const status = ossStatus({
+      ossGrantScope: 'org',
+      ossGrantRepos: [{ id: 1, fullName: 'acme-corp/old-only-this' }],
+      ossGrantExpiresAt: FUTURE,
+    } as any);
+
+    expect(status!.repos).toBeNull();
+  });
+
+  it('marks an expired org grant inactive rather than hiding it', () => {
+    const status = ossStatus({
+      ossGrantScope: 'org',
+      ossGrantExpiresAt: '2020-01-01T00:00:00.000Z',
+    } as any);
+
+    expect(status).not.toBeNull();
+    expect(status!.active).toBe(false);
+  });
+
+  it('still surfaces period and lifetime accrual under org scope', () => {
+    const status = ossStatus({
+      ossGrantScope: 'org',
+      ossGrantExpiresAt: FUTURE,
+      ossPeriod: PERIOD,
+      ossSponsoredCentsThisPeriod: 412,
+      ossSponsoredCentsLifetime: 9001,
+    } as any);
+
+    expect(status!.sponsoredThisPeriodCents).toBe(412);
+    expect(status!.sponsoredLifetimeCents).toBe(9001);
+  });
+});
+
+describe('ossStatus — repos scope stays as it was (#261)', () => {
+  it('reports a named-repo grant', () => {
+    const status = ossStatus({
+      ossGrantRepos: [{ id: 1, fullName: 'octocat/hello-world' }],
+      ossGrantExpiresAt: FUTURE,
+      ossMonthlyCapCents: 2000,
+    } as any);
+
+    expect(status!.scope).toBe('repos');
+    expect(status!.repos).toEqual(['octocat/hello-world']);
+  });
+
+  it('returns null for a repos-scoped grant naming nothing', () => {
+    expect(ossStatus({ ossGrantExpiresAt: FUTURE } as any)).toBeNull();
+  });
+
+  it('returns null for an installation with no grant at all', () => {
+    expect(ossStatus({} as any)).toBeNull();
+  });
+
+  it('returns null when a repo list exists but no expiry does', () => {
+    expect(ossStatus({ ossGrantRepos: [{ id: 1, fullName: 'a/b' }] } as any)).toBeNull();
+  });
+});

--- a/packages/lambda/src/handlers/billing.ts
+++ b/packages/lambda/src/handlers/billing.ts
@@ -237,16 +237,27 @@ async function handleWebhook(event: APIGatewayProxyEventV2): Promise<APIGatewayP
  * cap is actually applied — last month's spend never eats this month's
  * allowance.
  */
-function ossStatus(fields: Awaited<ReturnType<typeof getBillingFields>>) {
+export function ossStatus(fields: Awaited<ReturnType<typeof getBillingFields>>) {
   const repos = fields.ossGrantRepos ?? [];
-  if (!fields.ossGrantExpiresAt || repos.length === 0) return null;
+  const scope = fields.ossGrantScope ?? 'repos';
+
+  // #409 — an org-scoped grant has no repo list, so the old
+  // `repos.length === 0` bail would have reported "no grant" for every one of
+  // them. Coverage now mirrors evaluateOssGrant: org scope needs no list,
+  // repos scope is nothing without one.
+  const hasCoverage = scope === 'org' || repos.length > 0;
+  if (!fields.ossGrantExpiresAt || !hasCoverage) return null;
 
   const expiresAt = Date.parse(fields.ossGrantExpiresAt);
   const period = new Date().toISOString().slice(0, 7);
 
   return {
     active: Number.isFinite(expiresAt) && expiresAt > Date.now(),
-    repos: repos.map((r) => r.fullName),
+    scope,
+    account: fields.ossGrantAccount ?? null,
+    // Null rather than a stale list under org scope: the gate ignores any
+    // leftover repos there, and showing them would understate coverage.
+    repos: scope === 'org' ? null : repos.map((r) => r.fullName),
     expiresAt: fields.ossGrantExpiresAt,
     grantedAt: fields.ossGrantedAt ?? null,
     note: fields.ossGrantNote ?? null,

--- a/scripts/grant-oss.ts
+++ b/scripts/grant-oss.ts
@@ -317,27 +317,40 @@ async function resolveRepo(gh: GitHubClients, fullName: string): Promise<Resolve
   };
 }
 
+interface OrgInstallation {
+  installationId: string;
+  account: { id: number; login: string };
+  targetType: string;
+}
+
 /**
- * Resolve an org (or user) login to its installation, without needing a repo.
+ * Look up an installation by account login, distinguishing "not installed"
+ * from "could not tell".
  *
  * `GET /orgs/{org}/installation` and `GET /users/{username}/installation` are
- * both App-JWT-only endpoints, same as the per-repo lookup. An org login is
- * tried first because that is the overwhelmingly common case; a personal
- * account falls through to the user endpoint.
+ * both App-JWT-only, same as the per-repo lookup. An org login is tried first
+ * because that is the overwhelmingly common case; a personal account falls
+ * through to the user endpoint.
+ *
+ * Returns null ONLY when GitHub answered 404 on both — that is the real "no
+ * installation" signal. Any other failure (5xx, rate limit, network) aborts
+ * rather than being swallowed: treating a transient error as "not installed"
+ * would let `--preapprove` write a row for an org that IS installed, and such a
+ * row can never be claimed because `installation.created` has already fired.
+ * Nobody would notice until someone ran `--list-preapprovals`.
  */
-async function resolveOrgInstallation(
+async function findInstallationByLogin(
   gh: GitHubClients,
   login: string,
-): Promise<{ installationId: string; account: { id: number; login: string }; targetType: string }> {
-  const attempts: (() => Promise<{ data: { id: number; account: unknown; target_type: string } }>)[] = [
-    () => gh.jwt.apps.getOrgInstallation({ org: login }) as never,
-    () => gh.jwt.apps.getUserInstallation({ username: login }) as never,
+): Promise<OrgInstallation | null> {
+  const attempts: { label: string; run: () => Promise<{ data: { id: number; account: unknown; target_type: string } }> }[] = [
+    { label: `orgs/${login}/installation`, run: () => gh.jwt.apps.getOrgInstallation({ org: login }) as never },
+    { label: `users/${login}/installation`, run: () => gh.jwt.apps.getUserInstallation({ username: login }) as never },
   ];
 
-  let lastErr: unknown;
-  for (const attempt of attempts) {
+  for (const { label, run } of attempts) {
     try {
-      const { data } = await attempt();
+      const { data } = await run();
       const account = data.account as { id: number; login: string } | null;
       if (!account) {
         fail(`Installation ${data.id} for ${login} has no account attached — cannot grant.`);
@@ -348,15 +361,30 @@ async function resolveOrgInstallation(
         targetType: data.target_type,
       };
     } catch (err) {
-      lastErr = err;
+      const status = (err as { status?: number }).status;
+      if (status === 404) continue;
+      fail(
+        `Could not determine whether ${login} has installed the App.\n`
+        + `GET ${label} returned ${status ?? 'an error'}: ${(err as Error).message}\n\n`
+        + 'Refusing to guess. Treating this as "not installed" would write a\n'
+        + 'pre-approval that can never be claimed; treating it as "installed"\n'
+        + 'would refuse a legitimate one. Retry once GitHub is responding.',
+      );
     }
   }
+
+  return null;
+}
+
+/** As above, but for modes that require an existing installation. */
+async function resolveOrgInstallation(gh: GitHubClients, login: string): Promise<OrgInstallation> {
+  const found = await findInstallationByLogin(gh, login);
+  if (found) return found;
 
   fail(
     `The MergeWatch App is not installed on ${login} (or it does not exist).\n`
     + 'If they have not installed it yet, that is what --preapprove is for:\n'
-    + `  scripts/grant-oss.ts --preapprove ${login} --stage <stage>\n`
-    + `GitHub said: ${(lastErr as Error)?.message}`,
+    + `  scripts/grant-oss.ts --preapprove ${login} --stage <stage>`,
   );
 }
 
@@ -584,17 +612,9 @@ async function main() {
     // If they are already installed, a pre-approval would sit unclaimed
     // forever: `installation.created` has already fired and will not fire
     // again. Point at the mode that actually does something.
-    let alreadyInstalled: string | undefined;
-    try {
-      const { data } = await gh.jwt.apps.getOrgInstallation({ org: login });
-      alreadyInstalled = String(data.id);
-    } catch {
-      try {
-        const { data } = await gh.jwt.apps.getUserInstallation({ username: login });
-        alreadyInstalled = String(data.id);
-      } catch { /* not installed — the expected case here */ }
-    }
-    if (alreadyInstalled) {
+    const existingInstall = await findInstallationByLogin(gh, login);
+    if (existingInstall) {
+      const alreadyInstalled = existingInstall.installationId;
       fail(
         `${login} has ALREADY installed the App (installation ${alreadyInstalled}).\n`
         + 'A pre-approval is only claimed on installation.created, so this one would\n'

--- a/scripts/grant-oss.ts
+++ b/scripts/grant-oss.ts
@@ -10,32 +10,46 @@
  * row is therefore the sole record of who was granted what and why, which is
  * what `--note` and `--inspect` exist for.
  *
- * Usage:
+ * Usage — repo-scoped grants (#261):
  *   scripts/grant-oss.ts <owner/repo>[,<owner/repo>…] --stage dev|prod [options]
  *   scripts/grant-oss.ts --add <owner/repo>     --stage …
  *   scripts/grant-oss.ts --remove <owner/repo>  --stage …
- *   scripts/grant-oss.ts --revoke <owner/repo>  --stage …
+ *
+ * Usage — org-scoped grants (#409), covering every PUBLIC repo in the org:
+ *   scripts/grant-oss.ts --org <org-login> --stage …
+ *
+ * Usage — pre-approval (#409), for an org that has NOT installed yet:
+ *   scripts/grant-oss.ts --preapprove <org-login> --stage …
+ *   scripts/grant-oss.ts --list-preapprovals --stage …
+ *
+ * Usage — lifecycle, against either a repo or an org:
+ *   scripts/grant-oss.ts --revoke  <owner/repo> --stage …
+ *   scripts/grant-oss.ts --revoke  --org <org-login> --stage …
  *   scripts/grant-oss.ts --inspect <owner/repo> --stage …
+ *   scripts/grant-oss.ts --inspect --org <org-login> --stage …
  *
  * Options:
  *   --stage dev|prod   REQUIRED. No default — a grant must never land in the
  *                      wrong environment because someone forgot a flag.
  *   --cap <cents>      Monthly fair-use ceiling (default 2000 = $20).
  *   --months <n>       Grant term (default 12).
+ *   --ttl-days <n>     Pre-approval lifetime before it goes stale (default 90).
  *   --note "<text>"    Provenance: application reference, project, approver.
  *   --yes              Skip the confirmation prompt (for scripted use).
  *
  * Prerequisites:
  *   - AWS credentials for the `mergewatch` profile, with SSM read on the
  *     GitHub App parameters and write access to the installations table.
- *   - The maintainer has already installed the GitHub App on the repository
- *     (that is what creates the installation this grant attaches to).
+ *   - For everything EXCEPT `--preapprove`: the maintainer has already
+ *     installed the GitHub App (that is what creates the installation a grant
+ *     attaches to). `--preapprove` exists precisely for the case where they
+ *     have not.
  * =============================================================================
  */
 
 import { createInterface } from 'node:readline/promises';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { DynamoDBDocumentClient, QueryCommand, UpdateCommand, GetCommand } from '@aws-sdk/lib-dynamodb';
+import { DynamoDBDocumentClient, QueryCommand, UpdateCommand, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
 import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
 import { createAppAuth } from '@octokit/auth-app';
 import { Octokit } from '@octokit/rest';
@@ -43,47 +57,55 @@ import { Octokit } from '@octokit/rest';
 const PROFILE = 'mergewatch';
 const REGION = process.env.AWS_REGION ?? 'us-west-2';
 const SETTINGS_SK = '#SETTINGS';
+
+/**
+ * Mirrors of `@mergewatch/billing`'s constants and pre-approval row shape.
+ *
+ * Duplicated deliberately: workspace packages do not resolve from the repo
+ * root, so this script can only import hoisted third-party deps (the AWS SDK,
+ * Octokit) — never `@mergewatch/*`. `DEFAULT_CAP_CENTS` and
+ * `DEFAULT_TERM_MONTHS` were already duplicated here for the same reason.
+ *
+ * Source of truth: `packages/billing/src/constants.ts` and
+ * `packages/billing/src/oss-preapproval.ts`. Keep them in step.
+ */
 const DEFAULT_CAP_CENTS = 2000;
 const DEFAULT_TERM_MONTHS = 12;
+const DEFAULT_PREAPPROVAL_TTL_DAYS = 90;
+const PREAPPROVAL_PK = '#PENDING-OSS';
 
 // --- Arg parsing -------------------------------------------------------------
 
 interface Args {
+  /** owner/repo targets. Empty for org-targeted and pre-approval modes. */
   repos: string[];
+  /** Org (or user) login, for `--org` / `--preapprove`. */
+  orgLogin?: string;
   stage: string;
-  mode: 'grant' | 'add' | 'remove' | 'revoke' | 'inspect';
+  mode: 'grant' | 'org' | 'preapprove' | 'list-preapprovals'
+      | 'add' | 'remove' | 'revoke' | 'inspect';
   capCents: number;
   months: number;
+  ttlDays: number;
   note?: string;
   yes: boolean;
 }
 
+/**
+ * Value of `--flag <value>`, or undefined.
+ *
+ * A following token that itself starts with `--` is NOT a value: that is what
+ * makes `--revoke --org acme` parse as "revoke, targeting an org" rather than
+ * silently trying to revoke a repository literally named `--org`.
+ */
 function flag(argv: string[], name: string): string | undefined {
   const i = argv.indexOf(name);
-  return i === -1 ? undefined : argv[i + 1];
+  if (i === -1) return undefined;
+  const v = argv[i + 1];
+  return v === undefined || v.startsWith('--') ? undefined : v;
 }
 
 function parseArgs(argv: string[]): Args {
-  const modes = [
-    ['--add', 'add'],
-    ['--remove', 'remove'],
-    ['--revoke', 'revoke'],
-    ['--inspect', 'inspect'],
-  ] as const;
-
-  let mode: Args['mode'] = 'grant';
-  let repoArg: string | undefined;
-
-  for (const [f, m] of modes) {
-    const v = flag(argv, f);
-    if (v !== undefined) {
-      mode = m;
-      repoArg = v;
-      break;
-    }
-  }
-  if (mode === 'grant') repoArg = argv.find((a) => !a.startsWith('--') && a.includes('/'));
-
   const stage = flag(argv, '--stage');
   if (!stage || !['dev', 'prod'].includes(stage)) {
     fail(
@@ -92,15 +114,87 @@ function parseArgs(argv: string[]): Args {
       + 'lands in the wrong one.',
     );
   }
-  if (!repoArg) fail('No repository given. Expected owner/repo.');
 
-  const repos = repoArg!.split(',').map((r) => r.trim()).filter(Boolean);
+  const orgLogin = flag(argv, '--org');
+  const preapproveLogin = flag(argv, '--preapprove');
+
+  // Positional repo args: anything that isn't a flag and looks like owner/repo.
+  // Values consumed by flags are excluded so `--note "a/b"` isn't read as a repo.
+  const consumed = new Set<string>();
+  for (const f of ['--stage', '--org', '--preapprove', '--add', '--remove',
+                   '--revoke', '--inspect', '--cap', '--months', '--ttl-days', '--note']) {
+    const v = flag(argv, f);
+    if (v !== undefined) consumed.add(v);
+  }
+  const positionalRepos = argv.filter(
+    (a) => !a.startsWith('--') && a.includes('/') && !consumed.has(a),
+  );
+
+  let mode: Args['mode'];
+  let repoArg: string | undefined;
+
+  if (argv.includes('--list-preapprovals')) {
+    mode = 'list-preapprovals';
+  } else if (argv.includes('--preapprove')) {
+    mode = 'preapprove';
+    if (!preapproveLogin) fail('--preapprove needs an org login, e.g. --preapprove acme-corp');
+  } else if (argv.includes('--inspect')) {
+    mode = 'inspect';
+    repoArg = flag(argv, '--inspect');
+  } else if (argv.includes('--revoke')) {
+    mode = 'revoke';
+    repoArg = flag(argv, '--revoke');
+  } else if (argv.includes('--add')) {
+    mode = 'add';
+    repoArg = flag(argv, '--add');
+  } else if (argv.includes('--remove')) {
+    mode = 'remove';
+    repoArg = flag(argv, '--remove');
+  } else if (orgLogin) {
+    mode = 'org';
+  } else {
+    mode = 'grant';
+    repoArg = positionalRepos[0];
+  }
+
+  // An org login and a repo list mean two different coverage models. Guessing
+  // which one the operator meant is exactly the kind of silent wrong answer a
+  // grant script must never give.
+  const repoTargets = repoArg ?? (mode === 'grant' ? undefined : positionalRepos[0]);
+  if (orgLogin && repoTargets && mode !== 'inspect' && mode !== 'revoke') {
+    fail(
+      `--org ${orgLogin} covers every public repo in the org, but you also named\n`
+      + `repositories (${repoTargets}). Pick one: --org for org-wide, or a repo list\n`
+      + 'for named repos only.',
+    );
+  }
+  if (mode === 'org' && positionalRepos.length) {
+    fail(
+      `--org ${orgLogin} covers every public repo in the org, but you also named\n`
+      + `repositories (${positionalRepos.join(', ')}). Pick one.`,
+    );
+  }
+
+  const needsTarget = ['grant', 'add', 'remove', 'revoke', 'inspect'].includes(mode);
+  if (needsTarget && !repoTargets && !orgLogin) {
+    fail('No target given. Expected owner/repo, or --org <org-login>.');
+  }
+
+  const repos = repoTargets
+    ? repoTargets.split(',').map((r) => r.trim()).filter(Boolean)
+    : [];
   for (const r of repos) {
     if (!/^[^/\s]+\/[^/\s]+$/.test(r)) fail(`Not an owner/repo: ${r}`);
   }
 
+  const login = mode === 'preapprove' ? preapproveLogin : orgLogin;
+  if (login && /[/\s]/.test(login)) {
+    fail(`Not an org login: ${login} (did you mean a repository? drop --org)`);
+  }
+
   const capCents = Number(flag(argv, '--cap') ?? DEFAULT_CAP_CENTS);
   const months = Number(flag(argv, '--months') ?? DEFAULT_TERM_MONTHS);
+  const ttlDays = Number(flag(argv, '--ttl-days') ?? DEFAULT_PREAPPROVAL_TTL_DAYS);
   // A zero or negative cap is almost certainly a typo, and it produces a grant
   // that is active but sponsors nothing — the most confusing possible state for
   // a maintainer. Reject it here rather than letting it reach the row.
@@ -110,13 +204,18 @@ function parseArgs(argv: string[]): Args {
   if (!Number.isFinite(months) || months <= 0) {
     fail(`--months must be a positive number (got ${flag(argv, '--months')}).`);
   }
+  if (!Number.isFinite(ttlDays) || ttlDays <= 0) {
+    fail(`--ttl-days must be a positive number (got ${flag(argv, '--ttl-days')}).`);
+  }
 
   return {
     repos,
+    orgLogin: login,
     stage: stage!,
     mode,
     capCents,
     months,
+    ttlDays,
     note: flag(argv, '--note'),
     yes: argv.includes('--yes'),
   };
@@ -218,6 +317,49 @@ async function resolveRepo(gh: GitHubClients, fullName: string): Promise<Resolve
   };
 }
 
+/**
+ * Resolve an org (or user) login to its installation, without needing a repo.
+ *
+ * `GET /orgs/{org}/installation` and `GET /users/{username}/installation` are
+ * both App-JWT-only endpoints, same as the per-repo lookup. An org login is
+ * tried first because that is the overwhelmingly common case; a personal
+ * account falls through to the user endpoint.
+ */
+async function resolveOrgInstallation(
+  gh: GitHubClients,
+  login: string,
+): Promise<{ installationId: string; account: { id: number; login: string }; targetType: string }> {
+  const attempts: (() => Promise<{ data: { id: number; account: unknown; target_type: string } }>)[] = [
+    () => gh.jwt.apps.getOrgInstallation({ org: login }) as never,
+    () => gh.jwt.apps.getUserInstallation({ username: login }) as never,
+  ];
+
+  let lastErr: unknown;
+  for (const attempt of attempts) {
+    try {
+      const { data } = await attempt();
+      const account = data.account as { id: number; login: string } | null;
+      if (!account) {
+        fail(`Installation ${data.id} for ${login} has no account attached — cannot grant.`);
+      }
+      return {
+        installationId: String(data.id),
+        account: { id: account!.id, login: account!.login },
+        targetType: data.target_type,
+      };
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+
+  fail(
+    `The MergeWatch App is not installed on ${login} (or it does not exist).\n`
+    + 'If they have not installed it yet, that is what --preapprove is for:\n'
+    + `  scripts/grant-oss.ts --preapprove ${login} --stage <stage>\n`
+    + `GitHub said: ${(lastErr as Error)?.message}`,
+  );
+}
+
 // --- DynamoDB -----------------------------------------------------------------
 
 const table = (stage: string) => process.env.INSTALLATIONS_TABLE ?? `mergewatch-installations-${stage}`;
@@ -225,6 +367,8 @@ const table = (stage: string) => process.env.INSTALLATIONS_TABLE ?? `mergewatch-
 interface OssGrantRepo { id: number; fullName: string }
 
 interface GrantFields {
+  ossGrantScope?: 'repos' | 'org';
+  ossGrantAccount?: { id: number; login: string };
   ossGrantRepos?: OssGrantRepo[];
   ossGrantExpiresAt?: string;
   ossGrantedAt?: string;
@@ -267,8 +411,9 @@ async function installationRepos(stage: string, installationId: string): Promise
 async function writeGrant(
   stage: string,
   installationId: string,
-  fields: Required<Pick<GrantFields, 'ossGrantRepos' | 'ossGrantExpiresAt' | 'ossMonthlyCapCents'>>
-    & Pick<GrantFields, 'ossGrantedAt' | 'ossGrantNote'>,
+  fields: Required<Pick<GrantFields, 'ossGrantExpiresAt' | 'ossMonthlyCapCents'>>
+    & Pick<GrantFields, 'ossGrantRepos' | 'ossGrantScope' | 'ossGrantAccount'
+                      | 'ossGrantedAt' | 'ossGrantNote'>,
 ): Promise<void> {
   const names: Record<string, string> = {};
   const values: Record<string, unknown> = {};
@@ -288,6 +433,68 @@ async function writeGrant(
   }));
 }
 
+/**
+ * Pending pre-approval row. Mirrors `OssPreapproval` in
+ * `packages/billing/src/oss-preapproval.ts` — see the note on the constants
+ * above for why it is duplicated rather than imported.
+ *
+ * `repoFullName` is the table's sort key, not a repository: it holds the
+ * lowercased org login.
+ */
+interface PreapprovalRow {
+  installationId: string;
+  repoFullName: string;
+  orgLogin: string;
+  capCents: number;
+  months: number;
+  note?: string;
+  preapprovedAt: string;
+  preapprovalExpiresAt: string;
+  claimedAt?: string;
+  claimedInstallationId?: string;
+  expiredAt?: string;
+}
+
+const normalizeLogin = (login: string) => login.trim().toLowerCase();
+
+async function readPreapproval(stage: string, login: string): Promise<PreapprovalRow | null> {
+  const res = await dynamo.send(new GetCommand({
+    TableName: table(stage),
+    Key: { installationId: PREAPPROVAL_PK, repoFullName: normalizeLogin(login) },
+  }));
+  return (res.Item as PreapprovalRow | undefined) ?? null;
+}
+
+async function listPreapprovals(stage: string): Promise<PreapprovalRow[]> {
+  const out: PreapprovalRow[] = [];
+  let lastKey: Record<string, unknown> | undefined;
+  do {
+    const res = await dynamo.send(new QueryCommand({
+      TableName: table(stage),
+      KeyConditionExpression: 'installationId = :pk',
+      ExpressionAttributeValues: { ':pk': PREAPPROVAL_PK },
+      ExclusiveStartKey: lastKey,
+    }));
+    out.push(...((res.Items ?? []) as PreapprovalRow[]));
+    lastKey = res.LastEvaluatedKey;
+  } while (lastKey);
+  return out.sort((a, b) => a.repoFullName.localeCompare(b.repoFullName));
+}
+
+async function writePreapproval(stage: string, row: PreapprovalRow): Promise<void> {
+  await dynamo.send(new PutCommand({ TableName: table(stage), Item: row }));
+}
+
+/** A TTL is a duration, so plain millisecond arithmetic — never local-time setDate. */
+const addDays = (from: Date, days: number) => new Date(from.getTime() + days * 86_400_000);
+
+/** Calendar months in UTC, so a grant's expiry doesn't depend on the operator's timezone. */
+function addMonths(from: Date, months: number): Date {
+  const d = new Date(from.getTime());
+  d.setUTCMonth(d.getUTCMonth() + months);
+  return d;
+}
+
 // --- Presentation --------------------------------------------------------------
 
 const usd = (cents: number) => `$${(cents / 100).toFixed(2)}`;
@@ -295,19 +502,51 @@ const usd = (cents: number) => `$${(cents / 100).toFixed(2)}`;
 function renderGrant(grant: GrantFields, installationId: string): void {
   const repos = grant.ossGrantRepos ?? [];
   const expires = grant.ossGrantExpiresAt;
-  const active = !!expires && Date.parse(expires) > Date.now() && repos.length > 0;
+  const scope = grant.ossGrantScope ?? 'repos';
+  // An org-scoped grant needs no repo list; a repos-scoped one is nothing
+  // without it. Mirrors evaluateOssGrant so --inspect can't claim a grant is
+  // active that the gate would refuse.
+  const hasCoverage = scope === 'org' || repos.length > 0;
+  const active = !!expires && Date.parse(expires) > Date.now() && hasCoverage;
 
   console.log(`\nInstallation ${installationId}`);
   console.log(`  Status        ${active ? '✓ active' : '✗ no active grant'}`);
-  if (!expires && repos.length === 0) return;
+  if (!expires && repos.length === 0 && scope === 'repos') return;
 
-  console.log(`  Covered repos ${repos.length ? repos.map((r) => `${r.fullName} (id ${r.id})`).join('\n                ') : '(none)'}`);
+  console.log(`  Scope         ${scope === 'org' ? 'org — every PUBLIC repo in the installation' : 'repos — only those named below'}`);
+  if (grant.ossGrantAccount) {
+    console.log(`  Account       ${grant.ossGrantAccount.login} (id ${grant.ossGrantAccount.id})`);
+  }
+  if (scope === 'repos') {
+    console.log(`  Covered repos ${repos.length ? repos.map((r) => `${r.fullName} (id ${r.id})`).join('\n                ') : '(none)'}`);
+  } else if (repos.length) {
+    // Left over from an earlier repos-scoped grant. The gate ignores it, and
+    // saying so beats letting an operator think coverage is narrower than it is.
+    console.log(`  Stale list    ${repos.length} repo(s) from a previous grant — IGNORED under org scope`);
+  }
   console.log(`  Expires       ${expires ?? '(unset)'}`);
   console.log(`  Granted       ${grant.ossGrantedAt ?? '(unknown)'}`);
   console.log(`  Note          ${grant.ossGrantNote ?? '(none)'}`);
   console.log(`  Monthly cap   ${grant.ossMonthlyCapCents != null ? usd(grant.ossMonthlyCapCents) : '(uncapped)'}`);
   console.log(`  This period   ${grant.ossPeriod ?? '(none)'} — ${usd(grant.ossSponsoredCentsThisPeriod ?? 0)} sponsored`);
   console.log(`  Lifetime      ${usd(grant.ossSponsoredCentsLifetime ?? 0)} sponsored`);
+}
+
+/** One-line state for a pending pre-approval. */
+function preapprovalState(row: PreapprovalRow): string {
+  if (row.claimedAt) return `claimed ${row.claimedAt} by installation ${row.claimedInstallationId}`;
+  if (Date.parse(row.preapprovalExpiresAt) <= Date.now()) {
+    return `EXPIRED ${row.preapprovalExpiresAt}${row.expiredAt ? ` (noticed ${row.expiredAt})` : ''}`;
+  }
+  return `pending — expires ${row.preapprovalExpiresAt}`;
+}
+
+function renderPreapproval(row: PreapprovalRow): void {
+  console.log(`\n  Pre-approval  ${row.orgLogin}`);
+  console.log(`    State       ${preapprovalState(row)}`);
+  console.log(`    Approved    ${row.preapprovedAt}`);
+  console.log(`    Cap / term  ${usd(row.capCents)}/month · ${row.months} months`);
+  console.log(`    Note        ${row.note ?? '(none)'}`);
 }
 
 async function confirm(question: string, skip: boolean): Promise<boolean> {
@@ -322,24 +561,125 @@ async function confirm(question: string, skip: boolean): Promise<boolean> {
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
+
+  // --- Pre-approval modes: no installation involved -------------------------
+
+  if (args.mode === 'list-preapprovals') {
+    const rows = await listPreapprovals(args.stage);
+    if (!rows.length) {
+      console.log(`\nNo pre-approvals on ${args.stage}.\n`);
+      return;
+    }
+    console.log(`\n── PRE-APPROVALS · stage=${args.stage} ──`);
+    for (const row of rows) renderPreapproval(row);
+    console.log();
+    return;
+  }
+
   const gh = await githubClients(args.stage);
 
-  const resolved = await Promise.all(args.repos.map((r) => resolveRepo(gh, r)));
+  if (args.mode === 'preapprove') {
+    const login = args.orgLogin!;
 
-  // One grant lives on one installation. Mixing repos from different
-  // installations into a single invocation would silently write only one.
-  const installationIds = [...new Set(resolved.map((r) => r.installationId))];
-  if (installationIds.length > 1) {
-    fail(
-      `Those repos belong to different installations (${installationIds.join(', ')}).\n`
-      + 'Grants are per-installation — run the script once per installation.',
-    );
+    // If they are already installed, a pre-approval would sit unclaimed
+    // forever: `installation.created` has already fired and will not fire
+    // again. Point at the mode that actually does something.
+    let alreadyInstalled: string | undefined;
+    try {
+      const { data } = await gh.jwt.apps.getOrgInstallation({ org: login });
+      alreadyInstalled = String(data.id);
+    } catch {
+      try {
+        const { data } = await gh.jwt.apps.getUserInstallation({ username: login });
+        alreadyInstalled = String(data.id);
+      } catch { /* not installed — the expected case here */ }
+    }
+    if (alreadyInstalled) {
+      fail(
+        `${login} has ALREADY installed the App (installation ${alreadyInstalled}).\n`
+        + 'A pre-approval is only claimed on installation.created, so this one would\n'
+        + 'never fire. Grant them directly instead:\n'
+        + `  scripts/grant-oss.ts --org ${login} --stage ${args.stage}`,
+      );
+    }
+
+    const existing = await readPreapproval(args.stage, login);
+    if (existing) {
+      console.log(`\nAn existing pre-approval for ${login}:`);
+      renderPreapproval(existing);
+      if (existing.claimedAt) {
+        console.log('\n  ⚠ Overwriting a CLAIMED pre-approval resets it to pending. The grant');
+        console.log('    already written to the installation is NOT affected.');
+      }
+    }
+
+    const now = new Date();
+    const row: PreapprovalRow = {
+      installationId: PREAPPROVAL_PK,
+      repoFullName: normalizeLogin(login),
+      orgLogin: login.trim(),
+      capCents: args.capCents,
+      months: args.months,
+      ...(args.note ? { note: args.note } : {}),
+      preapprovedAt: now.toISOString(),
+      preapprovalExpiresAt: addDays(now, args.ttlDays).toISOString(),
+    };
+
+    console.log(`\n── PRE-APPROVE · stage=${args.stage} ──`);
+    console.log(`  Org          ${row.orgLogin} (key: ${row.repoFullName})`);
+    console.log(`  On install   an ORG-scoped grant covering every PUBLIC repo`);
+    console.log(`  Monthly cap  ${usd(row.capCents)} · term ${row.months} months from the claim`);
+    console.log(`  Stale after  ${row.preapprovalExpiresAt} (${args.ttlDays} days)`);
+    if (row.note) console.log(`  Note         ${row.note}`);
+    console.log('\n  Matched on the org LOGIN, not a numeric id — a rename before they');
+    console.log('  install means this silently will not fire.');
+
+    if (!(await confirm('\nProceed?', args.yes))) {
+      console.log('Aborted. Nothing written.\n');
+      return;
+    }
+    await writePreapproval(args.stage, row);
+    console.log('\n✓ Written.');
+    renderPreapproval((await readPreapproval(args.stage, login))!);
+    console.log();
+    return;
   }
-  const installationId = installationIds[0];
+
+  // --- Everything else targets an existing installation ---------------------
+
+  let installationId: string;
+  let account: { id: number; login: string } | undefined;
+  let resolved: ResolvedRepo[] = [];
+
+  if (args.orgLogin && args.repos.length === 0) {
+    const org = await resolveOrgInstallation(gh, args.orgLogin);
+    installationId = org.installationId;
+    account = org.account;
+    console.log(`✓ ${org.account.login} — ${org.targetType}, installation ${org.installationId}`);
+  } else {
+    resolved = await Promise.all(args.repos.map((r) => resolveRepo(gh, r)));
+
+    // One grant lives on one installation. Mixing repos from different
+    // installations into a single invocation would silently write only one.
+    const installationIds = [...new Set(resolved.map((r) => r.installationId))];
+    if (installationIds.length > 1) {
+      fail(
+        `Those repos belong to different installations (${installationIds.join(', ')}).\n`
+        + 'Grants are per-installation — run the script once per installation.',
+      );
+    }
+    installationId = installationIds[0];
+  }
+
   const existing = await readGrant(args.stage, installationId);
 
   if (args.mode === 'inspect') {
     renderGrant(existing, installationId);
+    const login = args.orgLogin ?? existing.ossGrantAccount?.login;
+    if (login) {
+      const pending = await readPreapproval(args.stage, login);
+      if (pending) renderPreapproval(pending);
+    }
     console.log();
     return;
   }
@@ -355,7 +695,10 @@ async function main() {
   }
 
   const current = existing.ossGrantRepos ?? [];
-  let next: OssGrantRepo[];
+  const revoking = args.mode === 'revoke';
+  const orgScoped = args.mode === 'org';
+  let next: OssGrantRepo[] = [];
+
   switch (args.mode) {
     case 'grant':
       next = resolved.map((r) => ({ id: r.id, fullName: r.fullName }));
@@ -367,15 +710,15 @@ async function main() {
     case 'remove':
       next = current.filter((c) => !resolved.some((r) => r.id === c.id));
       break;
+    case 'org':
     case 'revoke':
       next = current;
       break;
   }
 
-  const revoking = args.mode === 'revoke';
   const expiresAt = revoking
     ? new Date(Date.now() - 1000).toISOString()
-    : new Date(new Date().setMonth(new Date().getMonth() + args.months)).toISOString();
+    : addMonths(new Date(), args.months).toISOString();
 
   // Blast radius: what this covers, and — just as important — what in the same
   // installation it does not, so an accidental omission is visible before the write.
@@ -387,6 +730,27 @@ async function main() {
   if (revoking) {
     console.log(`  Revoking the grant (expiry set to the past). Reviews fall back to the`);
     console.log(`  standard free-tier/balance gate — they are not blocked outright.`);
+    if ((existing.ossGrantScope ?? 'repos') === 'org') {
+      console.log(`  This was an ORG-scoped grant covering every public repo.`);
+    }
+  } else if (orgScoped) {
+    console.log(`  Will sponsor EVERY PUBLIC repo in this installation, including ones`);
+    console.log(`  created later. Private repos are never sponsored.`);
+    console.log(`  Public repos known right now:`);
+    if (allRepos.length) {
+      for (const n of allRepos) console.log(`    • ${n}`);
+    } else {
+      console.log(`    (none recorded yet — coverage is still org-wide)`);
+    }
+    if (current.length) {
+      console.log(`  A previous repos-scoped list of ${current.length} repo(s) will be left in`);
+      console.log(`  place but IGNORED by the gate.`);
+    }
+    console.log(`  Monthly cap  ${usd(args.capCents)} (shared across the whole org)`);
+    console.log(`  Expires      ${expiresAt}`);
+    if (args.note) console.log(`  Note         ${args.note}`);
+    console.log('\n  ⚠ Open-core check: if any PUBLIC repo here is commercial rather than');
+    console.log('    open source, use a named repo list instead of --org.');
   } else {
     console.log(`  Will sponsor ${next.length} repo(s):`);
     for (const r of next) console.log(`    • ${r.fullName} (id ${r.id})`);
@@ -399,7 +763,7 @@ async function main() {
     if (args.note) console.log(`  Note         ${args.note}`);
   }
 
-  if (!next.length && !revoking) {
+  if (!next.length && !revoking && !orgScoped) {
     fail('That would leave the grant with no repositories. Use --revoke to end it instead.');
   }
 
@@ -409,7 +773,11 @@ async function main() {
   }
 
   await writeGrant(args.stage, installationId, {
-    ossGrantRepos: next,
+    // Revoking leaves scope alone — the expiry is what ends a grant, and
+    // rewriting scope here would quietly change what a later renewal covers.
+    ...(orgScoped ? { ossGrantScope: 'org' as const } : {}),
+    ...(orgScoped && account ? { ossGrantAccount: account } : {}),
+    ...(orgScoped ? {} : { ossGrantRepos: next }),
     ossGrantExpiresAt: expiresAt,
     ossMonthlyCapCents: args.capCents,
     ossGrantedAt: new Date().toISOString(),


### PR DESCRIPTION
**Stage 3 of 3 — the capstone** for #409. Stages [1](https://github.com/mergewatch/mergewatch.ai/pull/410) and [2](https://github.com/mergewatch/mergewatch.ai/pull/411) are merged; this makes both features reachable.

## Operator commands

| Situation | Command |
|---|---|
| Installed, some repos are OSS (open core) | a repo list — unchanged |
| Installed, everything public is OSS | `--org acme-corp` |
| Not installed yet | `--preapprove acme-corp` |

Plus `--list-preapprovals`, `--inspect --org`, and `--revoke --org`.

**`--org`** resolves the org to its installation via the JWT-only `GET /orgs/{org}/installation`, falling back to the user endpoint for a personal account. It prints every public repo currently known *and* an explicit open-core warning — under org scope there is no omission to spot the way the repo-list blast radius shows one, because coverage is unbounded by design. That makes the warning the useful thing to print instead.

**`--preapprove` refuses if the org has already installed.** A pre-approval is only ever claimed on `installation.created`; that event has already fired and will never fire again, so the row would sit unclaimed forever with nobody looking at it. It points at `--org` instead.

**Flag parsing** no longer treats a following `--flag` as a value, so `--revoke --org acme` parses as revoke-targeting-an-org rather than a repo literally named `--org`. And `--org` combined with a repo list is refused outright — two different coverage models, and guessing which one was meant is the kind of silent wrong answer a grant script must never give.

## Fixes the dashboard regression org scope would have caused

`ossStatus` bailed to `null` whenever the repo list was empty — which is the *normal* state of an org-scoped grant. The billing page would have told a sponsored org it had no grant at all.

It now mirrors `evaluateOssGrant`'s coverage test, reports `scope` and `account`, and returns `repos: null` under org scope rather than a stale list the gate ignores (rendering that list would understate coverage to the maintainer). `BillingClient` shows "All / Public repositories" and "Every public repository, including ones you create later".

`ossStatus` had to be exported to be testable — it's a pure function over billing fields, and the alternative was leaving the regression this stage fixes uncovered.

## Docs

`docs/oss-program.md` has said *"there is no installation-wide mode"* since #410 merged. Rewritten: both scopes and when to pick each, the pre-approval model and its three unattended-safety properties, the login-vs-numeric-id limitation, expiry, and a mode-selection table.

## Known duplication

`scripts/grant-oss.ts` duplicates a few constants (`#PENDING-OSS`, cap, term, TTL) and the pre-approval row shape from `@mergewatch/billing` rather than importing them. This is forced, not a shortcut: root `package.json` has no dependencies and pnpm only hoists third-party packages there, so the script can import the AWS SDK and Octokit but never `@mergewatch/*`. The file already duplicated `DEFAULT_CAP_CENTS` / `DEFAULT_TERM_MONTHS` for the same reason. Both sides carry a comment, and E2E-93 lists drift as an explicit failure mode.

If you'd rather kill the duplication, the fix is adding `@mergewatch/billing` to root `devDependencies` — I left that out because it changes install topology and Amplify builds from the workspace root.

## Verification

- `pnpm run build` — 12/12
- `pnpm run typecheck` — 20/20
- `pnpm run test` — 21/21; **108 lambda tests** (+8 for `ossStatus`)

New `ossStatus` coverage: org-scoped grant with no repo list reported (the regression); `repos: null` rather than a stale list; expired org grant reported inactive rather than hidden; accrual counters still surfaced; and every pre-#409 path unchanged (named grant, empty list → null, no grant → null, list without expiry → null).

Arg-parsing guards exercised manually — missing `--stage`, `--org` + repo list, no target, org login shaped like a repo, and zero/negative `--cap` / `--months` / `--ttl-days` all refuse correctly.

**Two things I could not verify here**, both covered by E2E-93:
- The live AWS paths — the `mergewatch` profile's session is expired in this environment, so no `--org` / `--preapprove` / `--list-preapprovals` run touched DynamoDB.
- Dashboard lint — `packages/dashboard` has no ESLint config and `pnpm run lint` drops into an interactive setup prompt. Pre-existing; it still builds.

**E2E-93** added covering the full operator lifecycle, including the guard cases and the dashboard rendering.

## After merge

`docs/oss-program.md` is already a graduated doc, so there's no `docs/pending` move — but E2E-91/92/93 need flipping from 🚧 to ✅ and the plan doc to `Shipped`. I'll do that as a small follow-up once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)