### PR TITLE
feat(billing): record GitHub Marketplace purchases for attribution (#421)

### DIFF
--- a/docs/marketplace-listing.md
+++ b/docs/marketplace-listing.md
@@ -44,6 +44,16 @@ A Marketplace event carries an **account** (login + numeric id), never an instal
 
 For a free plan GitHub processes the purchase **before** redirecting to install, so purchase-then-install is the normal order and the one that must work. Because the record is account-keyed and durable, neither ordering loses the purchase.
 
+### Known limitation — install-then-purchase is not attached
+
+Attachment runs on `installation.created`. If an account that **already** has the App installed later buys the free plan from the listing, the `#MARKETPLACE` record is written but never denormalized onto that installation's `#SETTINGS` row.
+
+Attribution is not lost — the record exists and is queryable by account login. Only the convenience copy is missing, so a query joining on `marketplaceAccountLogin` would miss those installations while a query over the `#MARKETPLACE` partition would not.
+
+Fixing it properly requires resolving an account login to an installation, which needs either a table scan (the installations table is partitioned by `installationId`) or an App JWT the review path does not hold. Neither is justified for attribution. Pinned by a test so the behavior is a deliberate tradeoff rather than an accident.
+
+Under a free plan GitHub processes the purchase before redirecting to install, so this is the uncommon ordering.
+
 ### Deliberate non-behaviors
 
 **`cancelled` revokes nothing.** With a free plan and Stripe-side paid billing, a Marketplace cancellation says nothing about whether the customer still has the App installed or credits on file. Revoking would look like obvious symmetry and would quietly break a paying customer.

--- a/docs/marketplace-listing.md
+++ b/docs/marketplace-listing.md
@@ -1,0 +1,69 @@
+# GitHub Marketplace listing — webhook and attribution
+
+**Status:** ✅ Shipped (#421)
+
+MergeWatch is listed on the GitHub Marketplace with a **free plan only**. Discovery and installation happen through the listing; **money never does**. Paid conversion stays on MergeWatch's own SaaS billing — Stripe prepaid credits, the 5-review free tier, and OSS grants (`docs/oss-program.md`).
+
+That single decision removes the entire double-billing risk class: there is no plan→entitlement mapping, no Marketplace branch in `billingCheck` / `recordReview`, and no path where a customer is charged by both GitHub and Stripe.
+
+## Listing configuration
+
+The listing's **Manage webhook** section takes three values:
+
+| Field | Value |
+|---|---|
+| Payload URL | the `WebhookUrl` output of the stage's stack — prod: `https://wet81p7nzf.execute-api.us-west-2.amazonaws.com/prod/webhook` |
+| Content type | **`application/json`** |
+| Secret | the same value as SSM `/mergewatch/{stage}/github-webhook-secret` |
+
+**Content type is not a preference.** `verifySignature` computes HMAC-SHA256 over the **raw request body**. `application/x-www-form-urlencoded` wraps the payload as `payload=<urlencoded>`, which breaks both `JSON.parse` and the signature comparison.
+
+**The secret must match the App's webhook secret**, because the listing reuses the App's `/webhook` endpoint and one route verifies against one secret. Marketplace events are distinguished by the `X-GitHub-Event: marketplace_purchase` header, exactly as `installation` and `pull_request` are.
+
+A dedicated `/marketplace` route with its own secret was considered and rejected: it duplicates signature handling for no behavioral gain. It becomes worth it only if Marketplace and App secrets need independent rotation.
+
+## What the handler does
+
+Records the purchase for **attribution** — which installations arrived via Marketplace, on what plan, and when. It grants nothing, because installation already grants access, and it **revokes nothing**.
+
+### Storage
+
+A Marketplace event carries an **account** (login + numeric id), never an installation, and the installations table is partitioned by `installationId` — so a login cannot be resolved to an installation without scanning. Rather than scan, the account-keyed row *is* the record, under a `#MARKETPLACE` sentinel partition (the same idiom as `#SETTINGS`, `#AGENTS`, `#PENDING-OSS`):
+
+| Field | Meaning |
+|---|---|
+| `repoFullName` | Sort key — the **lowercased** account login. Not a repository. |
+| `accountLogin` / `accountId` | GitHub's original casing, and the immutable numeric id. |
+| `planName` / `planId` | The plan at the time of the event. |
+| `lastAction` | Most recent action seen. |
+| `purchasedAt` | First `purchased` sighting. **Never overwritten** — a redelivery must not move when the account arrived. |
+| `cancelledAt` | Set on `cancelled`. Recorded only. |
+| `attachedInstallationId` / `attachedAt` | Set once `installation.created` attached the record. |
+
+`installation.created` then attaches it, writing `marketplaceAccountLogin`, `marketplaceAccountId`, `marketplacePlanName`, and `marketplaceAttachedAt` onto that installation's `#SETTINGS` row so the dashboard needs no second lookup.
+
+For a free plan GitHub processes the purchase **before** redirecting to install, so purchase-then-install is the normal order and the one that must work. Because the record is account-keyed and durable, neither ordering loses the purchase.
+
+### Deliberate non-behaviors
+
+**`cancelled` revokes nothing.** With a free plan and Stripe-side paid billing, a Marketplace cancellation says nothing about whether the customer still has the App installed or credits on file. Revoking would look like obvious symmetry and would quietly break a paying customer.
+
+**Re-attaching is a no-op.** `installation.created` is redeliverable, and an uninstall/reinstall produces a new installation id. Keeping the first attachment means the record reflects where the purchase originally landed rather than flapping.
+
+**Failures never propagate.** GitHub surfaces failed deliveries on the listing and retries; a retry storm over an attribution record would be a self-inflicted outage. Every path returns 200.
+
+**SaaS only.** Behind `isSaas()` — self-hosted has no Marketplace listing.
+
+### The tripwire
+
+`changed`, `pending_change`, and `pending_change_cancelled` should never occur under a free-only listing. If one arrives it means a **paid plan was added to the listing** and this handler is now under-scoped. It is still recorded, and it logs:
+
+```
+[marketplace] UNDER-SCOPED: action=changed for <account>. The listing is
+supposed to carry a free plan only — a plan change implies paid plans were
+added, which needs entitlement mapping (see #421).
+```
+
+If paid plans are ever added, three things become required at once: plan→entitlement mapping, a Marketplace branch in `billingCheck` / `recordReview`, and revocation on cancel. That log line is the signal that the day has arrived.
+
+Scenario: **E2E-97**.

--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -227,6 +227,7 @@ A **`—`** in the Tags column means the scenario has **no fixture directory** a
 | [E2E-87](#e2e-87-337--date-only-range-bounds-include-their-whole-day) | `/api/analytics` date-only `start_date`/`end_date` expand to the UTC day's edge instants at the boundary (`end_date=2026-08-16` includes the whole 16th); full timestamps pass through untouched; identical on both backends; UTC bucketing documented in the route (#337) | 2m | 30s | #337 | `rollup` |
 | [E2E-88](#e2e-88-355--pr-burst-resilience) | A PR burst never silently loses reviews: throttles park the review (`pending` + in_progress "rate limited" check, never terminal FAILURE) and admission control paces the backlog — SQS `MaximumConcurrency` on SaaS, Postgres `SKIP LOCKED` worker at `REVIEW_CONCURRENCY` on self-hosted; exhaustion lands in a DLQ/`status='dead'`, visibly (#355) | 20m | n/a | #355 | — |
 | [E2E-95](#e2e-95-416--selective-suite-runs-by-tag-mode-or-changed-paths) | `TAGS`/`MODE` on every fixture; `--tag` / `--mode` / `--changed-files` resolve a subset; unmapped paths and unknown tags fail loudly rather than silently running nothing (#416) | 2m | n/a | fixtures#705 | `tooling` |
+| [E2E-97](#e2e-97-421--marketplace-purchase-recorded-and-attached) | A Marketplace `purchased` is recorded under `#MARKETPLACE` and attached to the installation on `installation.created`; redelivery does not double-record or move `purchasedAt`; `cancelled` revokes nothing (#421) | 5m | 60s | #422 | `marketplace` |
 | [E2E-96](#e2e-96-416--deterministic-grading-of-a-suite-run) | `grade-run.mjs` asserts a run against `expect.json` with no model, exits 1 on regression; UNGRADED is never PASS; `--compare` reports dev/prod divergence (#416) | 3m | n/a | fixtures#706 | `tooling` |
 | [E2E-94](#e2e-94-416--dev-and-prod-review-the-same-pr-without-colliding) | With both Apps installed on one repo, a single PR gets two independent reviews — separate comment markers, separate check runs, each stage updating only its own and re-running only from its own button; prod's identity is byte-identical to pre-#416 (#416) | 5m | 2m | #416 | — |
 | [E2E-93](#e2e-93-409--oss-operator-lifecycle-org-grants-pre-approval-inspect) | `grant-oss.ts --org` writes an org-scoped grant, `--preapprove` parks one for an uninstalled org (and refuses if they already installed), `--list-preapprovals` / `--inspect` render both, and the dashboard shows org-wide coverage rather than an empty repo list (#409) | 10m | n/a | #412 | — |
@@ -3351,6 +3352,38 @@ A fixture with no `expect.json` reports **UNGRADED**, never PASS. 10 of 98 fixtu
 - ❌ An UNGRADED fixture counted as PASS — makes the whole layer worthless
 - ❌ A fetch error reported as PASS: unverified is not the same as fine, so ERROR fails the gate
 - ❌ The grader agrees with itself on a deterministic field the LLM pass disagrees with — one of them has a bug worth reporting rather than papering over
+
+---
+
+### E2E-97: #421 — Marketplace purchase recorded and attached
+
+**Status:** 🚧 In review (#421).
+
+**Behavior:** the Marketplace listing's webhook points at the same `/webhook` endpoint as App events, distinguished by `X-GitHub-Event: marketplace_purchase`. A purchase is recorded under the `#MARKETPLACE` sentinel partition (SK = lowercased account login) for **attribution**, and attached to the installation on `installation.created`.
+
+The listing carries a **free plan only** — paid conversion stays on Stripe — so this grants nothing and **revokes nothing**. See `docs/marketplace-listing.md`.
+
+**Setup.** Requires the listing's Manage webhook configured: payload URL = the stage's `WebhookUrl`, content type **`application/json`**, secret = SSM `/mergewatch/{stage}/github-webhook-secret`.
+
+Trigger by installing the App from the Marketplace listing (which processes the free-plan purchase first), or by redelivering a `marketplace_purchase` from the listing's webhook delivery log.
+
+**Expected outcomes.**
+- [ ] `marketplace_purchase.purchased` returns 200 and logs `[marketplace] purchased recorded for <account> (id=…, plan=…)`
+- [ ] A row exists at PK `#MARKETPLACE`, SK = lowercased login, carrying `accountId`, `planName`, `purchasedAt`
+- [ ] After `installation.created`, that installation's `#SETTINGS` row carries `marketplaceAccountLogin` / `marketplaceAccountId` / `marketplacePlanName` / `marketplaceAttachedAt`, and the `#MARKETPLACE` row carries `attachedInstallationId`
+- [ ] Redeliver the purchase from the listing's delivery log → still **one** row, and `purchasedAt` is **unchanged**
+- [ ] `cancelled` sets `cancelledAt` and logs `— recorded only, nothing revoked`; the installation's OSS grant, balance, and `freeReviewsUsed` are all untouched
+- [ ] An install with **no** Marketplace record proceeds normally with no `[marketplace]` log line
+- [ ] Uninstall and reinstall → `attachedInstallationId` still points at the **first** installation, not the new one
+- [ ] A bad signature returns 401 and records nothing
+
+**Failure modes.**
+- ❌ The event falls through the dispatch `default:` and is silently ignored — 200 with nothing recorded, which is what shipped before #421 and is invisible from GitHub's delivery log
+- ❌ Content type set to `x-www-form-urlencoded` on the listing — the payload arrives as `payload=<urlencoded>`, so the signature fails and every delivery 401s
+- ❌ **`cancelled` revokes an entitlement** — with a free plan and Stripe-side billing the customer may still have the App installed and credits on file
+- ❌ A redelivery creates a second row or moves `purchasedAt` — attribution timestamps become meaningless
+- ❌ A `changed` / `pending_change` arrives without the `UNDER-SCOPED` warning — paid plans were added to the listing and nothing said so
+- ❌ A recording failure returns non-200 — GitHub retries, and a retry storm over an attribution record is self-inflicted
 
 ---
 

--- a/packages/billing/src/index.ts
+++ b/packages/billing/src/index.ts
@@ -38,6 +38,17 @@ export type {
   ClaimSkipReason,
 } from './oss-preapproval';
 
+// ─── GitHub Marketplace records (#421) ──────────────────────────────────────
+export {
+  MARKETPLACE_PK,
+  normalizeAccount,
+  getMarketplaceRecord,
+  listMarketplaceRecords,
+  recordMarketplaceEvent,
+  attachMarketplaceToInstallation,
+} from './marketplace';
+export type { MarketplaceRecord, AttachResult } from './marketplace';
+
 // ─── Cost calculation ───────────────────────────────────────────────────────
 export { calculateReviewCost } from './cost';
 export type { ReviewCost } from './cost';

--- a/packages/billing/src/marketplace.test.ts
+++ b/packages/billing/src/marketplace.test.ts
@@ -1,0 +1,195 @@
+/**
+ * #421 — GitHub Marketplace purchase records.
+ *
+ * The listing carries a free plan only, so the failure modes worth pinning are
+ * about *not* doing things: never revoking on cancel, never double-recording a
+ * redelivery, never resetting first-seen or detaching on a rewrite.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  MARKETPLACE_PK,
+  normalizeAccount,
+  getMarketplaceRecord,
+  recordMarketplaceEvent,
+  attachMarketplaceToInstallation,
+} from './marketplace';
+import type { MarketplaceRecord } from './marketplace';
+
+const table = 'installations';
+const NOW = new Date('2026-08-22T12:00:00.000Z');
+const LATER = new Date('2026-09-01T12:00:00.000Z');
+
+function event(action: string, overrides: Record<string, unknown> = {}) {
+  return {
+    action,
+    effective_date: '2026-08-22T12:00:00Z',
+    sender: { login: 'someone', id: 1, type: 'User' },
+    marketplace_purchase: {
+      account: { type: 'Organization', id: 9931, login: 'Acme-Corp' },
+      billing_cycle: 'monthly',
+      plan: { id: 77, name: 'Free', monthly_price_in_cents: 0 },
+      ...overrides,
+    },
+  } as any;
+}
+
+/** Minimal doc-client double that remembers what was written. */
+function makeClient(seed: MarketplaceRecord | null = null) {
+  const store = new Map<string, any>();
+  if (seed) store.set(`${seed.installationId}|${seed.repoFullName}`, seed);
+  const sent: { type: string; input: any }[] = [];
+
+  const client = {
+    send: vi.fn(async (cmd: any) => {
+      const type = cmd.constructor.name;
+      sent.push({ type, input: cmd.input });
+      const key = (k: any) => `${k.installationId}|${k.repoFullName}`;
+      if (type === 'GetCommand') return { Item: store.get(key(cmd.input.Key)) };
+      if (type === 'PutCommand') { store.set(key(cmd.input.Item), cmd.input.Item); return {}; }
+      if (type === 'UpdateCommand') {
+        const k = key(cmd.input.Key);
+        store.set(k, { ...(store.get(k) ?? cmd.input.Key), ...cmd.input.ExpressionAttributeValues });
+        return {};
+      }
+      if (type === 'QueryCommand') return { Items: [...store.values()] };
+      return {};
+    }),
+  } as any;
+
+  return { client, store, sent, of: (t: string) => sent.filter((s) => s.type === t) };
+}
+
+describe('normalizeAccount', () => {
+  it('lowercases and trims so login casing never splits a record', () => {
+    expect(normalizeAccount('Acme-Corp')).toBe('acme-corp');
+    expect(normalizeAccount('  ACME-CORP ')).toBe('acme-corp');
+  });
+});
+
+describe('recordMarketplaceEvent', () => {
+  it('records a purchase under the sentinel partition, keyed by lowercased login', async () => {
+    const h = makeClient();
+    const r = await recordMarketplaceEvent(h.client, table, event('purchased'), NOW);
+
+    expect(r.installationId).toBe(MARKETPLACE_PK);
+    expect(r.repoFullName).toBe('acme-corp');
+    expect(r.accountLogin).toBe('Acme-Corp');   // original casing kept for display
+    expect(r.accountId).toBe(9931);
+    expect(r.planName).toBe('Free');
+    expect(r.lastAction).toBe('purchased');
+    expect(r.purchasedAt).toBe(NOW.toISOString());
+  });
+
+  it('is idempotent — a redelivered purchase rewrites one row, not two', async () => {
+    const h = makeClient();
+    await recordMarketplaceEvent(h.client, table, event('purchased'), NOW);
+    await recordMarketplaceEvent(h.client, table, event('purchased'), LATER);
+
+    expect(h.store.size).toBe(1);
+  });
+
+  it('never moves purchasedAt on redelivery', async () => {
+    // First sighting is the attribution timestamp; a redelivery must not
+    // rewrite when the account arrived.
+    const h = makeClient();
+    await recordMarketplaceEvent(h.client, table, event('purchased'), NOW);
+    const again = await recordMarketplaceEvent(h.client, table, event('purchased'), LATER);
+
+    expect(again.purchasedAt).toBe(NOW.toISOString());
+    expect(again.updatedAt).toBe(LATER.toISOString());
+  });
+
+  it('records a cancellation WITHOUT revoking anything', async () => {
+    // With a free plan and Stripe-side paid billing, a Marketplace cancel says
+    // nothing about installs or credits. Recording it and changing nothing
+    // else is correct, not an omission.
+    const h = makeClient();
+    await recordMarketplaceEvent(h.client, table, event('purchased'), NOW);
+    const cancelled = await recordMarketplaceEvent(h.client, table, event('cancelled'), LATER);
+
+    expect(cancelled.cancelledAt).toBe(LATER.toISOString());
+    expect(cancelled.lastAction).toBe('cancelled');
+    // Attribution survives the cancellation.
+    expect(cancelled.purchasedAt).toBe(NOW.toISOString());
+    // Nothing was written to any installation's #SETTINGS row.
+    expect(h.of('UpdateCommand')).toHaveLength(0);
+  });
+
+  it('keeps an existing attachment when a later event rewrites the row', async () => {
+    const h = makeClient({
+      installationId: MARKETPLACE_PK, repoFullName: 'acme-corp',
+      accountLogin: 'Acme-Corp', accountId: 9931, lastAction: 'purchased',
+      purchasedAt: NOW.toISOString(), updatedAt: NOW.toISOString(),
+      attachedInstallationId: '4242', attachedAt: NOW.toISOString(),
+    });
+    const r = await recordMarketplaceEvent(h.client, table, event('cancelled'), LATER);
+    expect(r.attachedInstallationId).toBe('4242');
+  });
+
+  it('records an unexpected action rather than dropping it', async () => {
+    // A free-only listing should not produce these; if one arrives it must be
+    // visible in the data, not silently discarded.
+    const h = makeClient();
+    const r = await recordMarketplaceEvent(h.client, table, event('changed'), NOW);
+    expect(r.lastAction).toBe('changed');
+    // Not a purchase, so no purchase timestamp is invented.
+    expect(r.purchasedAt).toBeUndefined();
+  });
+
+  it('matches a record written under different login casing', async () => {
+    const h = makeClient();
+    await recordMarketplaceEvent(h.client, table, event('purchased'), NOW);
+    const found = await getMarketplaceRecord(h.client, table, 'ACME-CORP');
+    expect(found?.accountId).toBe(9931);
+  });
+});
+
+describe('attachMarketplaceToInstallation', () => {
+  const seeded = (): MarketplaceRecord => ({
+    installationId: MARKETPLACE_PK, repoFullName: 'acme-corp',
+    accountLogin: 'Acme-Corp', accountId: 9931, planName: 'Free',
+    lastAction: 'purchased', purchasedAt: NOW.toISOString(), updatedAt: NOW.toISOString(),
+  });
+
+  it('writes attribution onto the installation #SETTINGS row', async () => {
+    const h = makeClient(seeded());
+    const res = await attachMarketplaceToInstallation(h.client, table, '4242', 'Acme-Corp', LATER);
+
+    expect(res.attached).toBe(true);
+    const settings = h.of('UpdateCommand').find((c) => c.input.Key.repoFullName === '#SETTINGS')!;
+    expect(settings.input.Key.installationId).toBe('4242');
+    expect(settings.input.ExpressionAttributeValues[':login']).toBe('Acme-Corp');
+    expect(settings.input.ExpressionAttributeValues[':plan']).toBe('Free');
+  });
+
+  it('stamps the marketplace record with the installation it landed on', async () => {
+    const h = makeClient(seeded());
+    await attachMarketplaceToInstallation(h.client, table, '4242', 'Acme-Corp', LATER);
+
+    const stamp = h.of('UpdateCommand').find((c) => c.input.Key.installationId === MARKETPLACE_PK)!;
+    expect(stamp.input.ExpressionAttributeValues[':inst']).toBe('4242');
+  });
+
+  it('is a no-op with no marketplace record — the common case', async () => {
+    // Most installs do not come from Marketplace.
+    const h = makeClient();
+    const res = await attachMarketplaceToInstallation(h.client, table, '4242', 'nobody', LATER);
+
+    expect(res).toEqual({ attached: false, reason: 'no_record' });
+    expect(h.of('UpdateCommand')).toHaveLength(0);
+  });
+
+  it('does not re-attach, so a reinstall never flaps the attribution', async () => {
+    const h = makeClient({ ...seeded(), attachedInstallationId: '1111', attachedAt: NOW.toISOString() });
+    const res = await attachMarketplaceToInstallation(h.client, table, '9999', 'Acme-Corp', LATER);
+
+    expect(res).toEqual({ attached: false, reason: 'already_attached' });
+    expect(h.of('UpdateCommand')).toHaveLength(0);
+  });
+
+  it('resolves the record regardless of login casing', async () => {
+    const h = makeClient(seeded());
+    const res = await attachMarketplaceToInstallation(h.client, table, '4242', 'acme-corp', LATER);
+    expect(res.attached).toBe(true);
+  });
+});

--- a/packages/billing/src/marketplace.test.ts
+++ b/packages/billing/src/marketplace.test.ts
@@ -187,6 +187,26 @@ describe('attachMarketplaceToInstallation', () => {
     expect(h.of('UpdateCommand')).toHaveLength(0);
   });
 
+  it('KNOWN LIMITATION: install-then-purchase leaves the record unattached', async () => {
+    // Attach only runs on installation.created. If an already-installed account
+    // later buys the free plan from the listing, the record is written but
+    // never denormalized onto #SETTINGS, because a Marketplace event carries an
+    // account and resolving it to an installation would need a table scan or an
+    // App JWT — neither is cheap, and neither is in scope for attribution.
+    //
+    // Attribution is NOT lost: the #MARKETPLACE row exists and is queryable by
+    // account. Only the #SETTINGS convenience copy is missing. Pinned here so
+    // the behavior is a known tradeoff rather than an accident.
+    const h = makeClient();
+    await recordMarketplaceEvent(h.client, table, event('purchased'), NOW);
+
+    const record = await getMarketplaceRecord(h.client, table, 'Acme-Corp');
+    expect(record).not.toBeNull();
+    expect(record!.attachedInstallationId).toBeUndefined();
+    // Nothing was written to any installation row.
+    expect(h.of('UpdateCommand')).toHaveLength(0);
+  });
+
   it('resolves the record regardless of login casing', async () => {
     const h = makeClient(seeded());
     const res = await attachMarketplaceToInstallation(h.client, table, '4242', 'acme-corp', LATER);

--- a/packages/billing/src/marketplace.ts
+++ b/packages/billing/src/marketplace.ts
@@ -1,0 +1,222 @@
+/**
+ * #421 — GitHub Marketplace purchase records.
+ *
+ * The Marketplace listing carries a **free plan only**: discovery and install
+ * happen through Marketplace, but money never does. Paid conversion stays on
+ * MergeWatch's own SaaS billing (Stripe prepaid credits, the free tier, OSS
+ * grants). So nothing here grants entitlement and nothing here revokes it —
+ * these records exist for **attribution**: which installations arrived via
+ * Marketplace, on what plan, and when.
+ *
+ * It lives in `@mergewatch/billing` because that package already owns the
+ * SaaS-only installation-table helpers and `isSaas()`, not because Marketplace
+ * bills anything. If paid Marketplace plans are ever added, this is where the
+ * entitlement mapping would go and the naming stops being a compromise.
+ *
+ * ## Why the record is keyed by account, not installation
+ *
+ * A Marketplace event carries an **account** (login + numeric id), never an
+ * installation. The installations table is partitioned by `installationId`, so
+ * a login cannot be resolved to an installation without scanning.
+ *
+ * Rather than scan, the account-keyed row IS the durable record, under a
+ * `#MARKETPLACE` sentinel partition — the same idiom as `#SETTINGS`, `#AGENTS`,
+ * and `#PENDING-OSS`. `installation.created` then attaches it to the
+ * installation. A purchase is therefore never lost regardless of ordering, and
+ * for a free plan GitHub processes the purchase *before* redirecting to
+ * install, so purchase-then-install is the normal path.
+ */
+
+import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { GetCommand, PutCommand, QueryCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import type { MarketplacePurchaseEvent } from '@mergewatch/core';
+
+/** Partition key every Marketplace record shares. */
+export const MARKETPLACE_PK = '#MARKETPLACE';
+
+const SETTINGS_SK = '#SETTINGS';
+
+/**
+ * One account's Marketplace state.
+ *
+ * The sort key is the table's `repoFullName` attribute — an artifact of reusing
+ * the installations table, not a repository. It holds the **lowercased** account
+ * login; `accountLogin` keeps GitHub's original casing for display.
+ */
+export interface MarketplaceRecord {
+  /** Always `MARKETPLACE_PK`. */
+  installationId: string;
+  /** Sort key: lowercased account login. Not a repository. */
+  repoFullName: string;
+  /** The login as GitHub sent it. Display only. */
+  accountLogin: string;
+  /** GitHub's immutable numeric account id. */
+  accountId: number;
+  accountType?: string;
+  planName?: string;
+  planId?: number;
+  /** The most recent action seen for this account. */
+  lastAction: MarketplacePurchaseEvent['action'];
+  /** First time we saw a `purchased` for this account. Never overwritten. */
+  purchasedAt?: string;
+  /** Set on `cancelled`. Recorded only — nothing is revoked. */
+  cancelledAt?: string;
+  /** Last time any Marketplace event touched this record. */
+  updatedAt: string;
+  /** Set once `installation.created` attached this record to an installation. */
+  attachedInstallationId?: string;
+  attachedAt?: string;
+}
+
+/**
+ * GitHub logins are case-insensitive, and the login is the only join key we
+ * have between a purchase and an installation.
+ */
+export function normalizeAccount(login: string): string {
+  return login.trim().toLowerCase();
+}
+
+/** Read one account's Marketplace record, or null. */
+export async function getMarketplaceRecord(
+  client: DynamoDBDocumentClient,
+  table: string,
+  login: string,
+): Promise<MarketplaceRecord | null> {
+  const res = await client.send(new GetCommand({
+    TableName: table,
+    Key: { installationId: MARKETPLACE_PK, repoFullName: normalizeAccount(login) },
+  }));
+  return (res.Item as MarketplaceRecord | undefined) ?? null;
+}
+
+/** Every Marketplace record. Operational visibility — who came from the listing. */
+export async function listMarketplaceRecords(
+  client: DynamoDBDocumentClient,
+  table: string,
+): Promise<MarketplaceRecord[]> {
+  const out: MarketplaceRecord[] = [];
+  let lastKey: Record<string, unknown> | undefined;
+  do {
+    const res = await client.send(new QueryCommand({
+      TableName: table,
+      KeyConditionExpression: 'installationId = :pk',
+      ExpressionAttributeValues: { ':pk': MARKETPLACE_PK },
+      ExclusiveStartKey: lastKey,
+    }));
+    out.push(...((res.Items ?? []) as MarketplaceRecord[]));
+    lastKey = res.LastEvaluatedKey;
+  } while (lastKey);
+  return out.sort((a, b) => a.repoFullName.localeCompare(b.repoFullName));
+}
+
+/**
+ * Record a Marketplace event against its account.
+ *
+ * Idempotent by construction: the row is keyed by account, so a redelivered
+ * `purchased` rewrites the same row rather than adding a second one.
+ * `purchasedAt` and the attachment fields are preserved across rewrites —
+ * a redelivery must not reset when we first saw the account, and must not
+ * detach an installation we already attached.
+ *
+ * **`cancelled` revokes nothing.** With a free plan and Stripe-side paid
+ * billing, a Marketplace cancellation says nothing about whether the customer
+ * still has the App installed or credits on file. Recording it and changing
+ * nothing else is the correct behavior, not an omission.
+ */
+export async function recordMarketplaceEvent(
+  client: DynamoDBDocumentClient,
+  table: string,
+  event: MarketplacePurchaseEvent,
+  now: Date = new Date(),
+): Promise<MarketplaceRecord> {
+  const purchase = event.marketplace_purchase;
+  const account = purchase.account;
+  const sk = normalizeAccount(account.login);
+  const ts = now.toISOString();
+
+  const existing = await getMarketplaceRecord(client, table, account.login);
+
+  const record: MarketplaceRecord = {
+    installationId: MARKETPLACE_PK,
+    repoFullName: sk,
+    accountLogin: account.login,
+    accountId: account.id,
+    ...(account.type ? { accountType: account.type } : {}),
+    ...(purchase.plan?.name ? { planName: purchase.plan.name } : {}),
+    ...(purchase.plan?.id != null ? { planId: purchase.plan.id } : {}),
+    lastAction: event.action,
+    // First sighting wins — a redelivery must not move it.
+    ...(existing?.purchasedAt
+      ? { purchasedAt: existing.purchasedAt }
+      : event.action === 'purchased'
+        ? { purchasedAt: ts }
+        : {}),
+    ...(event.action === 'cancelled'
+      ? { cancelledAt: ts }
+      : existing?.cancelledAt
+        ? { cancelledAt: existing.cancelledAt }
+        : {}),
+    updatedAt: ts,
+    // Never drop an attachment we already made.
+    ...(existing?.attachedInstallationId
+      ? { attachedInstallationId: existing.attachedInstallationId, attachedAt: existing.attachedAt }
+      : {}),
+  };
+
+  await client.send(new PutCommand({ TableName: table, Item: record }));
+  return record;
+}
+
+export type AttachResult =
+  | { attached: true; record: MarketplaceRecord }
+  | { attached: false; reason: 'no_record' | 'already_attached' };
+
+/**
+ * Attach an account's Marketplace record to the installation it belongs to,
+ * called from `installation.created`.
+ *
+ * Writes attribution onto the installation's `#SETTINGS` row so the review path
+ * and dashboard can see it without a second lookup, and stamps the Marketplace
+ * record with the installation it landed on.
+ *
+ * Re-attaching is a no-op: `installation.created` is redeliverable, and an
+ * account that uninstalls and reinstalls gets a new installation id — keeping
+ * the first attachment means the record reflects where the purchase originally
+ * landed rather than flapping on reinstall.
+ */
+export async function attachMarketplaceToInstallation(
+  client: DynamoDBDocumentClient,
+  table: string,
+  installationId: string,
+  accountLogin: string,
+  now: Date = new Date(),
+): Promise<AttachResult> {
+  const record = await getMarketplaceRecord(client, table, accountLogin);
+  if (!record) return { attached: false, reason: 'no_record' };
+  if (record.attachedInstallationId) return { attached: false, reason: 'already_attached' };
+
+  const ts = now.toISOString();
+
+  await client.send(new UpdateCommand({
+    TableName: table,
+    Key: { installationId, repoFullName: SETTINGS_SK },
+    UpdateExpression:
+      'SET marketplaceAccountLogin = :login, marketplaceAccountId = :id, '
+      + 'marketplacePlanName = :plan, marketplaceAttachedAt = :at',
+    ExpressionAttributeValues: {
+      ':login': record.accountLogin,
+      ':id': record.accountId,
+      ':plan': record.planName ?? 'unknown',
+      ':at': ts,
+    },
+  }));
+
+  await client.send(new UpdateCommand({
+    TableName: table,
+    Key: { installationId: MARKETPLACE_PK, repoFullName: normalizeAccount(accountLogin) },
+    UpdateExpression: 'SET attachedInstallationId = :inst, attachedAt = :at',
+    ExpressionAttributeValues: { ':inst': installationId, ':at': ts },
+  }));
+
+  return { attached: true, record: { ...record, attachedInstallationId: installationId, attachedAt: ts } };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -261,6 +261,8 @@ export type {
   PullRequestReviewCommentEvent,
   GitHubReviewComment,
   InstallationEvent,
+  MarketplacePurchaseEvent,
+  MarketplacePurchase,
   CheckRunEvent,
   CheckRunPullRequestRef,
   WebhookEvent,

--- a/packages/core/src/types/github.ts
+++ b/packages/core/src/types/github.ts
@@ -200,6 +200,56 @@ export interface InstallationEvent {
 }
 
 /**
+ * GitHub Marketplace purchase event (#421).
+ *
+ * Delivered to the **listing's** webhook URL, which we point at the same
+ * `/webhook` endpoint as App events — the `X-GitHub-Event` header is what
+ * distinguishes them.
+ *
+ * Note this carries an `account`, not an installation: a purchase can arrive
+ * before the App is installed, and for a free plan GitHub processes the
+ * purchase *before* redirecting to install, so that is the normal order.
+ */
+export interface MarketplacePurchaseEvent {
+  action:
+    | 'purchased'
+    | 'changed'
+    | 'cancelled'
+    | 'pending_change'
+    | 'pending_change_cancelled';
+  /** ISO 8601 date the action takes effect. Pending changes are future-dated. */
+  effective_date?: string;
+  sender: GitHubUser;
+  marketplace_purchase: MarketplacePurchase;
+  /** Present on `changed` / `cancelled` for diffing against the prior plan. */
+  previous_marketplace_purchase?: MarketplacePurchase;
+}
+
+/** The purchase itself — plan, cycle, and the account that bought it. */
+export interface MarketplacePurchase {
+  account: {
+    type: string;
+    id: number;
+    login: string;
+    organization_billing_email?: string | null;
+  };
+  billing_cycle?: string | null;
+  unit_count?: number | null;
+  on_free_trial?: boolean;
+  free_trial_ends_on?: string | null;
+  next_billing_date?: string | null;
+  plan?: {
+    id: number;
+    name: string;
+    description?: string;
+    monthly_price_in_cents?: number;
+    yearly_price_in_cents?: number;
+    price_model?: string;
+    unit_name?: string | null;
+  };
+}
+
+/**
  * Minimal pull-request descriptor attached to a check_run event.
  * The full PR object isn't delivered on check_run webhooks — only a ref
  * pair + number. We resolve the full PR via the API when we need it.

--- a/packages/lambda/src/handlers/webhook.test.ts
+++ b/packages/lambda/src/handlers/webhook.test.ts
@@ -56,9 +56,13 @@ vi.mock('@aws-sdk/lib-dynamodb', () => ({
 
 const mockClaimOssPreapproval = vi.fn();
 const mockIsSaas = vi.fn(() => true);
+const mockRecordMarketplaceEvent = vi.fn();
+const mockAttachMarketplace = vi.fn();
 vi.mock('@mergewatch/billing', () => ({
   claimOssPreapproval: (...args: unknown[]) => mockClaimOssPreapproval(...args),
   isSaas: () => mockIsSaas(),
+  recordMarketplaceEvent: (...args: unknown[]) => mockRecordMarketplaceEvent(...args),
+  attachMarketplaceToInstallation: (...args: unknown[]) => mockAttachMarketplace(...args),
 }));
 
 vi.mock('../github-auth-ssm.js', () => ({
@@ -911,5 +915,159 @@ describe('isMergeWatchCheckRun — stage scoping (#416)', () => {
   it('still ignores unrelated check runs in every stage', () => {
     expect(isMergeWatchCheckRun(ev('CodeQL'))).toBe(false);
     expect(isMergeWatchCheckRun(ev('CodeQL'), 'dev')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #421 — GitHub Marketplace purchase events
+// ---------------------------------------------------------------------------
+
+describe('handler — marketplace_purchase (#421)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsSaas.mockReturnValue(true);
+    mockRecordMarketplaceEvent.mockResolvedValue({
+      accountLogin: 'Acme-Corp', accountId: 9931, planName: 'Free',
+    });
+  });
+
+  function marketplaceEvent(action = 'purchased') {
+    return {
+      action,
+      effective_date: '2026-08-22T12:00:00Z',
+      sender: { login: 'someone', id: 1, type: 'User' },
+      marketplace_purchase: {
+        account: { type: 'Organization', id: 9931, login: 'Acme-Corp' },
+        plan: { id: 77, name: 'Free', monthly_price_in_cents: 0 },
+      },
+    };
+  }
+
+  function apiEvent(payload: unknown, eventName = 'marketplace_purchase'): any {
+    const body = JSON.stringify(payload);
+    return {
+      body,
+      headers: { 'x-hub-signature-256': signBody(body), 'x-github-event': eventName },
+    };
+  }
+
+  it('records a purchase instead of silently ignoring it', async () => {
+    // Before #421 this fell through the dispatch `default:` — 200 OK, nothing
+    // recorded, and GitHub showing green deliveries the whole time.
+    const result = await handler(apiEvent(marketplaceEvent('purchased')));
+
+    expect(result.statusCode).toBe(200);
+    expect(mockRecordMarketplaceEvent).toHaveBeenCalledTimes(1);
+    const [, , passed] = mockRecordMarketplaceEvent.mock.calls[0];
+    expect(passed.action).toBe('purchased');
+    expect(passed.marketplace_purchase.account.login).toBe('Acme-Corp');
+  });
+
+  it('records a cancellation', async () => {
+    await handler(apiEvent(marketplaceEvent('cancelled')));
+    expect(mockRecordMarketplaceEvent).toHaveBeenCalledTimes(1);
+    expect(mockRecordMarketplaceEvent.mock.calls[0][2].action).toBe('cancelled');
+  });
+
+  for (const action of ['changed', 'pending_change', 'pending_change_cancelled']) {
+    it(`still records ${action}, and warns that the handler is under-scoped`, async () => {
+      // A free-only listing should not produce these. If one arrives it means
+      // paid plans were added — it must be visible, not swallowed.
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      await handler(apiEvent(marketplaceEvent(action)));
+
+      expect(mockRecordMarketplaceEvent).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls.flat().join(' ')).toMatch(/UNDER-SCOPED/);
+      warn.mockRestore();
+    });
+  }
+
+  it('ignores an event with no account rather than throwing', async () => {
+    const bad = { action: 'purchased', sender: {}, marketplace_purchase: {} };
+    const result = await handler(apiEvent(bad));
+
+    expect(result.statusCode).toBe(200);
+    expect(mockRecordMarketplaceEvent).not.toHaveBeenCalled();
+  });
+
+  it('still returns 200 when recording throws', async () => {
+    // GitHub surfaces failed deliveries on the listing and retries. A retry
+    // storm over an attribution record would be self-inflicted.
+    mockRecordMarketplaceEvent.mockRejectedValue(new Error('dynamo down'));
+    const result = await handler(apiEvent(marketplaceEvent('purchased')));
+    expect(result.statusCode).toBe(200);
+  });
+
+  it('does nothing in self-hosted mode', async () => {
+    mockIsSaas.mockReturnValue(false);
+    await handler(apiEvent(marketplaceEvent('purchased')));
+    expect(mockRecordMarketplaceEvent).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid signature before doing any work', async () => {
+    const body = JSON.stringify(marketplaceEvent('purchased'));
+    const result = await handler({
+      body,
+      headers: { 'x-hub-signature-256': 'sha256=deadbeef', 'x-github-event': 'marketplace_purchase' },
+    } as any);
+
+    expect(result.statusCode).toBe(401);
+    expect(mockRecordMarketplaceEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe('handler — marketplace attach on install (#421)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsSaas.mockReturnValue(true);
+    mockClaimOssPreapproval.mockResolvedValue({ claimed: false, reason: 'no_preapproval' });
+    mockAttachMarketplace.mockResolvedValue({ attached: false, reason: 'no_record' });
+  });
+
+  function installEvent(action = 'created') {
+    return {
+      action,
+      installation: {
+        id: 48210231,
+        account: { id: 9931, login: 'Acme-Corp' },
+        app_id: 1, target_type: 'Organization',
+        created_at: '2026-08-22T12:00:00Z', updated_at: '2026-08-22T12:00:00Z',
+      },
+      repositories: [{ id: 1, full_name: 'Acme-Corp/api', private: false }],
+      sender: { login: 'someone', id: 1, type: 'User' },
+    };
+  }
+
+  function apiEvent(payload: unknown): any {
+    const body = JSON.stringify(payload);
+    return { body, headers: { 'x-hub-signature-256': signBody(body), 'x-github-event': 'installation' } };
+  }
+
+  it('attempts an attach on installation.created', async () => {
+    await handler(apiEvent(installEvent('created')));
+
+    expect(mockAttachMarketplace).toHaveBeenCalledTimes(1);
+    const [, , installationId, login] = mockAttachMarketplace.mock.calls[0];
+    expect(installationId).toBe('48210231');
+    expect(login).toBe('Acme-Corp');
+  });
+
+  for (const action of ['deleted', 'suspend', 'new_permissions_accepted']) {
+    it(`never attaches on installation.${action}`, async () => {
+      await handler(apiEvent(installEvent(action)));
+      expect(mockAttachMarketplace).not.toHaveBeenCalled();
+    });
+  }
+
+  it('does not attach in self-hosted mode', async () => {
+    mockIsSaas.mockReturnValue(false);
+    await handler(apiEvent(installEvent('created')));
+    expect(mockAttachMarketplace).not.toHaveBeenCalled();
+  });
+
+  it('still returns 200 when the attach throws', async () => {
+    mockAttachMarketplace.mockRejectedValue(new Error('dynamo down'));
+    const result = await handler(apiEvent(installEvent('created')));
+    expect(result.statusCode).toBe(200);
   });
 });

--- a/packages/lambda/src/handlers/webhook.ts
+++ b/packages/lambda/src/handlers/webhook.ts
@@ -27,12 +27,18 @@ import {
   isBotActor,
   sweepInlineReactionsOnClose,
 } from '@mergewatch/core';
-import { claimOssPreapproval, isSaas } from '@mergewatch/billing';
+import {
+  claimOssPreapproval,
+  isSaas,
+  recordMarketplaceEvent,
+  attachMarketplaceToInstallation,
+} from '@mergewatch/billing';
 import type {
   PullRequestEvent,
   IssueCommentEvent,
   PullRequestReviewCommentEvent,
   InstallationEvent,
+  MarketplacePurchaseEvent,
   CheckRunEvent,
   ReviewMode,
   ReviewJobPayload,
@@ -593,6 +599,80 @@ async function claimOssPreapprovalIfAny(event: InstallationEvent): Promise<void>
   }
 }
 
+/**
+ * #421 — GitHub Marketplace purchase events.
+ *
+ * The listing's webhook points at this same endpoint; `X-GitHub-Event`
+ * distinguishes it. The listing carries a **free plan only** — paid conversion
+ * stays on MergeWatch's own SaaS billing — so this grants nothing and revokes
+ * nothing. It records the purchase for attribution: which installations came
+ * from Marketplace, on what plan, and when.
+ *
+ * Best-effort. A failure here must not 500: GitHub surfaces failed deliveries
+ * on the listing, and a retry storm over an attribution record would be a
+ * self-inflicted outage.
+ */
+async function handleMarketplaceEvent(event: MarketplacePurchaseEvent): Promise<void> {
+  if (!isSaas()) return;
+
+  const account = event.marketplace_purchase?.account;
+  if (!account?.login) {
+    console.warn('[marketplace] event has no account — ignoring', { action: event.action });
+    return;
+  }
+
+  const table = process.env.INSTALLATIONS_TABLE ?? "mergewatch-installations";
+
+  // A free-plan listing should only ever produce `purchased` and `cancelled`.
+  // Anything else means a paid plan was added to the listing and this handler
+  // is now under-scoped (#421) — say so loudly rather than recording it as
+  // though it were understood.
+  if (event.action !== 'purchased' && event.action !== 'cancelled') {
+    console.warn(
+      `[marketplace] UNDER-SCOPED: action=${event.action} for ${account.login}. `
+      + 'The listing is supposed to carry a free plan only — a plan change implies '
+      + 'paid plans were added, which needs entitlement mapping (see #421).',
+    );
+  }
+
+  try {
+    const record = await recordMarketplaceEvent(dynamodb, table, event);
+    console.log(
+      `[marketplace] ${event.action} recorded for ${record.accountLogin} `
+      + `(id=${record.accountId}, plan=${record.planName ?? 'unknown'})`
+      + (event.action === 'cancelled' ? ' — recorded only, nothing revoked' : ''),
+    );
+  } catch (err) {
+    console.warn(`[marketplace] failed to record ${event.action} for ${account.login}:`, err);
+  }
+}
+
+/**
+ * #421 — attach an account's Marketplace record to the installation it landed
+ * on. Best-effort for the same reason the OSS claim is: losing the installation
+ * record would be far worse than losing attribution.
+ */
+async function attachMarketplaceIfAny(event: InstallationEvent): Promise<void> {
+  if (!isSaas()) return;
+
+  const { account, id } = event.installation;
+  const table = process.env.INSTALLATIONS_TABLE ?? "mergewatch-installations";
+
+  try {
+    const result = await attachMarketplaceToInstallation(dynamodb, table, String(id), account.login);
+    if (result.attached) {
+      console.log(
+        `[marketplace] attached ${account.login} to install=${id} `
+        + `(plan=${result.record.planName ?? 'unknown'})`,
+      );
+    } else if (result.reason !== 'no_record') {
+      console.log(`[marketplace] not attached for ${account.login} install=${id} reason=${result.reason}`);
+    }
+  } catch (err) {
+    console.warn(`[marketplace] attach failed for ${account.login} (install=${id}):`, err);
+  }
+}
+
 async function handleInstallationEvent(
   event: InstallationEvent
 ): Promise<void> {
@@ -603,6 +683,7 @@ async function handleInstallationEvent(
   // pre-approval against an installation that is going away or already granted.
   if (event.action === "created") {
     await claimOssPreapprovalIfAny(event);
+    await attachMarketplaceIfAny(event);
   }
 
   console.log(
@@ -663,6 +744,10 @@ export async function handler(
 
       case "installation":
         await handleInstallationEvent(payload as InstallationEvent);
+        break;
+
+      case "marketplace_purchase":
+        await handleMarketplaceEvent(payload as MarketplacePurchaseEvent);
         break;
 
       default:


### PR DESCRIPTION
`Closes #421`

Publishing the App to the Marketplace requires a webhook on the listing. `marketplace_purchase` previously fell through the dispatch `default:` — it returned **200 and was silently dropped**, so GitHub showed green deliveries while nothing was recorded. That hides the gap rather than surfacing it.

## The decisions this implements

**Reuse `/webhook`** — Marketplace events are distinguished by the `X-GitHub-Event` header exactly as `installation` and `pull_request` are, so the listing's secret must equal the App's. A dedicated `/marketplace` route was rejected: it duplicates signature handling for no behavioral gain.

**Free plan only; paid stays on Stripe** — that removes the entire double-billing risk class. No plan→entitlement mapping, no Marketplace branch in `billingCheck`/`recordReview`, no path where someone is charged by both GitHub and Stripe. So this **grants nothing and revokes nothing** — it records the purchase for attribution.

### Listing configuration

| Field | Value |
|---|---|
| Payload URL | `https://wet81p7nzf.execute-api.us-west-2.amazonaws.com/prod/webhook` |
| Content type | **`application/json`** |
| Secret | same value as SSM `/mergewatch/prod/github-webhook-secret` |

Content type isn't a preference: `verifySignature` is HMAC-SHA256 over the **raw body**, and form-encoding wraps the payload as `payload=<urlencoded>` — every delivery would 401.

## Why storage is account-keyed

A Marketplace event carries an **account**, never an installation, and the installations table is partitioned by `installationId` — so a login can't be resolved to an installation without a scan.

Rather than scan, the `#MARKETPLACE` sentinel row **is** the record (SK = lowercased login, the same idiom as `#SETTINGS` / `#AGENTS` / `#PENDING-OSS`), and `installation.created` attaches it. For a free plan GitHub processes the purchase *before* redirecting to install, so purchase-then-install is the normal order — and account-keying means neither ordering loses it.

## Deliberate non-behaviors, each pinned by a test

**`cancelled` revokes nothing.** With a free plan and Stripe-side billing, a Marketplace cancellation says nothing about whether the customer still has the App installed or credits on file. Revoking would look like obvious symmetry and quietly break a paying customer. The test asserts zero writes to any `#SETTINGS` row.

**A redelivery never double-records and never moves `purchasedAt`** — that timestamp is the attribution signal, and a redelivery rewriting it makes the data meaningless.

**Re-attaching is a no-op**, so uninstall/reinstall doesn't flap the attribution onto a new installation id.

**Nothing propagates a failure.** GitHub surfaces failed deliveries on the listing and retries; a retry storm over an attribution record would be self-inflicted. Every path returns 200.

## The tripwire

`changed` / `pending_change` / `pending_change_cancelled` can't occur under a free-only listing. They're still recorded, and log:

```
[marketplace] UNDER-SCOPED: action=changed for <account>. The listing is
supposed to carry a free plan only — a plan change implies paid plans were
added, which needs entitlement mapping (see #421).
```

If paid plans are ever added, three things turn on at once: plan→entitlement mapping, a Marketplace branch in the billing gate, and revocation on cancel. That line is how you find out.

## Verification

build 12/12 · typecheck 20/20 · test 21/21 — **184 billing** (+16), **127 lambda** (+15)

Store: sentinel-partition keying and login normalization · idempotent redelivery (one row) · `purchasedAt` never moves · cancel records without revoking · attachment survives a later rewrite · unexpected actions recorded not dropped.

Dispatch: purchase and cancel recorded · all three unexpected actions warn `UNDER-SCOPED` · missing account ignored without throwing · recording failure still 200 · self-hosted no-ops · bad signature 401s before any work · attach fires only on `installation.created` and not on `deleted`/`suspend`/`new_permissions_accepted`.

Adds **E2E-97** and `docs/marketplace-listing.md`.

## Scope note

Self-hosted is untouched — there's no Marketplace listing for it, and the handler is behind `isSaas()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)