### PR TITLE
chore: default review model to Sonnet 4.5

### DIFF
--- a/.mergewatch.yml
+++ b/.mergewatch.yml
@@ -4,7 +4,7 @@
 # All fields are optional; omitted fields use sensible defaults.
 
 # Primary model for review agents (Bedrock model ID).
-model: us.anthropic.claude-opus-4-6-v1
+model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
 
 # Built-in review agents — toggle each on/off.
 agents:

--- a/docs-site/configuration/mergewatch-yml.mdx
+++ b/docs-site/configuration/mergewatch-yml.mdx
@@ -35,7 +35,7 @@ MergeWatch validates the `.mergewatch.yml` file on the first webhook it receives
 version: 1
 
 # Model used for all agents. Must be a valid Bedrock model ID.
-model: us.anthropic.claude-opus-4-6-v1
+model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
 
 # Codebase awareness — enable agentic file fetching for cross-file context.
 codebaseAwareness: true
@@ -338,7 +338,7 @@ This enables all eight built-in agents with their default prompts, uses Claude S
 <Accordion title="Security-focused pipeline (e.g., payments service)">
 ```yaml .mergewatch.yml
 version: 1
-model: us.anthropic.claude-opus-4-6-v1
+model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
 agents:
   style: false
   diagram: false

--- a/docs-site/deployment/architecture.mdx
+++ b/docs-site/deployment/architecture.mdx
@@ -14,7 +14,7 @@ graph TD
     A[GitHub] -->|pull_request webhook| B[API Gateway]
     B --> C[WebhookHandler Lambda<br/>512 MB · 30s timeout]
     C -->|InvocationType.Event<br/>async invoke| D[ReviewAgent Lambda<br/>1024 MB · 300s timeout]
-    D -->|Promise.all — 8 agents| E[Amazon Bedrock<br/>us.anthropic.claude-opus-4-6-v1]
+    D -->|Promise.all — 8 agents| E[Amazon Bedrock<br/>us.anthropic.claude-sonnet-4-5-20250929-v1:0]
     D -->|Write review record| F[DynamoDB<br/>90-day TTL]
     D -->|Post comments + check run| A
 ```
@@ -28,7 +28,7 @@ graph TD
 | ReviewAgent | Lambda (Node 20, ARM64) | 1024 MB, 300s timeout | Fetch diff, fan out to 8 agents, post results |
 | DynamoDB | On-demand tables | 90-day TTL on reviews | Installation config, review history |
 | SSM Parameter Store | SecureString | KMS-encrypted | GitHub App credentials |
-| Bedrock | Model inference | `us.anthropic.claude-opus-4-6-v1` | Powers all 8 review agents |
+| Bedrock | Model inference | `us.anthropic.claude-sonnet-4-5-20250929-v1:0` | Powers all 8 review agents |
 
 ### SaaS latency breakdown
 

--- a/docs-site/deployment/deployment-models.mdx
+++ b/docs-site/deployment/deployment-models.mdx
@@ -71,7 +71,7 @@ MergeWatch runs the full pipeline on AWS — API Gateway, Lambda functions, Dyna
 ```
 PR opened → GitHub webhook → MergeWatch API Gateway
   → WebhookHandler Lambda (512 MB, 30s) → ReviewAgent Lambda (1024 MB, 300s)
-  → Bedrock (us.anthropic.claude-opus-4-6-v1)
+  → Bedrock (us.anthropic.claude-sonnet-4-5-20250929-v1:0)
   → Review posted to GitHub
   → DynamoDB (review history)
 ```

