### PR TITLE
chore(ci): 30-minute prod wait timer, and split dev/prod concurrency

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,22 @@
 # =============================================================================
 #
 # Pipeline:
-#   push to main → build & test → deploy to dev → deploy to prod (manual approval gate)
+#   push to main → build & test → deploy to dev → [30 min] → deploy to prod
 #   (prod also deployable on-demand via workflow_dispatch with deploy_prod=true)
+#
+# The production gate is a 30-minute WAIT TIMER, not an approval requirement.
+# Prod deploys on its own once the timer elapses; the window exists so a bad
+# merge can be stopped by cancelling the run, not so someone has to click
+# approve on every deploy.
+#
+# It used to be `required_reviewers`, and that failed in a specific way: a run
+# parked at the gate holds the `deploy-pipeline` concurrency lock, so every
+# later run queues behind it — including their DEV deploys. One run sat unapproved
+# for ~9.5 hours and GitHub cancelled the next run outright (only one run may be
+# pending per group). That very nearly shipped a merged-but-never-deployed
+# change: nothing anywhere reports "this landed on main but not in prod".
+#
+# With a timer the lock is held 30 minutes at most, and every merge reaches prod.
 #
 # Required GitHub Secrets:
 #   AWS_ROLE_ARN           — IAM role ARN for OIDC (e.g. arn:aws:iam::123456789012:role/mergewatch-github-deploy)
@@ -16,7 +30,9 @@
 #
 # Required GitHub Environments:
 #   development            — no protection rules needed
-#   production             — add "Required reviewers" for manual approval gate
+#   production             — "Wait timer" of 30 minutes, NO required reviewers.
+#                            Adding required reviewers back reintroduces the
+#                            parked-gate problem described above.
 #
 # Note: The Amplify web dashboard is managed via the AWS Console, not this pipeline.
 # =============================================================================


### PR DESCRIPTION
Two changes to how deploys are gated and serialized. Both come from the same failure.

## 1. The production gate is now a wait timer, not an approval

Already applied via the API; this PR updates the workflow's own docs, which still told operators to configure required reviewers.

```
before:  required_reviewers: 1 (santthosh)
after:   wait_timer: 30, reviewers: []
```

## 2. Dev and prod now have separate concurrency groups

```
before:  concurrency: { group: deploy-pipeline }   # whole workflow
after:   deploy-dev  → group: deploy-dev
         deploy-prod → group: deploy-prod
```

## Why — one failure, two causes

A run parked at the approval gate **held the workflow-wide `deploy-pipeline` lock**, so every later run queued behind it — *including their dev deploys*. One run sat unapproved for ~9.5 hours, and because GitHub keeps only one pending run per concurrency group, it **cancelled the next run outright**.

That cancelled run carried the Sonnet 4.6 default (#425). It survived only because deploys ship a *commit* rather than a diff, and the following run happened to contain it. **Reverse the merge order and a merged, closed, green change never reaches production** — with nothing anywhere reporting the gap.

Both changes are needed. The timer caps how long the gate holds anything at 30 minutes instead of indefinitely; the split means dev was never the right thing to hold hostage in the first place.

## What this trades

**Production now deploys unattended**, 30 minutes after merge. The window is an abort window — cancel the run to stop a bad merge. Build & Test and the dev deploy still gate it (`deploy-prod` needs `deploy-dev`), so a broken build or failed dev deploy still stops prod. What the timer does *not* do is check that dev is *healthy* before proceeding; it only waits.

**Neither group sets `cancel-in-progress`.** These jobs run `sam deploy`, and killing one mid-flight can strand the CloudFormation stack in `UPDATE_IN_PROGRESS` — worse than queueing behind it. Prod deploys therefore still serialize, which is what you want for ordered releases.

CI-config only — no application code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)