### PR TITLE
chore: default review model to Sonnet 4.6 for its 1M context (#423)

### DIFF
--- a/.mergewatch.yml
+++ b/.mergewatch.yml
@@ -4,7 +4,7 @@
 # All fields are optional; omitted fields use sensible defaults.
 
 # Primary model for review agents (Bedrock model ID).
-model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
+model: us.anthropic.claude-sonnet-4-6
 
 # Built-in review agents — toggle each on/off.
 agents:

--- a/docs-site/configuration/mergewatch-yml.mdx
+++ b/docs-site/configuration/mergewatch-yml.mdx
@@ -35,7 +35,7 @@ MergeWatch validates the `.mergewatch.yml` file on the first webhook it receives
 version: 1
 
 # Model used for all agents. Must be a valid Bedrock model ID.
-model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
+model: us.anthropic.claude-sonnet-4-6
 
 # Codebase awareness — enable agentic file fetching for cross-file context.
 codebaseAwareness: true
@@ -338,7 +338,7 @@ This enables all eight built-in agents with their default prompts, uses Claude S
 <Accordion title="Security-focused pipeline (e.g., payments service)">
 ```yaml .mergewatch.yml
 version: 1
-model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
+model: us.anthropic.claude-sonnet-4-6
 agents:
   style: false
   diagram: false

--- a/docs-site/deployment/architecture.mdx
+++ b/docs-site/deployment/architecture.mdx
@@ -14,7 +14,7 @@ graph TD
     A[GitHub] -->|pull_request webhook| B[API Gateway]
     B --> C[WebhookHandler Lambda<br/>512 MB · 30s timeout]
     C -->|InvocationType.Event<br/>async invoke| D[ReviewAgent Lambda<br/>1024 MB · 300s timeout]
-    D -->|Promise.all — 8 agents| E[Amazon Bedrock<br/>us.anthropic.claude-sonnet-4-5-20250929-v1:0]
+    D -->|Promise.all — 8 agents| E[Amazon Bedrock<br/>us.anthropic.claude-sonnet-4-6]
     D -->|Write review record| F[DynamoDB<br/>90-day TTL]
     D -->|Post comments + check run| A
 ```
@@ -28,7 +28,7 @@ graph TD
 | ReviewAgent | Lambda (Node 20, ARM64) | 1024 MB, 300s timeout | Fetch diff, fan out to 8 agents, post results |
 | DynamoDB | On-demand tables | 90-day TTL on reviews | Installation config, review history |
 | SSM Parameter Store | SecureString | KMS-encrypted | GitHub App credentials |
-| Bedrock | Model inference | `us.anthropic.claude-sonnet-4-5-20250929-v1:0` | Powers all 8 review agents |
+| Bedrock | Model inference | `us.anthropic.claude-sonnet-4-6` | Powers all 8 review agents |
 
 ### SaaS latency breakdown
 

--- a/docs-site/deployment/deployment-models.mdx
+++ b/docs-site/deployment/deployment-models.mdx
@@ -71,7 +71,7 @@ MergeWatch runs the full pipeline on AWS — API Gateway, Lambda functions, Dyna
 ```
 PR opened → GitHub webhook → MergeWatch API Gateway
   → WebhookHandler Lambda (512 MB, 30s) → ReviewAgent Lambda (1024 MB, 300s)
-  → Bedrock (us.anthropic.claude-sonnet-4-5-20250929-v1:0)
+  → Bedrock (us.anthropic.claude-sonnet-4-6)
   → Review posted to GitHub
   → DynamoDB (review history)
 ```

--- a/docs-site/deployment/sam-template.mdx
+++ b/docs-site/deployment/sam-template.mdx
@@ -24,7 +24,7 @@ The template accepts four parameters that control the deployment:
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `Stage` | String | `prod` | Deployment stage (`dev`, `staging`, `prod`). Scopes all resource names so multiple environments can coexist in the same AWS account. |
-| `DefaultBedrockModelId` | String | `us.anthropic.claude-sonnet-4-5-20250929-v1:0` | Default Bedrock model used by all agents. Can be overridden per-repo via `.mergewatch.yml`. |
+| `DefaultBedrockModelId` | String | `us.anthropic.claude-sonnet-4-6` | Default Bedrock model used by all agents. Can be overridden per-repo via `.mergewatch.yml`. |
 | `DeploymentMode` | String | `self-hosted` | Deployment mode. Set to `saas` to enable Stripe billing enforcement in the ReviewAgent and deploy the BillingHandler Lambda. `self-hosted` skips all billing checks. |
 | `DashboardBaseUrl` | String | `https://mergewatch.ai` | Base URL used in PR comment links that point back to the MergeWatch dashboard. |
 
@@ -122,7 +122,7 @@ resolve_s3 = true
 capabilities = "CAPABILITY_IAM"
 parameter_overrides = [
   "Stage=prod",
-  "DefaultBedrockModelId=us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+  "DefaultBedrockModelId=us.anthropic.claude-sonnet-4-6",
   "DeploymentMode=saas",
   "DashboardBaseUrl=https://mergewatch.example.com"
 ]
@@ -133,7 +133,7 @@ sam deploy \
   --stack-name mergewatch-staging \
   --parameter-overrides \
     Stage=staging \
-    DefaultBedrockModelId=us.anthropic.claude-sonnet-4-5-20250929-v1:0 \
+    DefaultBedrockModelId=us.anthropic.claude-sonnet-4-6 \
     DeploymentMode=self-hosted \
     DashboardBaseUrl=https://staging.mergewatch.example.com
 ```

--- a/docs-site/overview/how-it-works.mdx
+++ b/docs-site/overview/how-it-works.mdx
@@ -248,7 +248,7 @@ Codebase awareness is enabled by default. To revert to diff-only analysis (faste
     - **Billing mode:** On-demand (pay-per-request)
   </Card>
   <Card title="Amazon Bedrock">
-    - **Default model:** `us.anthropic.claude-sonnet-4-5-20250929-v1:0`
+    - **Default model:** `us.anthropic.claude-sonnet-4-6`
     - **Role:** Powers all eight review agents and the orchestrator
   </Card>
 </CardGroup>

--- a/docs-site/overview/introduction.mdx
+++ b/docs-site/overview/introduction.mdx
@@ -97,7 +97,7 @@ The managed SaaS runs on a serverless stack in MergeWatch's AWS account:
 - **AWS Lambda** — WebhookHandler (512 MB / 30 s) and ReviewAgent (1024 MB / 300 s)
 - **Amazon DynamoDB** — review state, repo config, user data
 - **API Gateway** — GitHub webhook receiver
-- **Amazon Bedrock** — Claude Sonnet (`us.anthropic.claude-sonnet-4-5-20250929-v1:0`)
+- **Amazon Bedrock** — Claude Sonnet (`us.anthropic.claude-sonnet-4-6`)
 
 Configuration lives in a `.mergewatch.yml` file at the root of each repository. The [dashboard](/dashboard/overview) provides a UI for monitoring reviews, managing repos, and adjusting settings.
 

--- a/docs-site/reference/troubleshooting.mdx
+++ b/docs-site/reference/troubleshooting.mdx
@@ -105,7 +105,7 @@ description: "Fixes for reviews not posting, webhooks not arriving, Docker conta
 
       ```yaml
       # .mergewatch.yml
-      model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
+      model: us.anthropic.claude-sonnet-4-6
       ```
 
       <Tip>

--- a/docs-site/saas/data-residency.mdx
+++ b/docs-site/saas/data-residency.mdx
@@ -11,7 +11,7 @@ When a pull request triggers a review, the PR diff is fetched by the **ReviewAge
 
 ## Bedrock model calls
 
-All LLM inference runs on Amazon Bedrock within MergeWatch's AWS account. The primary model is `us.anthropic.claude-sonnet-4-5-20250929-v1:0` for review agents. Lighter tasks such as summary generation and diagram creation use `us.anthropic.claude-haiku-4-5-20251001-v1:0` for cost efficiency. Model inputs (diff content, agent prompts) and outputs (review findings) exist only for the duration of the API call and are not logged or stored by MergeWatch beyond the review lifecycle.
+All LLM inference runs on Amazon Bedrock within MergeWatch's AWS account. The primary model is `us.anthropic.claude-sonnet-4-6` for review agents. Lighter tasks such as summary generation and diagram creation use `us.anthropic.claude-haiku-4-5-20251001-v1:0` for cost efficiency. Model inputs (diff content, agent prompts) and outputs (review findings) exist only for the duration of the API call and are not logged or stored by MergeWatch beyond the review lifecycle.
 
 ## What is stored
 

--- a/docs-site/saas/getting-started.mdx
+++ b/docs-site/saas/getting-started.mdx
@@ -33,7 +33,7 @@ When you open or update a pull request, the following happens in seconds:
 1. GitHub sends a `pull_request` webhook to MergeWatch's API Gateway.
 2. The **WebhookHandler** Lambda (512 MB, 30s timeout) validates the HMAC signature and invokes the **ReviewAgent** asynchronously.
 3. The **ReviewAgent** Lambda (1024 MB, 300s timeout) fetches the diff via the GitHub API.
-4. Eight specialized agents — **security**, **bugs**, **style**, **error handling**, **test coverage**, **comment accuracy**, **summary**, and **diagram** — run in parallel via `Promise.all()`, each calling Amazon Bedrock (`us.anthropic.claude-sonnet-4-5-20250929-v1:0`).
+4. Eight specialized agents — **security**, **bugs**, **style**, **error handling**, **test coverage**, **comment accuracy**, **summary**, and **diagram** — run in parallel via `Promise.all()`, each calling Amazon Bedrock (`us.anthropic.claude-sonnet-4-6`).
 5. Results are deduplicated, ranked by severity, and posted as inline review comments and a summary check run on your PR.
 
 <Note>

--- a/docs-site/self-hosting/install.mdx
+++ b/docs-site/self-hosting/install.mdx
@@ -65,7 +65,7 @@ LLM_MODEL=claude-opus-4-6
 | `NEXTAUTH_SECRET` | Yes | Random 32-byte secret for signing dashboard sessions (generate with `openssl rand -base64 32`) |
 | `ANTHROPIC_API_KEY` | If `LLM_PROVIDER=anthropic` | API key from [console.anthropic.com](https://console.anthropic.com) |
 | `LLM_PROVIDER` | No | Default: `anthropic`. Options: `anthropic`, `litellm`, `bedrock`, `ollama` |
-| `LLM_MODEL` | Yes for `anthropic` / `litellm` / `ollama` | Model ID. For Anthropic, use a native model ID like `claude-sonnet-4-5-20250929` — the built-in defaults are Bedrock inference profile IDs and only work for `LLM_PROVIDER=bedrock`. |
+| `LLM_MODEL` | Yes for `anthropic` / `litellm` / `ollama` | Model ID. For Anthropic, use a native model ID like `claude-sonnet-4-6` — the built-in defaults are Bedrock inference profile IDs and only work for `LLM_PROVIDER=bedrock`. |
 | `DASHBOARD_URL` | No | Public URL of the dashboard (e.g., `https://dashboard.example.com`). Used as the `NEXTAUTH_URL` for session callbacks. Defaults to `http://localhost:3001`. |
 | `DATABASE_URL` | No | Set automatically by docker-compose (Postgres sidecar) |
 | `PORT` | No | Default: `3000` |

--- a/docs-site/self-hosting/llm-providers/anthropic.mdx
+++ b/docs-site/self-hosting/llm-providers/anthropic.mdx
@@ -16,14 +16,14 @@ Set these environment variables in your `.env` file or container environment:
 | `LLM_MODEL` | Yes | Anthropic model ID to use (e.g., `claude-opus-4-6`) |
 
 <Note>
-When `LLM_PROVIDER=anthropic`, you **must** set `LLM_MODEL` to an Anthropic-native model ID. The built-in defaults (`us.anthropic.claude-sonnet-4-5-20250929-v1:0` for the primary model and `us.anthropic.claude-haiku-4-5-20251001-v1:0` for the light model) are [Bedrock inference profile IDs](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles.html) and are not valid on the Anthropic API.
+When `LLM_PROVIDER=anthropic`, you **must** set `LLM_MODEL` to an Anthropic-native model ID. The built-in defaults (`us.anthropic.claude-sonnet-4-6` for the primary model and `us.anthropic.claude-haiku-4-5-20251001-v1:0` for the light model) are [Bedrock inference profile IDs](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles.html) and are not valid on the Anthropic API.
 </Note>
 
 ## Model roles
 
 MergeWatch uses two model slots per review:
 
-- **Primary model** (`model` in `.mergewatch.yml`) — runs the agent pipeline (security, bugs, style, error handling, test coverage, comment accuracy). `claude-sonnet-4-5-20250929` matches the Bedrock default exactly. An Opus-tier model is a straight upgrade if cost allows.
+- **Primary model** (`model` in `.mergewatch.yml`) — runs the agent pipeline (security, bugs, style, error handling, test coverage, comment accuracy). `claude-sonnet-4-6` matches the Bedrock default exactly. An Opus-tier model is a straight upgrade if cost allows.
 - **Light model** (`lightModel` in `.mergewatch.yml`) — runs the summary and diagram passes. **`claude-haiku-4-5`** is the cost-optimized choice, and the native equivalent of the built-in `lightModel` default.
 
 Setting `LLM_MODEL` overrides **both** slots with the same model. For split primary/light models, configure them in `.mergewatch.yml` instead — see [mergewatch.yml reference](/configuration/mergewatch-yml).
@@ -35,15 +35,15 @@ Setting `LLM_MODEL` overrides **both** slots with the same model. For split prim
 LLM_PROVIDER=anthropic
 ANTHROPIC_API_KEY=sk-ant-api03-...
 
-# Pick a model — Sonnet 4.5 matches the Bedrock default
-LLM_MODEL=claude-sonnet-4-5-20250929
+# Pick a model — Sonnet 4.6 matches the Bedrock default
+LLM_MODEL=claude-sonnet-4-6
 ```
 
 ## Model suggestions
 
 | Anthropic model ID | Best for |
 | --- | --- |
-| `claude-sonnet-4-5-20250929` | The native equivalent of the built-in Bedrock default, so review behavior matches the documented defaults. |
+| `claude-sonnet-4-6` | The native equivalent of the built-in Bedrock default, so review behavior matches the documented defaults. |
 | `claude-sonnet-5` | Recommended. Current Sonnet tier — newer and stronger than 4.5 at comparable cost. |
 | `claude-opus-5` | Highest capability. Use when review quality matters more than per-token cost. |
 | `claude-haiku-4-5` | Cost-optimized. Faster and cheaper; the native equivalent of the built-in `lightModel`. |

--- a/docs-site/self-hosting/llm-providers/bedrock.mdx
+++ b/docs-site/self-hosting/llm-providers/bedrock.mdx
@@ -27,7 +27,7 @@ If MergeWatch runs on EC2, ECS, or Fargate, you can use an **IAM instance profil
 
 ## Default model
 
-MergeWatch uses **`us.anthropic.claude-sonnet-4-5-20250929-v1:0`** for review agents by default, and **`us.anthropic.claude-haiku-4-5-20251001-v1:0`** as the `lightModel` for low-complexity tasks such as summary generation. Both are **cross-region inference profiles** that route requests to the nearest available region.
+MergeWatch uses **`us.anthropic.claude-sonnet-4-6`** for review agents by default, and **`us.anthropic.claude-haiku-4-5-20251001-v1:0`** as the `lightModel` for low-complexity tasks such as summary generation. Both are **cross-region inference profiles** that route requests to the nearest available region.
 
 Override either with `model:` / `lightModel:` in `.mergewatch.yml` — see the [configuration reference](/configuration/mergewatch-yml).
 
@@ -65,7 +65,7 @@ Bedrock supports **cross-region inference profiles** that automatically route re
 | `eu.` | European regions (eu-west-1) |
 | `ap.` | Asia Pacific regions (ap-northeast-1, ap-southeast-1, ap-southeast-2) |
 
-The default model `us.anthropic.claude-sonnet-4-5-20250929-v1:0` uses the `us.` prefix, routing across US regions. If your deployment is in Europe or Asia Pacific, swap the prefix for the matching geography.
+The default model `us.anthropic.claude-sonnet-4-6` uses the `us.` prefix, routing across US regions. If your deployment is in Europe or Asia Pacific, swap the prefix for the matching geography.
 
 <Warning>
 Not every model is available as an inference profile in every geography, and the availability list changes over time. Before setting a prefixed ID, confirm the exact profile exists in your account — the [Bedrock Model Access console](https://console.aws.amazon.com/bedrock/home#/modelaccess) lists the inference profile IDs you can actually call. An ID that is valid in `us.` may not exist under `eu.` or `ap.`.
@@ -75,7 +75,7 @@ Not every model is available as an inference profile in every geography, and the
 
 ```bash
 # US cross-region (default)
-LLM_MODEL=us.anthropic.claude-sonnet-4-5-20250929-v1:0
+LLM_MODEL=us.anthropic.claude-sonnet-4-6
 
 # Europe cross-region — substitute a profile ID your account lists
 LLM_MODEL=eu.anthropic.<model-id>

--- a/infra/params/dev.env
+++ b/infra/params/dev.env
@@ -8,22 +8,27 @@
 
 # Bedrock model used for all review agents.
 #
-# Sonnet 4.5. Verified invocable on this account on 2026-08-20 with a live
+# Sonnet 4.6. Verified invocable on this account on 2026-08-22 with a live
 # InvokeModel — both the plain path (carrying `temperature: 0`, which this model
 # accepts) and the #390 forced-tool structured path returned successfully.
 # That verification is the gate: do not flip this line for any model until an
 # invoke succeeds, or the deploy ships a model that fails every review.
 #
+# WHY 4.6 OVER 4.5 (#423): context window. Sonnet 4.5 is 200K; Sonnet 4.6 is 1M,
+# at the same Sonnet-tier price. #414 moved the default from Opus 4.6 (1M) to
+# Sonnet 4.5 (200K) without noticing that anything depended on the larger
+# window — large PRs then hard-failed with "Input is too long for requested
+# model". 4.6 restores the window and keeps the cost saving.
+#
+# This is headroom, NOT the fix. There is still no input-size guard in the
+# review path, so a large enough diff overflows any window. See #423 and #424.
+#
 # Sonnet 5 (#262) remains blocked on this account: `us.anthropic.claude-sonnet-5`
 # returns AccessDeniedException ("not available for this account") even though
 # its Bedrock agreement, entitlement, authorization and region availability all
 # report AVAILABLE. Likely the Anthropic use-case submission, which no API
-# surfaces. Sonnet 4.5 is the reachable Sonnet-tier option in the meantime.
-#
-# NOTE: 4.5 is two generations behind the current Sonnet (4.6, then 5). It is
-# used here because it is what this account can actually invoke, not because it
-# is the best available model.
-DefaultBedrockModelId=us.anthropic.claude-sonnet-4-5-20250929-v1:0
+# surfaces.
+DefaultBedrockModelId=us.anthropic.claude-sonnet-4-6
 
 # Base URL used for dashboard links in PR comments.
 #

--- a/infra/params/prod.env
+++ b/infra/params/prod.env
@@ -30,14 +30,23 @@
 #
 # It is also what the rest of the repo now claims: template.yaml's parameter
 # Default, DEFAULT_CONFIG.model in packages/core, and this repo's own
-# .mergewatch.yml all name Sonnet 4.5.
+# .mergewatch.yml all name Sonnet 4.6.
+#
+# WHY 4.6 OVER 4.5 (#423): context window. Sonnet 4.5 is 200K; Sonnet 4.6 is 1M
+# at the same Sonnet-tier price. #414 moved the default from Opus 4.6 (1M) to
+# Sonnet 4.5 (200K) without noticing anything depended on the larger window;
+# large PRs then hard-failed with "Input is too long for requested model"
+# (santthosh/orca#116, #117). 4.6 restores the window and keeps the ~40% saving
+# over Opus 4.6.
+#
+# Headroom, NOT the fix. There is still no input-size guard in the review path,
+# so a large enough diff overflows any window. See #423 and #424.
 #
 # COST: Sonnet tier is $3/$15 per 1M base ($3.30/$16.50 on the `us.` profile we
-# actually bill at) versus Opus 4.6's $5.50/$27.50 — roughly 40% cheaper per
-# token. Priced in packages/core/src/llm/pricing.ts; an unpriced model makes
-# estimateCost return null and silently records zero-cost reviews.
+# actually bill at). Priced in packages/core/src/llm/pricing.ts; an unpriced
+# model makes estimateCost return null and silently records zero-cost reviews.
 #
-# Verified invocable on this account on 2026-08-20 with a live InvokeModel
+# Verified invocable on this account on 2026-08-22 with a live InvokeModel
 # carrying `temperature`, which this model accepts (unlike Opus 4.7+ and the 5
 # generation — see acceptsSamplingParams in packages/llm-bedrock). The #390
 # forced-tool structured path was verified in the same pass.
@@ -45,7 +54,7 @@
 # Sonnet 5 remains the intended destination (#262) and is cheaper still
 # ($2.20/$11), but it returns AccessDeniedException on this account despite
 # every Bedrock availability field reporting AVAILABLE.
-DefaultBedrockModelId=us.anthropic.claude-sonnet-4-5-20250929-v1:0
+DefaultBedrockModelId=us.anthropic.claude-sonnet-4-6
 
 # Base URL used for dashboard links in PR comments.
 DashboardBaseUrl=https://mergewatch.ai

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -52,7 +52,7 @@ Parameters:
   # via the modelId field in the mergewatch-installations table.
   DefaultBedrockModelId:
     Type: String
-    Default: us.anthropic.claude-sonnet-4-5-20250929-v1:0
+    Default: us.anthropic.claude-sonnet-4-6
     # WARNING (#264): this Default binds only when the stack is FIRST created.
     # On an update, CloudFormation retains the stack's existing value for any
     # parameter the deploy does not pass — editing this line does nothing to a

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -190,7 +190,7 @@ export interface MergeWatchConfig {
 }
 
 export const DEFAULT_CONFIG: MergeWatchConfig = {
-  model: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+  model: 'us.anthropic.claude-sonnet-4-6',
   lightModel: 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
   maxTokensPerAgent: 4096,
   agents: {

--- a/packages/core/src/llm/pricing.test.ts
+++ b/packages/core/src/llm/pricing.test.ts
@@ -41,12 +41,12 @@ describe('estimateCost', () => {
       expect(estimateCost('claude-opus-4-6', M, M)).toBeCloseTo(30, 6);
     });
 
-    it('Sonnet 4.5 — the deployment default — bills at $3.30/$16.50 on Bedrock, $3/$15 direct', () => {
+    it('Sonnet 4.5 bills at $3.30/$16.50 on Bedrock, $3/$15 direct', () => {
       expect(estimateCost('us.anthropic.claude-sonnet-4-5-20250929-v1:0', M, M)).toBeCloseTo(19.8, 6);
       expect(estimateCost('claude-sonnet-4-5-20250929', M, M)).toBeCloseTo(18, 6);
     });
 
-    it('Sonnet 4.6 bills at $3.30/$16.50 on Bedrock, $3/$15 direct', () => {
+    it('Sonnet 4.6 — the deployment default — bills at $3.30/$16.50 on Bedrock, $3/$15 direct', () => {
       expect(estimateCost('us.anthropic.claude-sonnet-4-6', M, M)).toBeCloseTo(19.8, 6);
       expect(estimateCost('claude-sonnet-4-6', M, M)).toBeCloseTo(18, 6);
     });

--- a/packages/llm-bedrock/src/bedrock-provider.ts
+++ b/packages/llm-bedrock/src/bedrock-provider.ts
@@ -22,6 +22,7 @@ import { StructuredOutputUnsupportedError } from '@mergewatch/core';
 // ─── Supported model IDs ───────────────────────────────────────────────────
 export const SUPPORTED_MODELS = {
   'claude-opus-4.6': 'us.anthropic.claude-opus-4-6-v1',
+  'claude-sonnet-4.6': 'us.anthropic.claude-sonnet-4-6',
   'claude-sonnet-4.5': 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
   'claude-sonnet-4': 'us.anthropic.claude-sonnet-4-20250514-v1:0',
   'claude-haiku-4.5': 'us.anthropic.claude-haiku-4-5-20251001-v1:0',


### PR DESCRIPTION
`Part of #423` · context for the longer-term work is in #424

## Why

#414 moved the default from Opus 4.6 to Sonnet 4.5 on cost. The two models do **not** share a context window:

| Model | Context |
|---|---|
| Opus 4.6 (before #414) | 1M |
| Sonnet 4.5 (after #414) | **200K** |
| Sonnet 4.6 (this PR) | **1M**, same Sonnet-tier price |

There is **no input-size guard anywhere in the review path**, so Opus 4.6's larger window had been silently absorbing big diffs. Large PRs then hard-failed with `Input is too long for requested model` — `santthosh/orca#116` and `#117`.

Sonnet 4.6 restores the window #414 lost while keeping the ~40% saving over Opus 4.6.

## Verified before flipping the line

`infra/params/*.env` requires a live invoke before this line moves, precisely so a deploy can't ship a model that fails every review. Two calls against `us-west-2`:

| Path | Result |
|---|---|
| Plain, carrying `temperature: 0` | 200 — `"OK"` |
| #390 forced-tool structured output | 200 — `stop_reason: tool_use`, schema-valid |

Both matter: every findings-bearing agent uses `invokeStructured`, so a model that invokes but can't do forced tool use would fail most of a review rather than none of it.

`acceptsSamplingParams` already handles this ID — neither the `opus-4-(7-9)` pattern nor the 5-generation pattern matches `sonnet-4-6`, so `temperature: 0` is still sent and reviews stay deterministic.

Already priced in `packages/core/src/llm/pricing.ts`, so the **"default model is always priced"** guard added in #414 covers this flip. That guard exists because an unpriced default silently records zero-cost reviews into `calculateReviewCost`, the OSS counters, and Stripe.

## ⚠️ This is headroom, not the fix

A large enough diff overflows any window. It raises the cliff 5×; it doesn't remove it. The input guard — artifact exclusion plus a pre-flight token budget — is separate work under #423, and the durable answer is the retrieval architecture in #424.

I'd rather say that plainly than let a green PR imply the problem is solved.

## Verification

build 12/12 · typecheck 20/20 · test 21/21

Also updated: `infra/params/{dev,prod}.env` (with the reasoning, so the next reader knows *why* 4.6 and not 4.5), `template.yaml`, `DEFAULT_CONFIG.model`, this repo's `.mergewatch.yml`, a `claude-sonnet-4.6` alias, 17 references across `docs-site/`, and the pricing-test labels so "the deployment default" names the right model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)