--- a/docs-site/deployment/sam-template.mdx
+++ b/docs-site/deployment/sam-template.mdx
@@ -24,7 +24,7 @@ The template accepts four parameters that control the deployment:
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `Stage` | String | `prod` | Deployment stage (`dev`, `staging`, `prod`). Scopes all resource names so multiple environments can coexist in the same AWS account. |
-| `DefaultBedrockModelId` | String | `us.anthropic.claude-opus-4-6-v1` | Default Bedrock model used by all agents. Can be overridden per-repo via `.mergewatch.yml`. |
+| `DefaultBedrockModelId` | String | `us.anthropic.claude-sonnet-4-5-20250929-v1:0` | Default Bedrock model used by all agents. Can be overridden per-repo via `.mergewatch.yml`. |
 | `DeploymentMode` | String | `self-hosted` | Deployment mode. Set to `saas` to enable Stripe billing enforcement in the ReviewAgent and deploy the BillingHandler Lambda. `self-hosted` skips all billing checks. |
 | `DashboardBaseUrl` | String | `https://mergewatch.ai` | Base URL used in PR comment links that point back to the MergeWatch dashboard. |
 
@@ -122,7 +122,7 @@ resolve_s3 = true
 capabilities = "CAPABILITY_IAM"
 parameter_overrides = [
   "Stage=prod",
-  "DefaultBedrockModelId=us.anthropic.claude-opus-4-6-v1",
+  "DefaultBedrockModelId=us.anthropic.claude-sonnet-4-5-20250929-v1:0",
   "DeploymentMode=saas",
   "DashboardBaseUrl=https://mergewatch.example.com"
 ]
@@ -133,7 +133,7 @@ sam deploy \
   --stack-name mergewatch-staging \
   --parameter-overrides \
     Stage=staging \
-    DefaultBedrockModelId=us.anthropic.claude-opus-4-6-v1 \
+    DefaultBedrockModelId=us.anthropic.claude-sonnet-4-5-20250929-v1:0 \
     DeploymentMode=self-hosted \
     DashboardBaseUrl=https://staging.mergewatch.example.com
 ```

--- a/docs-site/overview/how-it-works.mdx
+++ b/docs-site/overview/how-it-works.mdx
@@ -248,7 +248,7 @@ Codebase awareness is enabled by default. To revert to diff-only analysis (faste
     - **Billing mode:** On-demand (pay-per-request)
   </Card>
   <Card title="Amazon Bedrock">
-    - **Default model:** `us.anthropic.claude-opus-4-6-v1`
+    - **Default model:** `us.anthropic.claude-sonnet-4-5-20250929-v1:0`
     - **Role:** Powers all eight review agents and the orchestrator
   </Card>
 </CardGroup>

--- a/docs-site/overview/introduction.mdx
+++ b/docs-site/overview/introduction.mdx
@@ -97,7 +97,7 @@ The managed SaaS runs on a serverless stack in MergeWatch's AWS account:
 - **AWS Lambda** — WebhookHandler (512 MB / 30 s) and ReviewAgent (1024 MB / 300 s)
 - **Amazon DynamoDB** — review state, repo config, user data
 - **API Gateway** — GitHub webhook receiver
-- **Amazon Bedrock** — Claude Opus (`us.anthropic.claude-opus-4-6-v1`)
+- **Amazon Bedrock** — Claude Sonnet (`us.anthropic.claude-sonnet-4-5-20250929-v1:0`)
 
 Configuration lives in a `.mergewatch.yml` file at the root of each repository. The [dashboard](/dashboard/overview) provides a UI for monitoring reviews, managing repos, and adjusting settings.
 

--- a/docs-site/reference/troubleshooting.mdx
+++ b/docs-site/reference/troubleshooting.mdx
@@ -105,7 +105,7 @@ description: "Fixes for reviews not posting, webhooks not arriving, Docker conta
 
       ```yaml
       # .mergewatch.yml
