### PR TITLE
fix(core): dismiss only our own App's stale reviews (#418)

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -3270,6 +3270,8 @@ Then apply any fixture as usual (`scripts/apply-fixture.sh 01-clean-pr`).
 - [ ] Push a second commit → each stage **updates its own** comment in place; neither posts a duplicate and neither 403s trying to edit the other's
 - [ ] Click "Re-run" on the **dev** check → only dev re-reviews; prod's comment and check are untouched
 - [ ] Click "Re-run" on the **prod** check → only prod re-reviews
+- [ ] **Each stage keeps its own formal review** — prod shows `APPROVED` and dev shows `APPROVED`, neither `DISMISSED` (#418). Before that fix whichever stage reviewed second dismissed the other's review ~3s later
+- [ ] A third-party reviewer bot on the same PR (CopilotAI, dependabot, CodeQL) still has its review intact after a MergeWatch re-review (#418)
 - [ ] Inline findings carry the stage-scoped inline marker, and a 👍 on a dev inline comment is recorded against dev's stores only
 - [ ] On a repo with **only** the prod App, behavior is identical to before #416 — one comment, one check named `MergeWatch Review`
 
@@ -3278,6 +3280,8 @@ Then apply any fixture as usual (`scripts/apply-fixture.sh 01-clean-pr`).
 - ❌ A 403 in either stage's logs when updating a comment — it matched the other App's comment and tried to edit what it doesn't own
 - ❌ **Prod posts a duplicate comment on an existing PR** — the prod marker changed. This is the severe one: it orphans every bot comment in the wild, not just fixtures
 - ❌ Dev's "Re-run" button does nothing — `isMergeWatchCheckRun` still matches only the prod name, so dev ignores its own re-request
+- ❌ Either stage's formal review shows `DISMISSED` — `dismissStaleReviews` is dismissing across Apps again (#418). This also degrades prod on any repo the dev App shares with it
+- ❌ A third-party bot's review is dismissed — the #418 guard regressed, and MergeWatch is interfering with a vendor it has no business touching
 - ❌ Both stages reviewing `kitchensink` or any repo outside the A/B — the dev installation wasn't scoped down
 
 ---

--- a/packages/core/src/github/client.test.ts
+++ b/packages/core/src/github/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   mergeScoreToReviewEvent,
   buildInlineComments,
@@ -10,6 +10,9 @@ import {
   removePRReaction,
   submitPRReview,
   findExistingBotComment,
+  dismissStaleReviews,
+  resolveAppLogin,
+  __resetAppLoginCache,
 } from './client.js';
 import type { Octokit } from '@octokit/rest';
 
@@ -786,5 +789,152 @@ describe('findExistingBotComment — stage scoping (#416)', () => {
     // Back-compat: every comment written before #416 carries the bare marker.
     const octokit = octokitWith(['<!-- mergewatch-review -->\nold review']);
     expect(await findExistingBotComment(octokit, 'o', 'r', 1)).toBe(100);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #418 — dismissStaleReviews must only ever dismiss OUR OWN App's reviews
+// ---------------------------------------------------------------------------
+
+describe('dismissStaleReviews — only our own reviews (#418)', () => {
+  function octokitWith(reviews: Array<{ id: number; login: string; state?: string }>) {
+    const dismissed: number[] = [];
+    const octokit = {
+      pulls: {
+        listReviews: async () => ({
+          data: reviews.map((r) => ({
+            id: r.id,
+            state: r.state ?? 'APPROVED',
+            user: { login: r.login, type: 'Bot' },
+          })),
+        }),
+        dismissReview: async ({ review_id }: { review_id: number }) => {
+          dismissed.push(review_id);
+          return {};
+        },
+      },
+    } as any;
+    return { octokit, dismissed };
+  }
+
+  it('dismisses our own stale review', async () => {
+    const { octokit, dismissed } = octokitWith([{ id: 1, login: 'mergewatch' }]);
+    await dismissStaleReviews(octokit, 'o', 'r', 1, 'mergewatch');
+    expect(dismissed).toEqual([1]);
+  });
+
+  it('leaves the OTHER stage\'s review alone', async () => {
+    // The collision that surfaced this: dev and prod both installed on one
+    // repo, whichever ran second dismissed the other's review.
+    const { octokit, dismissed } = octokitWith([
+      { id: 1, login: 'mergewatch-ai-dev' },
+      { id: 2, login: 'mergewatch' },
+    ]);
+    await dismissStaleReviews(octokit, 'o', 'r', 1, 'mergewatch');
+    expect(dismissed).toEqual([2]);
+  });
+
+  it('leaves another vendor\'s bot alone', async () => {
+    // The pre-existing, customer-facing half: MergeWatch was dismissing
+    // CopilotAI / dependabot / CodeQL reviews on every re-review.
+    const { octokit, dismissed } = octokitWith([
+      { id: 1, login: 'copilot-pull-request-reviewer' },
+      { id: 2, login: 'dependabot' },
+      { id: 3, login: 'github-advanced-security' },
+      { id: 4, login: 'mergewatch' },
+    ]);
+    await dismissStaleReviews(octokit, 'o', 'r', 1, 'mergewatch');
+    expect(dismissed).toEqual([4]);
+  });
+
+  it('leaves a human review alone', async () => {
+    const { octokit, dismissed } = octokitWith([{ id: 1, login: 'santthosh' }]);
+    await dismissStaleReviews(octokit, 'o', 'r', 1, 'mergewatch');
+    expect(dismissed).toEqual([]);
+  });
+
+  it('skips reviews already dismissed', async () => {
+    const { octokit, dismissed } = octokitWith([
+      { id: 1, login: 'mergewatch', state: 'DISMISSED' },
+      { id: 2, login: 'mergewatch', state: 'CHANGES_REQUESTED' },
+    ]);
+    await dismissStaleReviews(octokit, 'o', 'r', 1, 'mergewatch');
+    expect(dismissed).toEqual([2]);
+  });
+
+  it('normalizes the [bot] suffix in either direction', async () => {
+    // REST and GraphQL disagree about the suffix; matching raw strings would
+    // silently fail to recognise our own review.
+    const { octokit, dismissed } = octokitWith([{ id: 1, login: 'mergewatch[bot]' }]);
+    await dismissStaleReviews(octokit, 'o', 'r', 1, 'mergewatch');
+    expect(dismissed).toEqual([1]);
+
+    const b = octokitWith([{ id: 2, login: 'mergewatch' }]);
+    await dismissStaleReviews(b.octokit, 'o', 'r', 1, 'MergeWatch[bot]');
+    expect(b.dismissed).toEqual([2]);
+  });
+
+  it('dismisses NOTHING when our identity is unknown', async () => {
+    // Fail-safe direction: leaving our own review stale is cosmetic, dismissing
+    // a stranger's is not. Also asserts we do not even list reviews.
+    for (const login of [undefined, null, '']) {
+      const { octokit, dismissed } = octokitWith([
+        { id: 1, login: 'mergewatch' },
+        { id: 2, login: 'dependabot' },
+      ]);
+      await dismissStaleReviews(octokit, 'o', 'r', 1, login as any);
+      expect(dismissed).toEqual([]);
+    }
+  });
+
+  it('survives a dismissReview failure without throwing', async () => {
+    const octokit = {
+      pulls: {
+        listReviews: async () => ({ data: [{ id: 1, state: 'APPROVED', user: { login: 'mergewatch' } }] }),
+        dismissReview: async () => { throw new Error('403'); },
+      },
+    } as any;
+    await expect(dismissStaleReviews(octokit, 'o', 'r', 1, 'mergewatch')).resolves.toBeUndefined();
+  });
+});
+
+describe('resolveAppLogin (#418)', () => {
+  beforeEach(() => __resetAppLoginCache());
+
+  it('reads our login from a comment we authored', async () => {
+    const octokit = {
+      issues: { getComment: async () => ({ data: { user: { login: 'mergewatch' } } }) },
+    } as any;
+    expect(await resolveAppLogin(octokit, 'o', 'r', 42)).toBe('mergewatch');
+  });
+
+  it('caches per key so the lookup costs one call per process', async () => {
+    let calls = 0;
+    const octokit = {
+      issues: {
+        getComment: async () => { calls++; return { data: { user: { login: 'mergewatch' } } }; },
+      },
+    } as any;
+    await resolveAppLogin(octokit, 'o', 'r', 1, 'k');
+    await resolveAppLogin(octokit, 'o', 'r', 2, 'k');
+    expect(calls).toBe(1);
+  });
+
+  it('keeps stages separate under different cache keys', async () => {
+    const make = (login: string) => ({
+      issues: { getComment: async () => ({ data: { user: { login } } }) },
+    }) as any;
+    expect(await resolveAppLogin(make('mergewatch'), 'o', 'r', 1, 'prod')).toBe('mergewatch');
+    expect(await resolveAppLogin(make('mergewatch-ai-dev'), 'o', 'r', 1, 'dev')).toBe('mergewatch-ai-dev');
+  });
+
+  it('returns null when the comment cannot be read', async () => {
+    const octokit = { issues: { getComment: async () => { throw new Error('404'); } } } as any;
+    expect(await resolveAppLogin(octokit, 'o', 'r', 1)).toBeNull();
+  });
+
+  it('returns null when the comment has no author', async () => {
+    const octokit = { issues: { getComment: async () => ({ data: {} }) } } as any;
+    expect(await resolveAppLogin(octokit, 'o', 'r', 1)).toBeNull();
   });
 });

--- a/packages/core/src/github/client.ts
+++ b/packages/core/src/github/client.ts
@@ -597,24 +597,102 @@ export async function dismissStaleReviews(
   owner: string,
   repo: string,
   prNumber: number,
+  selfLogin?: string | null,
 ): Promise<void> {
+  // #418 — dismiss ONLY our own App's reviews.
+  //
+  // This used to dismiss any review authored by a Bot, which is two bugs. It
+  // dismissed other vendors' bots (CopilotAI, dependabot, CodeQL, a customer's
+  // own reviewer) on every re-review — the exact interference the inline-reply
+  // path guards against. And with dev and prod both installed on one repo it
+  // made the two stages dismiss each other, which is how it was found.
+  //
+  // Without a known identity we dismiss NOTHING. Leaving our own stale review
+  // up is cosmetic; dismissing a stranger's is a correctness and trust problem,
+  // so the ambiguous case fails toward doing nothing.
+  if (!selfLogin) {
+    console.warn(
+      `[review] skipping stale-review dismissal on ${owner}/${repo}#${prNumber} — `
+      + 'own App login unknown, and dismissing another author\'s review is worse '
+      + 'than leaving ours stale (#418)',
+    );
+    return;
+  }
+
   const reviews = await octokit.pulls.listReviews({
     owner,
     repo,
     pull_number: prNumber,
   });
 
+  const want = normalizeLogin(selfLogin);
   for (const review of reviews.data) {
-    if (review.user?.type === 'Bot' && review.state !== 'DISMISSED') {
-      await octokit.pulls.dismissReview({
-        owner,
-        repo,
-        pull_number: prNumber,
-        review_id: review.id,
-        message: 'Superseded by new review on latest commit.',
-      }).catch(() => {});
-    }
+    if (review.state === 'DISMISSED') continue;
+    if (normalizeLogin(review.user?.login) !== want) continue;
+    await octokit.pulls.dismissReview({
+      owner,
+      repo,
+      pull_number: prNumber,
+      review_id: review.id,
+      message: 'Superseded by new review on latest commit.',
+    }).catch(() => {});
   }
+}
+
+/**
+ * Compare GitHub App logins.
+ *
+ * The `[bot]` suffix is reported inconsistently — REST and GraphQL disagree,
+ * and `gh pr view --json reviews` returns a bare `mergewatch` with
+ * `author.is_bot: null`. Matching raw strings therefore silently fails to
+ * recognise our own review, which is the failure mode that makes the caller
+ * dismiss nothing (or, before #418, dismiss everything).
+ */
+function normalizeLogin(login: string | null | undefined): string {
+  return (login ?? '').replace(/\[bot\]$/i, '').trim().toLowerCase();
+}
+
+/**
+ * Resolve the GitHub App login behind this installation client, from a comment
+ * the App itself authored (#418).
+ *
+ * Derived rather than configured: the review path already posts its summary
+ * comment before dismissing reviews, so the author of that comment IS us, in
+ * every stage and in self-hosted, with no env var to set and nothing to drift
+ * when an App is renamed. Costs one API call per process — the login is stable
+ * for the life of the App, so it is cached.
+ *
+ * Returns null when the comment can't be read; the caller treats that as
+ * "identity unknown" and declines to dismiss anything.
+ */
+const APP_LOGIN_CACHE = new Map<string, string>();
+
+export async function resolveAppLogin(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  commentId: number,
+  cacheKey = 'default',
+): Promise<string | null> {
+  const cached = APP_LOGIN_CACHE.get(cacheKey);
+  if (cached) return cached;
+
+  try {
+    const { data } = await octokit.issues.getComment({ owner, repo, comment_id: commentId });
+    const login = data.user?.login;
+    if (!login) return null;
+    APP_LOGIN_CACHE.set(cacheKey, login);
+    return login;
+  } catch {
+    // Best-effort: a failed lookup must not break the review, it just means we
+    // skip dismissal this time.
+    return null;
+  }
+}
+
+/** Test seam — the cache is process-wide and would otherwise leak between cases. */
+export function __resetAppLoginCache(): void {
+  APP_LOGIN_CACHE.clear();
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -128,6 +128,7 @@ export {
   submitPRReview,
   createStandaloneReviewComment,
   dismissStaleReviews,
+  resolveAppLogin,
   buildInlineComments,
   extractInlineCommentTitle,
   extractInlineCommentFingerprint,

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -73,7 +73,7 @@ import type {
   FileFetchOptions,
   ReviewDelta,
 } from '@mergewatch/core';
-import { buildWorkDoneSection, computeReviewDelta } from '@mergewatch/core';
+import { buildWorkDoneSection, computeReviewDelta, resolveAppLogin } from '@mergewatch/core';
 import { DynamoInstallationStore } from '@mergewatch/storage-dynamo';
 import {
 
@@ -978,7 +978,13 @@ export async function handler(
     // batched inline comments — no duplicate "Critical issues found" body.
     const reviewBody = '';
     try {
-      await dismissStaleReviews(octokit, owner, repo, prNumber);
+      // #418 — dismiss only OUR reviews. Our App login is read from the summary
+      // comment we just posted (cached per process); without it we skip
+      // dismissal rather than risk dismissing another App's or vendor's review.
+      const selfLogin = commentId
+        ? await resolveAppLogin(octokit, owner, repo, commentId, `lambda:${STAGE ?? 'prod'}`)
+        : null;
+      await dismissStaleReviews(octokit, owner, repo, prNumber, selfLogin);
       await submitPRReview(octokit, owner, repo, prNumber, reviewBody, reviewEvent, inlineComments);
     } catch (err) {
       console.warn('PR review submission failed — issue comment has the full review:', err);

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -6,7 +6,7 @@ import {
   loadCategoryDisputeRates,
   filterDiff,
   DEFAULT_CONFIG, mergeConfig,
-  BOT_COMMENT_MARKER, submitPRReview, dismissStaleReviews, mergeScoreToReviewEvent,
+  BOT_COMMENT_MARKER, submitPRReview, dismissStaleReviews, resolveAppLogin, mergeScoreToReviewEvent,
   buildInlineComments, extractInlineCommentTitle,
   fetchRepoConfig, fetchConventions,
   buildWorkDoneSection, computeReviewDelta,
@@ -837,7 +837,12 @@ export async function processReviewJob(
     // issues found" body.
     const reviewBody = '';
     try {
-      await dismissStaleReviews(octokit, owner, repo, prNumber);
+      // #418 — dismiss only OUR reviews; see the Lambda handler for the
+      // rationale. Identity comes from the comment we just wrote.
+      const selfLogin = commentId
+        ? await resolveAppLogin(octokit, owner, repo, commentId, `server:${STAGE ?? 'prod'}`)
+        : null;
+      await dismissStaleReviews(octokit, owner, repo, prNumber, selfLogin);
       await submitPRReview(octokit, owner, repo, prNumber, reviewBody, reviewEvent, inlineComments);
     } catch (err) {
       console.warn('PR review submission failed — issue comment has the full review:', err);


### PR DESCRIPTION
`Closes #418`

`dismissStaleReviews` filtered on **`review.user?.type === 'Bot'` and nothing else**, so it dismissed every bot's review on the PR.

## Two bugs in one line

**1. Cross-vendor — customer-facing today.** MergeWatch dismissed CopilotAI, dependabot, CodeQL, or a customer's own reviewer bot on every re-review. The inline-reply path guards against precisely this class of interference — `inline-reply.ts:473` names CopilotAI and dependabot explicitly — but `dismissStaleReviews` never got the same guard. This predates #416 entirely.

**2. Cross-stage — blocked the A/B.** With both Apps on one repo, whichever stage reviewed second dismissed the other's review. Observed live on `fixtures#707`:

```
15:00:36  mergewatch-ai-dev  DISMISSED   ← dev approved…
15:00:39  mergewatch         APPROVED    ← …prod dismissed it 3s later
```

It runs both ways, so enabling the dev App on any repo prod also reviews degrades prod's output. `mergewatch/kitchensink` is currently on both.

## The fix

Dismissal is scoped to reviews whose author matches our own App login.

**Identity is derived, not configured.** The review path already posts its summary comment before dismissing (`review-agent.ts:940/943` vs `:981`), so that comment's author *is* us — in every stage, in self-hosted, with no env var to set and nothing to drift when an App is renamed. One API call per process, cached.

I chose this over the three options I listed in the issue. An `GITHUB_APP_SLUG` env var was trivial but drifts silently on rename; a JWT `GET /app` lookup was most "correct" but needs a credential the review agent doesn't hold and a cold-start dependency. Deriving from a comment we demonstrably authored needs neither and self-corrects.

**Unknown identity dismisses nothing.** On the `postSummaryOnClean: false` path there's no comment, and the lookup can fail. Leaving our own review stale is cosmetic; dismissing a stranger's is a correctness and trust problem — so the ambiguous case fails toward inaction, and logs why.

**Logins compare with `[bot]` normalized.** REST and GraphQL disagree about the suffix, and `gh pr view --json reviews` returns a bare `mergewatch` with `author.is_bot: null`. Matching raw strings would silently fail to recognise our own review — that exact mismatch already bit the #416 grader, so it's pinned by a test here.

## Tests (+13, 950 core total)

`dismissStaleReviews`: dismisses our own · leaves the **other stage's** alone · leaves **CopilotAI / dependabot / CodeQL** alone · leaves humans alone · skips already-`DISMISSED` · normalizes `[bot]` in both directions · dismisses **nothing** for `undefined` / `null` / `''` identity · survives a `dismissReview` 403 without throwing.

`resolveAppLogin`: reads the login · caches to one call per process · keeps stages separate under different cache keys · returns null on a failed lookup · returns null when the comment has no author.

## Verification

build 12/12 · typecheck 20/20 · test 21/21

Extends **E2E-94** with the review-state expectation this unblocks and a third-party-bot case, plus the two matching failure modes.

## Note on rollout

This is a **behavior change in production**: MergeWatch stops dismissing other bots' reviews. That's the fix, and it's stated plainly rather than shipped quietly. Prod's deploy is currently parked at the approval gate on an earlier run, so this won't reach production until that's cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)