### PR TITLE
fix(core): validate agent findings shape before counting them (#401)

### DIFF
--- a/e2e/RUNBOOK.md
+++ b/e2e/RUNBOOK.md
@@ -227,6 +227,7 @@ A **`—`** in the Tags column means the scenario has **no fixture directory** a
 | [E2E-87](#e2e-87-337--date-only-range-bounds-include-their-whole-day) | `/api/analytics` date-only `start_date`/`end_date` expand to the UTC day's edge instants at the boundary (`end_date=2026-08-16` includes the whole 16th); full timestamps pass through untouched; identical on both backends; UTC bucketing documented in the route (#337) | 2m | 30s | #337 | `rollup` |
 | [E2E-88](#e2e-88-355--pr-burst-resilience) | A PR burst never silently loses reviews: throttles park the review (`pending` + in_progress "rate limited" check, never terminal FAILURE) and admission control paces the backlog — SQS `MaximumConcurrency` on SaaS, Postgres `SKIP LOCKED` worker at `REVIEW_CONCURRENCY` on self-hosted; exhaustion lands in a DLQ/`status='dead'`, visibly (#355) | 20m | n/a | #355 | — |
 | [E2E-95](#e2e-95-416--selective-suite-runs-by-tag-mode-or-changed-paths) | `TAGS`/`MODE` on every fixture; `--tag` / `--mode` / `--changed-files` resolve a subset; unmapped paths and unknown tags fail loudly rather than silently running nothing (#416) | 2m | n/a | fixtures#705 | `tooling` |
+| [E2E-99](#e2e-99-401--malformed-agent-output-is-disclosed-not-counted-as-suppression) | Agent responses that parse but return unusable findings no longer inflate the suppressed counter; they surface as a distinct "Malformed agent output" warning (#401) | 2m | 60s | #429 | `agents`, `output` |
 | [E2E-98](#e2e-98-423--oversized-diffs-skip-with-a-reason-never-hard-fail) | Build artifacts excluded by default and oversized files dropped by size; a diff still over the model's context budget yields a neutral "diff too large" skip naming sizes and remedy, never a raw ValidationException (#423) | 4m | 60s | #426 | `tooling`, `skip` |
 | [E2E-97](#e2e-97-421--marketplace-purchase-recorded-and-attached) | A Marketplace `purchased` is recorded under `#MARKETPLACE` and attached to the installation on `installation.created`; redelivery does not double-record or move `purchasedAt`; `cancelled` revokes nothing (#421) | 5m | 60s | #422 | `marketplace` |
 | [E2E-96](#e2e-96-416--deterministic-grading-of-a-suite-run) | `grade-run.mjs` asserts a run against `expect.json` with no model, exits 1 on regression; UNGRADED is never PASS; `--compare` reports dev/prod divergence (#416) | 3m | n/a | fixtures#706 | `tooling` |
@@ -3422,6 +3423,31 @@ Before this the diff went to the model unbounded: every fallback collapsed and t
 - ❌ A size drop is reported as a pattern exclusion, or not reported at all — the operator can't tell why a file vanished from review
 - ❌ The skip is silent (no check run) — worse than the hard failure, because nothing signals that the PR went unreviewed
 - ❌ An unknown model is assumed generous and overflows — the fallback must be the *smaller* window
+
+---
+
+### E2E-99: #401 — malformed agent output is disclosed, not counted as suppression
+
+**Status:** 🚧 In review (#401).
+
+**Behavior:** an agent response that parses as JSON but whose `findings` is not a usable array no longer contributes to `suppressedCount`. Only entries with a non-empty `title` count as findings; a response that is majority-junk (below 50% usable) is discarded entirely and reported as a **malformed agent output** warning, distinct from #382's **unparsed agent output**.
+
+Two production reviews reported `1430` and `3869 findings removed by dedup & quality filters` on 4-line diffs (fixtures#625, #628). Output tokens were normal — 3,794 and 3,233 — so nothing expensive happened: an agent emitted ~1,430 near-empty objects until `max_tokens` cut it off. The array parsed fine, every entry was correctly discarded downstream, and `suppressedCount` (raw − final) faithfully reported the junk as productive filtering. The counter was not lying; it was counting the wrong things.
+
+**Setup.** Hard to force deterministically — degenerate generation is a model behavior. Verify opportunistically on any suite run, and treat the unit tests in `packages/core/src/agents/parse-findings.test.ts` as the primary gate.
+
+**Expected outcomes.**
+- [ ] Across a full suite run, **no** review reports a suppressed count larger than plausible for its diff (single digits to low tens)
+- [ ] Where an agent does malfunction, the details drawer shows **⚠️ Malformed agent output — N agent response(s) returned unusable findings**, not an inflated Suppressed line
+- [ ] `[findings] DEGENERATE agent response: N of M entries unusable` appears in the logs when it happens
+- [ ] A normal review is unchanged — no new warning, suppressed counts still reflect real dedup work
+- [ ] `⚠️ Unparsed agent output` (#382) still appears independently for genuinely unparseable responses
+
+**Failure modes.**
+- ❌ An implausible Suppressed count reappears — something is still counting unvalidated entries toward `totalRawFindings`
+- ❌ A malfunctioning agent shows only an odd number and no warning — the disclosure regressed, and the symptom is again invisible
+- ❌ Real findings are dropped as "malformed" — the usability test is too strict; it requires only a non-empty `title`
+- ❌ The two warnings collapse into one message — a parse failure and a malformed shape have different causes and different remedies
 
 ---
 

--- a/packages/core/src/agents/parse-findings.test.ts
+++ b/packages/core/src/agents/parse-findings.test.ts
@@ -1,0 +1,115 @@
+/**
+ * #401 — suppressed-findings counter showed 1430 / 3869 on 4-line diffs.
+ *
+ * Diagnosis from production data: output tokens on both reviews were normal
+ * (3,794 and 3,233), so nothing expensive happened. An agent had emitted
+ * ~1,430 near-empty objects until `max_tokens` cut it off. The array parsed
+ * fine, every entry was discarded downstream, and `suppressedCount`
+ * (raw − final) faithfully reported the junk as "removed by dedup & quality
+ * filters" — describing an agent malfunction as productive work.
+ *
+ * These tests pin the shape validation, and the distinction between a
+ * malformed response and ordinary suppression.
+ */
+import { describe, it, expect } from 'vitest';
+import { parseAgentFindings, isUsableFinding } from './reviewer.js';
+import type { AgentDiagnostics } from './reviewer.js';
+
+const diag = (): AgentDiagnostics => ({ parseFailures: 0, degenerateResponses: 0 });
+const good = (title: string) => ({
+  file: 'src/a.ts', line: 1, severity: 'warning' as const,
+  title, description: 'd', suggestion: 's',
+});
+
+describe('isUsableFinding', () => {
+  it('accepts a finding with a title', () => {
+    expect(isUsableFinding(good('Null deref'))).toBe(true);
+  });
+
+  it('rejects the shapes that inflated the counter', () => {
+    for (const junk of [{}, null, undefined, '', 'a string', 42, [], { title: '' }, { title: '   ' }]) {
+      expect(isUsableFinding(junk)).toBe(false);
+    }
+  });
+});
+
+describe('parseAgentFindings', () => {
+  it('returns well-formed findings unchanged', () => {
+    const d = diag();
+    const out = parseAgentFindings(JSON.stringify({ findings: [good('A'), good('B')] }), d);
+    expect(out).toHaveLength(2);
+    expect(d.degenerateResponses).toBe(0);
+    expect(d.parseFailures).toBe(0);
+  });
+
+  it('reproduces #401: 1430 near-empty objects count as ZERO, not 1430', () => {
+    // The production failure. Before the fix these reached totalRawFindings
+    // and were reported as 1,430 suppressed findings.
+    const d = diag();
+    const out = parseAgentFindings(
+      JSON.stringify({ findings: Array.from({ length: 1430 }, () => ({})) }), d,
+    );
+    expect(out).toEqual([]);
+    expect(d.degenerateResponses).toBe(1);
+  });
+
+  it('flags a mostly-junk response as degenerate and discards ALL of it', () => {
+    // An agent that emitted 1,428 empty objects and 2 real findings has
+    // malfunctioned; keeping the 2 and reporting 1,428 suppressed would
+    // describe the malfunction as routine filtering.
+    const d = diag();
+    const findings = [...Array.from({ length: 1428 }, () => ({})), good('A'), good('B')];
+    expect(parseAgentFindings(JSON.stringify({ findings }), d)).toEqual([]);
+    expect(d.degenerateResponses).toBe(1);
+  });
+
+  it('keeps the good ones when only a few are malformed', () => {
+    // Above the ratio: ordinary partial junk, not a malfunction.
+    const d = diag();
+    const findings = [good('A'), good('B'), good('C'), {}];
+    const out = parseAgentFindings(JSON.stringify({ findings }), d);
+    expect(out.map((f) => f.title)).toEqual(['A', 'B', 'C']);
+    expect(d.degenerateResponses).toBe(0);
+  });
+
+  it('discards a non-array `findings` rather than counting its characters', () => {
+    // `.length` exists on strings, so an unchecked string would have
+    // contributed its character count to the raw total.
+    const d = diag();
+    const prose = 'x'.repeat(1430);
+    expect(parseAgentFindings(JSON.stringify({ findings: prose }), d)).toEqual([]);
+    expect(d.degenerateResponses).toBe(1);
+  });
+
+  it('discards an object `findings`', () => {
+    const d = diag();
+    expect(parseAgentFindings(JSON.stringify({ findings: { a: 1 } }), d)).toEqual([]);
+    expect(d.degenerateResponses).toBe(1);
+  });
+
+  it('treats a missing findings key as empty, not degenerate', () => {
+    // A legitimately clean review — no findings is the expected happy path.
+    const d = diag();
+    expect(parseAgentFindings(JSON.stringify({}), d)).toEqual([]);
+    expect(d.degenerateResponses).toBe(0);
+  });
+
+  it('treats an empty array as clean, not degenerate', () => {
+    const d = diag();
+    expect(parseAgentFindings(JSON.stringify({ findings: [] }), d)).toEqual([]);
+    expect(d.degenerateResponses).toBe(0);
+  });
+
+  it('counts unparseable JSON as a parse failure, not a degenerate response', () => {
+    // #382's diagnostic stays distinct from #401's — they have different causes
+    // and different remedies.
+    const d = diag();
+    expect(parseAgentFindings('not json at all', d)).toEqual([]);
+    expect(d.parseFailures).toBe(1);
+    expect(d.degenerateResponses).toBe(0);
+  });
+
+  it('works without a diagnostics object', () => {
+    expect(parseAgentFindings(JSON.stringify({ findings: [{}] }))).toEqual([]);
+  });
+});

--- a/packages/core/src/agents/reviewer.ts
+++ b/packages/core/src/agents/reviewer.ts
@@ -369,17 +369,94 @@ function safeParseJson<T>(raw: string, fallback: T, requiredKey?: string): T {
  */
 export interface AgentDiagnostics {
   parseFailures: number;
+  /**
+   * #401 — agent responses that parsed as JSON but whose `findings` was not a
+   * usable array of findings: a non-array value, or an array whose entries are
+   * mostly empty/malformed.
+   *
+   * Distinct from `parseFailures` on purpose. A parse failure is visibly
+   * broken; this one parses cleanly and looks like work got done, which is
+   * exactly why it went unnoticed — see the counter below.
+   */
+  degenerateResponses: number;
 }
 
-/** Shared findings-parse tail for every findings-bearing agent. */
-function parseAgentFindings(raw: string, diag?: AgentDiagnostics): AgentFinding[] {
+/**
+ * #401 — is this a usable finding, as opposed to a shape that merely occupies
+ * an array slot?
+ *
+ * A finding with no title carries nothing a reviewer could act on, and nothing
+ * downstream can render. Requiring one is the cheapest way to tell a real
+ * finding from `{}`.
+ */
+export function isUsableFinding(f: unknown): f is AgentFinding {
+  return !!f && typeof f === 'object' && typeof (f as AgentFinding).title === 'string'
+    && (f as AgentFinding).title.trim().length > 0;
+}
+
+/**
+ * Fraction of entries that must be usable before we trust the array at all.
+ *
+ * Below this the response is treated as degenerate rather than partially
+ * filtered: an agent that emitted 1,430 empty objects and two real findings has
+ * malfunctioned, and reporting "1,428 suppressed" describes that as routine
+ * dedup work.
+ */
+const DEGENERATE_USABLE_RATIO = 0.5;
+
+/**
+ * Shared findings-parse tail for every findings-bearing agent.
+ *
+ * #401 — validates the SHAPE, not just the JSON. Two production reviews
+ * reported "1430" and "3869 findings removed by dedup & quality filters" on
+ * 4-line diffs. Output-token counts were normal (3,794 and 3,233), so nothing
+ * expensive happened: an agent had emitted ~1,430 near-empty objects until
+ * `max_tokens` cut it off. The array parsed fine, every entry was correctly
+ * discarded downstream, and `suppressedCount` (raw − final) faithfully reported
+ * the junk as suppressed findings.
+ *
+ * The counter was not wrong so much as counting the wrong things. Validating
+ * here means only real findings ever reach the raw count, and a malfunctioning
+ * agent is reported as a malfunction instead of as productive filtering.
+ */
+export function parseAgentFindings(raw: string, diag?: AgentDiagnostics): AgentFinding[] {
   const parsed = tryParseJson<{ findings: AgentFinding[] }>(raw, 'findings');
   if (parsed === null) {
     console.warn('Could not parse agent JSON response, using fallback:', raw.trim().slice(0, 200));
     if (diag) diag.parseFailures++;
     return [];
   }
-  return parsed.findings ?? [];
+
+  const value = parsed.findings;
+  if (value == null) return [];
+
+  // `.length` exists on strings too, so an unchecked non-array silently
+  // contributes its character count to the raw total.
+  if (!Array.isArray(value)) {
+    console.warn(
+      '[findings] agent returned a non-array `findings` (%s) — discarding (#401)',
+      typeof value,
+    );
+    if (diag) diag.degenerateResponses++;
+    return [];
+  }
+
+  const usable = value.filter(isUsableFinding);
+  if (usable.length === value.length) return usable;
+
+  const dropped = value.length - usable.length;
+  if (usable.length < value.length * DEGENERATE_USABLE_RATIO) {
+    // Mostly junk — the agent malfunctioned rather than produced weak findings.
+    console.warn(
+      '[findings] DEGENERATE agent response: %d of %d entries unusable — discarding all (#401)',
+      dropped, value.length,
+    );
+    if (diag) diag.degenerateResponses++;
+    return [];
+  }
+
+  console.warn('[findings] dropped %d malformed finding(s) of %d (#401)', dropped, value.length);
+  return usable;
 }
 
 // ─── Agent invocation helper ────────────────────────────────────────────────
@@ -1453,6 +1530,12 @@ export interface ReviewPipelineResult {
    * `suppressedCount`; a non-zero value means findings may be missing.
    */
   parseFailureCount: number;
+  /**
+   * #401 — agents whose response parsed but was not a usable findings array.
+   * Surfaced like `parseFailureCount`: findings may be missing, and the cause
+   * is an agent malfunction rather than a parse error.
+   */
+  degenerateResponseCount: number;
   /** Number of enabled agents that ran */
   enabledAgentCount: number;
   /** Total input tokens used across all LLM invocations */
@@ -2568,7 +2651,7 @@ export async function runReviewPipeline(
   const changedFiles = Array.from(changedLines.keys());
 
   // #382 — collects agent-response parse failures for comment disclosure.
-  const diag: AgentDiagnostics = { parseFailures: 0 };
+  const diag: AgentDiagnostics = { parseFailures: 0, degenerateResponses: 0 };
 
   // Launch all enabled agents with bounded concurrency (see AGENT_CONCURRENCY).
   // Note: summary and diagram agents don't get file fetching (they benefit less from deep context)
@@ -2644,7 +2727,13 @@ export async function runReviewPipeline(
   // (totalRawFindings − filteredFindings.length) accurately reflects the
   // dedup work, alongside W10's same-region clustering + W11's coverage
   // suppression.
-  const totalRawFindings = taggedFindings.reduce((sum, t) => sum + (t.findings?.length ?? 0), 0);
+  // #401 — count only well-formed entries. parseAgentFindings already filters
+  // the built-in agents, but custom/org-agent results arrive by another path,
+  // and `.length` on any non-array would otherwise contribute silently.
+  const totalRawFindings = taggedFindings.reduce(
+    (sum, t) => sum + (Array.isArray(t.findings) ? t.findings.filter(isUsableFinding).length : 0),
+    0,
+  );
 
   // #385 — custom/org-agent findings are user-legislated policy, so they are
   // routed AROUND every model-taste layer: the orchestrator (whose
@@ -2929,6 +3018,7 @@ export async function runReviewPipeline(
     ...(disputeDisclosure ? { disputeDisclosure } : {}),
     suppressedCount: Math.max(0, totalRawFindings - filteredFindings.length),
     parseFailureCount: diag.parseFailures,
+    degenerateResponseCount: diag.degenerateResponses,
     enabledAgentCount,
     inputTokens: accumulator.totalInputTokens,
     outputTokens: accumulator.totalOutputTokens,

--- a/packages/core/src/comment-formatter.test.ts
+++ b/packages/core/src/comment-formatter.test.ts
@@ -647,3 +647,36 @@ describe('buildCheckTitle', () => {
       .toBe('1 critical issue found');
   });
 });
+
+describe('malformed agent output disclosure (#401)', () => {
+  const base = {
+    findings: [], mergeScore: 5 as const, mergeScoreReason: 'ok',
+    filesScanned: 1, linesReviewed: 4,
+  };
+
+  it('discloses a degenerate response so a malfunction is visible', () => {
+    const out = formatReviewComment({ ...base, degenerateResponseCount: 1 } as any);
+    expect(out).toContain('Malformed agent output');
+    expect(out).toContain('findings may be missing');
+  });
+
+  it('pluralizes correctly', () => {
+    const out = formatReviewComment({ ...base, degenerateResponseCount: 2 } as any);
+    expect(out).toContain('2 agent responses returned unusable findings');
+  });
+
+  it('says nothing when no response was degenerate', () => {
+    const out = formatReviewComment({ ...base, degenerateResponseCount: 0 } as any);
+    expect(out).not.toContain('Malformed agent output');
+  });
+
+  it('keeps the unparsed-output warning distinct from this one', () => {
+    // #382's parse failure and #401's malformed shape have different causes
+    // and different remedies — they must not collapse into one message.
+    const out = formatReviewComment({
+      ...base, parseFailureCount: 1, degenerateResponseCount: 1,
+    } as any);
+    expect(out).toContain('Unparsed agent output');
+    expect(out).toContain('Malformed agent output');
+  });
+});

--- a/packages/core/src/comment-formatter.ts
+++ b/packages/core/src/comment-formatter.ts
@@ -164,6 +164,13 @@ interface FormatOptions {
    * a non-zero value means findings may be missing from this review.
    */
   parseFailureCount?: number;
+  /**
+   * #401 — agents whose response parsed but was not a usable findings array
+   * (a non-array, or mostly-empty entries). Rendered as a reliability warning
+   * alongside unparsed output: findings may be missing, and the cause is an
+   * agent malfunction rather than a parse error.
+   */
+  degenerateResponseCount?: number;
   /** Number of enabled agents that ran */
   enabledAgentCount?: number;
   /** Total input tokens used */
@@ -324,6 +331,7 @@ export function formatReviewComment(options: FormatOptions): string {
     deltaCaption,
     suppressedCount,
     parseFailureCount,
+    degenerateResponseCount,
     inputTokens,
     outputTokens,
     estimatedCostUsd,
@@ -575,7 +583,8 @@ export function formatReviewComment(options: FormatOptions): string {
   const totalTokens = (inputTokens ?? 0) + (outputTokens ?? 0);
   const hasSuppressed = (suppressedCount ?? 0) > 0 && (ux?.showSuppressedCount !== false);
   const hasParseFailures = (parseFailureCount ?? 0) > 0;
-  const hasDetails = totalTokens > 0 || durationMs != null || model || hasSuppressed || hasParseFailures || !!conventionsSource;
+  const hasDegenerate = (degenerateResponseCount ?? 0) > 0;
+  const hasDetails = totalTokens > 0 || durationMs != null || model || hasSuppressed || hasParseFailures || hasDegenerate || !!conventionsSource;
   if (hasDetails) {
     const detailParts: string[] = [];
     if (totalTokens > 0) {
@@ -614,6 +623,11 @@ export function formatReviewComment(options: FormatOptions): string {
     }
     if (hasParseFailures) {
       lines.push(`| **\u26A0\uFE0F Unparsed agent output** | ${parseFailureCount} agent response${parseFailureCount !== 1 ? 's' : ''} could not be parsed \u2014 findings may be missing from this review |`);
+    }
+    if (hasDegenerate) {
+      // #401 — distinct from an unparsed response: this one parsed cleanly and
+      // would otherwise have been reported as ordinary suppression.
+      lines.push(`| **\u26A0\uFE0F Malformed agent output** | ${degenerateResponseCount} agent response${degenerateResponseCount !== 1 ? 's' : ''} returned unusable findings \u2014 findings may be missing from this review |`);
     }
     if (conventionsSource) {
       const suffix = conventionsTruncated ? ' (truncated)' : '';

--- a/packages/lambda/src/handlers/review-agent.ts
+++ b/packages/lambda/src/handlers/review-agent.ts
@@ -939,6 +939,7 @@ export async function handler(
       suppressedCount: result.suppressedCount,
       // #382 — disclose unparsed agent responses (findings may be missing).
       parseFailureCount: result.parseFailureCount,
+      degenerateResponseCount: result.degenerateResponseCount,
       enabledAgentCount: result.enabledAgentCount,
       inputTokens: result.inputTokens,
       outputTokens: result.outputTokens,

--- a/packages/server/src/review-processor.ts
+++ b/packages/server/src/review-processor.ts
@@ -793,6 +793,7 @@ export async function processReviewJob(
       suppressedCount: result.suppressedCount,
       // #382 — disclose unparsed agent responses (findings may be missing).
       parseFailureCount: result.parseFailureCount,
+      degenerateResponseCount: result.degenerateResponseCount,
       enabledAgentCount: result.enabledAgentCount,
       inputTokens: result.inputTokens,
       outputTokens: result.outputTokens,


### PR DESCRIPTION
`Closes #401`

## Which of the two readings it was

The issue posed a fork: a display bug, or a token-burn bug where the pipeline paid for thousands of discarded findings. The stored review rows settle it.

| PR | reported suppressed | **outputTokens** | findings kept |
|---|---|---|---|
| fixtures#625 | 1,430 | **3,794** | 0 |
| fixtures#628 | 3,869 | **3,233** | 1 |
| neighbours | 1–20 | 200–5,800 | 0–4 |

**Output tokens are normal**, so nothing expensive happened — `max_tokens` capped it. Not a token-burn bug.

But `totalRawFindings` genuinely *was* ~1,430. I ruled out the tempting explanation — that `findings` was a string and `.length` returned a character count — because `.map()` on a string throws `TypeError` and both reviews completed. It was a real array.

Which leaves arithmetic that's hard to argue with: **3,794 tokens ÷ 1,430 entries = 2.7 tokens each.** Only possible if the entries were near-empty. An agent went into a degenerate loop emitting `{}`-shaped objects until the cap cut it off. The array parsed fine, downstream validation correctly discarded all of it, and `suppressedCount` (raw − final) faithfully reported 1,430.

**The counter wasn't lying — it was counting the wrong things**, and describing an agent malfunction as productive dedup work.

That's the worse half. #382 added `parseFailureCount` precisely so silent agent failures get disclosed; this one slips past because the JSON *parses*. The only symptom was a strange number in a collapsed drawer.

## The fix

`parseAgentFindings` now validates the **shape**, not just the JSON:

- **Non-array `findings` is discarded.** `.length` exists on strings, so an unchecked string would contribute its *character* count to the raw total — a latent version of the same bug.
- **Entries without a non-empty `title` aren't findings.** Nothing downstream can render them and no reviewer can act on them.
- **Below 50% usable → discarded whole and flagged degenerate.** Keeping the 2 real findings out of 1,430 and reporting "1,428 suppressed" would *still* describe a malfunction as filtering.

`totalRawFindings` independently filters with the same predicate, since custom and org-agent results arrive by another path.

New `degenerateResponseCount` surfaces as **⚠️ Malformed agent output**, deliberately distinct from #382's **⚠️ Unparsed agent output** — different causes, different remedies, and collapsing them would lose that.

## Verification

build 12/12 · typecheck 20/20 · test 21/21 — **1000 core tests** (+16)

Includes a direct reproduction of the production shape: 1,430 empty objects now count as **zero** and raise the degenerate flag. Also covered: mostly-junk discarded whole · a few malformed entries filtered while the good ones survive · non-array and object `findings` discarded · missing/empty `findings` treated as clean rather than degenerate · unparseable JSON still counted as a *parse* failure, not a degenerate one · both warnings render independently.

Adds **E2E-99**.

## One honest caveat

Raw agent responses aren't retained, so "near-empty objects" is inferred from token arithmetic rather than observed. The fix doesn't depend on the exact shape — validating before counting handles a non-array, empty objects, or anything else array-like — but I'd rather flag the inference than present it as a measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)