-      model: us.anthropic.claude-opus-4-6-v1
+      model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
       ```
 
       <Tip>

--- a/docs-site/saas/data-residency.mdx
+++ b/docs-site/saas/data-residency.mdx
@@ -11,7 +11,7 @@ When a pull request triggers a review, the PR diff is fetched by the **ReviewAge
 
 ## Bedrock model calls
 
-All LLM inference runs on Amazon Bedrock within MergeWatch's AWS account. The primary model is `us.anthropic.claude-opus-4-6-v1` for review agents. Lighter tasks such as summary generation and diagram creation use `us.anthropic.claude-haiku-4-5-20251001-v1:0` for cost efficiency. Model inputs (diff content, agent prompts) and outputs (review findings) exist only for the duration of the API call and are not logged or stored by MergeWatch beyond the review lifecycle.
+All LLM inference runs on Amazon Bedrock within MergeWatch's AWS account. The primary model is `us.anthropic.claude-sonnet-4-5-20250929-v1:0` for review agents. Lighter tasks such as summary generation and diagram creation use `us.anthropic.claude-haiku-4-5-20251001-v1:0` for cost efficiency. Model inputs (diff content, agent prompts) and outputs (review findings) exist only for the duration of the API call and are not logged or stored by MergeWatch beyond the review lifecycle.
 
 ## What is stored
 

--- a/docs-site/saas/getting-started.mdx
+++ b/docs-site/saas/getting-started.mdx
@@ -33,7 +33,7 @@ When you open or update a pull request, the following happens in seconds:
 1. GitHub sends a `pull_request` webhook to MergeWatch's API Gateway.
 2. The **WebhookHandler** Lambda (512 MB, 30s timeout) validates the HMAC signature and invokes the **ReviewAgent** asynchronously.
 3. The **ReviewAgent** Lambda (1024 MB, 300s timeout) fetches the diff via the GitHub API.
-4. Eight specialized agents — **security**, **bugs**, **style**, **error handling**, **test coverage**, **comment accuracy**, **summary**, and **diagram** — run in parallel via `Promise.all()`, each calling Amazon Bedrock (`us.anthropic.claude-opus-4-6-v1`).
+4. Eight specialized agents — **security**, **bugs**, **style**, **error handling**, **test coverage**, **comment accuracy**, **summary**, and **diagram** — run in parallel via `Promise.all()`, each calling Amazon Bedrock (`us.anthropic.claude-sonnet-4-5-20250929-v1:0`).
 5. Results are deduplicated, ranked by severity, and posted as inline review comments and a summary check run on your PR.
 
 <Note>

--- a/docs-site/self-hosting/install.mdx
+++ b/docs-site/self-hosting/install.mdx
@@ -65,7 +65,7 @@ LLM_MODEL=claude-opus-4-6
 | `NEXTAUTH_SECRET` | Yes | Random 32-byte secret for signing dashboard sessions (generate with `openssl rand -base64 32`) |
 | `ANTHROPIC_API_KEY` | If `LLM_PROVIDER=anthropic` | API key from [console.anthropic.com](https://console.anthropic.com) |
 | `LLM_PROVIDER` | No | Default: `anthropic`. Options: `anthropic`, `litellm`, `bedrock`, `ollama` |
-| `LLM_MODEL` | Yes for `anthropic` / `litellm` / `ollama` | Model ID. For Anthropic, use a native model ID like `claude-opus-4-6` — the built-in defaults are Bedrock inference profile IDs and only work for `LLM_PROVIDER=bedrock`. |
+| `LLM_MODEL` | Yes for `anthropic` / `litellm` / `ollama` | Model ID. For Anthropic, use a native model ID like `claude-sonnet-4-5-20250929` — the built-in defaults are Bedrock inference profile IDs and only work for `LLM_PROVIDER=bedrock`. |
 | `DASHBOARD_URL` | No | Public URL of the dashboard (e.g., `https://dashboard.example.com`). Used as the `NEXTAUTH_URL` for session callbacks. Defaults to `http://localhost:3001`. |
 | `DATABASE_URL` | No | Set automatically by docker-compose (Postgres sidecar) |
 | `PORT` | No | Default: `3000` |

--- a/docs-site/self-hosting/llm-providers/anthropic.mdx
+++ b/docs-site/self-hosting/llm-providers/anthropic.mdx
@@ -16,14 +16,14 @@ Set these environment variables in your `.env` file or container environment:
 | `LLM_MODEL` | Yes | Anthropic model ID to use (e.g., `claude-opus-4-6`) |
 
 <Note>
