### PR TITLE
feat(core): stage-scoped review identity for dev/prod A/B (#416, stage 1)

### DIFF
--- a/docs/feat/20260821-01-e2e-ab-tags-and-grading.plan.md
+++ b/docs/feat/20260821-01-e2e-ab-tags-and-grading.plan.md
@@ -1,0 +1,157 @@
+# E2E infrastructure — dev/prod A/B, tagged selection, deterministic grading
+
+**Status:** In progress
+
+**Tracking issue:** #416
+
+## Summary
+
+Three changes that together turn the E2E suite from a manual, all-or-nothing, LLM-graded exercise into something that can gate a deploy:
+
+1. **Dev/prod A/B on one fixtures repo.** Install both GitHub Apps on `mergewatch/fixtures` so every fixture PR is reviewed twice — once per stage — on a byte-identical diff. Needs stage-scoped comment markers and check-run names so the two apps stop colliding.
+2. **Tagged selection.** Tag each fixture and derive an impacted subset from a changed-file map, so a prompt tweak runs 11 fixtures instead of 93.
+3. **Deterministic grading.** Add machine-checkable assertions alongside the existing LLM rubric, so a subset run can hard-fail CI without a model in the loop.
+
+## Why
+
+Today there is no way to test a change before it reaches production. Dev has been dark since 2026-06-25 (its App has **zero** webhook deliveries ever recorded), so `mergewatch/fixtures` is reviewed only by prod. The Sonnet 4.5 model swap (#414) shipped on the strength of a hand-built `InvokeModel` call and one manually-opened PR, because nothing better existed.
+
+A separate `fixtures.dev` repo was considered and rejected: it makes dev and prod run *different inputs*, which is precisely what a comparison must not do. One repo with both apps gives input parity by construction — same PR, same SHA, same diff — with no sync job and no drift.
+
+## What already exists
+
+Substantial machinery is already in `mergewatch/fixtures`, and this plan extends it rather than replacing it:
+
+| Component | What it does |
+|---|---|
+| `fixtures/NN-name/{README.md, meta.env, overlay/}` | Fixture definition. `meta.env` already carries `BRANCH`, `TITLE`, `BODY`, `DRAFT`, `LABELS`, `PREREQ_CHECK`, `SKIP_APPLY`, `MANUAL_ONLY`, `PUSH_TO_EXISTING_BRANCH` |
+| `scripts/apply-fixture.sh` | Reset to `e2e-baseline` → branch → overlay → commit → push → open PR |
+| `scripts/run-suite.sh` | Runs all fixtures, or a subset **named positionally**; writes `.e2e/last-run.json` |
+| `.claude/commands/verify-suite.md` | LLM grades the run against each fixture's prose README, files upstream issues |
+| `.claude/commands/runbook-sync.md` | Keeps fixture READMEs and `e2e/RUNBOOK.md` in step |
+
+The gaps are narrow and specific: **selection is by explicit name only**, **grading needs a model**, and **there is no A/B**.
+
+## Decisions
+
+| Fork | Chosen | Rationale |
+|---|---|---|
+| Fixtures repo shape | One repo, both apps | Input parity by construction. A `fixtures.dev` mirror would compare two different inputs, defeating the purpose. |
+| Tag source of truth | `TAGS=` in each fixture's `meta.env` | Lives next to the fixture it describes; `apply-fixture.sh` and `run-suite.sh` already parse `meta.env`. `runbook-sync` mirrors it into the RUNBOOK table. |
+| Impact selection | Tags + a checked-in path→tag map | Tags are the primitive; the map turns a diff into tags. Unmapped shared code falls back to the full suite — a missed regression is far worse than a slow run. |
+| Grading | Hybrid: `expect.json` + existing LLM pass | Roughly a third of RUNBOOK outcomes are qualitative ("findings quality unchanged or better") and cannot be asserted. Deterministic checks gate CI; the LLM keeps covering the rest. |
+| Stage plumbing | Explicit `stage` parameter, never `process.env` inside core | `packages/core` is deliberately env-agnostic (`pricing.ts:106`: "Pure + env-agnostic — the caller reads `process.env`"). The Lambda already has `STAGE=dev`. |
+| Staging | 3 PRs, spanning two repos | Stage 1 in `mergewatch.ai` unblocks the A/B; stages 2–3 are `mergewatch/fixtures`. |
+
+## Architecture
+
+### Stage-scoped identity (stage 1)
+
+Three constants currently make dev and prod indistinguishable on a shared repo:
+
+| Constant | File | Prod value — **must not change** |
+|---|---|---|
+| `BOT_COMMENT_MARKER` | `packages/core/src/github/client.ts:34` | `<!-- mergewatch-review -->` |
+| `INLINE_BOT_COMMENT_MARKER` | `client.ts:44` | `<!-- mergewatch-inline -->` |
+| `MERGEWATCH_CHECK_RUN_NAME` | `client.ts:308` | `MergeWatch Review` |
+
+`findExistingBotComment` (`client.ts:251`) matches on the marker alone with **no author filter**, so with both apps live the second reviewer finds the first's comment and tries to update it — which GitHub rejects, since an app may only edit its own comments.
+
+New `packages/core/src/stage.ts`:
+
+```ts
+export type Stage = 'prod' | (string & {});
+export function reviewMarker(stage?: Stage): string
+export function inlineMarker(stage?: Stage): string
+export function checkRunName(stage?: Stage): string
+```
+
+Absent or `'prod'` returns today's exact strings; any other stage returns a suffixed variant (`<!-- mergewatch-review:dev -->`, `MergeWatch Review (dev)`).
+
+**Both directions must move together.** These constants are read as well as written:
+
+- `packages/lambda/src/handlers/webhook.ts:459` and `packages/server/src/webhook-handler.ts:342` — `isMergeWatchCheckRun` matches the check name to decide whether a re-run click belongs to us. Stage-scoping the write side alone would make dev ignore its own "Re-run" button.
+- `packages/core/src/insights/disposition-writer.ts:310` and `packages/core/src/agents/inline-reply.ts:477` — match the inline marker to attribute reactions and replies.
+
+The existing constants stay exported (self-hosted callers and back-compat) and are documented as "the prod value; prefer the resolver".
+
+**The prod strings are load-bearing.** Changing `<!-- mergewatch-review -->` even once orphans every bot comment on every open PR in the wild: `findExistingBotComment` returns null and the next review posts a duplicate instead of updating. Pinned by explicit tests.
+
+### Tagged selection (stage 2)
+
+```
+fixtures/54d-null-deref/meta.env
+  TAGS=agents,bugs,critical-path
+```
+
+```
+e2e/impact-map.yml
+  packages/core/src/agents/prompts.ts:  [agents]
+  packages/core/src/skip-logic.ts:      [skip]
+  packages/billing/**:                  [billing]
+  packages/core/src/comment-formatter*: [output]
+  packages/llm-*/**:                    [ALL]    # model layer → full suite
+```
+
+`run-suite.sh` gains `--tag <t>` (repeatable) and `--impacted-by <ref>`. The latter reads the diff, resolves paths to tags, and unions the matching fixtures. **A changed path matching nothing in the map resolves to `ALL`**, and the run logs which paths forced the widening — silent under-selection is the failure mode that matters here.
+
+### Deterministic grading (stage 3)
+
+`fixtures/NN-name/expect.json`, all fields optional:
+
+```json
+{
+  "check": "failure",
+  "score": { "min": 1, "max": 2 },
+  "reviewState": "CHANGES_REQUESTED",
+  "mustFind": [{ "severity": "critical", "file": "src/payments.ts", "matches": "null|undefined" }],
+  "mustNotContain": ["Could not parse agent JSON", "structured invocation failed"]
+}
+```
+
+`scripts/grade-run.sh` (or `grade-run.ts`) reads `.e2e/last-run.json`, fetches each PR's check conclusion, review state, and bot comment, evaluates the assertions, and exits non-zero on any failure. A fixture with no `expect.json` is reported `UNGRADED`, never silently passed.
+
+`verify-suite.md` is updated to run the deterministic pass first and confine its LLM judgement to what assertions could not express.
+
+### A/B comparison
+
+With both apps live, each fixture PR carries two bot comments distinguished by marker. `grade-run.sh --compare` grades both and reports divergence:
+
+```
+E2E-54d  fixtures#712
+  prod  2/5 · 3 findings · caught null-deref ✅ · $0.21
+  dev   2/5 · 3 findings · caught null-deref ✅ · $0.09
+  → parity
+```
+
+## Phased breakdown
+
+### Phase 1 — stage-scoped identity (`mergewatch.ai`)
+
+- [x] **Goal:** dev and prod can review the same PR without colliding. No behavior change for prod. **Shipped in PR #417.**
+- **Files:** new `packages/core/src/stage.ts`; `packages/core/src/github/client.ts` (write + `findExistingBotComment`); `packages/core/src/index.ts`; `packages/core/src/insights/disposition-writer.ts`; `packages/core/src/agents/inline-reply.ts`; `packages/lambda/src/handlers/webhook.ts` + `review-agent.ts` (pass `process.env.STAGE`); `packages/server/src/webhook-handler.ts`.
+- **Tests:** prod resolves to the exact legacy strings (pinned literally, not derived); absent stage === `'prod'`; dev returns distinct values; `findExistingBotComment` scoped to one stage ignores the other stage's comment; `isMergeWatchCheckRun` matches its own stage's name and not the other's.
+- **RUNBOOK:** E2E-94 — both apps review one PR; two comments, two checks, neither clobbers the other.
+
+### Phase 2 — tags + impacted selection (`mergewatch/fixtures`)
+
+- [ ] **Goal:** `run-suite.sh --tag agents` and `--impacted-by <ref>` run a subset.
+- **Files:** `TAGS=` added to all 93 `fixtures/*/meta.env`; new `e2e/impact-map.yml`; `scripts/run-suite.sh`; `.claude/commands/runbook-sync.md` (mirror tags into the RUNBOOK table); RUNBOOK regression table gains a Tags column.
+- **Tests:** tag filter selects the expected set; unknown tag errors rather than silently running nothing; an unmapped changed path widens to `ALL` and says so.
+- **RUNBOOK:** E2E-95 — tagged and impacted selection pick the right subset.
+
+### Phase 3 — deterministic grading + nightly CI (`mergewatch/fixtures`)
+
+- [ ] **Goal:** a subset run hard-fails without a model; nightly full run.
+- **Files:** `expect.json` for the deterministic fixtures (start with the ~20 highest-value; the rest stay `UNGRADED`); `scripts/grade-run.sh`; `.claude/commands/verify-suite.md`; a nightly GitHub Action.
+- **Tests:** each assertion type passes and fails correctly; a missing `expect.json` reports `UNGRADED`, never `PASS`; `--compare` detects a seeded dev/prod divergence.
+- **RUNBOOK:** E2E-96 — grading catches a deliberately broken fixture.
+
+## Out of scope / deferred
+
+- **Turning on the dev App's webhook and scoping its installation.** Manual GitHub UI steps only the operator can do: point it at `https://fukmc5gjhk.execute-api.us-west-2.amazonaws.com/dev/webhook`, mark it Active, match the secret to SSM `/mergewatch/dev/github-webhook-secret`, and scope the `mergewatch` installation to `fixtures` **only** — it currently sees `kitchensink`, which prod also sees, so enabling it as-is double-reviews that repo. Nothing in phase 1 takes effect until this is done.
+- **Ava-Listens and assistants-hub** are on the dev App and look like real projects. They would start receiving dev-stack reviews the moment the webhook is enabled. Operator decision, not code.
+- **Backfilling `expect.json` for all 93 fixtures** — phase 3 covers the highest-value subset; the rest stay `UNGRADED` and visible as such.
+- **Tier-1 pipeline contract tests** (calling `runReviewPipeline()` directly against Bedrock, no GitHub) — genuinely valuable and much cheaper per run, but a separate shape from this suite. File separately.
+- **Cost.** Both apps reviewing every fixture PR roughly doubles fixture spend (~$0.07–0.50 per review, so a full 93-fixture A/B run is roughly $15–30). Scoping the dev App to `fixtures` alone is what keeps this contained.
+- **The stale dev installations table row** listing `mergewatch/fixtures` for installation 142368585 — a June artifact; dev cannot currently see that repo.

--- a/docs/pending/e2e-ab-testing.md
+++ b/docs/pending/e2e-ab-testing.md
@@ -1,0 +1,65 @@
+# E2E A/B testing — dev and prod on one fixtures repo
+
+**Status:** 🚧 In progress (#416) — stage 1 of 3 shipped.
+
+MergeWatch runs as two GitHub Apps: a dev App and a prod App. Installing **both** on `mergewatch/fixtures` is how a change gets tested before it reaches production: the same PR, at the same commit, reviewed twice, side by side in one thread.
+
+## Why one repo, not two
+
+A separate `fixtures.dev` repo is the obvious design and it is the wrong one. It makes dev and prod run **different inputs**, so any difference in their output is ambiguous — a real regression and a stale fixture look identical. It also adds a mirror to keep in sync, and the moment it drifts the comparison quietly stops meaning anything.
+
+One repo gives input parity by construction. There is nothing to sync, and the two reviews sit next to each other where a human can read them.
+
+## Stage-scoped identity
+
+Three values previously made the two stages indistinguishable on a shared repo, because `findExistingBotComment` matches on the comment marker alone with **no author filter**. With both Apps live, the second reviewer would find the first's comment and try to update it — which GitHub rejects, since an App may only edit comments it authored.
+
+`packages/core/src/stage.ts` resolves each per stage:
+
+| Resolver | prod (absent stage) | `dev` |
+|---|---|---|
+| `reviewMarker(stage)` | `<!-- mergewatch-review -->` | `<!-- mergewatch-review:dev -->` |
+| `inlineMarker(stage)` | `<!-- mergewatch-inline -->` | `<!-- mergewatch-inline:dev -->` |
+| `checkRunName(stage)` | `MergeWatch Review` | `MergeWatch Review (dev)` |
+
+**Prod's values are frozen.** They are returned verbatim, never derived, and pinned by tests asserting the literal strings. Changing `<!-- mergewatch-review -->` even once would orphan every bot comment on every open PR in the wild: the lookup returns null and the next review posts a duplicate instead of updating in place.
+
+**Absent, empty, and whitespace stages all read as prod.** A self-hosted deployment sets no `STAGE`; silently scoping its markers would make it stop finding its own comments.
+
+### Both directions move together
+
+These values are read as well as written, and scoping one side without the other fails silently:
+
+| Site | Direction |
+|---|---|
+| `client.ts` `postReviewComment` / `updateReviewComment` | writes the marker |
+| `client.ts` `findExistingBotComment` | reads it — a mismatch means a duplicate comment |
+| `client.ts` `createCheckRun` | writes the check name |
+| `lambda/handlers/webhook.ts`, `server/webhook-handler.ts` `isMergeWatchCheckRun` | reads it — a mismatch means the stage ignores its own "Re-run" button |
+| `client.ts` `buildInlineComments` | writes the inline marker |
+| `insights/disposition-writer.ts`, `agents/inline-reply.ts` | read it — a mismatch means reactions and replies are misattributed |
+
+### Where the stage comes from
+
+The stage is always an explicit parameter, never read from `process.env` inside `@mergewatch/core` — that package is deliberately environment-agnostic, the same way `llm/pricing.ts` leaves env reading to its caller.
+
+Each runtime resolves it once at module load (`const STAGE = process.env.STAGE`) and threads it through. The Lambda already has `STAGE` set by the SAM template; self-hosted leaves it unset and gets prod identity.
+
+## Operator setup
+
+Stage 1 is inert until these are done by hand — they are GitHub App settings and cannot be automated:
+
+1. **Enable the dev App's webhook.** URL `https://fukmc5gjhk.execute-api.us-west-2.amazonaws.com/dev/webhook`, mark **Active**, secret matching SSM `/mergewatch/dev/github-webhook-secret`. The dev App currently has **zero webhook deliveries ever recorded** — GitHub is not attempting delivery at all, which is why dev has been dark since 2026-06-25.
+2. **Scope the dev App's `mergewatch` installation to `fixtures` only.** It currently sees `kitchensink`, which prod also sees — enabling the webhook as-is would double-review that repo.
+3. **Decide about `Ava-Listens` (4 repos) and `assistants-hub` (3 repos).** Both are on the dev App and would start receiving dev-stack reviews the moment the webhook is enabled.
+
+## Cost
+
+Both Apps reviewing every fixture PR roughly doubles fixture spend (~$0.07–0.50 per review, so a full 93-fixture A/B run is roughly $15–30). Scoping the dev App to `fixtures` alone is what keeps that contained.
+
+## Still to come
+
+- **Stage 2** — `TAGS=` in each fixture's `meta.env` plus a path→tag map, so `run-suite.sh --tag agents` and `--impacted-by <ref>` run a subset instead of all 93.
+- **Stage 3** — `expect.json` deterministic assertions and `grade-run.sh`, so a subset run hard-fails CI without a model in the loop, plus `--compare` to report dev/prod divergence directly.
+
+Scenario: **E2E-94**.

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -215,6 +215,7 @@ Run these in order — they cover all current behaviors. ~30 minutes end-to-end.
 | [E2E-86](#e2e-86-336--p95-duration-nearest-rank--minimum-sample) | Analytics p95 duration uses nearest-rank (`⌈n × 0.95⌉`, clamped) instead of returning the maximum for n ≤ 20; below 20 completed reviews the UI shows "—" with an explanatory tooltip and no P95 bar (#336) | 2m | 30s | #336 |
 | [E2E-87](#e2e-87-337--date-only-range-bounds-include-their-whole-day) | `/api/analytics` date-only `start_date`/`end_date` expand to the UTC day's edge instants at the boundary (`end_date=2026-08-16` includes the whole 16th); full timestamps pass through untouched; identical on both backends; UTC bucketing documented in the route (#337) | 2m | 30s | #337 |
 | [E2E-88](#e2e-88-355--pr-burst-resilience) | A PR burst never silently loses reviews: throttles park the review (`pending` + in_progress "rate limited" check, never terminal FAILURE) and admission control paces the backlog — SQS `MaximumConcurrency` on SaaS, Postgres `SKIP LOCKED` worker at `REVIEW_CONCURRENCY` on self-hosted; exhaustion lands in a DLQ/`status='dead'`, visibly (#355) | 20m | n/a | #355 |
+| [E2E-94](#e2e-94-416--dev-and-prod-review-the-same-pr-without-colliding) | With both Apps installed on one repo, a single PR gets two independent reviews — separate comment markers, separate check runs, each stage updating only its own and re-running only from its own button; prod's identity is byte-identical to pre-#416 (#416) | 5m | 2m | #416 |
 | [E2E-93](#e2e-93-409--oss-operator-lifecycle-org-grants-pre-approval-inspect) | `grant-oss.ts --org` writes an org-scoped grant, `--preapprove` parks one for an uninstalled org (and refuses if they already installed), `--list-preapprovals` / `--inspect` render both, and the dashboard shows org-wide coverage rather than an empty repo list (#409) | 10m | n/a | #412 |
 | [E2E-92](#e2e-92-409--oss-pre-approval-claimed-automatically-on-install) | An org pre-approved before installing gets an org-scoped grant written automatically on `installation.created`; a webhook redelivery never resets an existing grant, a claimed row never re-fires on reinstall, and an expired pre-approval is ignored (#409) | 8m | n/a | #411 |
 | [E2E-91](#e2e-91-409--oss-org-scoped-grant-covers-every-public-repo) | An `ossGrantScope: 'org'` grant sponsors every PUBLIC repo in the installation including newly-created ones, while private repos, expiry, and the monthly cap still gate it; pre-#409 grants with no scope field still match only their named repo ids (#409) | 5m | n/a | #410 |
@@ -3245,6 +3246,39 @@ Then install the App on a test org that has **never** installed it before (an ex
 - ❌ `--preapprove` succeeds for an already-installed org — the row would sit unclaimed forever with nobody looking at it
 - ❌ A non-404 installation-lookup failure is swallowed as "not installed" — same outcome, but triggered by a transient blip rather than operator error, so it is even less likely to be noticed
 - ❌ Script constants drift from `packages/billing/src/constants.ts` (cap, term, TTL, `#PENDING-OSS`) — they are duplicated by necessity, so a change on one side must be mirrored
+
+---
+
+### E2E-94: #416 — dev and prod review the same PR without colliding
+
+**Status:** 🚧 In review (#416, stage 1).
+
+**Behavior:** with both GitHub Apps installed on `mergewatch/fixtures`, one PR is reviewed twice — once per stage — on a byte-identical diff. Each stage writes its own comment marker (`<!-- mergewatch-review -->` for prod, `<!-- mergewatch-review:dev -->` for dev) and its own check-run name (`MergeWatch Review` / `MergeWatch Review (dev)`), so neither finds or edits the other's artifacts. This is the A/B substrate: same PR, same commit SHA, same diff, two independent reviews side by side.
+
+Prod's identity is unchanged and frozen. A repo with only the prod App installed behaves exactly as before, and every comment written before #416 is still found by prod.
+
+**Setup.** Requires the operator steps in #416 first — none of this is reachable until they're done:
+1. Dev App webhook → `https://fukmc5gjhk.execute-api.us-west-2.amazonaws.com/dev/webhook`, **Active**, secret matching SSM `/mergewatch/dev/github-webhook-secret`.
+2. Dev App's `mergewatch` installation scoped to **`fixtures` only** (it currently sees `kitchensink`, which prod also sees → double reviews on a repo you're not A/B-ing).
+
+Then apply any fixture as usual (`scripts/apply-fixture.sh 01-clean-pr`).
+
+**Expected outcomes.**
+- [ ] The PR carries **two** bot comments — one per App identity — not one comment being overwritten
+- [ ] Prod's comment body starts with `<!-- mergewatch-review -->`; dev's with `<!-- mergewatch-review:dev -->`
+- [ ] **Two** check runs: `MergeWatch Review` and `MergeWatch Review (dev)`
+- [ ] Push a second commit → each stage **updates its own** comment in place; neither posts a duplicate and neither 403s trying to edit the other's
+- [ ] Click "Re-run" on the **dev** check → only dev re-reviews; prod's comment and check are untouched
+- [ ] Click "Re-run" on the **prod** check → only prod re-reviews
+- [ ] Inline findings carry the stage-scoped inline marker, and a 👍 on a dev inline comment is recorded against dev's stores only
+- [ ] On a repo with **only** the prod App, behavior is identical to before #416 — one comment, one check named `MergeWatch Review`
+
+**Failure modes.**
+- ❌ One comment that flips between two authors' content — the marker isn't scoped and each stage is overwriting the other
+- ❌ A 403 in either stage's logs when updating a comment — it matched the other App's comment and tried to edit what it doesn't own
+- ❌ **Prod posts a duplicate comment on an existing PR** — the prod marker changed. This is the severe one: it orphans every bot comment in the wild, not just fixtures
+- ❌ Dev's "Re-run" button does nothing — `isMergeWatchCheckRun` still matches only the prod name, so dev ignores its own re-request
+- ❌ Both stages reviewing `kitchensink` or any repo outside the A/B — the dev installation wasn't scoped down
 
 ---
 

--- a/packages/core/src/agents/inline-reply.ts
+++ b/packages/core/src/agents/inline-reply.ts
@@ -34,11 +34,12 @@ import {
   fetchReviewCommentThread,
   resolveReviewThread,
   findReviewThreadIdForComment,
-  INLINE_BOT_COMMENT_MARKER,
   extractInlineCommentTitle,
   extractInlineCommentFingerprint,
   type ReviewThreadComment,
 } from '../github/client.js';
+import { inlineMarker } from '../stage.js';
+import type { Stage } from '../stage.js';
 import { findingMatchKeys, type FindingLike } from '../review-delta.js';
 import type { IReviewStore } from '../storage/types.js';
 import type { ReviewItem } from '../types/db.js';
@@ -180,6 +181,12 @@ export interface InlineReplyContext {
   replyCommentId: number;
   /** Optional: repo conventions markdown to inject (caller already size-capped). */
   conventions?: string;
+  /**
+   * #416 — deployment stage, used to resolve the inline marker when checking
+   * that a thread root is ours. Absent means prod, so self-hosted and existing
+   * callers are unaffected.
+   */
+  stage?: Stage;
 }
 
 export interface InlineReplyDeps {
@@ -474,7 +481,7 @@ export async function handleInlineReply(
   // any other reviewer bot's threads would qualify and MergeWatch would
   // interfere in conversations it didn't start.
   const root = thread[0];
-  if (!root || !root.isBot || !root.body.includes(INLINE_BOT_COMMENT_MARKER)) {
+  if (!root || !root.isBot || !root.body.includes(inlineMarker(ctx.stage))) {
     return { action: 'skipped', reason: 'thread root is not a MergeWatch comment', inputTokens: 0, outputTokens: 0, estimatedCostUsd: 0 };
   }
 

--- a/packages/core/src/github/client.test.ts
+++ b/packages/core/src/github/client.test.ts
@@ -9,6 +9,7 @@ import {
   addPRReaction,
   removePRReaction,
   submitPRReview,
+  findExistingBotComment,
 } from './client.js';
 import type { Octokit } from '@octokit/rest';
 
@@ -744,5 +745,46 @@ describe('submitPRReview body handling (W6)', () => {
     const { octokit, calls } = captureCall();
     await submitPRReview(octokit, 'o', 'r', 1, '', 'COMMENT');
     expect('comments' in calls[0]).toBe(false);
+  });
+});
+
+describe('findExistingBotComment — stage scoping (#416)', () => {
+  // With dev and prod both installed on one repo, each stage must find only
+  // its own comment. Matching the other's would make the second reviewer try
+  // to edit a comment it does not own, which GitHub rejects.
+  function octokitWith(bodies: string[]) {
+    return {
+      paginate: {
+        iterator: () => (async function* () {
+          yield { data: bodies.map((body, i) => ({ id: 100 + i, body })) };
+        })(),
+      },
+      issues: { listComments: {} },
+    } as any;
+  }
+
+  it('prod ignores a dev comment', async () => {
+    const octokit = octokitWith(['<!-- mergewatch-review:dev -->\nreview']);
+    expect(await findExistingBotComment(octokit, 'o', 'r', 1)).toBeNull();
+  });
+
+  it('dev ignores a prod comment', async () => {
+    const octokit = octokitWith(['<!-- mergewatch-review -->\nreview']);
+    expect(await findExistingBotComment(octokit, 'o', 'r', 1, 'dev')).toBeNull();
+  });
+
+  it('each stage finds its own comment when both are present', async () => {
+    const octokit = octokitWith([
+      '<!-- mergewatch-review -->\nprod review',
+      '<!-- mergewatch-review:dev -->\ndev review',
+    ]);
+    expect(await findExistingBotComment(octokit, 'o', 'r', 1)).toBe(100);
+    expect(await findExistingBotComment(octokit, 'o', 'r', 1, 'dev')).toBe(101);
+  });
+
+  it('an absent stage still finds the legacy prod comment', async () => {
+    // Back-compat: every comment written before #416 carries the bare marker.
+    const octokit = octokitWith(['<!-- mergewatch-review -->\nold review']);
+    expect(await findExistingBotComment(octokit, 'o', 'r', 1)).toBe(100);
   });
 });

--- a/packages/core/src/github/client.ts
+++ b/packages/core/src/github/client.ts
@@ -22,6 +22,8 @@ import type {
   PassThreshold,
 } from '../config/defaults.js';
 import { PASS_THRESHOLDS } from '../config/defaults.js';
+import { reviewMarker, inlineMarker, checkRunName } from '../stage.js';
+import type { Stage } from '../stage.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -30,6 +32,11 @@ import { PASS_THRESHOLDS } from '../config/defaults.js';
 /**
  * HTML comment injected at the top of every MergeWatch review comment.
  * Used as a stable marker to locate an existing bot comment on a PR.
+ *
+ * This is the **production** marker. Prefer {@link reviewMarker} when a stage
+ * is available (#416) — with dev and prod both installed on one repo, each
+ * stage needs its own marker or they clobber each other's comments. Kept
+ * exported for self-hosted callers and back-compat; the value is frozen.
  */
 export const BOT_COMMENT_MARKER = "<!-- mergewatch-review -->";
 
@@ -40,6 +47,9 @@ export const BOT_COMMENT_MARKER = "<!-- mergewatch-review -->";
  * or any other reviewer bot. The marker is invisible to humans in the GitHub
  * UI but reliably distinguishes our inline findings from third-party ones,
  * regardless of the App name (SaaS or self-hosted).
+ *
+ * This is the **production** marker; prefer {@link inlineMarker} when a stage
+ * is available (#416). Frozen — see `stage.ts`.
  */
 export const INLINE_BOT_COMMENT_MARKER = "<!-- mergewatch-inline -->";
 
@@ -185,9 +195,10 @@ export async function postReviewComment(
   owner: string,
   repo: string,
   prNumber: number,
-  body: string
+  body: string,
+  stage?: Stage,
 ): Promise<number> {
-  const markedBody = `${BOT_COMMENT_MARKER}\n${body}`;
+  const markedBody = `${reviewMarker(stage)}\n${body}`;
 
   const { data } = await octokit.issues.createComment({
     owner,
@@ -214,9 +225,10 @@ export async function updateReviewComment(
   owner: string,
   repo: string,
   commentId: number,
-  body: string
+  body: string,
+  stage?: Stage,
 ): Promise<void> {
-  const markedBody = `${BOT_COMMENT_MARKER}\n${body}`;
+  const markedBody = `${reviewMarker(stage)}\n${body}`;
 
   await octokit.issues.updateComment({
     owner,
@@ -237,8 +249,12 @@ export async function findExistingBotComment(
   octokit: Octokit,
   owner: string,
   repo: string,
-  prNumber: number
+  prNumber: number,
+  stage?: Stage,
 ): Promise<number | null> {
+  // Must resolve from the same stage the writer used, or the lookup silently
+  // misses and the next review posts a duplicate instead of updating.
+  const marker = reviewMarker(stage);
   const iterator = octokit.paginate.iterator(octokit.issues.listComments, {
     owner,
     repo,
@@ -248,7 +264,7 @@ export async function findExistingBotComment(
 
   for await (const { data: comments } of iterator) {
     for (const comment of comments) {
-      if (comment.body?.includes(BOT_COMMENT_MARKER)) {
+      if (comment.body?.includes(marker)) {
         return comment.id;
       }
     }
@@ -304,6 +320,11 @@ export async function getCommentReactions(
  * Check Run name reported to GitHub. Also used by the webhook handler to
  * identify MergeWatch check runs in check_run.rerequested events so the
  * native "Re-run" button in the PR Checks UI triggers a fresh review.
+ *
+ * This is the **production** name; prefer {@link checkRunName} when a stage is
+ * available (#416). Both sides must resolve from the same stage — the webhook
+ * matches an incoming re-request against this name, so scoping only the write
+ * side leaves a non-prod stage ignoring its own re-run clicks.
  */
 export const MERGEWATCH_CHECK_RUN_NAME = 'MergeWatch Review';
 
@@ -326,13 +347,14 @@ export async function createCheckRun(
     summary: string;
     detailsUrl?: string;
   },
+  stage?: Stage,
 ): Promise<void> {
   try {
     await octokit.checks.create({
       owner,
       repo,
       head_sha: headSha,
-      name: MERGEWATCH_CHECK_RUN_NAME,
+      name: checkRunName(stage),
       status: params.status,
       ...(params.conclusion && { conclusion: params.conclusion }),
       ...(params.detailsUrl && { details_url: params.detailsUrl }),
@@ -495,7 +517,11 @@ export function buildInlineComments(
   findings: InlineCommentCandidate[],
   changedFiles: string[],
   changedLines?: Map<string, Set<number>>,
+  stage?: Stage,
 ): Array<{ path: string; line: number; side: string; body: string }> {
+  // Matched later by the disposition writer and the inline-reply guard, so
+  // both must resolve from the same stage (#416).
+  const marker = inlineMarker(stage);
   const changedSet = new Set(changedFiles);
 
   return findings
@@ -516,7 +542,7 @@ export function buildInlineComments(
       path: f.file,
       line: f.line,
       side: 'RIGHT',
-      body: `${INLINE_BOT_COMMENT_MARKER}\n**🔴 ${f.title}**\n\n${f.description}${f.suggestion ? `\n\n> **Suggestion:** ${f.suggestion}` : ''}${f.fingerprint ? `\n\n<!-- mw-fp:${encodeInlineFingerprint(f.fingerprint)} -->` : ''}`,
+      body: `${marker}\n**🔴 ${f.title}**\n\n${f.description}${f.suggestion ? `\n\n> **Suggestion:** ${f.suggestion}` : ''}${f.fingerprint ? `\n\n<!-- mw-fp:${encodeInlineFingerprint(f.fingerprint)} -->` : ''}`,
     }));
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -100,6 +100,10 @@ export {
 } from './agents/prompts.js';
 
 // ─── GitHub client (portable Octokit ops) ───────────────────────────────────
+// #416 — stage-scoped review identity (dev/prod A/B on one repo).
+export { reviewMarker, inlineMarker, checkRunName } from './stage.js';
+export type { Stage } from './stage.js';
+
 export {
   BOT_COMMENT_MARKER,
   INLINE_BOT_COMMENT_MARKER,

--- a/packages/core/src/insights/disposition-writer.ts
+++ b/packages/core/src/insights/disposition-writer.ts
@@ -17,7 +17,9 @@ import type { IFindingDispositionStore, IReviewStore } from '../storage/types.js
 import type { OrchestratedFinding, PreviousFinding } from '../agents/reviewer.js';
 import { findingMatchKeys, fingerprintFromCode } from '../review-delta.js';
 import { extractSignificantTokens } from '../finding-clustering.js';
-import { INLINE_BOT_COMMENT_MARKER, extractInlineCommentTitle } from '../github/client.js';
+import { extractInlineCommentTitle } from '../github/client.js';
+import { inlineMarker } from '../stage.js';
+import type { Stage } from '../stage.js';
 import type { Octokit } from '@octokit/rest';
 
 /**
@@ -267,6 +269,7 @@ export async function pollAndRecordInlineReactions(
   store: IFindingDispositionStore | undefined,
   installationId: string | number | undefined,
   repoFullName: string,
+  stage?: Stage,
 ): Promise<Record<string, Record<string, number>>> {
   const newSnapshot: Record<string, Record<string, number>> = {};
   if (!store || installationId == null) return newSnapshot;
@@ -307,7 +310,7 @@ export async function pollAndRecordInlineReactions(
     // the inline marker. Same guard the inline-reply path uses (so
     // CopilotAI / dependabot / human review comments don't sneak in).
     if (c.userType !== 'Bot') continue;
-    if (!c.body.includes(INLINE_BOT_COMMENT_MARKER)) continue;
+    if (!c.body.includes(inlineMarker(stage))) continue;
     if (!c.reactions) continue;
 
     // Capture current counts for the next-poll baseline regardless of

--- a/packages/core/src/stage.test.ts
+++ b/packages/core/src/stage.test.ts
@@ -1,0 +1,98 @@
+/**
+ * #416 — stage-scoped review identity.
+ *
+ * Two failure modes drive these tests, and both are silent:
+ *
+ * 1. **Prod's strings drift.** Every bot comment on every open PR in the wild
+ *    carries `<!-- mergewatch-review -->`. If the resolver ever returns
+ *    anything else for prod, `findExistingBotComment` stops matching and the
+ *    next review posts a duplicate instead of updating in place. The prod
+ *    assertions below are deliberately written as literals — deriving them from
+ *    the implementation would make them agree with a regression.
+ *
+ * 2. **Only one direction gets scoped.** The markers and the check-run name are
+ *    read as well as written; if a writer scopes and its reader does not, the
+ *    lookup silently misses.
+ */
+import { describe, it, expect } from 'vitest';
+import { reviewMarker, inlineMarker, checkRunName } from './stage.js';
+import {
+  BOT_COMMENT_MARKER,
+  INLINE_BOT_COMMENT_MARKER,
+  MERGEWATCH_CHECK_RUN_NAME,
+} from './github/client.js';
+
+describe('production identity is frozen', () => {
+  it('reviewMarker is exactly the legacy marker', () => {
+    expect(reviewMarker('prod')).toBe('<!-- mergewatch-review -->');
+    expect(reviewMarker()).toBe('<!-- mergewatch-review -->');
+  });
+
+  it('inlineMarker is exactly the legacy inline marker', () => {
+    expect(inlineMarker('prod')).toBe('<!-- mergewatch-inline -->');
+    expect(inlineMarker()).toBe('<!-- mergewatch-inline -->');
+  });
+
+  it('checkRunName is exactly the legacy check name', () => {
+    expect(checkRunName('prod')).toBe('MergeWatch Review');
+    expect(checkRunName()).toBe('MergeWatch Review');
+  });
+
+  it('still matches the exported constants callers may use directly', () => {
+    // Self-hosted code and anything not yet threaded still reads these.
+    // They must not diverge from what the prod resolver returns.
+    expect(reviewMarker()).toBe(BOT_COMMENT_MARKER);
+    expect(inlineMarker()).toBe(INLINE_BOT_COMMENT_MARKER);
+    expect(checkRunName()).toBe(MERGEWATCH_CHECK_RUN_NAME);
+  });
+});
+
+describe('absent / blank stage reads as prod', () => {
+  // A self-hosted deployment sets no STAGE. Silently scoping its markers would
+  // make it stop finding its own comments and duplicate on every review.
+  for (const stage of [undefined, '', '   '] as const) {
+    it(`${JSON.stringify(stage)} → prod identity`, () => {
+      expect(reviewMarker(stage)).toBe('<!-- mergewatch-review -->');
+      expect(inlineMarker(stage)).toBe('<!-- mergewatch-inline -->');
+      expect(checkRunName(stage)).toBe('MergeWatch Review');
+    });
+  }
+
+  it('is case-insensitive about "prod"', () => {
+    expect(reviewMarker('PROD')).toBe('<!-- mergewatch-review -->');
+    expect(checkRunName('Prod')).toBe('MergeWatch Review');
+  });
+});
+
+describe('non-prod stages get a distinct identity', () => {
+  it('dev markers and check name differ from prod', () => {
+    expect(reviewMarker('dev')).toBe('<!-- mergewatch-review:dev -->');
+    expect(inlineMarker('dev')).toBe('<!-- mergewatch-inline:dev -->');
+    expect(checkRunName('dev')).toBe('MergeWatch Review (dev)');
+  });
+
+  it('a dev marker never collides with the prod marker', () => {
+    // The whole point: with both apps on one repo, each must find only its own
+    // comment. `includes()` is how the lookup matches, so a prefix collision
+    // would be just as broken as an exact one.
+    expect(reviewMarker('dev').includes(reviewMarker('prod'))).toBe(false);
+    expect(reviewMarker('prod').includes(reviewMarker('dev'))).toBe(false);
+    expect(inlineMarker('dev').includes(inlineMarker('prod'))).toBe(false);
+  });
+
+  it('normalizes stage casing and padding so config typos still match', () => {
+    expect(reviewMarker(' DEV ')).toBe('<!-- mergewatch-review:dev -->');
+    expect(checkRunName('Dev')).toBe('MergeWatch Review (dev)');
+  });
+
+  it('supports a stage beyond dev/prod', () => {
+    expect(reviewMarker('staging')).toBe('<!-- mergewatch-review:staging -->');
+    expect(checkRunName('staging')).toBe('MergeWatch Review (staging)');
+  });
+
+  it('distinct stages never share an identity', () => {
+    const stages = ['prod', 'dev', 'staging'];
+    const markers = stages.map((s) => reviewMarker(s));
+    expect(new Set(markers).size).toBe(stages.length);
+  });
+});

--- a/packages/core/src/stage.ts
+++ b/packages/core/src/stage.ts
@@ -1,0 +1,90 @@
+/**
+ * #416 — stage-scoped review identity.
+ *
+ * MergeWatch runs as two separate GitHub Apps (dev and prod). Installing both
+ * on one repository is how dev and prod get compared: the same PR, at the same
+ * commit, reviewed twice, side by side. That only works if the two stages can
+ * tell their own artifacts apart.
+ *
+ * They currently cannot. `findExistingBotComment` matches on the comment marker
+ * alone with no author filter, so the second app to run finds the first app's
+ * comment and tries to update it — which GitHub rejects, because an App may
+ * only edit comments it authored.
+ *
+ * These resolvers give each non-prod stage its own marker and check-run name.
+ *
+ * **Prod's values are frozen.** They are returned verbatim, never derived, and
+ * pinned by tests asserting the literal strings. Changing
+ * `<!-- mergewatch-review -->` even once would orphan every bot comment on
+ * every open PR in the wild: the lookup returns null and the next review posts
+ * a duplicate instead of updating in place.
+ *
+ * The stage is always passed in, never read from `process.env` here — this
+ * package is deliberately environment-agnostic, the same way `llm/pricing.ts`
+ * leaves env reading to its caller. The Lambda already has `STAGE` set.
+ */
+
+/**
+ * Deployment stage. `'prod'` (or absent) selects the frozen production
+ * identity; anything else gets a scoped variant.
+ *
+ * Typed as an open union so callers can pass `process.env.STAGE` — which is
+ * `string | undefined` — without a cast, while `'prod'` still autocompletes.
+ */
+export type Stage = 'prod' | (string & {});
+
+/** The production comment marker. Frozen — see the module docstring. */
+const PROD_REVIEW_MARKER = '<!-- mergewatch-review -->';
+/** The production inline-comment marker. Frozen. */
+const PROD_INLINE_MARKER = '<!-- mergewatch-inline -->';
+/** The production check-run name. Frozen. */
+const PROD_CHECK_RUN_NAME = 'MergeWatch Review';
+
+/**
+ * Whether this stage uses the frozen production identity.
+ *
+ * Absent, empty, and whitespace all read as prod. That default matters: a
+ * self-hosted deployment sets no `STAGE`, and a misconfigured one that silently
+ * scoped its markers would stop finding its own comments and post a duplicate
+ * on every review.
+ */
+function isProd(stage?: Stage): boolean {
+  return !stage || stage.trim() === '' || stage.trim().toLowerCase() === 'prod';
+}
+
+/** Normalized suffix for a non-prod stage — lowercased, trimmed. */
+function suffix(stage: Stage): string {
+  return stage.trim().toLowerCase();
+}
+
+/**
+ * HTML marker identifying this stage's main review comment.
+ *
+ * Written into every review comment and matched when looking one up, so both
+ * sides must resolve it from the same stage or the lookup silently misses.
+ */
+export function reviewMarker(stage?: Stage): string {
+  return isProd(stage) ? PROD_REVIEW_MARKER : `<!-- mergewatch-review:${suffix(stage!)} -->`;
+}
+
+/**
+ * HTML marker identifying this stage's inline review comments.
+ *
+ * Also matched by the disposition writer and the inline-reply path when
+ * deciding whether a thread is ours.
+ */
+export function inlineMarker(stage?: Stage): string {
+  return isProd(stage) ? PROD_INLINE_MARKER : `<!-- mergewatch-inline:${suffix(stage!)} -->`;
+}
+
+/**
+ * Check-run name for this stage.
+ *
+ * Read as well as written: `isMergeWatchCheckRun` compares an incoming
+ * `check_run.rerequested` event's name against this to decide whether the
+ * native "Re-run" button was ours. Scoping the write side alone would leave a
+ * non-prod stage ignoring its own re-run clicks.
+ */
+export function checkRunName(stage?: Stage): string {
+  return isProd(stage) ? PROD_CHECK_RUN_NAME : `${PROD_CHECK_RUN_NAME} (${suffix(stage!)})`;
+}

--- a/packages/lambda/src/handlers/dlq-redrive.ts
+++ b/packages/lambda/src/handlers/dlq-redrive.ts
@@ -28,6 +28,11 @@ import {
 import { createCheckRun } from '@mergewatch/core';
 import type { ReviewJobPayload } from '@mergewatch/core';
 import { SSMGitHubAuthProvider } from '../github-auth-ssm.js';
+// #416 — deployment stage, so review artifacts (comment marker, check-run
+// name) are scoped per stage. Absent means prod, which is the frozen
+// production identity — see packages/core/src/stage.ts.
+const STAGE = process.env.STAGE;
+
 
 const sqs = new SQSClient({});
 const authProvider = new SSMGitHubAuthProvider();
@@ -77,7 +82,7 @@ async function completeAbandonedCheck(payload: ReviewJobPayload): Promise<void> 
         'MergeWatch retried this review across several queue generations and the model provider '
         + 'was still rate limiting. The job has been dropped so it does not cycle indefinitely. '
         + 'Re-run this check or comment `@mergewatch review` to try again.',
-    });
+    }, STAGE);
     console.log(`Completed abandoned check run for ${owner}/${repo}#${prNumber}`);
   } catch (err) {
     console.error(`Failed to complete abandoned check run for ${owner}/${repo}#${prNumber}:`, err);

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -76,6 +76,7 @@ import type {
 import { buildWorkDoneSection, computeReviewDelta } from '@mergewatch/core';
 import { DynamoInstallationStore } from '@mergewatch/storage-dynamo';
 import {
+
   DynamoReviewStore,
   DynamoFindingDispositionStore,
   DEFAULT_FINDING_DISPOSITIONS_TABLE,
@@ -92,6 +93,10 @@ import { BedrockLLMProvider, SUPPORTED_MODELS } from '@mergewatch/llm-bedrock';
 import { isSaas, billingCheck, recordReview, postBlockedCheckRun, ensureBillingIssue, updateBillingFields, getStripe, isLapsedOssGrant } from '@mergewatch/billing';
 import { SSMGitHubAuthProvider } from '../github-auth-ssm.js';
 import { payloadFromEvent, attemptFromEvent, rateLimitedCheckSummary, type ReviewAgentEvent } from './review-agent-event.js';
+// #416 — deployment stage, so review artifacts (comment marker, check-run
+// name) are scoped per stage. Absent means prod, which is the frozen
+// production identity — see packages/core/src/stage.ts.
+const STAGE = process.env.STAGE;
 
 // -- Singletons (re-used across warm invocations) ----------------------------
 
@@ -453,7 +458,7 @@ export async function handler(
       conclusion: 'neutral',
       title: 'Review skipped',
       summary: skipReason,
-    });
+    }, STAGE);
 
     return {
       statusCode: 200,
@@ -533,7 +538,7 @@ export async function handler(
     status: 'in_progress',
     title: 'Review in progress',
     summary: `MergeWatch is reviewing PR #${prNumber}...`,
-  });
+  }, STAGE);
 
   try {
     const diff = await getPRDiff(octokit, owner, repo, prNumber);
@@ -605,7 +610,7 @@ export async function handler(
         conclusion: 'neutral',
         title: 'Review skipped',
         summary: rulesSkip.reason,
-      });
+      }, STAGE);
 
       return {
         statusCode: 200,
@@ -855,7 +860,7 @@ export async function handler(
       dispositionStore,
       installationId,
       repoFullName,
-    );
+    STAGE);
 
     const durationMs = Date.now() - new Date(reviewStartedAt).getTime();
 
@@ -920,7 +925,7 @@ export async function handler(
     }
 
     if (!targetCommentId) {
-      targetCommentId = (await findExistingBotComment(octokit, owner, repo, prNumber)) ?? undefined;
+      targetCommentId = (await findExistingBotComment(octokit, owner, repo, prNumber, STAGE)) ?? undefined;
     }
 
     // #350 — postSummaryOnClean: false means a clean PR gets no comment. Only
@@ -932,10 +937,10 @@ export async function handler(
     if (stayingSilent) {
       console.log(`[post-summary] clean PR and postSummaryOnClean=false — staying silent on ${repoFullName}#${prNumber}`);
     } else if (targetCommentId) {
-      await updateReviewComment(octokit, owner, repo, targetCommentId, commentBody);
+      await updateReviewComment(octokit, owner, repo, targetCommentId, commentBody, STAGE);
       commentId = targetCommentId;
     } else {
-      commentId = await postReviewComment(octokit, owner, repo, prNumber, commentBody);
+      commentId = await postReviewComment(octokit, owner, repo, prNumber, commentBody, STAGE);
     }
 
     if (!commentId && !stayingSilent) {
@@ -943,7 +948,7 @@ export async function handler(
     }
 
     // ── Step B: Build inline comments for critical findings ──────────────
-    let inlineComments = buildInlineComments(result.findings, prContext.files, result.changedLines);
+    let inlineComments = buildInlineComments(result.findings, prContext.files, result.changedLines, STAGE);
 
     // Filter out carried-over findings (same file+line+title as previous review)
     if (prevComplete?.findings && inlineComments.length > 0) {
@@ -1138,7 +1143,7 @@ export async function handler(
         ? `Found: ${findingSummaryParts.join(', ')}`
         : 'No issues detected in this PR.',
       detailsUrl: reviewDetailUrl,
-    });
+    }, STAGE);
 
     console.log(
       `Review complete for ${repoFullName}#${prNumber}: ${result.findings.length} findings`,
@@ -1170,7 +1175,7 @@ export async function handler(
         // #370 — attempt + parked-at + expectations: a parked review must be
         // distinguishable from a hung one at a glance.
         summary: rateLimitedCheckSummary(deliveryAttempt, new Date().toISOString()),
-      }).catch((checkErr) => {
+      }, STAGE).catch((checkErr) => {
         console.error('Failed to post rate-limited check run:', checkErr);
       });
 
@@ -1190,7 +1195,7 @@ export async function handler(
       conclusion: 'failure',
       title: 'Review failed',
       summary: `MergeWatch encountered an error: ${error instanceof Error ? error.message : 'Unknown error'}`,
-    });
+    }, STAGE);
 
     return {
       statusCode: 500,

--- a/packages/lambda/src/handlers/webhook.test.ts
+++ b/packages/lambda/src/handlers/webhook.test.ts
@@ -882,3 +882,34 @@ describe('handler — OSS pre-approval claim on install (#409)', () => {
     expect(mockClaimOssPreapproval).toHaveBeenCalledTimes(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// #416 — isMergeWatchCheckRun must match its own stage's check-run name
+// ---------------------------------------------------------------------------
+
+describe('isMergeWatchCheckRun — stage scoping (#416)', () => {
+  const ev = (name: string) => ({ check_run: { name } } as any);
+
+  it('prod matches the prod check name', () => {
+    expect(isMergeWatchCheckRun(ev('MergeWatch Review'))).toBe(true);
+    expect(isMergeWatchCheckRun(ev('MergeWatch Review'), 'prod')).toBe(true);
+  });
+
+  it('prod ignores a dev check run', () => {
+    // Otherwise prod would re-review on a "Re-run" click that belongs to dev.
+    expect(isMergeWatchCheckRun(ev('MergeWatch Review (dev)'))).toBe(false);
+  });
+
+  it('dev matches its own check run, not prod\'s', () => {
+    // The direction that breaks silently: scoping only the write side leaves
+    // dev publishing "MergeWatch Review (dev)" while still matching the bare
+    // prod name here, so its own Re-run button does nothing.
+    expect(isMergeWatchCheckRun(ev('MergeWatch Review (dev)'), 'dev')).toBe(true);
+    expect(isMergeWatchCheckRun(ev('MergeWatch Review'), 'dev')).toBe(false);
+  });
+
+  it('still ignores unrelated check runs in every stage', () => {
+    expect(isMergeWatchCheckRun(ev('CodeQL'))).toBe(false);
+    expect(isMergeWatchCheckRun(ev('CodeQL'), 'dev')).toBe(false);
+  });
+});

--- a/packages/lambda/src/handlers/webhook.ts
+++ b/packages/lambda/src/handlers/webhook.ts
@@ -20,6 +20,7 @@ import {
   REVIEW_TRIGGERING_ACTIONS,
   COMMENT_LOOKUP_ACTIONS,
   MERGEWATCH_CHECK_RUN_NAME,
+  checkRunName,
   classifyPrSource,
   fetchRepoConfig,
   mergeConfig,
@@ -42,6 +43,11 @@ import {
   DynamoReviewStore, DynamoFindingDispositionStore, DEFAULT_FINDING_DISPOSITIONS_TABLE,
 } from '@mergewatch/storage-dynamo';
 import { SSMGitHubAuthProvider, getWebhookSecret } from '../github-auth-ssm.js';
+// #416 — deployment stage, so review artifacts (comment marker, check-run
+// name) are scoped per stage. Absent means prod, which is the frozen
+// production identity — see packages/core/src/stage.ts.
+const STAGE = process.env.STAGE;
+
 
 // ---------------------------------------------------------------------------
 // AWS clients (re-used across warm invocations)
@@ -275,7 +281,7 @@ async function handlePullRequestEvent(
 
   let existingCommentId: number | undefined;
   if ((COMMENT_LOOKUP_ACTIONS as readonly string[]).includes(action)) {
-    const commentId = await findExistingBotComment(octokit, owner, repo, prNumber);
+    const commentId = await findExistingBotComment(octokit, owner, repo, prNumber, STAGE);
     if (commentId) {
       existingCommentId = commentId;
     }
@@ -348,7 +354,7 @@ async function handleIssueCommentEvent(
 
   const octokit = await authProvider.getInstallationOctokit(installationId);
   const existingCommentId =
-    (await findExistingBotComment(octokit, owner, repo, prNumber)) ?? undefined;
+    (await findExistingBotComment(octokit, owner, repo, prNumber, STAGE)) ?? undefined;
 
   // #400 — an issue_comment payload carries no head SHA, so without this fetch
   // the job runs with `headSha: undefined` and every downstream config read
@@ -455,8 +461,11 @@ async function handleReviewCommentEvent(
  * Exported for unit testing. We match by name (stable across deploys) since
  * check_run.app.id requires knowing our GitHub App ID at runtime.
  */
-export function isMergeWatchCheckRun(event: CheckRunEvent): boolean {
-  return event.check_run?.name === MERGEWATCH_CHECK_RUN_NAME;
+export function isMergeWatchCheckRun(event: CheckRunEvent, stage?: string): boolean {
+  // #416 — must resolve from the same stage `createCheckRun` wrote with. A
+  // non-prod stage publishes "MergeWatch Review (dev)"; matching only the prod
+  // name here would make it ignore its own "Re-run" clicks.
+  return event.check_run?.name === checkRunName(stage);
 }
 
 /**
@@ -466,7 +475,7 @@ export function isMergeWatchCheckRun(event: CheckRunEvent): boolean {
  */
 async function handleCheckRunEvent(event: CheckRunEvent): Promise<void> {
   if (event.action !== 'rerequested') return;
-  if (!isMergeWatchCheckRun(event)) return;
+  if (!isMergeWatchCheckRun(event, STAGE)) return;
 
   const installationId = event.installation?.id;
   if (!installationId) {
@@ -520,7 +529,7 @@ async function handleCheckRunEvent(event: CheckRunEvent): Promise<void> {
     : { source: undefined, agentKind: undefined };
 
   const existingCommentId =
-    (await findExistingBotComment(octokit, owner, repo, prNumber)) ?? undefined;
+    (await findExistingBotComment(octokit, owner, repo, prNumber, STAGE)) ?? undefined;
 
   await enqueueReviewJob({
     installationId,

--- a/packages/server/src/review-processor.test.ts
+++ b/packages/server/src/review-processor.test.ts
@@ -159,6 +159,7 @@ describe('processReviewJob — check runs', () => {
         title: 'Review in progress',
         summary: 'MergeWatch is reviewing PR #1...',
       }),
+      undefined, // #416 stage — unset in tests means prod
     );
   });
 
@@ -175,6 +176,7 @@ describe('processReviewJob — check runs', () => {
         title: 'Review skipped',
         summary: 'Only lockfile changes',
       }),
+      undefined, // #416 stage — unset in tests means prod
     );
   });
 
@@ -200,6 +202,7 @@ describe('processReviewJob — check runs', () => {
         title: 'Review skipped',
         summary: 'Draft PR skipped',
       }),
+      undefined, // #416 stage — unset in tests means prod
     );
   });
 
@@ -243,6 +246,7 @@ describe('processReviewJob — check runs', () => {
         title: 'Review failed',
         summary: 'MergeWatch encountered an error while reviewing this PR. Please try again or contact support if the issue persists.',
       }),
+      undefined, // #416 stage — unset in tests means prod
     );
   });
 
@@ -1085,7 +1089,7 @@ describe('processReviewJob — postSummaryOnClean (#350)', () => {
     const deps = makeDeps();
     await processReviewJob(makeJob(), deps);
 
-    expect(updateReviewComment).toHaveBeenCalledWith(mockOctokit, 'test', 'repo', 42, 'formatted comment');
+    expect(updateReviewComment).toHaveBeenCalledWith(mockOctokit, 'test', 'repo', 42, 'formatted comment', undefined);
     expect(postReviewComment).not.toHaveBeenCalled();
   });
 

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -21,6 +21,11 @@ import {
   findingMatchKeys,
 } from '@mergewatch/core';
 import type { WebhookDeps } from './webhook-handler.js';
+// #416 — deployment stage, so review artifacts (comment marker, check-run
+// name) are scoped per stage. Absent means prod, which is the frozen
+// production identity — see packages/core/src/stage.ts.
+const STAGE = process.env.STAGE;
+
 
 // -- LLM cost pricing (#233) -------------------------------------------------
 
@@ -373,7 +378,7 @@ export async function processReviewJob(
     status: 'in_progress',
     title: 'Review in progress',
     summary: `MergeWatch is reviewing PR #${prNumber}...`,
-  }).catch((err) => console.warn('Failed to create in-progress check run:', err));
+  }, STAGE).catch((err) => console.warn('Failed to create in-progress check run:', err));
 
   // yamlConfig was fetched earlier for the autoReview silent-skip gate and
   // is reused below for includePatterns + runtimeConfig — no second round-trip.
@@ -391,7 +396,7 @@ export async function processReviewJob(
       conclusion: 'neutral',
       title: 'Review skipped',
       summary: skipReason,
-    }).catch((err) => console.warn('Failed to create skip check run:', err));
+    }, STAGE).catch((err) => console.warn('Failed to create skip check run:', err));
     console.log(`Skipped ${repoFullName}#${prNumber}: ${skipReason}`);
     await clearEyes();
     return;
@@ -472,7 +477,7 @@ export async function processReviewJob(
       conclusion: 'neutral',
       title: 'Review skipped',
       summary: rulesSkip.reason,
-    }).catch((err) => console.warn('Failed to create rules skip check run:', err));
+    }, STAGE).catch((err) => console.warn('Failed to create rules skip check run:', err));
     console.log(`Rules skip ${repoFullName}#${prNumber} (${rulesSkip.kind}): ${rulesSkip.reason}`);
     await clearEyes();
     return;
@@ -724,7 +729,7 @@ export async function processReviewJob(
       deps.dispositionStore,
       installationId,
       repoFullName,
-    );
+    STAGE);
 
     // Compute cumulative cost across all reviews on this PR
     const prevCost = prevReviewsResult.reduce((sum, r) => sum + (r.estimatedCostUsd ?? 0), 0);
@@ -781,7 +786,7 @@ export async function processReviewJob(
     // Look up existing comment: job payload → store → API scan
     let targetCommentId = job.existingCommentId
       || (prevReviewsResult.find((r) => r.commentId && r.prNumberCommitSha !== prNumberCommitSha)?.commentId as number | undefined)
-      || (await findExistingBotComment(octokit, owner, repo, prNumber)) || undefined;
+      || (await findExistingBotComment(octokit, owner, repo, prNumber, STAGE)) || undefined;
 
     // #350 — postSummaryOnClean: false means a clean PR gets no comment. Only
     // the INITIAL post is gated: an existing MergeWatch comment is always
@@ -792,10 +797,10 @@ export async function processReviewJob(
     if (stayingSilent) {
       console.log('[post-summary] clean PR and postSummaryOnClean=false — staying silent on %s#%d', repoFullName, prNumber);
     } else if (targetCommentId) {
-      await updateReviewComment(octokit, owner, repo, targetCommentId, comment);
+      await updateReviewComment(octokit, owner, repo, targetCommentId, comment, STAGE);
       commentId = targetCommentId;
     } else {
-      commentId = await postReviewComment(octokit, owner, repo, prNumber, comment);
+      commentId = await postReviewComment(octokit, owner, repo, prNumber, comment, STAGE);
     }
 
     if (!commentId && !stayingSilent) {
@@ -803,7 +808,7 @@ export async function processReviewJob(
     }
 
     // ── Step B: Build inline comments for critical findings ──────────────
-    let inlineComments = buildInlineComments(result.findings, prContext.files, result.changedLines);
+    let inlineComments = buildInlineComments(result.findings, prContext.files, result.changedLines, STAGE);
 
     // Filter out carried-over findings (same file+line+title as previous review)
     if (prevComplete?.findings && inlineComments.length > 0) {
@@ -969,7 +974,7 @@ export async function processReviewJob(
       detailsUrl: deps.dashboardBaseUrl
         ? `${deps.dashboardBaseUrl}/dashboard/reviews/${encodeURIComponent(repoFullName)}/${encodeURIComponent(prNumberCommitSha)}`
         : undefined,
-    }).catch((err) => console.warn('Failed to create completion check run:', err));
+    }, STAGE).catch((err) => console.warn('Failed to create completion check run:', err));
 
     console.log(`Review complete: ${repoFullName}#${prNumber} — score ${result.mergeScore}/5, ${result.findings.length} findings, ${durationMs}ms`);
   } catch (err) {
@@ -985,7 +990,7 @@ export async function processReviewJob(
         status: 'in_progress',
         title: 'Review queued — rate limited',
         summary: 'The model provider is rate limiting requests. MergeWatch will retry this review shortly.',
-      }).catch((checkErr) => console.warn('Failed to post rate-limited check run:', checkErr));
+      }, STAGE).catch((checkErr) => console.warn('Failed to post rate-limited check run:', checkErr));
       throw err;
     }
 
@@ -998,7 +1003,7 @@ export async function processReviewJob(
       conclusion: 'failure',
       title: 'Review failed',
       summary: 'MergeWatch encountered an error while reviewing this PR. Please try again or contact support if the issue persists.',
-    }).catch((checkErr) => console.warn('Failed to create error check run:', checkErr));
+    }, STAGE).catch((checkErr) => console.warn('Failed to create error check run:', checkErr));
     throw err;
   } finally {
     await clearEyes();

--- a/packages/server/src/webhook-handler.ts
+++ b/packages/server/src/webhook-handler.ts
@@ -2,8 +2,13 @@ import { createHmac, timingSafeEqual } from 'crypto';
 import type { Request, Response } from 'express';
 import type { IInstallationStore, IReviewStore, IFindingDispositionStore, IFPInsightStore, IPRLifecycleStore, ISatisfactionStore, IReviewCostStore, IGitHubAuthProvider, ILLMProvider, AgentReviewConfig } from '@mergewatch/core';
 import type { ReviewJobPayload, ReviewMode, PullRequestEvent, IssueCommentEvent, PullRequestReviewCommentEvent, InstallationEvent, CheckRunEvent, IReviewJobQueue } from '@mergewatch/core';
-import { REVIEW_TRIGGERING_ACTIONS, COMMENT_LOOKUP_ACTIONS, MERGEWATCH_CHECK_RUN_NAME, findExistingBotComment, classifyPrSource, fetchRepoConfig, mergeConfig, isBotActor, sweepInlineReactionsOnClose } from '@mergewatch/core';
+import { REVIEW_TRIGGERING_ACTIONS, COMMENT_LOOKUP_ACTIONS, MERGEWATCH_CHECK_RUN_NAME, checkRunName, findExistingBotComment, classifyPrSource, fetchRepoConfig, mergeConfig, isBotActor, sweepInlineReactionsOnClose } from '@mergewatch/core';
 import { processReviewJob } from './review-processor.js';
+// #416 — deployment stage, so review artifacts (comment marker, check-run
+// name) are scoped per stage. Absent means prod, which is the frozen
+// production identity — see packages/core/src/stage.ts.
+const STAGE = process.env.STAGE;
+
 
 /**
  * #355 — route a review job through the durable queue when wired, else run
@@ -215,7 +220,7 @@ async function handlePullRequest(payload: PullRequestEvent, deps: WebhookDeps) {
   let existingCommentId: number | undefined;
   if (octokit && (COMMENT_LOOKUP_ACTIONS as readonly string[]).includes(action)) {
     try {
-      const commentId = await findExistingBotComment(octokit, owner, repo, prNumber);
+      const commentId = await findExistingBotComment(octokit, owner, repo, prNumber, STAGE);
       if (commentId) existingCommentId = commentId;
     } catch (err) {
       console.warn('Failed to look up existing bot comment:', err);
@@ -338,8 +343,11 @@ async function handleReviewComment(payload: PullRequestReviewCommentEvent, deps:
  * True when a check_run event describes a MergeWatch-created check. Matches
  * by name since check_run.app.id requires knowing the GitHub App ID at runtime.
  */
-export function isMergeWatchCheckRun(event: CheckRunEvent): boolean {
-  return event.check_run?.name === MERGEWATCH_CHECK_RUN_NAME;
+export function isMergeWatchCheckRun(event: CheckRunEvent, stage?: string): boolean {
+  // #416 — must resolve from the same stage `createCheckRun` wrote with. A
+  // non-prod stage publishes "MergeWatch Review (dev)"; matching only the prod
+  // name here would make it ignore its own "Re-run" clicks.
+  return event.check_run?.name === checkRunName(stage);
 }
 
 /**
@@ -349,7 +357,7 @@ export function isMergeWatchCheckRun(event: CheckRunEvent): boolean {
  */
 async function handleCheckRun(payload: CheckRunEvent, deps: WebhookDeps) {
   if (payload.action !== 'rerequested') return;
-  if (!isMergeWatchCheckRun(payload)) return;
+  if (!isMergeWatchCheckRun(payload, STAGE)) return;
 
   const installationId = payload.installation?.id;
   if (!installationId) return;
@@ -386,7 +394,7 @@ async function handleCheckRun(payload: CheckRunEvent, deps: WebhookDeps) {
   const classification = await classifyPrSource(pr as never, octokit, agentReviewConfig);
 
   const existingCommentId =
-    (await findExistingBotComment(octokit, owner, repo, prNumber).catch(() => null)) ?? undefined;
+    (await findExistingBotComment(octokit, owner, repo, prNumber, STAGE).catch(() => null)) ?? undefined;
 
   const job: ReviewJobPayload = {
     installationId,


### PR DESCRIPTION
**Stage 1 of 3** for #416. Plan doc: `docs/feat/20260821-01-e2e-ab-tags-and-grading.plan.md` (included).

Lets the dev and prod Apps both review the same PR on one repo — the substrate for comparing a change against production on a **byte-identical diff**, which is impossible today.

## The collision this fixes

`findExistingBotComment` (`client.ts:251`) matches on the comment marker alone, with **no author filter**. With both Apps live, the second reviewer finds the first's comment and tries to update it — which GitHub rejects, since an App may only edit comments it authored.

New `packages/core/src/stage.ts`:

| Resolver | prod (absent stage) | `dev` |
|---|---|---|
| `reviewMarker()` | `<!-- mergewatch-review -->` | `<!-- mergewatch-review:dev -->` |
| `inlineMarker()` | `<!-- mergewatch-inline -->` | `<!-- mergewatch-inline:dev -->` |
| `checkRunName()` | `MergeWatch Review` | `MergeWatch Review (dev)` |

## ⚠️ Prod's strings are load-bearing

They're returned verbatim, never derived, and pinned by tests asserting the **literal** strings — deriving them from the implementation would make the tests agree with a regression.

Changing `<!-- mergewatch-review -->` even once orphans every bot comment on every open PR in the wild: the lookup returns null and the next review posts a duplicate instead of updating in place. That's the severe failure mode here, and it wouldn't be confined to fixtures.

Absent, empty, and whitespace stages all read as prod — self-hosted sets no `STAGE` and must not silently scope its markers.

## Both directions move together

These values are read as well as written, and scoping one side alone fails *silently*:

| Writer | Reader | If they disagree |
|---|---|---|
| `post`/`updateReviewComment` | `findExistingBotComment` | duplicate comment instead of an update |
| `createCheckRun` | `isMergeWatchCheckRun` (both runtimes) | the stage ignores its own "Re-run" button |
| `buildInlineComments` | `disposition-writer`, `inline-reply` | reactions and replies misattributed |

That last pair matters more than it looks: `inline-reply` uses the marker to confirm a thread is ours before replying, so a mismatch would make a stage either ignore its own threads or barge into another bot's.

## Where the stage comes from

An explicit parameter, never `process.env` inside core — that package is deliberately environment-agnostic (`llm/pricing.ts:106`: *"Pure + env-agnostic — the caller reads `process.env`"*). Each runtime resolves `STAGE` once at module load and threads it through 30 call sites.

## Verification

build 12/12 · typecheck 20/20 · test 21/21 — **937 core** (+17), **112 lambda** (+4), **121 server**

New coverage: prod identity frozen against literals; absent/empty/whitespace/`PROD` all resolve to prod; resolvers agree with the exported constants; dev and prod markers never substring-collide (the lookup uses `includes()`, so a prefix collision would be just as broken); each stage finds only its own comment when both are present; a pre-#416 comment is still found by prod; `isMergeWatchCheckRun` matches its own stage and not the other's.

Four server tests pinned exact argument lists and now assert the trailing stage argument **explicitly** rather than loosening the matcher — a silently dropped stage is precisely what would break the A/B.

## This PR is inert until two manual steps

Neither can be automated — they're GitHub App settings:

1. **Enable the dev App's webhook** — URL `https://fukmc5gjhk.execute-api.us-west-2.amazonaws.com/dev/webhook`, **Active**, secret matching SSM `/mergewatch/dev/github-webhook-secret`. The dev App has **zero webhook deliveries ever recorded** — GitHub isn't attempting delivery at all, which is why dev has been dark since 2026-06-25.
2. **Scope the dev App's `mergewatch` installation to `fixtures` only** — it currently sees `kitchensink`, which prod also sees, so enabling as-is double-reviews that repo.

Also worth a decision: `Ava-Listens` (4 repos) and `assistants-hub` (3 repos) are on the dev App and would start receiving dev-stack reviews the moment the webhook is on.

## Deferred

- **Stage 2** — `TAGS=` in `meta.env` + path→tag map + `--tag` / `--impacted-by` (in `mergewatch/fixtures`)
- **Stage 3** — `expect.json` + `grade-run.sh` + nightly Action + `--compare`

Adds **E2E-94** and `docs/pending/e2e-ab-testing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)