### PR TITLE
docs: flip E2E-98 to shipped with the production verification (#423)

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -3390,7 +3390,11 @@ Trigger by installing the App from the Marketplace listing (which processes the 
 
 ### E2E-98: #423 — oversized diffs skip with a reason, never hard-fail
 
-**Status:** 🚧 In review (#423).
+**Status:** ✅ SHIPPED (#426) — verified in production 2026-08-23 on `mergewatch/fixtures#708`.
+
+> **Verified run.** A 353KB machine-generated `tsconfig.tsbuildinfo` alongside a real source file carrying an off-by-one and a SQL injection. Logs: `Excluded 1 file(s) from diff: verify/tsconfig.tsbuildinfo` → `Review complete: 2 findings`. Both defects caught, verdict 1/5, no `ValidationException`.
+>
+> That run used **Sonnet 4.5** (`source=repo-config` — the fixtures repo pins it), the same 200K model that hard-failed `santthosh/orca#117`. So the fix is the artifact exclusion, not the larger context window — #425's Sonnet 4.6 is headroom, as claimed.
 
 **Behavior:** the review path now bounds its own input. Three layers, in order:
 


### PR DESCRIPTION
`Part of #423`

E2E-98 was written alongside #426 but had never been run. It has now been verified in production on [fixtures#708](https://github.com/mergewatch/fixtures/pull/708).

```
Excluded 1 file(s) from diff: verify/tsconfig.tsbuildinfo
Review complete for mergewatch/fixtures#708: 2 findings
```

A 353KB machine-generated `tsconfig.tsbuildinfo` alongside a real source file carrying an off-by-one and a SQL injection. Both defects caught, verdict 1/5, **no `ValidationException` on any path** — the failure mode #423 was filed for.

## The part worth recording

That run used **Sonnet 4.5** — `source=repo-config`, because the fixtures repo pins it in its own `.mergewatch.yml`. That's the same 200K model that hard-failed `santthosh/orca#117`.

So the fix is the **artifact exclusion**, not the larger context window. #425's Sonnet 4.6 is headroom exactly as both PR bodies claimed, and this is the evidence rather than the assertion. I've put that in the card so a future reader doesn't have to re-derive why the two PRs were framed the way they were.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)