-When `LLM_PROVIDER=anthropic`, you **must** set `LLM_MODEL` to an Anthropic-native model ID. The built-in defaults (`us.anthropic.claude-opus-4-6-v1` for the primary model and `us.anthropic.claude-haiku-4-5-20251001-v1:0` for the light model) are [Bedrock inference profile IDs](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles.html) and are not valid on the Anthropic API.
+When `LLM_PROVIDER=anthropic`, you **must** set `LLM_MODEL` to an Anthropic-native model ID. The built-in defaults (`us.anthropic.claude-sonnet-4-5-20250929-v1:0` for the primary model and `us.anthropic.claude-haiku-4-5-20251001-v1:0` for the light model) are [Bedrock inference profile IDs](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles.html) and are not valid on the Anthropic API.
 </Note>
 
 ## Model roles
 
 MergeWatch uses two model slots per review:
 
-- **Primary model** (`model` in `.mergewatch.yml`) — runs the agent pipeline (security, bugs, style, error handling, test coverage, comment accuracy). Use an **Opus-tier** model; `claude-opus-4-6` matches the Bedrock default exactly.
+- **Primary model** (`model` in `.mergewatch.yml`) — runs the agent pipeline (security, bugs, style, error handling, test coverage, comment accuracy). `claude-sonnet-4-5-20250929` matches the Bedrock default exactly. An Opus-tier model is a straight upgrade if cost allows.
 - **Light model** (`lightModel` in `.mergewatch.yml`) — runs the summary and diagram passes. **`claude-haiku-4-5`** is the cost-optimized choice, and the native equivalent of the built-in `lightModel` default.
 
 Setting `LLM_MODEL` overrides **both** slots with the same model. For split primary/light models, configure them in `.mergewatch.yml` instead — see [mergewatch.yml reference](/configuration/mergewatch-yml).
@@ -35,17 +35,17 @@ Setting `LLM_MODEL` overrides **both** slots with the same model. For split prim
 LLM_PROVIDER=anthropic
 ANTHROPIC_API_KEY=sk-ant-api03-...
 
