### PR TITLE
fix(core): contain worktree path traversal before retrieval lands (#424)

### DIFF
--- a/packages/core/src/context/agentic-fetcher.ts
+++ b/packages/core/src/context/agentic-fetcher.ts
@@ -12,6 +12,7 @@ import type { Octokit } from '@octokit/rest';
 import type { ILLMProvider } from '../llm/types.js';
 import { normalizeLLMResult } from '../llm/types.js';
 import { fetchFileContents } from './file-fetcher.js';
+import { sanitizeRelativePath } from './safe-path.js';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -51,25 +52,13 @@ Rules:
 
 // ─── Core logic ─────────────────────────────────────────────────────────────
 
-/**
- * Sanitize a file path from LLM output.
- * Rejects paths with directory traversal or absolute paths.
+/*
+ * Path validation lives in `safe-path.ts` (#424). This module's paths are
+ * resolved by the GitHub API against a repo tree, so lexical checks are
+ * sufficient here — but the same strings will be joined onto a real worktree
+ * once retrieval lands, and one validator with one set of tests is how the
+ * two paths stay in step.
  */
-function sanitizeFilePath(filePath: string): string | null {
-  // Reject empty paths
-  if (!filePath || filePath.trim().length === 0) return null;
-
-  // Reject absolute paths
-  if (filePath.startsWith('/') || filePath.startsWith('\\')) return null;
-
-  // Reject directory traversal
-  if (filePath.includes('..')) return null;
-
-  // Reject paths with null bytes
-  if (filePath.includes('\0')) return null;
-
-  return filePath.trim();
-}
 
 /**
  * Parse a model response to check if it's a file request.
@@ -97,7 +86,7 @@ function parseFileRequest(response: string): string[] | null {
     ) {
       // Sanitize and filter paths, cap at 10 files
       const sanitized = parsed.requestFiles
-        .map((p: string) => sanitizeFilePath(p))
+        .map((p: string) => sanitizeRelativePath(p))
         .filter((p: string | null): p is string => p !== null)
         .slice(0, 10);
 

--- a/packages/core/src/context/safe-path.test.ts
+++ b/packages/core/src/context/safe-path.test.ts
@@ -1,0 +1,212 @@
+/**
+ * #424 — these tests build real symlinks on a real filesystem on purpose.
+ *
+ * The vulnerability is invisible to lexical reasoning: every escaping path
+ * here passes every string check, and only the filesystem reveals where it
+ * lands. A mocked fs would assert the bug away.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtemp, mkdir, writeFile, symlink, rm, realpath } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, sep } from 'node:path';
+import {
+  sanitizeRelativePath,
+  isWithinRoot,
+  resolveWithinRoot,
+  GIT_HARDENING_ARGS,
+  GIT_CLONE_SAFETY_ARGS,
+} from './safe-path.js';
+
+describe('sanitizeRelativePath', () => {
+  it('accepts ordinary repo-relative paths', () => {
+    expect(sanitizeRelativePath('src/index.ts')).toBe('src/index.ts');
+    expect(sanitizeRelativePath('  packages/core/src/a.ts  ')).toBe('packages/core/src/a.ts');
+  });
+
+  it('collapses redundant separators and single dots', () => {
+    expect(sanitizeRelativePath('src//a/./b.ts')).toBe('src/a/b.ts');
+    expect(sanitizeRelativePath('./src/a.ts')).toBe('src/a.ts');
+  });
+
+  it('rejects absolute and drive-relative paths', () => {
+    expect(sanitizeRelativePath('/etc/passwd')).toBeNull();
+    expect(sanitizeRelativePath('C:/Windows/system.ini')).toBeNull();
+  });
+
+  it('rejects traversal segments', () => {
+    expect(sanitizeRelativePath('../secret')).toBeNull();
+    expect(sanitizeRelativePath('src/../../secret')).toBeNull();
+    expect(sanitizeRelativePath('..')).toBeNull();
+  });
+
+  it('allows dots inside a filename — only a bare `..` segment is traversal', () => {
+    // The predecessor rejected any path *containing* "..", which also refused
+    // legitimate names. Segment-wise checking is both stricter and kinder.
+    expect(sanitizeRelativePath('src/foo..bar.ts')).toBe('src/foo..bar.ts');
+    expect(sanitizeRelativePath('...eslintrc')).toBe('...eslintrc');
+  });
+
+  it('rejects NUL bytes', () => {
+    // Truncated at the syscall boundary: validated whole, opened as "a.ts".
+    expect(sanitizeRelativePath('a.ts\0../../etc/passwd')).toBeNull();
+  });
+
+  it('rejects backslashes', () => {
+    expect(sanitizeRelativePath('src\\a.ts')).toBeNull();
+    expect(sanitizeRelativePath('..\\..\\etc')).toBeNull();
+  });
+
+  it('rejects empty and dot-only paths', () => {
+    expect(sanitizeRelativePath('')).toBeNull();
+    expect(sanitizeRelativePath('   ')).toBeNull();
+    expect(sanitizeRelativePath('.')).toBeNull();
+    expect(sanitizeRelativePath('./.')).toBeNull();
+  });
+});
+
+describe('isWithinRoot', () => {
+  it('treats the root itself as inside', () => {
+    expect(isWithinRoot('/repo', '/repo')).toBe(true);
+  });
+
+  it('accepts descendants', () => {
+    expect(isWithinRoot('/repo', `/repo${sep}src${sep}a.ts`)).toBe(true);
+  });
+
+  it('rejects a sibling that shares a prefix', () => {
+    // The separator is the whole point: a bare startsWith says yes here.
+    expect(isWithinRoot('/repo', '/repo-evil/secret')).toBe(false);
+    expect(isWithinRoot('/repo', '/repository/secret')).toBe(false);
+  });
+
+  it('rejects ancestors', () => {
+    expect(isWithinRoot('/repo/src', '/repo')).toBe(false);
+  });
+
+  it('handles a root with a trailing separator', () => {
+    expect(isWithinRoot(`/repo${sep}`, `/repo${sep}a.ts`)).toBe(true);
+    expect(isWithinRoot(`/repo${sep}`, '/repo-evil/a.ts')).toBe(false);
+  });
+});
+
+describe('resolveWithinRoot — against a real filesystem', () => {
+  let base: string;
+  let root: string;
+  let outside: string;
+
+  beforeAll(async () => {
+    base = await mkdtemp(join(tmpdir(), 'mw-safepath-'));
+    root = join(base, 'worktree');
+    outside = join(base, 'outside');
+
+    await mkdir(join(root, 'src'), { recursive: true });
+    await mkdir(outside, { recursive: true });
+
+    await writeFile(join(root, 'src', 'real.ts'), 'export const a = 1;\n');
+    await writeFile(join(outside, 'secret.txt'), 'do not read me\n');
+
+    // The attack from the design doc: a symlink to an absolute path outside.
+    await symlink('/etc', join(root, 'etc-link'), 'dir');
+    // The relative variant — escapes without the path ever containing "..".
+    await symlink('..', join(root, 'up'), 'dir');
+    await symlink(outside, join(root, 'out-link'), 'dir');
+    // A legitimate in-repo symlink, which must keep working.
+    await symlink(join(root, 'src', 'real.ts'), join(root, 'alias.ts'), 'file');
+    // A dangling symlink.
+    await symlink(join(base, 'nope'), join(root, 'dangling.ts'), 'file');
+  });
+
+  afterAll(async () => {
+    await rm(base, { recursive: true, force: true });
+  });
+
+  it('resolves an ordinary file inside the root', async () => {
+    const got = await resolveWithinRoot(root, 'src/real.ts');
+    expect(got).not.toBeNull();
+    expect(got).toBe(join(await realpath(root), 'src', 'real.ts'));
+  });
+
+  it('BLOCKS a symlink to an absolute path outside the root', async () => {
+    // The exact string from the design doc: no "..", not absolute, passes
+    // every lexical check, and reads /etc/passwd if unguarded.
+    expect(await resolveWithinRoot(root, 'etc-link/passwd')).toBeNull();
+  });
+
+  it('BLOCKS a symlink pointing at the parent directory', async () => {
+    expect(await resolveWithinRoot(root, 'up/outside/secret.txt')).toBeNull();
+  });
+
+  it('BLOCKS a symlink to a sibling directory outside the root', async () => {
+    expect(await resolveWithinRoot(root, 'out-link/secret.txt')).toBeNull();
+  });
+
+  it('BLOCKS the symlink directory itself, not merely paths under it', async () => {
+    expect(await resolveWithinRoot(root, 'etc-link')).toBeNull();
+  });
+
+  it('allows a symlink that stays inside the root, resolved to its target', async () => {
+    const got = await resolveWithinRoot(root, 'alias.ts');
+    expect(got).toBe(join(await realpath(root), 'src', 'real.ts'));
+  });
+
+  it('returns null for a dangling symlink', async () => {
+    expect(await resolveWithinRoot(root, 'dangling.ts')).toBeNull();
+  });
+
+  it('returns null for a file that does not exist', async () => {
+    expect(await resolveWithinRoot(root, 'src/missing.ts')).toBeNull();
+  });
+
+  it('returns null for lexically invalid input without touching the fs', async () => {
+    expect(await resolveWithinRoot(root, '../outside/secret.txt')).toBeNull();
+    expect(await resolveWithinRoot(root, '/etc/passwd')).toBeNull();
+    expect(await resolveWithinRoot(root, '')).toBeNull();
+  });
+
+  it('works when the ROOT ITSELF is reached through a symlink', async () => {
+    // Not hypothetical: /tmp is a symlink to /private/tmp on macOS, so a root
+    // that is not itself resolved never prefix-matches what realpath returns
+    // and every legitimate read fails.
+    const linkedRoot = join(base, 'root-via-link');
+    await symlink(root, linkedRoot, 'dir');
+
+    const got = await resolveWithinRoot(linkedRoot, 'src/real.ts');
+    expect(got).not.toBeNull();
+    expect(got).toBe(join(await realpath(root), 'src', 'real.ts'));
+
+    // Containment still holds through the aliased root.
+    expect(await resolveWithinRoot(linkedRoot, 'etc-link/passwd')).toBeNull();
+  });
+
+  it('rejects a sibling directory that shares the root name as a prefix', async () => {
+    const evil = `${root}-evil`;
+    await mkdir(evil, { recursive: true });
+    await writeFile(join(evil, 'secret.txt'), 'nope\n');
+    await symlink(evil, join(root, 'prefix-link'), 'dir');
+
+    expect(await resolveWithinRoot(root, 'prefix-link/secret.txt')).toBeNull();
+  });
+
+  it('throws when the root itself does not exist — a caller bug, not repo input', async () => {
+    await expect(resolveWithinRoot(join(base, 'no-such-root'), 'a.ts')).rejects.toThrow();
+  });
+});
+
+describe('git hardening flags', () => {
+  it('disables symlink materialisation, hooks, and ext:: remotes', () => {
+    const joined = GIT_HARDENING_ARGS.join(' ');
+    expect(joined).toContain('core.symlinks=false');
+    expect(joined).toContain('core.hooksPath=/dev/null');
+    expect(joined).toContain('protocol.ext.allow=never');
+  });
+
+  it('refuses submodules on clone', () => {
+    expect(GIT_CLONE_SAFETY_ARGS).toContain('--no-recurse-submodules');
+  });
+
+  it('are frozen, so a caller cannot quietly drop a flag', () => {
+    expect(Object.isFrozen(GIT_HARDENING_ARGS)).toBe(true);
+    expect(Object.isFrozen(GIT_CLONE_SAFETY_ARGS)).toBe(true);
+  });
+});

--- a/packages/core/src/context/safe-path.ts
+++ b/packages/core/src/context/safe-path.ts
@@ -1,0 +1,168 @@
+/**
+ * #424 — path containment for tools that read a real checkout.
+ *
+ * The retrieval architecture materialises an attacker-controlled tree: the
+ * corpus is a worktree of the PR head, and a PR may add anything a git tree
+ * can express — including symlinks.
+ *
+ * `sanitizeFilePath` in `agentic-fetcher.ts` is sufficient for the path it
+ * guards, because that path is resolved by the GitHub *API* against a repo
+ * tree: a symlink there is a blob whose content is the link text, and the API
+ * never traverses it. Once the same string is joined onto a directory on disk,
+ * the guarantee evaporates. A PR containing
+ *
+ *     docs/notes -> /etc
+ *
+ * makes `read_file("docs/notes/passwd")` a read of `/etc/passwd`. That string
+ * has no `..`, is not absolute, and passes every lexical check there is.
+ * Lexical validation cannot see it; only the filesystem can.
+ *
+ * Two independent layers, either of which closes the hole:
+ *
+ * 1. `GIT_HARDENING_ARGS` sets `core.symlinks=false`, so checkout writes
+ *    symlinks as *plain files containing the link text*. No symlink is ever
+ *    created, so there is nothing to traverse.
+ * 2. `resolveWithinRoot` resolves the path through the filesystem and verifies
+ *    the result is still under the root, so a symlink that exists anyway —
+ *    left by an earlier clone, a shared volume, an operator's own mirror —
+ *    still cannot escape.
+ *
+ * Belt and braces on purpose: layer 1 depends on every clone site remembering
+ * a flag, and this is not a mistake we want to be one forgotten flag away from.
+ */
+
+import { realpath } from 'node:fs/promises';
+import { resolve, sep } from 'node:path';
+
+/**
+ * `git` flags that make a checkout of untrusted content inert.
+ *
+ * Pass these to **every** git invocation that materialises a tree.
+ *
+ * - `core.symlinks=false` — checkout writes symlinks as small plain files
+ *   holding the link text. This is git's own mechanism for filesystems without
+ *   symlink support; here it is the primary containment layer.
+ * - `core.hooksPath=/dev/null` — hooks are not transferred by clone, but a
+ *   mirror that is re-fetched into, or any path where `.git` is reused, can
+ *   carry them. Nothing in a reviewed repo should ever execute.
+ * - `protocol.ext.allow=never` — `ext::` remote URLs run a shell command.
+ *   Modern git already defaults to `never`; stating it means we do not inherit
+ *   an operator's looser global config.
+ */
+export const GIT_HARDENING_ARGS: readonly string[] = Object.freeze([
+  '-c', 'core.symlinks=false',
+  '-c', 'core.hooksPath=/dev/null',
+  '-c', 'protocol.ext.allow=never',
+]);
+
+/**
+ * Clone flags that go with the hardening config.
+ *
+ * Submodules are opt-in for `git clone`, so this is belt-and-braces again —
+ * but a submodule is a second attacker-controlled tree fetched from an
+ * attacker-chosen URL, and CVE-2022-39253 is what that class of bug looks
+ * like. Say no explicitly.
+ */
+export const GIT_CLONE_SAFETY_ARGS: readonly string[] = Object.freeze([
+  '--no-recurse-submodules',
+]);
+
+/**
+ * Lexical validation of a repo-relative path. No filesystem access.
+ *
+ * This is a *pre-filter*, not the containment check — it rejects the obvious
+ * junk cheaply so `resolveWithinRoot` does not pay a syscall for it. Passing
+ * this proves nothing about where the path lands on disk.
+ *
+ * Returns the normalised path, or `null` if it is not a usable relative path.
+ */
+export function sanitizeRelativePath(input: string): string | null {
+  if (typeof input !== 'string') return null;
+
+  const trimmed = input.trim();
+  if (trimmed.length === 0) return null;
+
+  // A NUL truncates the path at the syscall boundary: "a.ts\0../../etc" is
+  // validated whole and opened as "a.ts".
+  if (trimmed.includes('\0')) return null;
+
+  // Backslash is a separator on Windows and a quoting character in enough
+  // shells that treating it as an ordinary filename character is a trap.
+  if (trimmed.includes('\\')) return null;
+
+  if (trimmed.startsWith('/')) return null;      // POSIX absolute
+  if (/^[a-zA-Z]:/.test(trimmed)) return null;   // Windows drive-relative
+
+  const parts: string[] = [];
+  for (const segment of trimmed.split('/')) {
+    if (segment === '' || segment === '.') continue; // collapse // and ./
+    // Reject rather than collapse. `a/../b` is arithmetically fine, but a
+    // model emitting it means something went wrong upstream, and silently
+    // rewriting a path we were asked to read is worse than refusing it.
+    if (segment === '..') return null;
+    parts.push(segment);
+  }
+  if (parts.length === 0) return null;
+
+  return parts.join('/');
+}
+
+/**
+ * Whether `candidate` lies at or beneath `root`. Both must already be
+ * absolute and fully resolved — this is pure string work.
+ *
+ * The separator matters: a bare `startsWith` says `/repo-evil` is inside
+ * `/repo`.
+ */
+export function isWithinRoot(root: string, candidate: string): boolean {
+  if (candidate === root) return true;
+  const prefix = root.endsWith(sep) ? root : root + sep;
+  return candidate.startsWith(prefix);
+}
+
+/**
+ * Resolve a repo-relative path against a worktree root, following symlinks,
+ * and return it only if it is genuinely inside that root.
+ *
+ * **Callers must read the returned path, not the path they passed in.** The
+ * return value is the fully resolved location; re-joining the original
+ * relative path would reintroduce the traversal this function exists to stop.
+ *
+ * A symlink pointing *within* the worktree resolves and is allowed —
+ * repositories use those legitimately.
+ *
+ * Returns `null` when the path is unusable: malformed, missing, unreadable, a
+ * dangling symlink, or escaping the root. These are deliberately not
+ * distinguished — the caller's response to all of them is the same, and a
+ * caller that reports "outside the repo" differently from "not found" tells an
+ * attacker which paths exist.
+ *
+ * Throws only if `root` itself cannot be resolved, which is a bug in the
+ * caller rather than anything the reviewed repo controls.
+ */
+export async function resolveWithinRoot(
+  root: string,
+  relPath: string,
+): Promise<string | null> {
+  const rel = sanitizeRelativePath(relPath);
+  if (rel === null) return null;
+
+  // The root is resolved too, and this is load-bearing rather than tidiness:
+  // /tmp is a symlink to /private/tmp on macOS, so a literal root of
+  // /tmp/wt-1 would never prefix-match anything realpath returns.
+  const realRoot = await realpath(resolve(root));
+
+  const candidate = resolve(realRoot, rel);
+  // Cheap reject before a second syscall. Only reachable via odd inputs, since
+  // sanitizeRelativePath already removed `..`.
+  if (!isWithinRoot(realRoot, candidate)) return null;
+
+  let resolved: string;
+  try {
+    resolved = await realpath(candidate);
+  } catch {
+    return null;
+  }
+
+  return isWithinRoot(realRoot, resolved) ? resolved : null;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -229,6 +229,13 @@ export type { ConventionsLoadResult } from './config/conventions.js';
 
 // ─── Context (agentic file fetching) ─────────────────────────────────────────
 export { fetchFileContents } from './context/file-fetcher.js';
+export {
+  sanitizeRelativePath,
+  isWithinRoot,
+  resolveWithinRoot,
+  GIT_HARDENING_ARGS,
+  GIT_CLONE_SAFETY_ARGS,
+} from './context/safe-path.js';
 export { invokeWithFileFetching, FILE_REQUEST_INSTRUCTION } from './context/agentic-fetcher.js';
 export type { FileFetchOptions, AgenticInvokeResult } from './context/agentic-fetcher.js';
 


### PR DESCRIPTION
#431 recorded symlink containment as the item that gates the rest of the retrieval work. This is that item — landing the primitive before any code reads a worktree, rather than after.

## The hole

`sanitizeFilePath` is sufficient **where it currently stands**. Its paths are resolved by the GitHub API against a repo tree, where a symlink is a blob holding the link text and the API never traverses it.

Join the same string onto a directory on disk and that guarantee is gone. A PR containing

```
docs/notes -> /etc
```

makes `read_file("docs/notes/passwd")` a read of `/etc/passwd`. No `..`, not absolute, passes every lexical check there is. Lexical validation cannot see this; only the filesystem can.

Verified before writing the guard rather than assumed — the naive `join` returns **143 lines of `/etc/passwd`**.

## Two layers

| | |
|---|---|
| `GIT_HARDENING_ARGS` | `core.symlinks=false` makes checkout write symlinks as plain files holding the link text. No symlink is created, so there is nothing to traverse. Also disables hooks and `ext::` remotes. |
| `resolveWithinRoot` | Resolves through the filesystem and verifies the result is still under the root — so a symlink that exists anyway (earlier clone, shared volume, an operator's own mirror) still cannot escape. |

Belt and braces deliberately: layer 1 depends on every future clone site remembering a flag, and this isn't a mistake worth being one forgotten flag away from.

## Details worth flagging

**The root is resolved too**, and it's load-bearing rather than tidiness: `/tmp` is a symlink to `/private/tmp` on macOS, so an unresolved root would never prefix-match what `realpath` returns and *every legitimate read would fail*. That's a bug that would only appear in local dev and look like "retrieval is broken."

**Callers must read the returned path**, not the one they passed in — documented on the function, since re-joining the original would reintroduce the traversal.

**Failure modes are deliberately indistinguishable.** Malformed, missing, unreadable, dangling, escaping — all `null`. Reporting "outside the repo" differently from "not found" tells an attacker which paths exist.

**In-repo symlinks still work.** Repos use those legitimately; only escapes are blocked.

## De-duplication

`sanitizeFilePath` is replaced by the shared `sanitizeRelativePath`, so the API path and the future worktree path share one validator and one set of tests. Two behaviour changes, both fixes:

- Segment-wise `..` checking no longer refuses legitimate names like `foo..bar.ts` or `...eslintrc` (the old substring check rejected them).
- Redundant separators and `./` collapse.

## Tests

28 new tests that build **real symlinks on a real filesystem** on purpose — absolute escape, relative-parent escape, sibling escape, the symlink directory itself, prefix-confusion (`/repo` vs `/repo-evil`), dangling, in-repo symlinks still resolving, and the aliased-root case. Every escaping path here passes every string check, so a mocked fs would assert the bug away.

Full suite green: **1028 core tests**, 21/21 turbo tasks.

Refs #424.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M46oixQnwB24o8tc7HojJp