### PR TITLE
fix(scripts): narrowing an org-scoped OSS grant to a repo list now works

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -3225,6 +3225,7 @@ Then install the App on a test org that has **never** installed it before (an ex
 - [ ] `--org <test-org> --stage dev` prints every public repo currently known, the open-core warning, cap and expiry, then writes `ossGrantScope=org` + `ossGrantAccount`
 - [ ] `--inspect --org <test-org> --stage dev` shows `Scope: org — every PUBLIC repo`, the account, cap, and accrual counters
 - [ ] Granting `--org` over an installation that had a repos-scoped grant reports the old list as "IGNORED under org scope" and leaves it in place
+- [ ] **Narrowing works**: granting a repo list over an existing ORG-scoped grant sets `ossGrantScope=repos`, so the list actually takes effect — `--inspect` shows `Scope: repos` and the named repos, and an unnamed public repo in the same installation stops being sponsored
 - [ ] `--revoke --org <test-org> --stage dev` sets expiry to the past and says the grant was org-scoped
 - [ ] Dashboard `/dashboard/billing` shows "All / Public repositories" and "Every public repository, including ones you create later" — **not** an empty repo list or a missing panel
 
@@ -3239,6 +3240,7 @@ Then install the App on a test org that has **never** installed it before (an ex
 **Failure modes.**
 - ❌ `--org` writes a grant but leaves `ossGrantScope` unset — the gate would read `'repos'`, find no list, and sponsor nothing while `--inspect` claims the grant is active
 - ❌ `--revoke` rewrites `ossGrantScope` — a later renewal would silently change what the grant covers
+- ❌ A repo-list grant leaves a previous `ossGrantScope=org` in place — the operator believes they narrowed an org-wide grant to a few repos, the gate keeps sponsoring everything public, and only `--inspect` reveals it
 - ❌ The dashboard shows an org-scoped grant as "no grant" (the `ossStatus` regression this stage fixes) or renders a stale repo list as if it were the coverage
 - ❌ `--preapprove` succeeds for an already-installed org — the row would sit unclaimed forever with nobody looking at it
 - ❌ A non-404 installation-lookup failure is swallowed as "not installed" — same outcome, but triggered by a transient blip rather than operator error, so it is even less likely to be noticed

--- a/scripts/grant-oss.ts
+++ b/scripts/grant-oss.ts
@@ -793,9 +793,16 @@ async function main() {
   }
 
   await writeGrant(args.stage, installationId, {
-    // Revoking leaves scope alone — the expiry is what ends a grant, and
-    // rewriting scope here would quietly change what a later renewal covers.
-    ...(orgScoped ? { ossGrantScope: 'org' as const } : {}),
+    // Scope is written explicitly by every mode that changes coverage, so
+    // narrowing actually narrows: a repo list left `ossGrantScope: 'org'` in
+    // place (every claimed pre-approval sets it) would be silently ignored by
+    // the gate, and the operator would believe they had restricted an org-wide
+    // grant to a handful of repos.
+    //
+    // Revoking is the exception — it leaves scope alone, because the expiry is
+    // what ends a grant and rewriting scope here would quietly change what a
+    // later renewal covers.
+    ...(revoking ? {} : { ossGrantScope: orgScoped ? ('org' as const) : ('repos' as const) }),
     ...(orgScoped && account ? { ossGrantAccount: account } : {}),
     ...(orgScoped ? {} : { ossGrantRepos: next }),
     ossGrantExpiresAt: expiresAt,


### PR DESCRIPTION
Found while onboarding an open-core org, where the intended flow was *"pre-approve now, narrow to the genuinely-OSS repos once they install"* — and that flow silently did nothing.

## The bug

A repo-list grant wrote `ossGrantRepos` but never wrote `ossGrantScope`:

```js
...(orgScoped ? { ossGrantScope: 'org' } : {}),   // ← nothing written for a repo list
...(orgScoped ? {} : { ossGrantRepos: next }),
```

Every claimed pre-approval sets `ossGrantScope: 'org'` (#411). So narrowing an org-scoped grant left the row org-scoped — `evaluateOssGrant` matches on scope before it ever looks at the list, so the list was ignored entirely.

The operator sees `✓ Written.` and believes coverage is now three repos. In reality every public repo in the org stays sponsored — and for a commercial open-core org, that includes its marketing site. `--inspect` would show `Stale list … IGNORED under org scope`, but nothing else surfaces it, and there is no reason to re-inspect after a write that reported success.

## The fix

Scope is written explicitly by every mode that changes coverage, so narrowing actually narrows.

`--revoke` still leaves scope alone, deliberately — the expiry is what ends a grant, and rewriting scope there would change what a later renewal covers. That distinction is now stated in the comment rather than implied by the shape of the code.

## Verification

E2E-93 extended with the narrowing case and its failure mode. Script typechecks clean; no package code touched, so build/typecheck/test are unaffected.

Worth noting this was reachable the moment #411 and #412 were both live — any org onboarded via pre-approval and later narrowed would have hit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)