-# Pick a model — Opus 4.6 matches the Bedrock default
-LLM_MODEL=claude-opus-4-6
+# Pick a model — Sonnet 4.5 matches the Bedrock default
+LLM_MODEL=claude-sonnet-4-5-20250929
 ```
 
 ## Model suggestions
 
 | Anthropic model ID | Best for |
 | --- | --- |
-| `claude-opus-4-6` | Recommended. The native equivalent of the built-in Bedrock default, so review behavior matches the documented defaults. |
-| `claude-opus-5` | Current Opus tier. Higher capability than 4.6; use it if you want the newest model rather than parity with the defaults. |
-| `claude-sonnet-5` | Balanced. Lower cost than Opus with strong coding and review quality. |
+| `claude-sonnet-4-5-20250929` | The native equivalent of the built-in Bedrock default, so review behavior matches the documented defaults. |
+| `claude-sonnet-5` | Recommended. Current Sonnet tier — newer and stronger than 4.5 at comparable cost. |
+| `claude-opus-5` | Highest capability. Use when review quality matters more than per-token cost. |
 | `claude-haiku-4-5` | Cost-optimized. Faster and cheaper; the native equivalent of the built-in `lightModel`. |
 
 ## Pricing

--- a/docs-site/self-hosting/llm-providers/bedrock.mdx
+++ b/docs-site/self-hosting/llm-providers/bedrock.mdx
@@ -27,7 +27,7 @@ If MergeWatch runs on EC2, ECS, or Fargate, you can use an **IAM instance profil
 
 ## Default model
 
-MergeWatch uses **`us.anthropic.claude-opus-4-6-v1`** for review agents by default, and **`us.anthropic.claude-haiku-4-5-20251001-v1:0`** as the `lightModel` for low-complexity tasks such as summary generation. Both are **cross-region inference profiles** that route requests to the nearest available region.
+MergeWatch uses **`us.anthropic.claude-sonnet-4-5-20250929-v1:0`** for review agents by default, and **`us.anthropic.claude-haiku-4-5-20251001-v1:0`** as the `lightModel` for low-complexity tasks such as summary generation. Both are **cross-region inference profiles** that route requests to the nearest available region.
 
 Override either with `model:` / `lightModel:` in `.mergewatch.yml` — see the [configuration reference](/configuration/mergewatch-yml).
 
@@ -65,7 +65,7 @@ Bedrock supports **cross-region inference profiles** that automatically route re
 | `eu.` | European regions (eu-west-1) |
 | `ap.` | Asia Pacific regions (ap-northeast-1, ap-southeast-1, ap-southeast-2) |
 
-The default model `us.anthropic.claude-opus-4-6-v1` uses the `us.` prefix, routing across US regions. If your deployment is in Europe or Asia Pacific, swap the prefix for the matching geography.
+The default model `us.anthropic.claude-sonnet-4-5-20250929-v1:0` uses the `us.` prefix, routing across US regions. If your deployment is in Europe or Asia Pacific, swap the prefix for the matching geography.
 
 <Warning>
 Not every model is available as an inference profile in every geography, and the availability list changes over time. Before setting a prefixed ID, confirm the exact profile exists in your account — the [Bedrock Model Access console](https://console.aws.amazon.com/bedrock/home#/modelaccess) lists the inference profile IDs you can actually call. An ID that is valid in `us.` may not exist under `eu.` or `ap.`.
@@ -75,7 +75,7 @@ Not every model is available as an inference profile in every geography, and the
 
 ```bash
 # US cross-region (default)
-LLM_MODEL=us.anthropic.claude-opus-4-6-v1
+LLM_MODEL=us.anthropic.claude-sonnet-4-5-20250929-v1:0
 
 # Europe cross-region — substitute a profile ID your account lists
 LLM_MODEL=eu.anthropic.<model-id>

--- a/infra/params/dev.env
+++ b/infra/params/dev.env
@@ -8,18 +8,22 @@
 
 # Bedrock model used for all review agents.
 #
-# Dev and prod deliberately differ right now: dev is on Opus 4.6 while prod
-# stayed on Sonnet 4. That divergence was an accident of the deploy workflow
-# (#264), not a decision — it is recorded here so it is at least visible.
+# Sonnet 4.5. Verified invocable on this account on 2026-08-20 with a live
+# InvokeModel — both the plain path (carrying `temperature: 0`, which this model
+# accepts) and the #390 forced-tool structured path returned successfully.
+# That verification is the gate: do not flip this line for any model until an
+# invoke succeeds, or the deploy ships a model that fails every review.
 #
-# Moving dev to Sonnet 5 is the intended next step (#262) and is a one-line
-# change here, but it is BLOCKED: `us.anthropic.claude-sonnet-5` returns
-# AccessDeniedException ("not available for this account") on this account,
-# even though its Bedrock agreement, entitlement, authorization and region
-# availability all report AVAILABLE. Likely the Anthropic use-case submission,
-# which no API surfaces. Do not flip this line until an invoke succeeds — the
-# deploy would otherwise ship a model that 400s on every review.
-DefaultBedrockModelId=us.anthropic.claude-opus-4-6-v1
+# Sonnet 5 (#262) remains blocked on this account: `us.anthropic.claude-sonnet-5`
+# returns AccessDeniedException ("not available for this account") even though
+# its Bedrock agreement, entitlement, authorization and region availability all
+# report AVAILABLE. Likely the Anthropic use-case submission, which no API
+# surfaces. Sonnet 4.5 is the reachable Sonnet-tier option in the meantime.
+#
+# NOTE: 4.5 is two generations behind the current Sonnet (4.6, then 5). It is
+# used here because it is what this account can actually invoke, not because it
+# is the best available model.
+DefaultBedrockModelId=us.anthropic.claude-sonnet-4-5-20250929-v1:0
 
 # Base URL used for dashboard links in PR comments.
 #

--- a/infra/params/prod.env
+++ b/infra/params/prod.env
@@ -28,21 +28,24 @@
 # uncovered, where prod sat on Sonnet 4 because the prod deploy omitted this
 # parameter while dev passed it — so dev never exercised what prod ran.
 #
-# It is also what the rest of the repo has always claimed: template.yaml's
-# parameter Default, DEFAULT_CONFIG.model in packages/core, and this repo's own
-# .mergewatch.yml all name Opus 4.6.
+# It is also what the rest of the repo now claims: template.yaml's parameter
+# Default, DEFAULT_CONFIG.model in packages/core, and this repo's own
+# .mergewatch.yml all name Sonnet 4.5.
 #
-# COST: Opus tier is $5/$25 per 1M versus Sonnet 4's $3/$15 — roughly 67% more
-# per token. That is a deliberate quality-for-cost trade, not an accident.
+# COST: Sonnet tier is $3/$15 per 1M base ($3.30/$16.50 on the `us.` profile we
+# actually bill at) versus Opus 4.6's $5.50/$27.50 — roughly 40% cheaper per
+# token. Priced in packages/core/src/llm/pricing.ts; an unpriced model makes
+# estimateCost return null and silently records zero-cost reviews.
 #
-# Verified invocable on this account with a live InvokeModel carrying
-# `temperature`, which this model accepts (unlike Opus 4.7+ and the 5
-# generation — see acceptsSamplingParams in packages/llm-bedrock).
+# Verified invocable on this account on 2026-08-20 with a live InvokeModel
+# carrying `temperature`, which this model accepts (unlike Opus 4.7+ and the 5
+# generation — see acceptsSamplingParams in packages/llm-bedrock). The #390
+# forced-tool structured path was verified in the same pass.
 #
-# Sonnet 5 remains the intended destination (#262) and is cheaper per token
+# Sonnet 5 remains the intended destination (#262) and is cheaper still
 # ($2.20/$11), but it returns AccessDeniedException on this account despite
 # every Bedrock availability field reporting AVAILABLE.
-DefaultBedrockModelId=us.anthropic.claude-opus-4-6-v1
+DefaultBedrockModelId=us.anthropic.claude-sonnet-4-5-20250929-v1:0
 
 # Base URL used for dashboard links in PR comments.
 DashboardBaseUrl=https://mergewatch.ai

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -52,7 +52,7 @@ Parameters:
   # via the modelId field in the mergewatch-installations table.
   DefaultBedrockModelId:
     Type: String
-    Default: us.anthropic.claude-opus-4-6-v1
+    Default: us.anthropic.claude-sonnet-4-5-20250929-v1:0
     # WARNING (#264): this Default binds only when the stack is FIRST created.
     # On an update, CloudFormation retains the stack's existing value for any
     # parameter the deploy does not pass — editing this line does nothing to a

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -190,7 +190,7 @@ export interface MergeWatchConfig {
 }
 
 export const DEFAULT_CONFIG: MergeWatchConfig = {
-  model: 'us.anthropic.claude-opus-4-6-v1',
+  model: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
   lightModel: 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
   maxTokensPerAgent: 4096,
   agents: {

--- a/packages/core/src/llm/pricing.test.ts
+++ b/packages/core/src/llm/pricing.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { estimateCost, DEFAULT_PRICING, parseEnvModelPricing } from './pricing.js';
+import { DEFAULT_CONFIG } from '../config/defaults.js';
 
 describe('estimateCost', () => {
   it('returns correct cost for a known Bedrock model', () => {
@@ -38,6 +39,11 @@ describe('estimateCost', () => {
       expect(estimateCost('us.anthropic.claude-opus-4-6-v1', M, M)).toBeCloseTo(33, 6);
       // The published rate would have produced 30.
       expect(estimateCost('claude-opus-4-6', M, M)).toBeCloseTo(30, 6);
+    });
+
+    it('Sonnet 4.5 — the deployment default — bills at $3.30/$16.50 on Bedrock, $3/$15 direct', () => {
+      expect(estimateCost('us.anthropic.claude-sonnet-4-5-20250929-v1:0', M, M)).toBeCloseTo(19.8, 6);
+      expect(estimateCost('claude-sonnet-4-5-20250929', M, M)).toBeCloseTo(18, 6);
     });
 
     it('Sonnet 4.6 bills at $3.30/$16.50 on Bedrock, $3/$15 direct', () => {
@@ -189,5 +195,21 @@ describe('parseEnvModelPricing (#233)', () => {
     expect(estimateCost(ARN, 1_000_000, 1_000_000, pricing)).toBeCloseTo(30, 6);
     // ...and without it the same model is unpriced.
     expect(estimateCost(ARN, 1_000_000, 1_000_000)).toBeNull();
+  });
+});
+
+/**
+ * The failure this guards against is silent: `estimateCost` returns null for an
+ * unpriced model, so switching the default to one that isn't in the table
+ * records every review at zero cost — no error, no log line. That figure feeds
+ * calculateReviewCost, the OSS sponsored-spend counters, and Stripe billing.
+ */
+describe('the configured default model is always priced', () => {
+  it('DEFAULT_CONFIG.model has a pricing entry', () => {
+    expect(estimateCost(DEFAULT_CONFIG.model, 1_000_000, 1_000_000)).not.toBeNull();
+  });
+
+  it('DEFAULT_CONFIG.lightModel has a pricing entry', () => {
+    expect(estimateCost(DEFAULT_CONFIG.lightModel, 1_000_000, 1_000_000)).not.toBeNull();
   });
 });

--- a/packages/core/src/llm/pricing.ts
+++ b/packages/core/src/llm/pricing.ts
@@ -54,6 +54,7 @@ export const DEFAULT_PRICING: Record<string, ModelPricing> = {
   'us.anthropic.claude-opus-4-20250514-v1:0': { inputPer1M: 16.50, outputPer1M: 82.50 },
 
   // Sonnet tier — base $3/$15
+  'us.anthropic.claude-sonnet-4-5-20250929-v1:0': { inputPer1M: 3.30, outputPer1M: 16.50 },
   'us.anthropic.claude-sonnet-4-6': { inputPer1M: 3.30, outputPer1M: 16.50 },
   'us.anthropic.claude-sonnet-4-20250514-v1:0': { inputPer1M: 3.30, outputPer1M: 16.50 },
 
@@ -72,6 +73,7 @@ export const DEFAULT_PRICING: Record<string, ModelPricing> = {
   'claude-opus-4-8': { inputPer1M: 5, outputPer1M: 25 },
   'claude-opus-4-6': { inputPer1M: 5, outputPer1M: 25 },
   'claude-opus-4-20250514': { inputPer1M: 15, outputPer1M: 75 },
+  'claude-sonnet-4-5-20250929': { inputPer1M: 3, outputPer1M: 15 },
   'claude-sonnet-4-6': { inputPer1M: 3, outputPer1M: 15 },
   'claude-sonnet-4-20250514': { inputPer1M: 3, outputPer1M: 15 },
   'claude-haiku-4-5-20251001': { inputPer1M: 1, outputPer1M: 5 },

--- a/packages/llm-bedrock/src/bedrock-provider.ts
+++ b/packages/llm-bedrock/src/bedrock-provider.ts
@@ -22,6 +22,7 @@ import { StructuredOutputUnsupportedError } from '@mergewatch/core';
 // ─── Supported model IDs ───────────────────────────────────────────────────
 export const SUPPORTED_MODELS = {
   'claude-opus-4.6': 'us.anthropic.claude-opus-4-6-v1',
+  'claude-sonnet-4.5': 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
   'claude-sonnet-4': 'us.anthropic.claude-sonnet-4-20250514-v1:0',
   'claude-haiku-4.5': 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
   'amazon-titan-text': 'amazon.titan-text-express-v1',


### PR DESCRIPTION
Switches the default Bedrock model from `us.anthropic.claude-opus-4-6-v1` to **`us.anthropic.claude-sonnet-4-5-20250929-v1:0`**.

## Verified before flipping the line

`infra/params/dev.env` explicitly requires this, and for good reason — Sonnet 5 (#262) is *still* blocked on this account with `AccessDeniedException` despite every Bedrock availability field reporting AVAILABLE, and shipping an uninvocable model 400s every review.

Two live `InvokeModel` calls against `us-west-2` on 2026-08-20:

| Path | Result |
|---|---|
| Plain, carrying `temperature: 0` | 200 — `"OK"`, 4 output tokens |
| #390 forced-tool structured output | 200 — `stop_reason: tool_use`, schema-valid input |

Both matter: the pipeline uses `invokeStructured` for every findings-bearing agent, so a model that invokes but can't do forced tool use would fail most of a review rather than none of it.

## Sampling params were already handled

`acceptsSamplingParams` gets this right without changes — its regex comment names `claude-sonnet-4-5` as deliberately **not** the 5 generation ("contains a 5 but is not the 5 generation"). So `temperature: 0` is still sent and reviews stay deterministic, and there's already a test pinning it.

## ⚠️ The part that would have broken quietly

`estimateCost` returns **null** for a model missing from `DEFAULT_PRICING`. Switching the default without adding pricing would have recorded **every review at zero cost** — no error, no log line — and that figure feeds `calculateReviewCost`, the OSS sponsored-spend counters (#409), and Stripe billing.

Added at the Sonnet-tier rate: `$3/$15` base, `$3.30/$16.50` on the `us.` profile we're actually billed at, consistent with the existing 10%-premium rows.

Then added the regression test for the whole class:

```ts
describe('the configured default model is always priced', () => {
  it('DEFAULT_CONFIG.model has a pricing entry', () => {
    expect(estimateCost(DEFAULT_CONFIG.model, 1_000_000, 1_000_000)).not.toBeNull();
  });
```

I confirmed it actually fails by temporarily pointing the default at an unpriced ID — `1 failed | 919 passed` — then restored it.

## Where the default is declared

| File | Note |
|---|---|
| `infra/params/dev.env`, `prod.env` | **The values that actually take effect** (#264) |
| `infra/template.yaml` | Parameter `Default:` — inert, since params are always passed |
| `packages/core/src/config/defaults.ts` | `DEFAULT_CONFIG.model` |
| `.mergewatch.yml` | This repo's own config |
| `packages/llm-bedrock` | Added a `claude-sonnet-4.5` alias |
| `docs-site/` (12 files) | IDs **and** prose |

The prose mattered: several lines named the tier ("Claude **Opus** (`<id>`)", "Use an **Opus-tier** model; `claude-opus-4-6` matches the Bedrock default exactly"). Swapping only the IDs would have left self-contradicting docs and re-created exactly the drift #408 just closed.

## Worth flagging

**Sonnet 4.5 is two generations behind current Sonnet** (4.6, then 5). It's here because it's what this account can invoke today, not because it's the strongest option. Recorded in `infra/params/*.env` so the next reader doesn't mistake it for a quality judgment.

Cost moves the right way: Sonnet tier is ~40% cheaper per token than Opus 4.6 ($3.30/$16.50 vs $5.50/$27.50). Review quality is the tradeoff — Opus 4.6 was described in `prod.env` as "a deliberate quality-for-cost trade".

**Deploy is manual** — merging this does not move prod. It needs `gh workflow run deploy.yml -f deploy_prod=true`.

## Verification

build 12/12 · typecheck 20/20 · test 21/21 (920 core tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)